### PR TITLE
fix: update supported file types in error message

### DIFF
--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -457,7 +457,7 @@ export function KnowledgeDropdown() {
       if (filteredFiles.length === 0) {
         toast.error("No supported files found", {
           description:
-            "Please select a folder containing supported document files (PDF, DOCX, PPTX, XLSX, CSV, HTML, images, etc.).",
+            "Please select a folder containing supported document files (PDF, DOCX, TXT, MD, HTML, CSV, etc.).",
         });
         return;
       }


### PR DESCRIPTION
## Summary
- The error message shown when no supported files are found listed PPTX, XLSX, and images as supported types, but these are not currently in `SUPPORTED_FILE_TYPES`.
- Updated the message to reflect the actual supported types: PDF, DOCX, TXT, MD, HTML, CSV.

Closes #1362