### PR TITLE
fix: make DOCLING_SERVE_URL a runtime passthrough instead of startup …

### DIFF
--- a/src/api/docling.py
+++ b/src/api/docling.py
@@ -77,15 +77,18 @@ def determine_docling_host() -> str:
     return "localhost"
 
 
-# Use explicit URL if provided, otherwise auto-detect host
-_docling_url_override = os.getenv("DOCLING_SERVE_URL")
-if _docling_url_override:
-    DOCLING_SERVICE_URL = _docling_url_override.rstrip("/")
-    HOST_IP = _docling_url_override  # For display in health responses
-    logger.info("Using DOCLING_SERVE_URL override: %s", DOCLING_SERVICE_URL)
-else:
-    HOST_IP = determine_docling_host()
-    DOCLING_SERVICE_URL = f"http://{HOST_IP}:5001"
+def get_docling_service_url() -> str:
+    """Return the Docling Serve URL, reading DOCLING_SERVE_URL from the environment
+    at call time so that runtime changes to the variable are picked up without
+    requiring a server restart.
+    """
+    override = os.getenv("DOCLING_SERVE_URL")
+    if override:
+        url = override.rstrip("/")
+        logger.debug("Using DOCLING_SERVE_URL override: %s", url)
+        return url
+    host = determine_docling_host()
+    return f"http://{host}:5001"
 
 
 async def health(request: Request) -> JSONResponse:
@@ -93,7 +96,8 @@ async def health(request: Request) -> JSONResponse:
     Proxy health check to docling-serve.
     This allows the frontend to check docling status via same-origin request.
     """
-    health_url = f"{DOCLING_SERVICE_URL}/health"
+    docling_url = get_docling_service_url()
+    health_url = f"{docling_url}/health"
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(
@@ -104,14 +108,14 @@ async def health(request: Request) -> JSONResponse:
             if response.status_code == 200:
                 return JSONResponse({
                     "status": "healthy",
-                    "host": HOST_IP
+                    "host": docling_url
                 })
             else:
                 logger.warning("Docling health check failed", url=health_url, status_code=response.status_code)
                 return JSONResponse({
                     "status": "unhealthy",
                     "message": f"Health check failed with status: {response.status_code}",
-                    "host": HOST_IP
+                    "host": docling_url
                 }, status_code=503)
 
     except httpx.TimeoutException:
@@ -119,12 +123,12 @@ async def health(request: Request) -> JSONResponse:
         return JSONResponse({
             "status": "unhealthy",
             "message": "Connection timeout",
-            "host": HOST_IP
+            "host": docling_url
         }, status_code=503)
     except Exception as e:
         logger.error("Docling health check failed", url=health_url, error=str(e))
         return JSONResponse({
             "status": "unhealthy",
             "message": str(e),
-            "host": HOST_IP
+            "host": docling_url
         }, status_code=503)

--- a/src/utils/docling_client.py
+++ b/src/utils/docling_client.py
@@ -20,9 +20,10 @@ async def _send_convert_request(
     file_bytes: bytes,
 ) -> dict:
     """Send a file to docling-serve and return the DoclingDocument dict."""
-    from api.docling import DOCLING_SERVICE_URL
+    from api.docling import get_docling_service_url
 
-    url = f"{DOCLING_SERVICE_URL}/v1/convert/file"
+    docling_url = get_docling_service_url()
+    url = f"{docling_url}/v1/convert/file"
 
     ocr_engine = os.getenv("DOCLING_OCR_ENGINE")
     data: dict[str, str] = {"to_formats": "json"}
@@ -41,7 +42,7 @@ async def _send_convert_request(
         response.raise_for_status()
     except httpx.ConnectError as exc:
         raise DoclingServeError(
-            f"Cannot connect to docling-serve at {DOCLING_SERVICE_URL}. "
+            f"Cannot connect to docling-serve at {docling_url}. "
             f"Is it running? Start with: uvx docling-serve run"
         ) from exc
     except httpx.TimeoutException as exc:


### PR DESCRIPTION
…snapshot

Fixes #1375

Previously, DOCLING_SERVICE_URL and HOST_IP were resolved once at module import time in src/api/docling.py. Any change to DOCLING_SERVE_URL after onboarding (e.g. pointing to a different docling-serve instance) was silently ignored until the backend process was fully restarted.

Changes:
- src/api/docling.py: replace the module-level static URL assignment with a get_docling_service_url() function that reads os.getenv("DOCLING_SERVE_URL") on every call, falling back to the auto-detected host when not set. health() now calls get_docling_service_url() per request.
- src/utils/docling_client.py: import get_docling_service_url() instead of the stale DOCLING_SERVICE_URL string so every conversion request resolves the current URL from the environment at call time.