### PR TITLE
docs: add gitcgr code graph badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 [![GitHub forks](https://img.shields.io/github/forks/langflow-ai/openrag?style=social)](https://github.com/langflow-ai/openrag/network/members)
 
 [![Documentation](https://img.shields.io/badge/Documentation-773eff)](https://docs.openr.ag) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/langflow-ai/openrag)
+[![gitcgr](https://gitcgr.com/badge/langflow-ai/openrag.svg)](https://gitcgr.com/langflow-ai/openrag)
 
 </div>
 


### PR DESCRIPTION
Adds a [gitcgr](https://gitcgr.com) badge to the README showing code graph statistics for this repository.

**Badge preview:**

[![gitcgr](https://gitcgr.com/badge/langflow-ai/openrag.svg)](https://gitcgr.com/langflow-ai/openrag)

---

[gitcgr.com](https://gitcgr.com) visualizes any GitHub repo as an interactive code graph — just change `hub` to `cgr` in the URL.

Generated automatically by [gitcgr](https://gitcgr.com).