### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -142,17 +142,17 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
 
       - name: Build and push ${{ matrix.image }} (${{ matrix.arch }})
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ${{ matrix.file }}
@@ -171,7 +171,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
@@ -233,7 +233,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
 
       - name: Build wheel and source distribution
         run: |

--- a/.github/workflows/conventional-labels.yml
+++ b/.github/workflows/conventional-labels.yml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request_target' && github.event.pull_request.user.type != 'Bot'
     steps:
-      - uses: bcoe/conventional-release-labels@b503ca473654e07521c051628c5f1f969e7436da # v1
+      - uses: bcoe/conventional-release-labels@886f696738527c7be444262c327c89436dfb95a8  # v1.3.1
         with:
           type_labels: '{"feat": "enhancement","fix": "bug","docs": "documentation","style": "style","refactor": "refactor","perf": "performance","test": "test","chore": "chore","build": "build"}'
 

--- a/.github/workflows/deploy-docs-draft.yml
+++ b/.github/workflows/deploy-docs-draft.yml
@@ -143,7 +143,7 @@ jobs:
 
       - name: Create Build Success Comment
         if: success()
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: "${{ env.BUILD_SUCCESS_COMMENT }}"
@@ -151,7 +151,7 @@ jobs:
 
       - name: Create Build Failure Comment
         if: failure()
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body: |
@@ -162,7 +162,7 @@ jobs:
       - name: Find Comment
         id: fc
         if: success()
-        uses: peter-evans/find-comment@v3
+        uses: peter-evans/find-comment@v4
         with:
           issue-number: ${{ github.event.pull_request.number }}
           body-includes: Build successful!
@@ -251,7 +251,7 @@ jobs:
 
       - name: Update Comment
         if: ${{ steps.fc.outputs.comment-id != '' }}
-        uses: peter-evans/create-or-update-comment@v4
+        uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.fc.outputs.comment-id }}
           body: |

--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Extract version from pyproject.toml
         id: version

--- a/.github/workflows/publish-sdk-python.yml
+++ b/.github/workflows/publish-sdk-python.yml
@@ -26,7 +26,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
 
       - name: Extract version from pyproject.toml
         id: version

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up UV
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: latest
 

--- a/.github/workflows/test-integration.yml
+++ b/.github/workflows/test-integration.yml
@@ -62,7 +62,7 @@ jobs:
           ls -la
 
       - name: Set up UV
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
         with:
           version: latest
 

--- a/.github/workflows/update-uv-lock.yml
+++ b/.github/workflows/update-uv-lock.yml
@@ -33,7 +33,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v7
 
       - name: Update uv.lock
         run: uv sync


### PR DESCRIPTION
Bumps GitHub Actions to their latest versions for bug fixes and security patches.

## Changes

| Action | Old Version(s) | New Version | Compare | Files |
|--------|---------------|-------------|---------|-------|
| `astral-sh/setup-uv` | [`v3`](https://github.com/astral-sh/setup-uv/releases/tag/v3), [`v4`](https://github.com/astral-sh/setup-uv/releases/tag/v4) | [`v7`](https://github.com/astral-sh/setup-uv/releases/tag/v7) | [Diff](https://github.com/astral-sh/setup-uv/compare/v3...v7) | build-multiarch.yml, publish-mcp.yml, publish-sdk-python.yml, test-e2e.yml, test-integration.yml, update-uv-lock.yml |
| `bcoe/conventional-release-labels` | [`b503ca4`](https://github.com/bcoe/conventional-release-labels/commit/b503ca473654e07521c051628c5f1f969e7436da) | [`886f696`](https://github.com/bcoe/conventional-release-labels/commit/886f696738527c7be444262c327c89436dfb95a8) | [Diff](https://github.com/bcoe/conventional-release-labels/compare/b503ca473654...886f69673852) | conventional-labels.yml |
| `docker/build-push-action` | [`v6`](https://github.com/docker/build-push-action/releases/tag/v6) | [`v7`](https://github.com/docker/build-push-action/releases/tag/v7) | [Diff](https://github.com/docker/build-push-action/compare/v6...v7) | build-multiarch.yml |
| `docker/login-action` | [`v3`](https://github.com/docker/login-action/releases/tag/v3) | [`v4`](https://github.com/docker/login-action/releases/tag/v4) | [Diff](https://github.com/docker/login-action/compare/v3...v4) | build-multiarch.yml |
| `docker/setup-buildx-action` | [`v3`](https://github.com/docker/setup-buildx-action/releases/tag/v3) | [`v4`](https://github.com/docker/setup-buildx-action/releases/tag/v4) | [Diff](https://github.com/docker/setup-buildx-action/compare/v3...v4) | build-multiarch.yml |
| `peter-evans/create-or-update-comment` | [`v4`](https://github.com/peter-evans/create-or-update-comment/releases/tag/v4) | [`v5`](https://github.com/peter-evans/create-or-update-comment/releases/tag/v5) | [Diff](https://github.com/peter-evans/create-or-update-comment/compare/v4...v5) | deploy-docs-draft.yml |
| `peter-evans/find-comment` | [`v3`](https://github.com/peter-evans/find-comment/releases/tag/v3) | [`v4`](https://github.com/peter-evans/find-comment/releases/tag/v4) | [Diff](https://github.com/peter-evans/find-comment/compare/v3...v4) | deploy-docs-draft.yml |

## Release Notes

<details>
<summary>Release notes for docker/setup-buildx-action</summary>

### [v4.0.0](https://github.com/docker/setup-buildx-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/setup-buildx-action/pull/483
* Remove deprecated inputs/outputs by @crazy-max in https://github.com/docker/setup-buildx-action/pull/464
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/setup-buildx-action/pull/481
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/dock

*...truncated*

### [v3.12.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.12.0)

* Deprecate `install` input by @crazy-max in https://github.com/docker/setup-buildx-action/pull/455
* Bump @docker/actions-toolkit from 0.62.1 to 0.63.0 in https://github.com/docker/setup-buildx-action/pull/434
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/setup-buildx-action/pull/436
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/setup-buildx-action/pull/432
* Bump undici from 5.28.4 to 5.29.0 in https://github.com/docker/setup-buildx-action/pu

*...truncated*

### [v3.11.1](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.1)

* Fix `keep-state` not being respected by @crazy-max in https://github.com/docker/setup-buildx-action/pull/429

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.11.0...v3.11.1

### [v3.11.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.11.0)

* Keep BuildKit state support by @crazy-max in https://github.com/docker/setup-buildx-action/pull/427
* Remove aliases created when installing by default by @hashhar in https://github.com/docker/setup-buildx-action/pull/139
* Bump @docker/actions-toolkit from 0.56.0 to 0.62.1 in https://github.com/docker/setup-buildx-action/pull/422 https://github.com/docker/setup-buildx-action/pull/425

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.10.0...v3.11.0

### [v3.10.0](https://github.com/docker/setup-buildx-action/releases/tag/v3.10.0)

* Bump @docker/actions-toolkit from 0.54.0 to 0.56.0 in https://github.com/docker/setup-buildx-action/pull/408

**Full Changelog**: https://github.com/docker/setup-buildx-action/compare/v3.9.0...v3.10.0

</details>

<details>
<summary>Release notes for docker/login-action</summary>

### [v4.0.0](https://github.com/docker/login-action/releases/tag/v4.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/login-action/pull/929
* Switch to ESM and update config/test wiring by @crazy-max in https://github.com/docker/login-action/pull/927
* Bump @actions/core from 1.11.1 to 3.0.0 in https://github.com/docker/login-action/pull/919
* Bump @aws-sdk/client-ecr from 3.890.0 to 3.1000.0 in https://github.com/docker/login-action/pu

*...truncated*

### [v3.7.0](https://github.com/docker/login-action/releases/tag/v3.7.0)

* Add `scope` input to set scopes for the authentication token by @crazy-max in https://github.com/docker/login-action/pull/912
* Add support for AWS European Sovereign Cloud ECR by @dphi in https://github.com/docker/login-action/pull/914
* Ensure passwords are redacted with `registry-auth` input by @crazy-max in https://github.com/docker/login-action/pull/911
* build(deps): bump lodash from 4.17.21 to 4.17.23 in https://github.com/docker/login-action/pull/915

**Full Changelog**: https://g

*...truncated*

### [v3.6.0](https://github.com/docker/login-action/releases/tag/v3.6.0)

* Add `registry-auth` input for raw authentication to registries by @crazy-max in https://github.com/docker/login-action/pull/887
* Bump @aws-sdk/client-ecr to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @aws-sdk/client-ecr-public to 3.890.0 in https://github.com/docker/login-action/pull/882 https://github.com/docker/login-action/pull/890
* Bump @docker/actions-toolkit from 0.62.1 to 0.63.0 in https://github.com/docker/logi

*...truncated*

### [v3.5.0](https://github.com/docker/login-action/releases/tag/v3.5.0)

* Support dual-stack endpoints for AWS ECR by @Spacefish @crazy-max in https://github.com/docker/login-action/pull/874 https://github.com/docker/login-action/pull/876
* Bump @aws-sdk/client-ecr to 3.859.0 in https://github.com/docker/login-action/pull/860 https://github.com/docker/login-action/pull/878
* Bump @aws-sdk/client-ecr-public to 3.859.0 in https://github.com/docker/login-action/pull/860 https://github.com/docker/login-action/pull/878
* Bump @docker/actions-toolkit from 0.57.0 to 0.6

*...truncated*

### [v3.4.0](https://github.com/docker/login-action/releases/tag/v3.4.0)

* Bump @actions/core from 1.10.1 to 1.11.1 in https://github.com/docker/login-action/pull/791
* Bump @aws-sdk/client-ecr to 3.766.0 in https://github.com/docker/login-action/pull/789 https://github.com/docker/login-action/pull/856
* Bump @aws-sdk/client-ecr-public to 3.758.0 in https://github.com/docker/login-action/pull/789 https://github.com/docker/login-action/pull/856
* Bump @docker/actions-toolkit from 0.35.0 to 0.57.0 in https://github.com/docker/login-action/pull/801 https://github.com

*...truncated*

</details>

<details>
<summary>Release notes for docker/build-push-action</summary>

### [v7.0.0](https://github.com/docker/build-push-action/releases/tag/v7.0.0)

* Node 24 as default runtime (requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later) by @crazy-max in https://github.com/docker/build-push-action/pull/1470
* Remove deprecated `DOCKER_BUILD_NO_SUMMARY` and `DOCKER_BUILD_EXPORT_RETENTION_DAYS` envs by @crazy-max in https://github.com/docker/build-push-action/pull/1473
* Remove legacy export-build tool support for build summary by @crazy-max in https://github.com/docker/build-push-action/pull/1474


*...truncated*

### [v6.19.2](https://github.com/docker/build-push-action/releases/tag/v6.19.2)

* Preserve port in `GIT_AUTH_TOKEN` host by @crazy-max in https://github.com/docker/build-push-action/pull/1458

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.19.1...v6.19.2

### [v6.19.1](https://github.com/docker/build-push-action/releases/tag/v6.19.1)

* Derive `GIT_AUTH_TOKEN` host from GitHub server URL by @crazy-max in https://github.com/docker/build-push-action/pull/1456

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.19.0...v6.19.1

### [v6.19.0](https://github.com/docker/build-push-action/releases/tag/v6.19.0)

* Scope default git auth token to `github.com` by @crazy-max in https://github.com/docker/build-push-action/pull/1451
* Bump brace-expansion from 1.1.11 to 1.1.12 in https://github.com/docker/build-push-action/pull/1396
* Bump form-data from 2.5.1 to 2.5.5 in https://github.com/docker/build-push-action/pull/1391
* Bump js-yaml from 3.14.1 to 3.14.2 in https://github.com/docker/build-push-action/pull/1429
* Bump lodash from 4.17.21 to 4.17.23 in https://github.com/docker/build-push-action/pul

*...truncated*

### [v6.18.0](https://github.com/docker/build-push-action/releases/tag/v6.18.0)

* Bump @docker/actions-toolkit from 0.61.0 to 0.62.1 in https://github.com/docker/build-push-action/pull/1381

> [!NOTE]
> [Build summary](https://docs.docker.com/build/ci/github-actions/build-summary/) is now supported with [Docker Build Cloud](https://docs.docker.com/build-cloud/).

**Full Changelog**: https://github.com/docker/build-push-action/compare/v6.17.0...v6.18.0

</details>

<details>
<summary>Release notes for astral-sh/setup-uv</summary>

### [v7.5.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.5.0)

# No more rate-limits

This release addresses a long-standing source of timeouts and rate-limit failures in setup-uv.

 Previously, the action resolved version identifiers like 0.5.x by iterating over available uv releases via the GitHub API to find the best match. In contrast, latest and exact versions such as 0.5.0 skipped version resolution entirely and downloaded uv directly.

The `manifest-file` input was an earlier attempt to improve this. It allows providing an url to a file that li

*...truncated*

### [v7.4.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.4.0)

## Changes

Thank you @luhenry for adding support for riscv64 arch

## 🚀 Enhancements

- Add riscv64 architecture support to platform detection @luhenry (#791)

## 🧰 Maintenance

- Delete .github/workflows/dependabot-build.yml @eifinger (#789)
- Harden Dependabot build workflow @eifinger (#788)
- Fix: check PR author instead of event sender for Dependabot detection @eifinger-bot (#787)
- chore: update known checksums for 0.10.9 @[github-actions[bot]](https://github.com/apps/github-a

*...truncated*

### [v7.3.1](https://github.com/astral-sh/setup-uv/releases/tag/v7.3.1)

## Changes

This release adds support for running in containers like `debian:testing` or `debian:unstable`

## 🐛 Bug fixes

- fix: fall back to VERSION_CODENAME when VERSION_ID is not available @eifinger-bot (#774)

## 🧰 Maintenance

- chore: update known checksums for 0.10.6 @[github-actions[bot]](https://github.com/apps/github-actions) (#771)
- chore: update known checksums for 0.10.5 @[github-actions[bot]](https://github.com/apps/github-actions) (#770)
- chore: update known checks

*...truncated*

### [v7.3.0](https://github.com/astral-sh/setup-uv/releases/tag/v7.3.0)

## Changes

This release contains a few bug fixes and a new feature for the activate-environment functionality.

## 🐛 Bug fixes

- fix: warn instead of error when no python to cache @eifinger (#762)
- fix: use --clear to create venv @eifinger (#761)

## 🚀 Enhancements

- feat: add venv-path input for activate-environment @eifinger (#746)

## 🧰 Maintenance

- chore: update known checksums for 0.10.0 @[github-actions[bot]](https://github.com/apps/github-actions) (#759)
- refactor: 

*...truncated*

### [v7.2.1](https://github.com/astral-sh/setup-uv/releases/tag/v7.2.1)

## Changes

## 🧰 Maintenance

- chore: update known checksums for 0.9.28 @[github-actions[bot]](https://github.com/apps/github-actions) (#744)
- chore: update known checksums for 0.9.27 @[github-actions[bot]](https://github.com/apps/github-actions) (#742)
- chore: update known checksums for 0.9.26 @[github-actions[bot]](https://github.com/apps/github-actions) (#734)
- chore: update known checksums for 0.9.25 @[github-actions[bot]](https://github.com/apps/github-actions) (#733)
- chore: u

*...truncated*

</details>

<details>
<summary>Release notes for bcoe/conventional-release-labels</summary>

### [v1.3.1](https://github.com/bcoe/conventional-release-labels/releases/tag/v1.3.1)

## [1.3.1](https://github.com/bcoe/conventional-release-labels/compare/v1.3.0...v1.3.1) (2022-07-18)


### Bug Fixes

* **deps:** address vulnerabilities, upgrading ansi-regex and minimist and node-fetch ([#31](https://github.com/bcoe/conventional-release-labels/issues/31)) ([61b86a2](https://github.com/bcoe/conventional-release-labels/commit/61b86a2a704f99ca3fcdfcba903bd2a0c5d54d53))

### [v1.3.0](https://github.com/bcoe/conventional-release-labels/releases/tag/v1.3.0)

### Features

* allow certain conventional commit types to be ignored ([#24](https://www.github.com/bcoe/conventional-release-labels/issues/24)) ([b5da323](https://www.github.com/bcoe/conventional-release-labels/commit/b5da3232375eda581c995454aeae2eecb591f526))

### [v1.2.2](https://github.com/bcoe/conventional-release-labels/releases/tag/v1.2.2)

### Bug Fixes

* shorten description ([6c0719e](https://www.github.com/bcoe/conventional-release-labels/commit/6c0719ed8c4f380ec8fd49273fab3c90c8c23751))

### [v1.2.1](https://github.com/bcoe/conventional-release-labels/releases/tag/v1.2.1)

### Bug Fixes

* correct formatting in action.yml ([ce968b7](https://www.github.com/bcoe/conventional-release-labels/commit/ce968b74723c0a5bfcd78ac2deef241a5cecfb04))

### [v1.2.0](https://github.com/bcoe/conventional-release-labels/releases/tag/v1.2.0)

### Features

* **docs:** update action description ([#20](https://www.github.com/bcoe/conventional-release-labels/issues/20)) ([8306bff](https://www.github.com/bcoe/conventional-release-labels/commit/8306bff82003d0b7ff4ed50d07c2c043092e7f65))

</details>

<details>
<summary>Release notes for peter-evans/create-or-update-comment</summary>

### [v5.0.0](https://github.com/peter-evans/create-or-update-comment/releases/tag/v5.0.0)

⚙️ Requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later if you are using a self-hosted runner for Node 24 support.

## What's Changed
* build(deps): bump peter-evans/create-or-update-comment from 3 to 4 by @dependabot[bot] in https://github.com/peter-evans/create-or-update-comment/pull/307
* build(deps-dev): bump @types/node from 18.19.8 to 18.19.11 by @dependabot[bot] in https://github.com/peter-evans/create-or-update-comment/pull/308
* build

*...truncated*

</details>

<details>
<summary>Release notes for peter-evans/find-comment</summary>

### [v4.0.0](https://github.com/peter-evans/find-comment/releases/tag/v4.0.0)

⚙️ Requires [Actions Runner v2.327.1](https://github.com/actions/runner/releases/tag/v2.327.1) or later if you are using a self-hosted runner for Node 24 support.

## What's Changed
* build(deps-dev): bump @types/node from 18.19.28 to 18.19.30 by @dependabot[bot] in https://github.com/peter-evans/find-comment/pull/301
* build(deps-dev): bump @types/node from 18.19.30 to 18.19.31 by @dependabot[bot] in https://github.com/peter-evans/find-comment/pull/302
* build(deps-dev): bump @types/node f

*...truncated*

### [v3.1.0](https://github.com/peter-evans/find-comment/releases/tag/v3.1.0)

## What's Changed
* build(deps-dev): bump @types/node from 18.19.8 to 18.19.10 by @dependabot in https://github.com/peter-evans/find-comment/pull/283
* build(deps-dev): bump @types/node from 18.19.10 to 18.19.14 by @dependabot in https://github.com/peter-evans/find-comment/pull/284
* build(deps): bump peter-evans/create-pull-request from 5 to 6 by @dependabot in https://github.com/peter-evans/find-comment/pull/285
* build(deps): bump peter-evans/slash-command-dispatch from 3 to 4 by @dependa

*...truncated*

</details>

## Notes

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA).

Worth running the workflows on a branch before merging to make sure everything still works.
