### PR TITLE
update Dockerfile to use the latest Langflow image version

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM langflowai/langflow:1.9.0
+FROM langflowai/langflow:latest
 
 # Install uv and pre-create the Langflow data directory.
 # The base image already runs as uid=1000 and owns /app, so no root or chown needed.


### PR DESCRIPTION
this fixes the chat error:
Error creating class. ModuleNotFoundError(No module named 'lfx.base.models.unified_models.handle_model_input_update'; 'lfx.base.models.unified_models' is not a package).