### PR TITLE
Upgrade GitHub Actions for Node 24 compatibility

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -18,7 +18,7 @@ jobs:
       is_prerelease: ${{ steps.version.outputs.is_prerelease }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -139,7 +139,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -168,7 +168,7 @@ jobs:
     if: github.event_name != 'pull_request' && needs.check-version.outputs.skip_release != 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Login to Docker Hub
         uses: docker/login-action@v3
@@ -225,7 +225,7 @@ jobs:
     if: needs.check-version.outputs.skip_release != 'true'
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -248,7 +248,7 @@ jobs:
           done
 
       - name: Upload build artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: python-packages
           path: dist/

--- a/.github/workflows/dependency-audit.yml
+++ b/.github/workflows/dependency-audit.yml
@@ -14,10 +14,10 @@ jobs:
       matrix:
         directory: ['frontend', 'docs', 'sdks/typescript']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -42,7 +42,7 @@ jobs:
       matrix:
         directory: ['.', 'sdks/python']
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v6

--- a/.github/workflows/deploy-docs-draft.yml
+++ b/.github/workflows/deploy-docs-draft.yml
@@ -18,10 +18,10 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20.20.0
           cache: npm
@@ -259,7 +259,7 @@ jobs:
           reactions: hooray
 
       - name: Upload Deploy Log
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: deploy.log

--- a/.github/workflows/deploy-gh-pages.yml
+++ b/.github/workflows/deploy-gh-pages.yml
@@ -13,8 +13,8 @@ jobs:
     name: Deploy to GitHub Pages
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: 20.20.0
           cache: npm

--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -11,10 +11,10 @@ jobs:
     name: Biome
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/publish-sdk-typescript.yml
+++ b/.github/workflows/publish-sdk-typescript.yml
@@ -21,10 +21,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -46,7 +46,7 @@ jobs:
           done || true
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up UV
         uses: astral-sh/setup-uv@v3
@@ -54,7 +54,7 @@ jobs:
           version: latest
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 
@@ -156,7 +156,7 @@ jobs:
         run: npx playwright test
 
       - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-report
@@ -164,7 +164,7 @@ jobs:
           retention-days: 14
 
       - name: Upload test results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: ${{ !cancelled() }}
         with:
           name: playwright-test-results

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -53,7 +53,7 @@ jobs:
       - run: df -h
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Verify workspace
         run: |
@@ -67,7 +67,7 @@ jobs:
           version: latest
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -22,7 +22,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.head_ref || github.ref }}


### PR DESCRIPTION
> [!WARNING]
> You may currently be seeing a warning like this in your workflow runs:
>
> ```
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20
> and may not work as expected: actions/checkout@v4, actions/upload-artifact@v4, actions/setup-node@v4.
> Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026.
> Please check if updated versions of these actions are available that support Node.js 24.
> To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment
> variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you
> can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true.
> For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/
> ```
>
> The exact actions listed will vary per workflow.

Upgrades GitHub Actions to versions that support Node 24, since Node 20 is reaching EOL in April 2026.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `actions/checkout` | [`v4`](https://github.com/actions/checkout/releases/tag/v4) | [`v6`](https://github.com/actions/checkout/releases/tag/v6) | [Diff](https://github.com/actions/checkout/compare/v4...v6) | build-multiarch.yml, dependency-audit.yml, deploy-docs-draft.yml, deploy-gh-pages.yml, lint-frontend.yml, publish-mcp.yml, publish-sdk-python.yml, publish-sdk-typescript.yml, test-e2e.yml, test-integration.yml, update-uv-lock.yml |
| `actions/setup-node` | [`v4`](https://github.com/actions/setup-node/releases/tag/v4) | [`v6`](https://github.com/actions/setup-node/releases/tag/v6) | [Diff](https://github.com/actions/setup-node/compare/v4...v6) | dependency-audit.yml, deploy-docs-draft.yml, deploy-gh-pages.yml, lint-frontend.yml, publish-sdk-typescript.yml, test-e2e.yml, test-integration.yml |
| `actions/upload-artifact` | [`v4`](https://github.com/actions/upload-artifact/releases/tag/v4) | [`v7`](https://github.com/actions/upload-artifact/releases/tag/v7) | [Diff](https://github.com/actions/upload-artifact/compare/v4...v7) | build-multiarch.yml, deploy-docs-draft.yml, test-e2e.yml |
## Context

Per [GitHub's announcement](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/), Node 20 is being deprecated and runners will default to Node 24 starting June 2nd, 2026.

- Node 20 EOL: April 2026
- Node 24 becomes default: June 2nd, 2026

## Release Notes

<details>
<summary>Release notes for actions/checkout</summary>

### [v6.0.2](https://github.com/actions/checkout/releases/tag/v6.0.2)

## What's Changed
* Add orchestration_id to git user-agent when ACTIONS_ORCHESTRATION_ID is set by @TingluoHuang in https://github.com/actions/checkout/pull/2355
* Fix tag handling: preserve annotations and explicit fetch-tags by @ericsciple in https://github.com/actions/checkout/pull/2356

**Full Changelog**: https://github.com/actions/checkout/compare/v6.0.1...v6.0.2

### [v6.0.1](https://github.com/actions/checkout/releases/tag/v6.0.1)

## What's Changed
* Update all references from v5 and v4 to v6 by @ericsciple in https://github.com/actions/checkout/pull/2314
* Add worktree support for persist-credentials includeIf by @ericsciple in https://github.com/actions/checkout/pull/2327
* Clarify v6 README by @ericsciple in https://github.com/actions/checkout/pull/2328


**Full Changelog**: https://github.com/actions/checkout/compare/v6...v6.0.1

### [v6.0.0](https://github.com/actions/checkout/releases/tag/v6.0.0)

## What's Changed
* Update README to include Node.js 24 support details and requirements by @salmanmkc in https://github.com/actions/checkout/pull/2248
* Persist creds to a separate file by @ericsciple in https://github.com/actions/checkout/pull/2286
* v6-beta by @ericsciple in https://github.com/actions/checkout/pull/2298
* update readme/changelog for v6 by @ericsciple in https://github.com/actions/checkout/pull/2311


**Full Changelog**: https://github.com/actions/checkout/compare/v5.0.

*...truncated*

### [v5.0.1](https://github.com/actions/checkout/releases/tag/v5.0.1)

## What's Changed
* Port v6 cleanup to v5 by @ericsciple in https://github.com/actions/checkout/pull/2301


**Full Changelog**: https://github.com/actions/checkout/compare/v5...v5.0.1

### [v4.3.1](https://github.com/actions/checkout/releases/tag/v4.3.1)

## What's Changed
* Port v6 cleanup to v4 by @ericsciple in https://github.com/actions/checkout/pull/2305


**Full Changelog**: https://github.com/actions/checkout/compare/v4...v4.3.1

</details>

<details>
<summary>Release notes for actions/upload-artifact</summary>

### [v7.0.0](https://github.com/actions/upload-artifact/releases/tag/v7.0.0)

## v7 What's new

### Direct Uploads

Adds support for uploading single files directly (unzipped). Callers can set the new `archive` parameter to `false` to skip zipping the file during upload. Right now, we only support single files. The action will fail if the glob passed resolves to multiple files. The `name` parameter is also ignored with this setting. Instead, the name of the artifact will be the name of the uploaded file.

### ESM

To support new versions of the `@actions/*` packag

*...truncated*

### [v6.0.0](https://github.com/actions/upload-artifact/releases/tag/v6.0.0)

## v6 - What's new

> [!IMPORTANT]
> actions/upload-artifact@v6 now runs on Node.js 24 (`runs.using: node24`) and requires a minimum Actions Runner version of 2.327.1. If you are using self-hosted runners, ensure they are updated before upgrading.
### Node.js 24

This release updates the runtime to Node.js 24. v5 had preliminary support for Node.js 24, however this action was by default still running on Node.js 20. Now this action by default will run on Node.js 24.

## What's Changed
* 

*...truncated*

### [v5.0.0](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)

## What's Changed

**BREAKING CHANGE:** this update supports Node `v24.x`. This is not a breaking change per-se but we're treating it as such.

* Update README.md by @GhadimiR in https://github.com/actions/upload-artifact/pull/681
* Update README.md by @nebuk89 in https://github.com/actions/upload-artifact/pull/712
* Readme: spell out the first use of GHES by @danwkennedy in https://github.com/actions/upload-artifact/pull/727
* Update GHES guidance to include reference to Node 20 version 

*...truncated*

### [v4.6.2](https://github.com/actions/upload-artifact/releases/tag/v4.6.2)

## What's Changed
* Update to use artifact 2.3.2 package & prepare for new upload-artifact release by @salmanmkc in https://github.com/actions/upload-artifact/pull/685

## New Contributors
* @salmanmkc made their first contribution in https://github.com/actions/upload-artifact/pull/685

**Full Changelog**: https://github.com/actions/upload-artifact/compare/v4...v4.6.2

### [v4.6.1](https://github.com/actions/upload-artifact/releases/tag/v4.6.1)

## What's Changed
* Update to use artifact 2.2.2 package by @yacaovsnc in https://github.com/actions/upload-artifact/pull/673


**Full Changelog**: https://github.com/actions/upload-artifact/compare/v4...v4.6.1

</details>

<details>
<summary>Release notes for actions/setup-node</summary>

### [v6.3.0](https://github.com/actions/setup-node/releases/tag/v6.3.0)

## What's Changed

### Enhancements:
* Support parsing `devEngines` field by @susnux in https://github.com/actions/setup-node/pull/1283
>  When using node-version-file: package.json, setup-node now prefers devEngines.runtime over engines.node.

### Dependency updates:
* Fix npm audit issues by @gowridurgad in https://github.com/actions/setup-node/pull/1491
* Replace uuid with crypto.randomUUID() by @trivikr in https://github.com/actions/setup-node/pull/1378
* Upgrade minimatch from 3.1.

*...truncated*

### [v6.2.0](https://github.com/actions/setup-node/releases/tag/v6.2.0)

## What's Changed

### Documentation
* Documentation update related to absence of Lockfile by @mahabaleshwars in https://github.com/actions/setup-node/pull/1454
* Correct mirror option typos by @MikeMcC399 in https://github.com/actions/setup-node/pull/1442
* Readme update on checkout version v6 by @deining in https://github.com/actions/setup-node/pull/1446
* Readme typo fixes @munyari in https://github.com/actions/setup-node/pull/1226
* Advanced document update on checkout version v6 by @

*...truncated*

### [v6.1.0](https://github.com/actions/setup-node/releases/tag/v6.1.0)

## What's Changed
### Enhancement:
* Remove always-auth configuration handling by @priyagupta108 in https://github.com/actions/setup-node/pull/1436

### Dependency updates:
* Upgrade @actions/cache from 4.0.3 to 4.1.0 by @dependabot[bot] in https://github.com/actions/setup-node/pull/1384
* Upgrade actions/checkout from 5 to 6 by @dependabot[bot] in https://github.com/actions/setup-node/pull/1439
* Upgrade js-yaml from 3.14.1 to 3.14.2 by @dependabot[bot] in https://github.com/actions/setu

*...truncated*

### [v6.0.0](https://github.com/actions/setup-node/releases/tag/v6.0.0)

## What's Changed

**Breaking Changes**

- Limit automatic caching to npm, update workflows and documentation by @priyagupta108 in https://github.com/actions/setup-node/pull/1374

**Dependency Upgrades**

- Upgrade ts-jest from 29.1.2 to 29.4.1 and document breaking changes in v5 by @dependabot[bot] in [#1336](https://github.com/actions/setup-node/pull/1336)
- Upgrade prettier from 2.8.8 to 3.6.2 by @dependabot[bot] in [#1334](https://github.com/actions/setup-node/pull/1334)
- Upgrade 

*...truncated*

### [v5.0.0](https://github.com/actions/setup-node/releases/tag/v5.0.0)

## What's Changed

### Breaking Changes
* Enhance caching in setup-node with automatic package manager detection by @priya-kinthali in https://github.com/actions/setup-node/pull/1348

This update, introduces automatic caching when a valid `packageManager` field is present in your `package.json`. This aims to improve workflow performance and make dependency management more seamless. 
To disable this automatic caching, set `package-manager-cache: false`
```yaml
steps:
- uses: actions/chec

*...truncated*

</details>

## Notes

Worth running the workflows on a branch before merging to make sure everything still works.
