### PR TITLE
fix: keep Langflow retry env vars when saving TUI config

### DIFF
--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -40,6 +40,8 @@ class EnvConfig:
     langflow_chat_flow_id: str = "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
     langflow_ingest_flow_id: str = "5488df7c-b93f-4f87-a446-b67028bc0813"
     langflow_url_ingest_flow_id: str = "72c3d17c-2dac-4a73-b48a-6518473d7830"
+    langflow_key_retries: str = "15"
+    langflow_key_retry_delay: str = "2.0"
 
     # Provider API keys and endpoints
     anthropic_api_key: str = ""
@@ -178,6 +180,8 @@ class EnvManager:
             "LANGFLOW_CHAT_FLOW_ID": "langflow_chat_flow_id",
             "LANGFLOW_INGEST_FLOW_ID": "langflow_ingest_flow_id",
             "LANGFLOW_URL_INGEST_FLOW_ID": "langflow_url_ingest_flow_id",
+            "LANGFLOW_KEY_RETRIES": "langflow_key_retries",
+            "LANGFLOW_KEY_RETRY_DELAY": "langflow_key_retry_delay",
             "NUDGES_FLOW_ID": "nudges_flow_id",
             "GOOGLE_OAUTH_CLIENT_ID": "google_oauth_client_id",
             "GOOGLE_OAUTH_CLIENT_SECRET": "google_oauth_client_secret",  # pragma: allowlist secret
@@ -436,6 +440,10 @@ class EnvManager:
                     f"LANGFLOW_INGEST_FLOW_ID={self._quote_env_value(self.config.langflow_ingest_flow_id)}\n"
                 )
                 f.write(f"LANGFLOW_URL_INGEST_FLOW_ID={self._quote_env_value(self.config.langflow_url_ingest_flow_id)}\n")
+                f.write(f"LANGFLOW_KEY_RETRIES={self._quote_env_value(self.config.langflow_key_retries)}\n")
+                f.write(
+                    f"LANGFLOW_KEY_RETRY_DELAY={self._quote_env_value(self.config.langflow_key_retry_delay)}\n"
+                )
                 f.write(f"NUDGES_FLOW_ID={self._quote_env_value(self.config.nudges_flow_id)}\n")
                 f.write(f"OPENSEARCH_PASSWORD={self._quote_env_value(self.config.opensearch_password)}\n")
                 if self.config.opensearch_username and self.config.opensearch_username != "admin":

--- a/tests/unit/test_env_manager.py
+++ b/tests/unit/test_env_manager.py
@@ -162,6 +162,37 @@ class TestSaveEnvFilePermissions:
         # Managed password should be updated, not duplicated.
         assert "OPENSEARCH_PASSWORD='AnotherNewPass!789'" in content
         assert 'OPENSEARCH_PASSWORD="old-password"' not in content
+
+    def test_writes_langflow_retry_env_defaults(self, env_manager, tmp_path):
+        """TUI saves the Langflow API key retry vars so editing .env does not drop them."""
+        env_file = tmp_path / ".env"
+
+        with patch("tui.utils.version_check.get_current_version", return_value="1.0.0"):
+            result = env_manager.save_env_file()
+
+        assert result is True
+        content = env_file.read_text()
+        assert "LANGFLOW_KEY_RETRIES='15'" in content
+        assert "LANGFLOW_KEY_RETRY_DELAY='2.0'" in content
+
+    def test_preserves_existing_langflow_retry_values(self, env_manager, tmp_path, monkeypatch):
+        """Existing retry settings in .env should round-trip through load+save unchanged."""
+        env_file = tmp_path / ".env"
+        env_file.write_text(
+            "LANGFLOW_KEY_RETRIES='8'\n"
+            "LANGFLOW_KEY_RETRY_DELAY='3.5'\n"
+        )
+        monkeypatch.delenv("LANGFLOW_KEY_RETRIES", raising=False)
+        monkeypatch.delenv("LANGFLOW_KEY_RETRY_DELAY", raising=False)
+        env_manager.load_existing_env()
+
+        with patch("tui.utils.version_check.get_current_version", return_value="1.0.0"):
+            result = env_manager.save_env_file()
+
+        assert result is True
+        content = env_file.read_text()
+        assert "LANGFLOW_KEY_RETRIES='8'" in content
+        assert "LANGFLOW_KEY_RETRY_DELAY='3.5'" in content
 # ---------------------------------------------------------------------------
 # ensure_openrag_version
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add `LANGFLOW_KEY_RETRIES` and `LANGFLOW_KEY_RETRY_DELAY` to the TUI-managed env config
- write both retry settings into the generated `.env` so editing config from the TUI does not drop them
- add regression tests for default writing and round-tripping existing retry values

## Testing
- `PYTHONPATH=src .venv/bin/python -m pytest --confcutdir=tests/unit tests/unit/test_env_manager.py -q -k 'langflow_retry or preserves_unmanaged_env_variables'`

Closes #1014
