### PR TITLE
fix: remove hardcoded host.docker.internal default for DOCLING_SERVE_URL

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -163,7 +163,7 @@ services:
       - OPENSEARCH_PORT=${OPENSEARCH_PORT:-9200}
       - OPENSEARCH_URL=https://${OPENSEARCH_HOST:-opensearch}:${OPENSEARCH_PORT:-9200}
       - OPENSEARCH_INDEX_NAME=${OPENSEARCH_INDEX_NAME:-documents}
-      - DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-http://host.docker.internal:5001}
+      - DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-}
       - FILENAME=None
       - MIMETYPE=None
       - FILESIZE=0


### PR DESCRIPTION
## Summary

The `openrag-backend` container fails to reach `docling-serve` in pure WSL2 Docker environments because `docker-compose.yml` hardcodes `DOCLING_SERVE_URL` to `http://host.docker.internal:5001`, which does not resolve without Docker Desktop.

## Problem

When running `uvx openrag` in a pure WSL2 environment with native Docker engine:

1. `docker-compose.yml` sets `DOCLING_SERVE_URL=http://host.docker.internal:5001` as the default
2. Pure WSL Docker does not resolve `host.docker.internal`
3. The backend's `determine_docling_host()` function (which handles WSL via gateway IP fallback) is never called because the env var override takes precedence
4. Result: continuous 503 errors, UI blocked at onboarding

## Root cause

The `DOCLING_SERVE_URL` default in `docker-compose.yml` line 166 preempts the container-aware auto-detection logic in `src/api/docling.py`:

```yaml
# Before: always overrides auto-detection
DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-http://host.docker.internal:5001}
```

## Fix

Remove the hardcoded default so the variable is empty when unset:

```yaml
# After: falls through to determine_docling_host() auto-detection
DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-}
```

This allows `determine_docling_host()` to run its full detection chain:
1. Container-specific host (if in container)
2. `host.docker.internal` / `host.containers.internal` (if resolvable)
3. Gateway IP from `/proc/net/route` (WSL fallback)
4. Bridge IP guess (last resort)
5. `localhost` (when not in container)

Users who need a specific URL can still set `DOCLING_SERVE_URL` explicitly in their `.env` or environment.

## Testing

- WSL2 with native Docker: backend now auto-detects host via gateway IP
- Docker Desktop: `host.docker.internal` still resolves normally via auto-detection
- Explicit `DOCLING_SERVE_URL` in `.env` still works as before

Closes #1162