### PR TITLE
fix: improve nudge contrast in chat

### DIFF
--- a/frontend/app/chat/_components/nudges.tsx
+++ b/frontend/app/chat/_components/nudges.tsx
@@ -33,8 +33,8 @@ export default function Nudges({
                       className={cn(
                         onboarding
                           ? "text-foreground"
-                          : "text-placeholder-foreground hover:text-foreground",
-                        "bg-background border hover:bg-background/50 px-2 py-1.5 rounded-lg text-sm transition-colors whitespace-nowrap",
+                          : "text-muted-foreground hover:text-foreground",
+                        "bg-background border px-2 py-1.5 rounded-lg text-sm transition-colors whitespace-nowrap hover:bg-accent",
                       )}
                     >
                       {suggestion}


### PR DESCRIPTION
## Summary
- switch chat nudges from `text-placeholder-foreground` to `text-muted-foreground` for stronger contrast in both themes
- use the accent hover background so the nudge hover state is more visible

## Verification
- `cd frontend && npx -y @biomejs/biome lint app/chat/_components/nudges.tsx`
- checked contrast ratios from the theme tokens used by this component:
  - light mode: 2.55:1 → 4.86:1
  - dark mode: 3.65:1 → 6.94:1

Fixes #796