### PR TITLE
fix: pin Python to 3.13 for uvx/docling-serve to resolve pyarrow build failure on Python 3.14

### DIFF
--- a/src/tui/managers/docling_manager.py
+++ b/src/tui/managers/docling_manager.py
@@ -291,6 +291,7 @@ class DoclingManager:
 
             cmd = [
                 "uvx",
+                "--python", "3.13",
                 "--from", "docling-serve[ui]==1.5.0",
                 "--with", "onnxruntime",
                 "--with", "easyocr",


### PR DESCRIPTION
## Summary

Forces `uvx` to use Python 3.13 when running `docling-serve`, preventing
a build-from-source failure of `pyarrow` that occurs on Python 3.14.

---

## Problem

When `uvx` picks up Python 3.14 (the system default), the dependency chain for
`docling-serve` pulls in `pyarrow` — which has **no pre-built wheel for Python 3.14**
yet. This causes `pip` to attempt a source build, which fails because the Apache Arrow
C++ CMake configuration is not installed:
```
CMake Error at CMakeLists.txt:293 (find_package):
  Could not find a package configuration file provided by "Arrow" with any
  of the following names:

    ArrowConfig.cmake
    arrow-config.cmake

error: command '/usr/bin/cmake' failed with exit code 1
```

**Dependency chain:**
```
docling-serve (v1.5.0)
  └── docling-jobkit (v1.5.0)
        └── pyarrow (v19.0.1)   ← no wheel for Python 3.14
```

---

## Root Cause

`pyarrow` v19.0.1 does not publish a pre-built wheel for Python 3.14. When no wheel
is available, `pip` falls back to a source build — which requires the Apache Arrow C++
development libraries and CMake config that are not present in standard environments.

---

## Fix

Pin the Python interpreter used by `uvx` to **3.13** using the `--python` flag:
```bash
uvx --python 3.13 docling-serve
```

---

## Testing

Verified on a system where Python 3.14 is the default:
```bash
# Before — fails
uvx docling-serve
# → CMake error, pyarrow source build failure

# After — succeeds
uvx --python 3.13 docling-serve
# → All wheels resolved, server starts normally
```

---

## References

- [`pyarrow` PyPI release page](https://pypi.org/project/pyarrow/#files) — wheel availability per Python version
- [`uv` Python version docs](https://docs.astral.sh/uv/concepts/python-versions/)