### PR TITLE
fix: stop reporting full startup success when docling fails

### DIFF
--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -344,7 +344,10 @@ def _start_services_cli(
     console.print()
     console.print("Starting OpenRAG services...", style="bold")
 
-    async def _inner():
+    async def _inner() -> tuple[bool | None, bool]:
+        container_started: bool | None = None
+        docling_started = docling_manager.is_running()
+
         # Start container services
         if container_manager.is_available():
             async for item in container_manager.start_services():
@@ -358,22 +361,43 @@ def _start_services_cli(
                 else:
                     console.print(f"  {message}")
 
-                if not success and "error" in message.lower():
+                if success and message == "Services started successfully":
+                    container_started = True
+                elif not success and message == "Failed to start services. See output above for details.":
+                    container_started = False
+                elif not success and "error" in message.lower():
                     console.print(f"  [red]✗ {message}[/red]")
         else:
             console.print("  [yellow]No container runtime available[/yellow]")
 
         # Start docling
-        if not docling_manager.is_running():
+        if not docling_started:
             success, message = await docling_manager.start()
             if success:
                 console.print(f"  {message}")
+                docling_started = docling_manager.is_running()
             else:
                 console.print(f"  [yellow]{message}[/yellow]")
+                docling_started = False
+
+        return container_started, docling_started
 
     try:
-        asyncio.run(_inner())
-        console.print("[green]✓ All services started[/green]")
+        container_started, docling_started = asyncio.run(_inner())
+        if container_started is False and not docling_started:
+            console.print(
+                "[yellow]⚠ Services only started partially: containers failed and docling-serve is not running.[/yellow]"
+            )
+        elif container_started is False:
+            console.print(
+                "[yellow]⚠ Containers did not start cleanly. Run Show status for details.[/yellow]"
+            )
+        elif not docling_started:
+            console.print(
+                "[yellow]⚠ Containers started, but docling-serve is not running. Run Show status for details.[/yellow]"
+            )
+        else:
+            console.print("[green]✓ All services started[/green]")
     except Exception as e:
         console.print(f"[red]✗ Error starting services: {e}[/red]")
 

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,0 +1,78 @@
+"""Regression tests for CLI start-services summaries."""
+
+from src.tui import cli
+
+
+class FakeContainerManager:
+    def __init__(self, items=None, available=True):
+        self._items = items or []
+        self._available = available
+
+    def is_available(self):
+        return self._available
+
+    async def start_services(self):
+        for item in self._items:
+            yield item
+
+
+class FakeDoclingManager:
+    def __init__(self, running=False, start_result=(True, "Docling serve starting on http://localhost:5001")):
+        self._running = running
+        self._start_result = start_result
+
+    def is_running(self):
+        return self._running
+
+    async def start(self):
+        success, message = self._start_result
+        self._running = success
+        return success, message
+
+
+class PrintCapture:
+    def __init__(self):
+        self.lines = []
+
+    def __call__(self, *args, **kwargs):
+        self.lines.append(" ".join(str(arg) for arg in args))
+
+
+def test_start_services_cli_warns_when_docling_fails(monkeypatch):
+    capture = PrintCapture()
+    monkeypatch.setattr(cli.console, "print", capture)
+
+    container_manager = FakeContainerManager(
+        items=[
+            (False, "Starting OpenRAG services...", False),
+            (True, "Services started successfully", False),
+        ]
+    )
+    docling_manager = FakeDoclingManager(
+        running=False,
+        start_result=(False, "Docling serve process exited immediately (code: 1)"),
+    )
+
+    cli._start_services_cli(container_manager, docling_manager)
+
+    output = "\n".join(capture.lines)
+    assert "All services started" not in output
+    assert "docling-serve is not running" in output
+
+
+def test_start_services_cli_reports_success_when_containers_and_docling_start(monkeypatch):
+    capture = PrintCapture()
+    monkeypatch.setattr(cli.console, "print", capture)
+
+    container_manager = FakeContainerManager(
+        items=[
+            (False, "Starting OpenRAG services...", False),
+            (True, "Services started successfully", False),
+        ]
+    )
+    docling_manager = FakeDoclingManager(running=False)
+
+    cli._start_services_cli(container_manager, docling_manager)
+
+    output = "\n".join(capture.lines)
+    assert "✓ All services started" in output


### PR DESCRIPTION
## Summary
- stop the CLI from always printing `✓ All services started` when docling startup already failed
- distinguish full success vs partial startup so users get an immediate warning to check status
- add a focused regression test for the docling-failure and all-success summaries

## Testing
- `python3 -m py_compile src/tui/cli.py tests/unit/test_cli.py`
- executed the extracted `_start_services_cli` source directly against fakes to verify both the failure and success summaries in this shell (the full pytest/uv env is not installed here)

Fixes #1102