### PR TITLE
fix: resolve fresh deploy broken chat — missing flows and UnboundLocalError (#1229)

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -763,9 +763,9 @@ async def async_langflow_chat_stream(
                 "error": error_occurred,  # Mark if this was an error response
             }
             # Store usage data if available (from response.completed event)
-        if usage_data:
-            assistant_message["response_data"] = {"usage": usage_data}
-        conversation_state["messages"].append(assistant_message)
+            if usage_data:
+                assistant_message["response_data"] = {"usage": usage_data}
+            conversation_state["messages"].append(assistant_message)
 
         # Store the conversation thread with its response_id
         if response_id:
@@ -773,13 +773,13 @@ async def async_langflow_chat_stream(
             await store_conversation_thread(user_id, response_id, conversation_state)
 
             # Claim session ownership for this user
-        try:
-            from services.session_ownership_service import session_ownership_service
+            try:
+                from services.session_ownership_service import session_ownership_service
 
-            session_ownership_service.claim_session(user_id, response_id)
-            logger.debug(f"Claimed session {response_id} for user {user_id}")
-        except Exception as e:
-            logger.warning(f"Failed to claim session ownership: {e}")
+                session_ownership_service.claim_session(user_id, response_id)
+                logger.debug(f"Claimed session {response_id} for user {user_id}")
+            except Exception as e:
+                logger.warning(f"Failed to claim session ownership: {e}")
 
             logger.debug(
                 f"Stored langflow conversation thread for user {user_id} with response_id: {response_id}"

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1083,6 +1083,19 @@ async def onboarding(
                 status_code=503,
             )
 
+        # Ensure all flows exist in Langflow before configuring them.
+        # On fresh deployments, the background startup_tasks may not have
+        # created the flows yet (race condition). This is idempotent —
+        # if startup_tasks already ran, it's a fast no-op.
+        try:
+            await flows_service.ensure_flows_exist()
+        except Exception as e:
+            logger.error("Failed to ensure Langflow flows exist during onboarding", error=str(e))
+            return JSONResponse(
+                {"error": "Failed to initialize Langflow flows. Please try again."},
+                status_code=503,
+            )
+
         # Set Langflow global variables and model values based on provider configuration
         try:
             # Check if any provider-related fields were provided


### PR DESCRIPTION


On a fresh Docker deployment, Langflow flows were never imported into Langflow's database, causing all chat and ingestion to fail with 404s and an UnboundLocalError crash in the streaming chat path.

Two fixes:

1. Call ensure_flows_exist() in the onboarding endpoint before configuring model values. On fresh deploys the background startup_tasks may not have created the flows yet (race condition). The call is idempotent so it's a no-op if startup already ran.

2. Fix indentation bugs in async_langflow_chat_stream (agent.py):
   - assistant_message was defined inside `if full_response:` but referenced outside it, causing UnboundLocalError when the Langflow stream returned no content.
   - Session claiming try/except was outside `if response_id:`, running unconditionally instead of only when a response existed.