### PR TITLE
feat: Set python-preference to only-managed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,5 +40,6 @@ openrag = "tui.main:run_tui"
 
 [tool.uv]
 package = true
+python-preference = "only-managed"
 
 


### PR DESCRIPTION
Add python-preference = "only-managed" to the [tool.uv] section in pyproject.toml to prefer managed Python interpreters (rather than system/global Python). This helps ensure builds and packaging use the project's managed Python environment.
_______
This pull request makes a minor configuration change to the `pyproject.toml` file, specifying that only managed Python versions should be used for the project.

