### PR TITLE
Add preflight validation

### DIFF
--- a/src/config/startup_validation.py
+++ b/src/config/startup_validation.py
@@ -1,0 +1,343 @@
+"""Preemptive startup validation to catch configuration issues early."""
+
+import json
+import os
+import subprocess
+import sys
+from typing import List, Optional, Tuple
+
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Minimum memory requirements (in MB)
+MIN_OPENSEARCH_MEMORY_MB = 2048  # 2GB minimum for OpenSearch
+MIN_CONTAINER_MEMORY_MB = 4096  # 4GB minimum for container runtime
+
+
+class ValidationError(Exception):
+    """Raised when startup validation fails."""
+    pass
+
+
+def check_required_env_vars(env: dict = None) -> List[str]:
+    """Check for required environment variables.
+
+    Args:
+        env: Dictionary of environment variables to check. Defaults to os.environ.
+
+    Returns:
+        List of missing required environment variable names.
+    """
+    if env is None:
+        env = os.environ
+
+    missing = []
+
+    # OPENSEARCH_PASSWORD is always required
+    if not env.get("OPENSEARCH_PASSWORD"):
+        missing.append("OPENSEARCH_PASSWORD")
+
+    # Langflow credentials are required unless AUTO_LOGIN is enabled
+    langflow_auto_login = env.get("LANGFLOW_AUTO_LOGIN", "False").lower() in ("true", "1", "yes")
+
+    if not langflow_auto_login:
+        if not env.get("LANGFLOW_SUPERUSER"):
+            missing.append("LANGFLOW_SUPERUSER")
+        if not env.get("LANGFLOW_SUPERUSER_PASSWORD"):
+            missing.append("LANGFLOW_SUPERUSER_PASSWORD")
+
+    return missing
+
+
+def detect_container_runtime() -> Optional[str]:
+    """Detect which container runtime is being used.
+    
+    Returns:
+        'docker', 'podman', 'colima', or None if none detected
+    """
+    # Check for Colima first (it provides docker-compatible API)
+    try:
+        result = subprocess.run(
+            ["colima", "status"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0 and "Running" in result.stdout:
+            return "colima"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    
+    # Check for Podman
+    try:
+        result = subprocess.run(
+            ["podman", "info"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            return "podman"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    
+    # Check for Docker (could be Docker Desktop, Docker Engine, or Colima masquerading)
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        if result.returncode == 0:
+            # Check if it's actually Podman masquerading as Docker
+            if "podman" in result.stdout.lower():
+                return "podman"
+            return "docker"
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    
+    return None
+
+
+def check_opensearch_container_memory() -> Tuple[bool, str]:
+    """Check if OpenSearch container has sufficient memory.
+    
+    Returns:
+        Tuple of (is_sufficient, error_message)
+    """
+    container_name = "os"  # OpenSearch container name from docker-compose
+    runtime = detect_container_runtime()
+    
+    if not runtime:
+        # No container runtime detected - might be non-containerized environment
+        # Assume OK for now
+        return True, ""
+    
+    # Try to check if container exists and get its memory limit
+    # Use generic 'docker' command (works with Docker, Podman, and Colima)
+    try:
+        # Check if container exists
+        result = subprocess.run(
+            ["docker", "inspect", container_name, "--format", "{{.State.Status}}"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        
+        if result.returncode != 0:
+            # Container doesn't exist yet, which is OK - it might not be started
+            # We'll check the container runtime memory instead
+            return check_container_runtime_memory(runtime)
+        
+        # Container exists, check its memory limit
+        mem_result = subprocess.run(
+            ["docker", "inspect", container_name, "--format", "{{.HostConfig.Memory}}"],
+            capture_output=True,
+            text=True,
+            timeout=5
+        )
+        
+        if mem_result.returncode == 0 and mem_result.stdout.strip():
+            memory_bytes = int(mem_result.stdout.strip())
+            if memory_bytes > 0:
+                memory_mb = memory_bytes // (1024 * 1024)
+                if memory_mb < MIN_OPENSEARCH_MEMORY_MB:
+                    return False, (
+                        f"OpenSearch container has insufficient memory: {memory_mb}MB "
+                        f"(minimum {MIN_OPENSEARCH_MEMORY_MB}MB required). "
+                        f"Increase container memory limit or use a container runtime with more memory."
+                    )
+                return True, ""
+        
+        # No explicit memory limit set, check runtime memory
+        return check_container_runtime_memory(runtime)
+        
+    except FileNotFoundError:
+        # Docker command not found - shouldn't happen if runtime was detected
+        return check_container_runtime_memory(runtime)
+    except Exception as e:
+        logger.warning("Could not check OpenSearch container memory", error=str(e))
+        # Don't fail on check errors, but warn
+        return True, ""
+
+
+def check_container_runtime_memory(runtime: Optional[str] = None) -> Tuple[bool, str]:
+    """Check container runtime memory allocation.
+    
+    Args:
+        runtime: Detected runtime ('docker', 'podman', 'colima', or None)
+    
+    Returns:
+        Tuple of (is_sufficient, error_message)
+    """
+    if runtime is None:
+        runtime = detect_container_runtime()
+    
+    if runtime == "colima":
+        # Check Colima VM memory
+        try:
+            result = subprocess.run(
+                ["colima", "status", "--json"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            if result.returncode == 0:
+                status = json.loads(result.stdout)
+                # Colima stores memory in different places depending on version
+                memory_mb = None
+                if "memory" in status:
+                    memory_mb = int(status["memory"])
+                elif "vm" in status and "memory" in status["vm"]:
+                    memory_mb = int(status["vm"]["memory"])
+                
+                if memory_mb and memory_mb < MIN_CONTAINER_MEMORY_MB:
+                    return False, (
+                        f"Colima VM has insufficient memory: {memory_mb}MB "
+                        f"(minimum {MIN_CONTAINER_MEMORY_MB}MB recommended for OpenRAG). "
+                        f"Stop Colima and restart with more memory:\n"
+                        f"  colima stop\n"
+                        f"  colima start --memory {MIN_CONTAINER_MEMORY_MB}"
+                    )
+                if memory_mb:
+                    return True, ""
+        except (FileNotFoundError, subprocess.TimeoutExpired, ValueError, json.JSONDecodeError, KeyError):
+            pass
+    
+    if runtime == "podman":
+        # Check Podman machine memory (macOS/Linux)
+        try:
+            # Try to list machines and get memory for the default or first one
+            list_result = subprocess.run(
+                ["podman", "machine", "list", "--format", "{{.Name}}"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            
+            if list_result.returncode == 0 and list_result.stdout.strip():
+                machine_name = list_result.stdout.strip().split('\n')[0] or "podman-machine-default"
+                
+                result = subprocess.run(
+                    ["podman", "machine", "inspect", machine_name, "--format", "{{.Resources.Memory}}"],
+                    capture_output=True,
+                    text=True,
+                    timeout=5
+                )
+                
+                if result.returncode == 0 and result.stdout.strip():
+                    memory_mb = int(result.stdout.strip())
+                    if memory_mb < MIN_CONTAINER_MEMORY_MB:
+                        return False, (
+                            f"Podman machine has insufficient memory: {memory_mb}MB "
+                            f"(minimum {MIN_CONTAINER_MEMORY_MB}MB recommended for OpenRAG). "
+                            f"Recreate Podman machine with more memory:\n"
+                            f"  podman machine stop\n"
+                            f"  podman machine rm\n"
+                            f"  podman machine init --memory {MIN_CONTAINER_MEMORY_MB}\n"
+                            f"  podman machine start"
+                        )
+                    return True, ""
+        except (FileNotFoundError, subprocess.TimeoutExpired, ValueError, IndexError):
+            pass
+    
+    # Check Docker/Docker Desktop memory (works for Docker Desktop, Docker Engine, or Colima)
+    if runtime in ("docker", "colima", None):
+        try:
+            # Try to get Docker system info
+            result = subprocess.run(
+                ["docker", "system", "info", "--format", "{{.MemTotal}}"],
+                capture_output=True,
+                text=True,
+                timeout=5
+            )
+            
+            if result.returncode == 0 and result.stdout.strip():
+                mem_total = result.stdout.strip()
+                # Docker returns memory in various formats, try to parse
+                if mem_total and mem_total != "0":
+                    # Try to extract number (might be in bytes or human-readable)
+                    import re
+                    numbers = re.findall(r'\d+', mem_total)
+                    if numbers:
+                        # Assume it's in bytes if large, MB if small
+                        mem_value = int(numbers[0])
+                        if mem_value > 1000000:  # Likely bytes
+                            memory_mb = mem_value // (1024 * 1024)
+                        else:  # Likely MB
+                            memory_mb = mem_value
+                        
+                        if memory_mb < MIN_CONTAINER_MEMORY_MB:
+                            runtime_name = "Colima" if runtime == "colima" else "Docker"
+                            return False, (
+                                f"{runtime_name} has insufficient memory: {memory_mb}MB "
+                                f"(minimum {MIN_CONTAINER_MEMORY_MB}MB recommended for OpenRAG). "
+                                + (
+                                    f"Stop and restart Colima with more memory:\n"
+                                    f"  colima stop\n"
+                                    f"  colima start --memory {MIN_CONTAINER_MEMORY_MB}"
+                                    if runtime == "colima"
+                                    else "Increase Docker Desktop memory allocation in settings."
+                                )
+                            )
+                        return True, ""
+        except (FileNotFoundError, subprocess.TimeoutExpired, ValueError):
+            pass
+    
+    # If we can't check, assume OK (might be Linux with no limits or non-containerized)
+    return True, ""
+
+
+def validate_startup_requirements():
+    """Validate all startup requirements and raise ValidationError if any fail.
+    
+    Raises:
+        ValidationError: If any validation check fails.
+    """
+    errors = []
+    
+    # Check required environment variables
+    missing_vars = check_required_env_vars()
+    if missing_vars:
+        error_msg = (
+            "Missing required environment variables:\n"
+            + "\n".join(f"  - {var}" for var in missing_vars)
+            + "\n\n"
+            + "Please set these environment variables before starting OpenRAG.\n"
+            + "See CONTRIBUTING.md or docs for configuration details."
+        )
+        errors.append(error_msg)
+    
+    # Check OpenSearch memory
+    memory_ok, memory_error = check_opensearch_container_memory()
+    if not memory_ok:
+        errors.append(f"Memory check failed:\n  {memory_error}")
+    
+    # If any errors, raise exception
+    if errors:
+        error_message = "\n\n".join(errors)
+        logger.error("Startup validation failed", errors=errors)
+        raise ValidationError(
+            "=" * 80 + "\n"
+            "STARTUP VALIDATION FAILED\n"
+            "=" * 80 + "\n\n"
+            + error_message + "\n\n"
+            + "=" * 80 + "\n"
+            + "Please fix the issues above and restart OpenRAG.\n"
+            + "=" * 80
+        )
+    
+    logger.info("Startup validation passed")
+
+
+if __name__ == "__main__":
+    """Run validation as a standalone script."""
+    try:
+        validate_startup_requirements()
+        print("✓ Startup validation passed")
+        sys.exit(0)
+    except ValidationError as e:
+        print(str(e), file=sys.stderr)
+        sys.exit(1)

--- a/src/main.py
+++ b/src/main.py
@@ -636,6 +636,7 @@ async def startup_tasks(services):
 async def initialize_services():
     """Initialize all services and their dependencies"""
     await TelemetryClient.send_event(Category.SERVICE_INITIALIZATION, MessageId.ORB_SVC_INIT_START)
+    
     # Generate JWT keys if they don't exist
     generate_jwt_keys()
 

--- a/src/tui/managers/container_manager.py
+++ b/src/tui/managers/container_manager.py
@@ -1043,6 +1043,24 @@ class ContainerManager:
             yield False, format_port_conflict_message(conflicts), False
             return
 
+        # Validate environment variables from .env file
+        yield False, "Validating startup configuration...", False
+        from config.startup_validation import check_required_env_vars, check_container_runtime_memory
+        env_vars = self._get_env_from_file()
+        missing_vars = check_required_env_vars(env_vars)
+        if missing_vars:
+            yield False, "ERROR: Missing required environment variables:", False
+            for var in missing_vars:
+                yield False, f"  - {var}", False
+            yield False, "Please set these in your .env file and try again.", False
+            return
+
+        # Validate container runtime memory (let it auto-detect runtime for colima support)
+        memory_ok, memory_error = check_container_runtime_memory()
+        if not memory_ok:
+            yield False, f"WARNING: {memory_error}", False
+            yield False, "Services may fail to start with insufficient memory.", False
+
         yield False, "Starting OpenRAG services...", False
 
         missing_images: List[str] = []

--- a/tests/unit/test_startup_validation.py
+++ b/tests/unit/test_startup_validation.py
@@ -1,0 +1,250 @@
+"""Tests for startup validation module."""
+
+import os
+from unittest.mock import patch, MagicMock
+import pytest
+
+from config.startup_validation import (
+    check_required_env_vars,
+    detect_container_runtime,
+    check_container_runtime_memory,
+    check_opensearch_container_memory,
+    validate_startup_requirements,
+    ValidationError,
+)
+
+
+class TestCheckRequiredEnvVars:
+    """Tests for check_required_env_vars."""
+
+    def test_all_vars_set(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "MyStr0ng!Pass",
+            "LANGFLOW_SUPERUSER": "admin",
+            "LANGFLOW_SUPERUSER_PASSWORD": "Admin!Pass123",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        assert check_required_env_vars(env) == []
+
+    def test_missing_opensearch_password(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "",
+            "LANGFLOW_SUPERUSER": "admin",
+            "LANGFLOW_SUPERUSER_PASSWORD": "pass",
+        }
+        missing = check_required_env_vars(env)
+        assert "OPENSEARCH_PASSWORD" in missing
+
+    def test_missing_langflow_superuser(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "pass",
+            "LANGFLOW_SUPERUSER": "",
+            "LANGFLOW_SUPERUSER_PASSWORD": "pass",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        missing = check_required_env_vars(env)
+        assert "LANGFLOW_SUPERUSER" in missing
+
+    def test_missing_langflow_superuser_password(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "pass",
+            "LANGFLOW_SUPERUSER": "admin",
+            "LANGFLOW_SUPERUSER_PASSWORD": "",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        missing = check_required_env_vars(env)
+        assert "LANGFLOW_SUPERUSER_PASSWORD" in missing
+
+    def test_langflow_auto_login_skips_superuser_checks(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "pass",
+            "LANGFLOW_SUPERUSER": "",
+            "LANGFLOW_SUPERUSER_PASSWORD": "",
+            "LANGFLOW_AUTO_LOGIN": "True",
+        }
+        assert check_required_env_vars(env) == []
+
+    def test_all_missing(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "",
+            "LANGFLOW_SUPERUSER": "",
+            "LANGFLOW_SUPERUSER_PASSWORD": "",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        missing = check_required_env_vars(env)
+        assert "OPENSEARCH_PASSWORD" in missing
+        assert "LANGFLOW_SUPERUSER" in missing
+        assert "LANGFLOW_SUPERUSER_PASSWORD" in missing
+
+    def test_defaults_to_os_environ(self):
+        """When no env dict is passed, falls back to os.environ."""
+        env = {
+            "OPENSEARCH_PASSWORD": "pass",
+            "LANGFLOW_SUPERUSER": "admin",
+            "LANGFLOW_SUPERUSER_PASSWORD": "pass",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            assert check_required_env_vars() == []
+
+
+class TestDetectContainerRuntime:
+    """Tests for detect_container_runtime."""
+
+    def test_colima_detected(self):
+        mock_result = MagicMock(returncode=0, stdout="Running")
+        with patch("subprocess.run", return_value=mock_result) as mock_run:
+            assert detect_container_runtime() == "colima"
+            mock_run.assert_called_once()
+
+    def test_docker_detected(self):
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "colima":
+                raise FileNotFoundError
+            if cmd[0] == "podman":
+                raise FileNotFoundError
+            return MagicMock(returncode=0, stdout="Docker Engine")
+
+        with patch("subprocess.run", side_effect=side_effect):
+            assert detect_container_runtime() == "docker"
+
+    def test_podman_detected(self):
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "colima":
+                raise FileNotFoundError
+            if cmd[0] == "podman":
+                return MagicMock(returncode=0, stdout="podman")
+            raise FileNotFoundError
+
+        with patch("subprocess.run", side_effect=side_effect):
+            assert detect_container_runtime() == "podman"
+
+    def test_podman_masquerading_as_docker(self):
+        def side_effect(cmd, **kwargs):
+            if cmd[0] == "colima":
+                raise FileNotFoundError
+            if cmd[0] == "podman":
+                raise FileNotFoundError
+            # docker info returns podman info
+            return MagicMock(returncode=0, stdout="podman version 4.0")
+
+        with patch("subprocess.run", side_effect=side_effect):
+            assert detect_container_runtime() == "podman"
+
+    def test_no_runtime(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            assert detect_container_runtime() is None
+
+
+class TestCheckContainerRuntimeMemory:
+    """Tests for check_container_runtime_memory."""
+
+    def test_colima_sufficient_memory(self):
+        import json
+        status = json.dumps({"memory": 8192})
+        mock_result = MagicMock(returncode=0, stdout=status)
+        with patch("subprocess.run", return_value=mock_result):
+            ok, msg = check_container_runtime_memory("colima")
+            assert ok is True
+            assert msg == ""
+
+    def test_colima_insufficient_memory(self):
+        import json
+        status = json.dumps({"memory": 2048})
+        mock_result = MagicMock(returncode=0, stdout=status)
+        with patch("subprocess.run", return_value=mock_result):
+            ok, msg = check_container_runtime_memory("colima")
+            assert ok is False
+            assert "insufficient memory" in msg.lower()
+            assert "colima" in msg.lower()
+
+    def test_no_runtime_returns_ok(self):
+        """When no runtime is detected, assume OK."""
+        with patch("config.startup_validation.detect_container_runtime", return_value=None):
+            with patch("subprocess.run", side_effect=FileNotFoundError):
+                ok, msg = check_container_runtime_memory(None)
+                assert ok is True
+
+
+class TestCheckOpensearchContainerMemory:
+    """Tests for check_opensearch_container_memory."""
+
+    def test_no_runtime_detected(self):
+        with patch("config.startup_validation.detect_container_runtime", return_value=None):
+            ok, msg = check_opensearch_container_memory()
+            assert ok is True
+
+    def test_container_not_running_falls_back_to_runtime_check(self):
+        def mock_run(cmd, **kwargs):
+            if "inspect" in cmd:
+                return MagicMock(returncode=1, stdout="", stderr="no such container")
+            if cmd[0] == "colima":
+                return MagicMock(returncode=0, stdout='{"memory": 8192}')
+            if "system" in cmd:
+                return MagicMock(returncode=0, stdout="8589934592")
+            return MagicMock(returncode=1)
+
+        with patch("config.startup_validation.detect_container_runtime", return_value="colima"):
+            with patch("subprocess.run", side_effect=mock_run):
+                ok, msg = check_opensearch_container_memory()
+                assert ok is True
+
+
+class TestValidateStartupRequirements:
+    """Tests for validate_startup_requirements."""
+
+    def test_passes_with_valid_config(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "MyStr0ng!Pass",
+            "LANGFLOW_SUPERUSER": "admin",
+            "LANGFLOW_SUPERUSER_PASSWORD": "Admin!Pass123",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch("config.startup_validation.check_opensearch_container_memory", return_value=(True, "")):
+                # Should not raise
+                validate_startup_requirements()
+
+    def test_raises_on_missing_env_vars(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "",
+            "LANGFLOW_SUPERUSER": "",
+            "LANGFLOW_SUPERUSER_PASSWORD": "",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch("config.startup_validation.check_opensearch_container_memory", return_value=(True, "")):
+                with pytest.raises(ValidationError, match="Missing required environment variables"):
+                    validate_startup_requirements()
+
+    def test_raises_on_insufficient_memory(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "MyStr0ng!Pass",
+            "LANGFLOW_SUPERUSER": "admin",
+            "LANGFLOW_SUPERUSER_PASSWORD": "Admin!Pass123",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch(
+                "config.startup_validation.check_opensearch_container_memory",
+                return_value=(False, "Colima has insufficient memory: 2048MB"),
+            ):
+                with pytest.raises(ValidationError, match="Memory check failed"):
+                    validate_startup_requirements()
+
+    def test_raises_with_both_errors(self):
+        env = {
+            "OPENSEARCH_PASSWORD": "",
+            "LANGFLOW_SUPERUSER": "",
+            "LANGFLOW_SUPERUSER_PASSWORD": "",
+            "LANGFLOW_AUTO_LOGIN": "False",
+        }
+        with patch.dict(os.environ, env, clear=False):
+            with patch(
+                "config.startup_validation.check_opensearch_container_memory",
+                return_value=(False, "insufficient memory"),
+            ):
+                with pytest.raises(ValidationError) as exc_info:
+                    validate_startup_requirements()
+                error_msg = str(exc_info.value)
+                assert "Missing required environment variables" in error_msg
+                assert "Memory check failed" in error_msg


### PR DESCRIPTION
In this PR, we add a startup validation step to run on host before containers start to make sure OpenRAG can actually run successfully. Namely, OpenRAG will **not start or work correctly if:**

1. `OPENSEARCH_PASSWORD` is blank in `.env`. This is a hard requirement in recent versions of OpenSearch.
2. Langflow authentication environment variables are not set.
3. The container runtime doesn't have sufficient memory resources.

This PR checks those 3 things before attempting to start containers and if those conditions are not met, it gives a constructive, actionable error to users beforehand.