### PR TITLE
fix: support file upload for filenames with unicode characters

### DIFF
--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+from urllib.parse import quote
 
 from config.settings import LANGFLOW_INGEST_FLOW_ID, clients
 from utils.logging_config import get_logger
@@ -153,7 +154,7 @@ class LangflowFileService:
                 "X-Langflow-Global-Var-OWNER_NAME": str(owner_name),
                 "X-Langflow-Global-Var-OWNER_EMAIL": str(owner_email),
                 "X-Langflow-Global-Var-CONNECTOR_TYPE": str(connector_type),
-                "X-Langflow-Global-Var-FILENAME": filename,
+                "X-Langflow-Global-Var-FILENAME": quote(filename, safe=''),
                 "X-Langflow-Global-Var-MIMETYPE": mimetype,
                 "X-Langflow-Global-Var-FILESIZE": str(file_size_bytes),
                 "X-Langflow-Global-Var-SELECTED_EMBEDDING_MODEL": str(embedding_model),


### PR DESCRIPTION
Fixes #769 

> [!Note]
> This sends the filename as a percent-encoded string to the Langflow API. Langflow does not currently decode those strings, so the filename will travel through Langflow as `super%E2%80%93interesting%E2%80%93document.pdf` instead of `super–interesting–document.pdf` (those are en-dashes) and ultimately be stored with the percent-encoded filename. This shows back up in OpenRAG as ugly looking strings. 
>
> We could decode all the strings in OpenRAG everywhere we display them, but it shouldn't be OpenRAG's job to do that. I opened [this PR on Langflow](https://github.com/langflow-ai/langflow/pull/11658) to decode the headers before they are set in the global variables. This will lead to the filename being properly decoded and stored as its original string, so that when it is read by OpenRAG it looks normal again.