### PR TITLE
fix: normalize settings and filter label capitalization

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useQueryClient } from "@tanstack/react-query";
 import {
   type CheckboxSelectionCallbackParams,
   type ColDef,
@@ -8,7 +9,6 @@ import {
   type ValueFormatterParams,
 } from "ag-grid-community";
 import { AgGridReact, type CustomCellRendererProps } from "ag-grid-react";
-import { useQueryClient } from "@tanstack/react-query";
 import { Cloud, FileIcon, Globe, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
@@ -233,7 +233,7 @@ function SearchPage() {
     },
     {
       field: "avgScore",
-      headerName: "Avg score",
+      headerName: "Avg. Score",
       cellRenderer: ({ value }: CustomCellRendererProps<File>) => {
         return (
           <span className="text-xs text-accent-emerald-foreground bg-accent-emerald px-2 py-1 rounded">
@@ -244,7 +244,7 @@ function SearchPage() {
     },
     {
       field: "embedding_model",
-      headerName: "Embedding model",
+      headerName: "Embedding Model",
       minWidth: 200,
       cellRenderer: ({ data }: CustomCellRendererProps<File>) => (
         <span className="text-xs text-muted-foreground">

--- a/frontend/app/onboarding/_components/advanced.tsx
+++ b/frontend/app/onboarding/_components/advanced.tsx
@@ -36,11 +36,11 @@ export function AdvancedOnboarding({
   return (
     <Accordion type="single" collapsible>
       <AccordionItem value="item-1">
-        <AccordionTrigger>Advanced settings</AccordionTrigger>
+        <AccordionTrigger>Advanced Settings</AccordionTrigger>
         <AccordionContent className="space-y-6">
           {hasEmbeddingModels && (
             <LabelWrapper
-              label="Embedding model"
+              label="Embedding Model"
               helperText="Model used for knowledge ingest and retrieval"
               id="embedding-model"
               required={true}
@@ -55,7 +55,7 @@ export function AdvancedOnboarding({
           )}
           {hasLanguageModels && (
             <LabelWrapper
-              label="Language model"
+              label="Language Model"
               helperText="Model used for chat"
               id="embedding-model"
               required={true}

--- a/frontend/app/onboarding/_components/ollama-onboarding.tsx
+++ b/frontend/app/onboarding/_components/ollama-onboarding.tsx
@@ -133,7 +133,7 @@ export function OllamaOnboarding({
       </div>
       {isEmbedding && setEmbeddingModel && (
         <LabelWrapper
-          label="Embedding model"
+          label="Embedding Model"
           helperText="Model used for knowledge ingest and retrieval"
           id="embedding-model"
           required={true}
@@ -153,7 +153,7 @@ export function OllamaOnboarding({
       )}
       {!isEmbedding && setLanguageModel && (
         <LabelWrapper
-          label="Language model"
+          label="Language Model"
           helperText="Model used for chat"
           id="embedding-model"
           required={true}

--- a/frontend/app/settings/_components/model-selectors.tsx
+++ b/frontend/app/settings/_components/model-selectors.tsx
@@ -64,7 +64,7 @@ export function ModelSelectors({
       {embeddingModels !== undefined && (
         <div className="space-y-2">
           <LabelWrapper
-            label="Embedding model"
+            label="Embedding Model"
             helperText="Model used for knowledge ingest and retrieval"
             id="embedding-model"
             required={true}
@@ -72,7 +72,7 @@ export function ModelSelectors({
             <Controller
               control={control}
               name={embeddingModelName}
-              rules={{ required: "Embedding model is required" }}
+              rules={{ required: "Embedding Model is required" }}
               render={({ field }) => (
                 <ModelSelector
                   options={embeddingModels}
@@ -99,7 +99,7 @@ export function ModelSelectors({
       {languageModels !== undefined && (
         <div className="space-y-2">
           <LabelWrapper
-            label="Language model"
+            label="Language Model"
             helperText="Model used for chat"
             id="language-model"
             required={true}
@@ -107,7 +107,7 @@ export function ModelSelectors({
             <Controller
               control={control}
               name={languageModelName}
-              rules={{ required: "Language model is required" }}
+              rules={{ required: "Language Model is required" }}
               render={({ field }) => (
                 <ModelSelector
                   options={languageModels}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -662,7 +662,7 @@ function KnowledgeSourcesPage() {
               <ConfirmationDialog
                 trigger={
                   <Button ignoreTitleCase={true} variant="outline">
-                    Restore flow
+                    Restore Flow
                   </Button>
                 }
                 title="Restore default Agent flow"
@@ -733,7 +733,7 @@ function KnowledgeSourcesPage() {
           <div className="space-y-6">
             <div className="space-y-2">
               <LabelWrapper
-                label="Language model"
+                label="Language Model"
                 helperText="Model used for chat"
                 id="language-model"
                 required={true}
@@ -810,7 +810,7 @@ function KnowledgeSourcesPage() {
               <ConfirmationDialog
                 trigger={
                   <Button ignoreTitleCase={true} variant="outline">
-                    Restore flow
+                    Restore Flow
                   </Button>
                 }
                 title="Restore default Ingest flow"
@@ -883,7 +883,7 @@ function KnowledgeSourcesPage() {
               <LabelWrapper
                 helperText="Model used for knowledge ingest and retrieval"
                 id="embedding-model-select"
-                label="Embedding model"
+                label="Embedding Model"
                 required={true}
               >
                 <ModelSelector
@@ -900,7 +900,7 @@ function KnowledgeSourcesPage() {
             </div>
             <div className="grid grid-cols-2 gap-4">
               <div className="space-y-2">
-                <LabelWrapper id="chunk-size" label="Chunk size">
+                <LabelWrapper id="chunk-size" label="Chunk Size">
                   <div className="relative [&:has(input:hover):not(:has(input:focus))_button]:border-muted-foreground [&:has(input:focus)_button]:border-foreground">
                     <Input
                       id="chunk-size"
@@ -943,7 +943,7 @@ function KnowledgeSourcesPage() {
                 </LabelWrapper>
               </div>
               <div className="space-y-2">
-                <LabelWrapper id="chunk-overlap" label="Chunk overlap">
+                <LabelWrapper id="chunk-overlap" label="Chunk Overlap">
                   <div className="relative [&:has(input:hover):not(:has(input:focus))_button]:border-muted-foreground [&:has(input:focus)_button]:border-foreground">
                     <Input
                       id="chunk-overlap"
@@ -1156,7 +1156,7 @@ function KnowledgeSourcesPage() {
                   size="sm"
                 >
                   <Plus className="h-4 w-4 mr-2" />
-                  Create your first API key
+                  Create Your First API Key
                 </Button>
               </div>
             )}

--- a/frontend/components/cloud-picker/ingest-settings.tsx
+++ b/frontend/components/cloud-picker/ingest-settings.tsx
@@ -132,7 +132,7 @@ export const IngestSettings = ({
               isOpen ? "rotate-90" : ""
             }`}
           />
-          <span className="text-sm font-medium">Ingest settings</span>
+          <span className="text-sm font-medium">Ingest Settings</span>
         </div>
       </CollapsibleTrigger>
 
@@ -142,7 +142,7 @@ export const IngestSettings = ({
           <LabelWrapper
             helperText="Model used for knowledge ingest and retrieval"
             id="embedding-model-select"
-            label="Embedding model"
+            label="Embedding Model"
           >
             <Select
               disabled={false}
@@ -179,7 +179,7 @@ export const IngestSettings = ({
             <div className="w-full">
               <NumberInput
                 id="chunk-size"
-                label="Chunk size"
+                label="Chunk Size"
                 value={currentSettings.chunkSize}
                 onChange={(value) => handleSettingsChange({ chunkSize: value })}
                 unit="characters"
@@ -188,7 +188,7 @@ export const IngestSettings = ({
             <div className="w-full">
               <NumberInput
                 id="chunk-overlap"
-                label="Chunk overlap"
+                label="Chunk Overlap"
                 value={currentSettings.chunkOverlap}
                 onChange={(value) =>
                   handleSettingsChange({ chunkOverlap: value })
@@ -232,7 +232,7 @@ export const IngestSettings = ({
           <div className="flex items-center justify-between">
             <div>
               <div className="text-sm pb-2 font-semibold">
-                Picture descriptions
+                Picture Descriptions
               </div>
               <div className="text-sm text-muted-foreground">
                 Adds captions for images. Ingest is more expensive when enabled.

--- a/frontend/components/knowledge-filter-list.tsx
+++ b/frontend/components/knowledge-filter-list.tsx
@@ -150,7 +150,7 @@ export function KnowledgeFilterList({
                         {(() => {
                           const dataSources = parseQueryData(filter.query_data)
                             .filters.data_sources;
-                          if (dataSources[0] === "*") return "All sources";
+                          if (dataSources[0] === "*") return "All Sources";
                           const count = dataSources.length;
                           return `${count} ${
                             count === 1 ? "source" : "sources"

--- a/frontend/components/knowledge-filter-panel.tsx
+++ b/frontend/components/knowledge-filter-panel.tsx
@@ -266,7 +266,7 @@ export function KnowledgeFilterPanel() {
           <div className="space-y-3">
             <div className="space-y-2">
               <Label htmlFor="filter-name" className="gap-1">
-                Filter name
+                Filter Name
                 <span className="text-destructive">*</span>
               </Label>
               <div className="flex items-center gap-2">
@@ -287,7 +287,7 @@ export function KnowledgeFilterPanel() {
                     }
                   }}
                   required
-                  placeholder="Filter name"
+                  placeholder="Filter Name"
                   ref={nameInputRef}
                   aria-invalid={!!nameError}
                 />
@@ -347,7 +347,7 @@ export function KnowledgeFilterPanel() {
                   handleFilterChange("data_sources", values)
                 }
                 placeholder="Select sources..."
-                allOptionLabel="All sources"
+                allOptionLabel="All Sources"
               />
             </div>
 
@@ -365,7 +365,7 @@ export function KnowledgeFilterPanel() {
                   handleFilterChange("document_types", values)
                 }
                 placeholder="Select types..."
-                allOptionLabel="All types"
+                allOptionLabel="All Types"
               />
             </div>
 
@@ -397,7 +397,7 @@ export function KnowledgeFilterPanel() {
                   handleFilterChange("connector_types", values)
                 }
                 placeholder="Select connectors..."
-                allOptionLabel="All connectors"
+                allOptionLabel="All Connectors"
               />
             </div>
 
@@ -406,7 +406,7 @@ export function KnowledgeFilterPanel() {
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <Label className="text-sm font-medium text-nowrap">
-                    Response limit
+                    Response Limit
                   </Label>
                   <Input
                     type="number"
@@ -438,7 +438,7 @@ export function KnowledgeFilterPanel() {
               <div className="space-y-2">
                 <div className="flex items-center justify-between">
                   <Label className="text-sm font-medium text-nowrap">
-                    Score threshold
+                    Score Threshold
                   </Label>
                   <Input
                     type="number"


### PR DESCRIPTION
## Summary
- normalize the Settings labels called out in the issue to title case
- align the knowledge filter panel/list and upload ingest settings labels with the same capitalization style
- update the knowledge table headers for related label consistency

## Testing
- `npx @biomejs/biome check app/knowledge/page.tsx app/settings/page.tsx app/onboarding/_components/advanced.tsx app/onboarding/_components/ollama-onboarding.tsx app/settings/_components/model-selectors.tsx components/cloud-picker/ingest-settings.tsx components/knowledge-filter-list.tsx components/knowledge-filter-panel.tsx` *(passes with pre-existing warnings in touched files: `noExplicitAny`, `noUnusedVariables`, `noStaticElementInteractions`, `noConsole`)*
- `git diff --check`

Closes #795.
