### PR TITLE
feat: Lazily resolve config file & load dotenv earlier

### DIFF
--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -163,16 +163,19 @@ class ConfigManager:
         """Initialize configuration manager.
 
         Args:
-            config_file: Path to configuration file. Defaults to 'config.yaml' in project root.
+            config_file: Path to configuration file. If None, resolved lazily
+                from OPENRAG_CONFIG_PATH on first access.
         """
-        if config_file:
-            self.config_file = Path(config_file)
-        else:
-            from config.paths import get_config_file_path
-            self.config_file = Path(get_config_file_path())
+        self._config_file: Optional[Path] = Path(config_file) if config_file else None
         self._config: Optional[OpenRAGConfig] = None
 
-
+    @property
+    def config_file(self) -> Path:
+        """Lazily resolve config file path on first access."""
+        if self._config_file is None:
+            from config.paths import get_config_file_path
+            self._config_file = Path(get_config_file_path())
+        return self._config_file
 
     def load_config(self) -> OpenRAGConfig:
         """Load configuration from environment variables and config file.

--- a/src/config/paths.py
+++ b/src/config/paths.py
@@ -6,7 +6,8 @@ Variables are read directly via ``os.getenv`` here to avoid circular imports
 """
 
 import os
-
+from utils.logging_config import get_logger
+logger = get_logger(__name__)
 
 # ---------------------------------------------------------------------------
 # Documents directory
@@ -17,6 +18,7 @@ def get_documents_path() -> str:
     Environment variable: OPENRAG_DOCUMENTS_PATH
     Default: ``openrag-documents``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_DOCUMENTS_PATH: {os.getenv('OPENRAG_DOCUMENTS_PATH')}")
     return os.getenv("OPENRAG_DOCUMENTS_PATH") or "openrag-documents"
 
 
@@ -29,6 +31,7 @@ def get_keys_path() -> str:
     Environment variable: OPENRAG_KEYS_PATH
     Default: ``keys``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_KEYS_PATH: {os.getenv('OPENRAG_KEYS_PATH')}")
     return os.getenv("OPENRAG_KEYS_PATH") or "keys"
 
 
@@ -41,6 +44,7 @@ def get_flows_path() -> str:
     Environment variable: OPENRAG_FLOWS_PATH
     Default: ``flows``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_FLOWS_PATH: {os.getenv('OPENRAG_FLOWS_PATH')}")
     return os.getenv("OPENRAG_FLOWS_PATH") or "flows"
 
 
@@ -50,6 +54,7 @@ def get_flows_backup_path() -> str:
     Environment variable: OPENRAG_FLOWS_BACKUP_PATH
     Default: ``<flows_path>/backup``
     """
+    logger.debug(f"OPENRAG_FLOWS_BACKUP_PATH: {os.getenv('OPENRAG_FLOWS_BACKUP_PATH')}")
     return os.getenv("OPENRAG_FLOWS_BACKUP_PATH") or os.path.join(get_flows_path(), "backup")
 
 
@@ -62,11 +67,14 @@ def get_config_path() -> str:
     Environment variable: OPENRAG_CONFIG_PATH
     Default: ``config``  (relative to the working directory)
     """
+
+    logger.debug(f"OPENRAG_CONFIG_PATH: {os.getenv('OPENRAG_CONFIG_PATH')}")
     return os.getenv("OPENRAG_CONFIG_PATH") or "config"
 
 
 def get_config_file_path() -> str:
     """Return the full path to the config.yaml file."""
+    logger.debug(f"get_config_file_path: {os.path.join(get_config_path(), 'config.yaml')}")
     return os.path.join(get_config_path(), "config.yaml")
 
 
@@ -79,6 +87,7 @@ def get_data_path() -> str:
     Environment variable: OPENRAG_DATA_PATH
     Default: ``data``  (relative to the working directory)
     """
+    logger.debug(f"OPENRAG_DATA_PATH: {os.getenv('OPENRAG_DATA_PATH')}")
     return os.getenv("OPENRAG_DATA_PATH") or "data"
 
 
@@ -90,4 +99,5 @@ def get_data_file(filename: str) -> str:
         get_data_file("conversations.json")
         # → "data/conversations.json"  (or $OPENRAG_DATA_PATH/conversations.json)
     """
+    logger.debug(f"get_data_file: {os.path.join(get_data_path(), filename)}")
     return os.path.join(get_data_path(), filename)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,4 +1,3 @@
-from config.paths import get_flows_path
 import asyncio
 import os
 import threading
@@ -8,6 +7,15 @@ from utils.env_utils import get_env_int, get_env_float
 import httpx
 from agentd.patch import patch_openai_with_mcp
 from dotenv import load_dotenv
+
+from dotenv import load_dotenv
+load_dotenv(override=False)
+load_dotenv("../", override=False)
+
+from config.paths import get_flows_path
+from utils.env_utils import get_env_int, get_env_float
+
+import httpx
 from openai import AsyncOpenAI
 from opensearchpy import AsyncOpenSearch
 from opensearchpy._async.http_aiohttp import AIOHttpConnection
@@ -16,11 +24,7 @@ from config.embedding_constants import OPENAI_DEFAULT_EMBEDDING_MODEL
 from utils.container_utils import get_container_host
 from utils.embedding_fields import build_knn_vector_field
 from utils.logging_config import get_logger
-# Import configuration manager
 from .config_manager import config_manager
-
-load_dotenv(override=False)
-load_dotenv("../", override=False)
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
Make ConfigManager defer resolving the config file path: store an optional _config_file in __init__ and add a config_file property that lazily imports get_config_file_path and sets the Path on first access. In settings.py, load environment files earlier (load_dotenv and parent dir) and reorder imports so env vars are available before importing config.paths and other config modules; remove duplicate dotenv calls and tidy imports. These changes avoid premature evaluation of paths/configs that depend on environment variables.