### PR TITLE
Fix: remove duplicate /templates prefix in helm checksum paths

### DIFF
--- a/kubernetes/helm/openrag/Chart.yaml
+++ b/kubernetes/helm/openrag/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: openrag
 description: A Helm chart for deploying OpenRAG - an open-source agentic RAG platform
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: "0.1.52"
 keywords:
   - openrag

--- a/kubernetes/helm/openrag/Chart.yaml
+++ b/kubernetes/helm/openrag/Chart.yaml
@@ -3,7 +3,7 @@ name: openrag
 description: A Helm chart for deploying OpenRAG - an open-source agentic RAG platform
 type: application
 version: 0.2.1
-appVersion: "0.1.52"
+appVersion: "0.4.1"
 keywords:
   - openrag
   - rag

--- a/kubernetes/helm/openrag/templates/backend/deployment.yaml
+++ b/kubernetes/helm/openrag/templates/backend/deployment.yaml
@@ -23,7 +23,7 @@ spec:
         checksum/config-flows: {{ include (print $.Template.BasePath "/configmaps/flow-ids-configmap.yaml") . | sha256sum }}
         checksum/config-app: {{ include (print $.Template.BasePath "/configmaps/app-config-configmap.yaml") . | sha256sum }}
         checksum/secret-backend: {{ include (print $.Template.BasePath "/secrets/backend-secret.yaml") . | sha256sum }}
-        checksum/secret-dotenv: {{ include (print $.Template.BasePath "/templates/backend/backend-dotenv.yaml") . | sha256sum }}
+        checksum/secret-dotenv: {{ include (print $.Template.BasePath "/backend/backend-dotenv.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "openrag.serviceAccountName" . }}
       {{- with .Values.podSecurityContext }}

--- a/kubernetes/helm/openrag/templates/langflow/deployment.yaml
+++ b/kubernetes/helm/openrag/templates/langflow/deployment.yaml
@@ -20,7 +20,7 @@ spec:
       annotations:
         checksum/secret: {{ include (print $.Template.BasePath "/secrets/langflow-secret.yaml") . | sha256sum }}
         checksum/config: {{ include (print $.Template.BasePath "/configmaps/flow-ids-configmap.yaml") . | sha256sum }}
-        checksum/dotenv: {{ include (print $.Template.BasePath "/templates/langflow/langflow-dotenv.yaml") . | sha256sum }}
+        checksum/dotenv: {{ include (print $.Template.BasePath "/langflow/langflow-dotenv.yaml") . | sha256sum }}
     spec:
       serviceAccountName: {{ include "openrag.serviceAccountName" . }}
 

--- a/kubernetes/helm/openrag/values.yaml
+++ b/kubernetes/helm/openrag/values.yaml
@@ -276,7 +276,6 @@ backend:
 
 
   # Logging
-  logLevel: "INFO"                        # DEBUG, INFO, WARNING, ERROR, CRITICAL
   noColor: false                          # Set true to disable ANSI color codes in log output
   accessLog: true                         # Set false to disable HTTP access log events
 


### PR DESCRIPTION
**Problem**

When running `helm template`, you'd get this error
```
Error: Error: template: templates/langflow/deployment.yaml:23:28: executing "templates/langflow/deployment.yaml"  
  at <include (print $.Template.BasePath "/templates/langflow/langflow-dotenv.yaml") .>: error calling include: template: no        
  template "templates/templates/langflow/langflow-dotenv.yaml" associated with template "gotpl"
```

**Reason**

The `$.Template.BasePath` variable already resolves to the `templates/` directory, so including `/templates/` in the path caused an incorrect checksum annotations for the backend and langflow deployments. 

**Fix**

This fix removes the redundant prefix so Helm can correctly locate and hash the dotenv files, ensuring pods are restarted when their configuration changes.
                                                                                                                                    
Also 
- Bumps the chart version to `0.2.1` because of the fix
- Adjust `appVersion` to `0.4.1` to reflect the current release.
- Remove duplicated `loglevel` key under the `backend` key for Helm values