### PR TITLE
fix: update upgrade instructions to reflect new command for upgrading OpenRAG

### DIFF
--- a/src/tui/widgets/upgrade_instructions_modal.py
+++ b/src/tui/widgets/upgrade_instructions_modal.py
@@ -92,7 +92,7 @@ class UpgradeInstructionsModal(ModalScreen[bool]):
                 "To upgrade the TUI:\n"
                 "1. Exit TUI (press 'q')\n"
                 "2. Run one of:\n"
-                "   • pip install --upgrade openrag\n"
+                "   • uv add --upgrade openrag\n"
                 "   • uv pip install --upgrade openrag\n"
                 "   • uvx --from openrag openrag\n"
                 "3. Restart: openrag\n\n"

--- a/src/tui/widgets/upgrade_instructions_modal.py
+++ b/src/tui/widgets/upgrade_instructions_modal.py
@@ -92,8 +92,8 @@ class UpgradeInstructionsModal(ModalScreen[bool]):
                 "To upgrade the TUI:\n"
                 "1. Exit TUI (press 'q')\n"
                 "2. Run one of:\n"
+                "   • pip install --upgrade openrag\n"
                 "   • uv add --upgrade openrag\n"
-                "   • uv pip install --upgrade openrag\n"
                 "   • uvx --from openrag openrag\n"
                 "3. Restart: openrag\n\n"
                 "After upgrading, containers will automatically use the new version.",


### PR DESCRIPTION
This pull request updates the upgrade instructions shown in the TUI modal to reflect the preferred way to upgrade `openrag`. The instructions now recommend using `uv add --upgrade openrag` instead of `pip install --upgrade openrag`.

Upgrade instructions update:

* Changed the recommended upgrade command in the instructions modal from `pip install --upgrade openrag` to `uv add --upgrade openrag` in `src/tui/widgets/upgrade_instructions_modal.py`.