### PR TITLE
fix(cli): warn when services partially start instead of false success

### DIFF
--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -345,6 +345,9 @@ def _start_services_cli(
     console.print("Starting OpenRAG services...", style="bold")
 
     async def _inner():
+        all_success = True
+        failed_services = []
+        
         # Start container services
         if container_manager.is_available():
             async for item in container_manager.start_services():
@@ -359,7 +362,8 @@ def _start_services_cli(
                     console.print(f"  {message}")
 
                 if not success and "error" in message.lower():
-                    console.print(f"  [red]✗ {message}[/red]")
+                    all_success = False
+                    failed_services.append(message)
         else:
             console.print("  [yellow]No container runtime available[/yellow]")
 
@@ -369,11 +373,19 @@ def _start_services_cli(
             if success:
                 console.print(f"  {message}")
             else:
-                console.print(f"  [yellow]{message}[/yellow]")
+                all_success = False
+                failed_services.append(f"docling: {message}")
+                console.print(f"  [red]✗ {message}[/red]")
+        
+        return all_success, failed_services
 
     try:
-        asyncio.run(_inner())
-        console.print("[green]✓ All services started[/green]")
+        all_success, failed_services = asyncio.run(_inner())
+        if all_success:
+            console.print("[green]✓ All services started[/green]")
+        else:
+            console.print(f"[yellow]⚠ Partial startup: {len(failed_services)} service(s) failed[/yellow]")
+            console.print("[yellow]  Run 'Show status' for details[/yellow]")
     except Exception as e:
         console.print(f"[red]✗ Error starting services: {e}[/red]")
 


### PR DESCRIPTION
Fixes #1102

## Root Cause
CLI always printed '✓ All services started' after asyncio.run(), regardless of whether docling or container services actually started successfully.

## Solution
- Return (all_success, failed_services) from async _inner()
- Check status after completion
- Show warning on partial startup instead of false success
- Guide users to check status for details

## Changes
- src/tui/cli.py: _start_services_cli()

## Testing
- [x] All services success → '✓ All services started'
- [x] Docling fails → '⚠ Partial startup: 1 service(s) failed'
- [x] Container fails → Warning shown, no false success

## Impact
Users now get accurate feedback when startup is incomplete.