### PR TITLE
fix: add numeric comparator for Size column and case-insensitive sort for Source

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -332,6 +332,8 @@ function SearchPage() {
     {
       field: "filename",
       headerName: "Source",
+      comparator: (a: string, b: string) =>
+        (a ?? "").localeCompare(b ?? "", undefined, { sensitivity: "base" }),
       checkboxSelection: (params: CheckboxSelectionCallbackParams<File>) =>
         (params?.data?.status || "active") === "active",
       headerCheckboxSelection: true,
@@ -389,6 +391,7 @@ function SearchPage() {
     {
       field: "size",
       headerName: "Size",
+      comparator: (a: number | null, b: number | null) => (a ?? 0) - (b ?? 0),
       valueFormatter: (params: ValueFormatterParams<File>) =>
         params.value ? `${Math.round(params.value / 1024)} KB` : "-",
     },


### PR DESCRIPTION
## Summary

Sorting by "Size" in the Knowledge list does not produce correct results because AG Grid's default comparator sorts the formatted string values lexicographically (e.g., "9 KB" > "10 KB"). The "Source" column also sorts case-sensitively, grouping capitalized filenames separately from lowercase ones.

## Problem

The `size` column definition has a `valueFormatter` that formats bytes as KB, but no `comparator`. AG Grid defaults to string comparison on the formatted output, producing incorrect sort order for numeric data.

Similarly, the `filename`/Source column uses default string comparison which is case-sensitive, so "Report.pdf" sorts separately from "analysis.docx".

## Fix

- Add `comparator: (a, b) => (a ?? 0) - (b ?? 0)` to the Size column for proper numeric sorting
- Add `comparator` with `localeCompare(..., { sensitivity: "base" })` to the Source column for case-insensitive sorting

## Testing

- Size column now sorts numerically: 1 KB < 5 KB < 10 KB < 100 KB
- Source column now sorts case-insensitively: analysis.docx, Report.pdf, summary.txt

Closes #1172