### PR TITLE
feat: Make Index name dynamic at runtime

### DIFF
--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -153,6 +153,8 @@ class LangflowFileService:
         # Get the current embedding model and provider credentials from config
         from config.settings import get_openrag_config
         from utils.langflow_headers import add_provider_credentials_to_headers
+        from config.settings import get_index_name
+   
         
         config = get_openrag_config()
         embedding_model = config.knowledge.embedding_model
@@ -169,6 +171,7 @@ class LangflowFileService:
             "X-Langflow-Global-Var-SELECTED_EMBEDDING_MODEL": str(embedding_model),
             "X-Langflow-Global-Var-DOCUMENT_ID": str(document_id) if document_id else "",
             "X-Langflow-Global-Var-SOURCE_URL": str(source_url) if source_url else "",
+            "X-Langflow-Global-Var-OPENSEARCH_INDEX_NAME": str(get_index_name()),
         }
 
         # Serialize ACL lists as JSON strings for Langflow global vars
@@ -279,6 +282,7 @@ class LangflowFileService:
 
         from config.settings import get_openrag_config
         from utils.langflow_headers import add_provider_credentials_to_headers
+        from config.settings import get_index_name
 
         config = get_openrag_config()
         embedding_model = config.knowledge.embedding_model
@@ -295,6 +299,7 @@ class LangflowFileService:
     
             "X-Langflow-Global-Var-ALLOWED_USERS": json.dumps( []),
             "X-Langflow-Global-Var-ALLOWED_GROUPS": json.dumps( []),
+            "X-Langflow-Global-Var-OPENSEARCH_INDEX_NAME": str(get_index_name()),
         }
         await add_provider_credentials_to_headers(headers, config, flows_service=self.flows_service, jwt_token=jwt_token)
 


### PR DESCRIPTION
This pull request updates the ingestion flows in `langflow_file_service.py` to include the OpenSearch index name in the headers sent during ingestion. This ensures that downstream services are aware of which OpenSearch index to use, improving integration and configurability.

**Enhancements to ingestion flow headers:**

* Added import of `get_index_name` from `config.settings` in both `run_ingestion_flow` and `run_url_ingestion_flow` to retrieve the OpenSearch index name. [[1]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958R156-R157) [[2]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958R285)
* Included the `X-Langflow-Global-Var-OPENSEARCH_INDEX_NAME` header in both ingestion flows, setting its value to the current OpenSearch index name. [[1]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958R174) [[2]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958R302)