### PR TITLE
Fix dependencies (OpenRAG on OpenSearch)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,6 @@ services:
     #context: .
     #dockerfile: Dockerfile
     container_name: os
-    depends_on:
-      - openrag-backend
     environment:
       - discovery.type=single-node
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD}
@@ -50,6 +48,7 @@ services:
       dockerfile: Dockerfile.backend
     container_name: openrag-backend
     depends_on:
+      - opensearch
       - langflow
     environment:
       - OPENSEARCH_HOST=opensearch


### PR DESCRIPTION
Please feel free to close if this is made in error, but there seems to be a misconfiguration where OpenSearch _depends on_ OpenRAG backend when in reality, the OpenRAG backend depends on OpenSearch?

I consistently receive this error and cannot use knowledge at all. Could this be why?

<img width="1840" height="1089" alt="Screenshot 2026-02-16 at 13 15 23" src="https://github.com/user-attachments/assets/c76bf9c6-743a-4824-bf99-866ba3c3458c" />
