### PR TITLE
feat: Disable use of private / public keys when IBM_AUTH_ENABLED is true

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1345,14 +1345,15 @@ async def initialize_services():
     await TelemetryClient.send_event(
         Category.SERVICE_INITIALIZATION, MessageId.ORB_SVC_INIT_START
     )
-    # Generate JWT keys if they don't exist and a JWT signing key isn't specified
-    if not os.getenv("JWT_SIGNING_KEY"):
-        generate_jwt_keys()
-
     from config.settings import IBM_AUTH_ENABLED
 
     if IBM_AUTH_ENABLED:
         logger.info("IBM auth mode enabled — JWT validation delegated to Traefik")
+
+    # Generate JWT keys if they don't exist, a JWT signing key isn't specified,
+    # and IBM auth is not enabled (IBM mode delegates all auth to Traefik)
+    if not os.getenv("JWT_SIGNING_KEY") and not IBM_AUTH_ENABLED:
+        generate_jwt_keys()
 
     # Initialize clients (now async to generate Langflow API key)
     try:

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -9,6 +9,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa, ec, ed25519, ed448
 
 import os
 from utils.logging_config import get_logger
+from config.settings import IBM_AUTH_ENABLED
 
 logger = get_logger(__name__)
 @dataclass
@@ -116,9 +117,16 @@ class SessionManager:
                 self.public_key_pem = None  # No JWKS for symmetric
                 self.algorithm = "HS256"
         else:
-            # Fall back to file-based RSA keys
-            self._load_rsa_keys()
-            self.algorithm = "RS256"
+            if IBM_AUTH_ENABLED:
+                # IBM Auth Mode: Traefik handles auth (no local JWT signing required)
+                self.private_key = None
+                self.public_key = None
+                self.public_key_pem = None
+                self.algorithm = None
+            else:
+                # Fall back to file-based RSA keys
+                self._load_rsa_keys()
+                self.algorithm = "RS256"
         logger.info(f"Initialized JWT signing with {self.algorithm}")
 
 
@@ -225,11 +233,17 @@ class SessionManager:
         if token and (token.startswith("Bearer ") or token.startswith("Basic ")):
             return token
         if not token:
+            if self.private_key is None:
+                logger.error("create_jwt_token called but JWT signing is disabled (IBM auth mode)")
+                return None
             token = jwt.encode(token_payload, self.private_key, algorithm=self.algorithm)
         return f"Bearer {token}"
 
     def verify_token(self, token: str) -> Optional[Dict[str, Any]]:
         """Verify JWT token and return user info"""
+        if IBM_AUTH_ENABLED:
+            # IBM Auth Mode: Token verification handled externally by Traefik
+            return None
         try:
             payload = jwt.decode(
                 token,
@@ -267,7 +281,7 @@ class SessionManager:
         # Get the effective JWT token (handles anonymous JWT creation)
         jwt_token = self.get_effective_jwt_token(user_id, jwt_token)
 
-        from config.settings import IBM_AUTH_ENABLED, clients
+        from config.settings import clients
 
         # In IBM mode credentials may rotate per-request — always create a fresh client
         if IBM_AUTH_ENABLED:
@@ -283,7 +297,7 @@ class SessionManager:
 
     def get_effective_jwt_token(self, user_id: str, jwt_token: str) -> str:
         """Get the effective JWT token, creating anonymous JWT if needed in no-auth mode"""
-        from config.settings import IBM_AUTH_ENABLED, is_no_auth_mode
+        from config.settings import is_no_auth_mode
 
         # IBM JWT is used as-is — never override with an anonymous OpenRAG JWT
         if IBM_AUTH_ENABLED and jwt_token:
@@ -294,6 +308,9 @@ class SessionManager:
 
         # No token — create one
         if is_no_auth_mode() or user_id in (None, AnonymousUser().user_id):
+            # IBM Auth Mode: No anonymous JWT concept (disable signing)
+            if self.private_key is None:
+                return None
             # anonymous JWT (cached)
             if not hasattr(self, "_anonymous_jwt"):
                 self._anonymous_jwt = self._create_anonymous_jwt()


### PR DESCRIPTION
### Issue

- #1393

### Related Pull Requests

- `main`: https://github.com/langflow-ai/openrag/pull/1410

### Summary

- Disabled JWT key generation and local token signing/verification when `IBM_AUTH_ENABLED` is true, delegating all authentication to Traefik in IBM/SaaS deployments.

### Session Manager Updates

- Imported `IBM_AUTH_ENABLED` at module level in `session_manager.py` instead of inside individual methods.
- Set `private_key`, `public_key`, `public_key_pem`, and `algorithm` to `None` when IBM auth mode is active and no explicit signing key is configured (RSA key loading skipped).
- Guarded `create_jwt_token` to return `None` early and log an error when `private_key` is `None` (IBM auth mode).
- Guarded `verify_token` to return `None` immediately when `IBM_AUTH_ENABLED` is set, since token verification is handled externally by Traefik.
- Guarded `get_effective_jwt_token` to return `None` when `private_key` is `None`, preventing anonymous JWT creation in IBM auth mode.

### Startup / Key Generation Updates

- Skipped `generate_jwt_keys()` call in `initialize_services()` when `IBM_AUTH_ENABLED` is true, preventing unnecessary RSA key file creation in IBM/SaaS deployments.