### PR TITLE
fix(api): secure exception handling and prevent information disclosure

### DIFF
--- a/src/api/auth.py
+++ b/src/api/auth.py
@@ -3,6 +3,7 @@ from typing import Optional
 from fastapi import Depends, Request
 from fastapi.responses import JSONResponse
 from utils.telemetry import TelemetryClient, Category, MessageId
+from utils.logging_config import get_logger
 
 from dependencies import (
     get_auth_service,
@@ -11,6 +12,8 @@ from dependencies import (
 )
 from pydantic import BaseModel
 from session_manager import User
+
+logger = get_logger(__name__)
 
 
 class AuthInitBody(BaseModel):
@@ -47,11 +50,9 @@ async def auth_init(
         return JSONResponse(result)
 
     except Exception as e:
-        import traceback
-
-        traceback.print_exc()
+        logger.exception("Failed to initialize OAuth")
         return JSONResponse(
-            {"error": f"Failed to initialize OAuth: {str(e)}"}, status_code=500
+            {"error": "Failed to initialize OAuth"}, status_code=500
         )
 
 
@@ -87,11 +88,9 @@ async def auth_callback(
             return JSONResponse(result)
 
     except Exception as e:
-        import traceback
-
-        traceback.print_exc()
+        logger.exception("OAuth callback failed")
         await TelemetryClient.send_event(Category.AUTHENTICATION, MessageId.ORB_AUTH_OAUTH_FAILED)
-        return JSONResponse({"error": f"Callback failed: {str(e)}"}, status_code=500)
+        return JSONResponse({"error": "Callback failed"}, status_code=500)
 
 
 async def auth_me(

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -122,11 +122,9 @@ async def langflow_endpoint(
             return JSONResponse(result)
 
     except Exception as e:
-        import traceback
-        traceback.print_exc()
-        logger.error("Langflow request failed", error=str(e))
+        logger.exception("Langflow request failed")
         return JSONResponse(
-            {"error": f"Langflow request failed: {str(e)}"}, status_code=500
+            {"error": "Langflow request failed"}, status_code=500
         )
 
 
@@ -139,8 +137,9 @@ async def chat_history_endpoint(
         history = await chat_service.get_chat_history(user.user_id)
         return JSONResponse(history)
     except Exception as e:
+        logger.exception("Failed to get chat history")
         return JSONResponse(
-            {"error": f"Failed to get chat history: {str(e)}"}, status_code=500
+            {"error": "Failed to get chat history"}, status_code=500
         )
 
 
@@ -153,8 +152,9 @@ async def langflow_history_endpoint(
         history = await chat_service.get_langflow_history(user.user_id)
         return JSONResponse(history)
     except Exception as e:
+        logger.exception("Failed to get langflow history")
         return JSONResponse(
-            {"error": f"Failed to get langflow history: {str(e)}"}, status_code=500
+            {"error": "Failed to get langflow history"}, status_code=500
         )
 
 
@@ -175,7 +175,7 @@ async def delete_session_endpoint(
                 status_code=500
             )
     except Exception as e:
-        logger.error(f"Error deleting session: {e}")
+        logger.exception("Failed to delete session")
         return JSONResponse(
-            {"error": f"Failed to delete session: {str(e)}"}, status_code=500
+            {"error": "Failed to delete session"}, status_code=500
         )

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -260,9 +260,9 @@ async def connector_sync(
         )
 
     except Exception as e:
-        logger.error("Connector sync failed", error=str(e))
+        logger.exception("Connector sync failed")
         await TelemetryClient.send_event(Category.CONNECTOR_OPERATIONS, MessageId.ORB_CONN_SYNC_FAILED)
-        return JSONResponse({"error": f"Sync failed: {str(e)}"}, status_code=500)
+        return JSONResponse({"error": "Sync failed"}, status_code=500)
 
 
 async def connector_status(
@@ -499,30 +499,23 @@ async def connector_webhook(
             )
 
         except Exception as e:
-            logger.error(
-                "Failed to process webhook for connection",
-                connection_id=connection.connection_id,
-                error=str(e),
-            )
-            import traceback
-
-            traceback.print_exc()
+            logger.exception("Failed to process webhook for connection")
 
             return JSONResponse(
                 {
                     "status": "error",
                     "connector_type": connector_type,
                     "channel_id": channel_id,
-                    "error": str(e),
+                    "error": "Internal server error",
                 },
                 status_code=500,
             )
 
     except Exception as e:
-        logger.error("Webhook processing failed", error=str(e))
+        logger.exception("Webhook processing failed")
         await TelemetryClient.send_event(Category.CONNECTOR_OPERATIONS, MessageId.ORB_CONN_WEBHOOK_FAILED)
         return JSONResponse(
-            {"error": f"Webhook processing failed: {str(e)}"}, status_code=500
+            {"error": "Webhook processing failed"}, status_code=500
         )
 
 async def connector_disconnect(
@@ -591,13 +584,9 @@ async def connector_disconnect(
         )
 
     except Exception as e:
-        logger.error(
-            "Failed to disconnect connector",
-            connector_type=connector_type,
-            error=str(e),
-        )
+        logger.exception("Failed to disconnect connector")
         return JSONResponse(
-            {"error": f"Disconnect failed: {str(e)}"},
+            {"error": "Disconnect failed"},
             status_code=500,
         )
 
@@ -750,9 +739,9 @@ async def sync_all_connectors(
         )
 
     except Exception as e:
-        logger.error("Sync all connectors failed", error=str(e))
+        logger.exception("Sync all connectors failed")
         await TelemetryClient.send_event(Category.CONNECTOR_OPERATIONS, MessageId.ORB_CONN_SYNC_FAILED)
-        return JSONResponse({"error": f"Sync failed: {str(e)}"}, status_code=500)
+        return JSONResponse({"error": "Sync failed"}, status_code=500)
 
 
 async def connector_token(
@@ -854,12 +843,14 @@ async def connector_token(
                 return JSONResponse({"access_token": access_token, "expires_in": None})
             except ValueError as e:
                 # Typical when acquire_token_silent fails (e.g., needs re-auth)
-                return JSONResponse({"error": f"Failed to get access token: {str(e)}"}, status_code=401)
+                logger.exception("Failed to get access token")
+                return JSONResponse({"error": "Failed to get access token"}, status_code=401)
             except Exception as e:
-                return JSONResponse({"error": f"Authentication error: {str(e)}"}, status_code=500)
+                logger.exception("Authentication error")
+                return JSONResponse({"error": "Authentication error"}, status_code=500)
 
         return JSONResponse({"error": "Token not available for this connector type"}, status_code=400)
 
     except Exception as e:
-        logger.error("Error getting connector token", exc_info=True)
-        return JSONResponse({"error": str(e)}, status_code=500)
+        logger.exception("Error getting connector token")
+        return JSONResponse({"error": "Internal server error"}, status_code=500)

--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -58,12 +58,12 @@ async def check_filename_exists(
         return JSONResponse({"exists": exists, "filename": filename}, status_code=200)
 
     except Exception as e:
-        logger.error("Error checking filename existence", filename=filename, error=str(e))
+        logger.exception("Error checking filename existence")
         error_str = str(e)
         if "AuthenticationException" in error_str:
             return JSONResponse({"error": "Access denied: insufficient permissions"}, status_code=403)
         else:
-            return JSONResponse({"error": str(e)}, status_code=500)
+            return JSONResponse({"error": "Internal server error"}, status_code=500)
 
 
 async def delete_documents_by_filename(
@@ -104,9 +104,9 @@ async def delete_documents_by_filename(
         }, status_code=200)
 
     except Exception as e:
-        logger.error("Error deleting documents by filename", filename=body.filename, error=str(e))
+        logger.exception("Error deleting documents by filename")
         error_str = str(e)
         if "AuthenticationException" in error_str:
             return JSONResponse({"error": "Access denied: insufficient permissions"}, status_code=403)
         else:
-            return JSONResponse({"error": str(e)}, status_code=500)
+            return JSONResponse({"error": "Internal server error"}, status_code=500)


### PR DESCRIPTION
Error handling in OAuth and chat endpoints was returning raw exception messages to clients, which could lead to sensitive information disclosure about the system's internal structure or environment. 

Replacing these raw responses with generic, user-friendly error messages ensures the API remains robust and secure. Full tracebacks are now correctly routed to the server logs via the existing logger for debugging purposes, while the client only sees a high-level error state.

All security-sensitive paths in `src/api/auth.py`, `src/api/chat.py`, `src/api/connectors.py`, and `src/api/documents.py` have been updated to follow this pattern. This approach prevents potential attackers from gaining insights into the application's underlying logic or configuration through error strings.

Verified the changes locally. All API endpoints now return sanitized JSON responses on failure.