### PR TITLE
fix: check .md variant when verifying .txt file existence for overwrite

### DIFF
--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -122,24 +122,32 @@ async def check_filename_exists(
 
         from utils.opensearch_queries import build_filename_search_body
 
-        search_body = build_filename_search_body(filename, size=1, source=["filename"])
+        # .txt files are renamed to .md for Langflow compatibility during
+        # ingestion, so the overwrite check must also look for the .md variant.
+        names_to_check = [filename]
+        if filename.lower().endswith('.txt'):
+            names_to_check.append(filename[:-4] + '.md')
 
         logger.debug("Checking filename existence", filename=filename, index_name=get_index_name())
 
         try:
-            response = await opensearch_client.search(
-                index=get_index_name(),
-                body=search_body
-            )
+            exists = False
+            for name in names_to_check:
+                search_body = build_filename_search_body(name, size=1, source=["filename"])
+                response = await opensearch_client.search(
+                    index=get_index_name(),
+                    body=search_body
+                )
+                hits = response.get("hits", {}).get("hits", [])
+                if len(hits) > 0:
+                    exists = True
+                    break
         except Exception as search_err:
             if "index_not_found_exception" in str(search_err):
                 logger.info("Index does not exist, creating it now before upload")
                 await _ensure_index_exists()
                 return JSONResponse({"exists": False, "filename": filename}, status_code=200)
             raise
-
-        hits = response.get("hits", {}).get("hits", [])
-        exists = len(hits) > 0
 
         return JSONResponse({"exists": exists, "filename": filename}, status_code=200)
 

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -72,19 +72,23 @@ class TaskProcessor:
         max_retries = 3
         retry_delay = 1.0
 
+        # .txt files are renamed to .md for Langflow during ingestion
+        names_to_check = [filename]
+        if filename.lower().endswith('.txt'):
+            names_to_check.append(filename[:-4] + '.md')
+
         for attempt in range(max_retries):
             try:
-                # Search for any document with this exact filename
-                search_body = build_filename_search_body(filename, size=1, source=False)
-
-                response = await opensearch_client.search(
-                    index=get_index_name(),
-                    body=search_body
-                )
-
-                # Check if any hits were found
-                hits = response.get("hits", {}).get("hits", [])
-                return len(hits) > 0
+                for name in names_to_check:
+                    search_body = build_filename_search_body(name, size=1, source=False)
+                    response = await opensearch_client.search(
+                        index=get_index_name(),
+                        body=search_body
+                    )
+                    hits = response.get("hits", {}).get("hits", [])
+                    if len(hits) > 0:
+                        return True
+                return False
 
             except (asyncio.TimeoutError, Exception) as e:
                 if attempt == max_retries - 1:


### PR DESCRIPTION
## Summary

The overwrite functionality is unavailable for `.txt` files because `.txt` files are renamed to `.md` for Langflow compatibility during ingestion, but the duplicate/existence check only searches for the original `.txt` filename in OpenSearch.

## Problem

1. User uploads `report.txt` — ingestion renames it to `report.md` and indexes under that name
2. User uploads `report.txt` again — the overwrite check searches OpenSearch for `report.txt`
3. OpenSearch has no document named `report.txt` (it's stored as `report.md`) — check returns `exists: false`
4. The overwrite dialog never appears, and the file is re-ingested as a duplicate

## Root cause

`check_filename_exists()` in `src/api/documents.py` and `check_existing_document()` in `src/models/processors.py` both search only for the exact filename passed in, unaware of the `.txt` → `.md` rename that happens in `LangflowFileProcessor._process_file()` (line 769).

## Fix

When the filename ends with `.txt`, also check for the `.md` variant in both:
- `src/api/documents.py` — API endpoint used by the frontend
- `src/models/processors.py` — processor-level duplicate check

This is consistent with the existing rename logic at line 769 of processors.py.

## Testing

- Upload a `.txt` file → gets indexed as `.md` ✓
- Upload the same `.txt` file again → overwrite dialog now appears ✓
- Non-`.txt` files are unaffected ✓

Closes #1174