### PR TITLE
fix: Knowledge search fails with embedding model error

### DIFF
--- a/frontend/app/api/mutations/useUpdateSettingsMutation.ts
+++ b/frontend/app/api/mutations/useUpdateSettingsMutation.ts
@@ -38,7 +38,48 @@ export interface UpdateSettingsRequest {
   remove_openai_config?: boolean;
   remove_anthropic_config?: boolean;
   remove_watsonx_config?: boolean;
+  // Bypass the "this provider's embedding models are still in use" guard.
+  force_remove?: boolean;
 }
+
+export interface AffectedEmbeddingModel {
+  model: string;
+  doc_count: number;
+}
+
+// Typed error that preserves the structured 409 payload returned by
+// POST /api/settings when removing a provider whose embedding models are
+// still referenced by indexed documents.
+export class UpdateSettingsError extends Error {
+  readonly status: number;
+  readonly code?: string;
+  readonly affectedProvider?: string;
+  readonly affectedModels?: AffectedEmbeddingModel[];
+
+  constructor(status: number, data: Record<string, unknown>) {
+    const message =
+      typeof data.error === "string" ? data.error : "Failed to update settings";
+    super(message);
+    this.name = "UpdateSettingsError";
+    this.status = status;
+    this.code = typeof data.code === "string" ? data.code : undefined;
+    this.affectedProvider =
+      typeof data.affected_provider === "string"
+        ? data.affected_provider
+        : undefined;
+    this.affectedModels = Array.isArray(data.affected_models)
+      ? (data.affected_models as AffectedEmbeddingModel[])
+      : undefined;
+  }
+}
+
+export const isEmbeddingProviderInUseError = (
+  err: unknown,
+): err is UpdateSettingsError =>
+  err instanceof UpdateSettingsError &&
+  err.code === "embedding_provider_in_use" &&
+  Array.isArray(err.affectedModels) &&
+  err.affectedModels.length > 0;
 
 export interface UpdateSettingsResponse {
   message: string;
@@ -67,7 +108,7 @@ export const useUpdateSettingsMutation = (
 
     if (!response.ok) {
       const errorData = await response.json().catch(() => ({}));
-      throw new Error(errorData.error || "Failed to update settings");
+      throw new UpdateSettingsError(response.status, errorData);
     }
 
     return response.json();

--- a/frontend/app/api/queries/useGetSearchQuery.ts
+++ b/frontend/app/api/queries/useGetSearchQuery.ts
@@ -64,6 +64,24 @@ export interface File {
   allowed_groups?: string[];
 }
 
+// Non-fatal signal from the backend — e.g. an embedding provider was removed
+// so some models in the corpus can't be queried semantically. Results still
+// come back via keyword matching.
+export interface SearchWarning {
+  code: string;
+  models?: string[];
+  semantic_search_available?: boolean;
+  message?: string;
+}
+
+export interface SearchResult {
+  files: File[];
+  warnings: SearchWarning[];
+}
+
+const EMPTY_SEARCH_RESULT: SearchResult = { files: [], warnings: [] };
+export { EMPTY_SEARCH_RESULT };
+
 export const useGetSearchQuery = (
   query: string,
   queryData?: ParsedQueryData | null,
@@ -88,7 +106,7 @@ export const useGetSearchQuery = (
   const effectiveQuery = query || queryData?.query || "*";
   const normalizedQuery = effectiveQuery.trim();
 
-  async function getFiles(): Promise<File[]> {
+  async function getFiles(): Promise<SearchResult> {
     try {
       // For wildcard queries, use a high limit to get all files
       // Otherwise use the limit from queryData or default to 100
@@ -211,7 +229,11 @@ export const useGetSearchQuery = (
         allowed_groups: file.allowed_groups || [],
       }));
 
-      return files;
+      const warnings: SearchWarning[] = Array.isArray(data.warnings)
+        ? data.warnings
+        : [];
+
+      return { files, warnings };
     } catch (error) {
       console.error("Error getting files", error);
       // Re-throw the error so React Query can handle it and trigger onError callbacks

--- a/frontend/app/api/queries/useGetSearchQuery.ts
+++ b/frontend/app/api/queries/useGetSearchQuery.ts
@@ -245,6 +245,7 @@ export const useGetSearchQuery = (
     {
       queryKey: ["search", queryData, query],
       placeholderData: (prev) => prev,
+      staleTime: 0,
       queryFn: getFiles,
       retry: false, // Don't retry on errors - show them immediately
       ...options,

--- a/frontend/app/knowledge/chunks/page.tsx
+++ b/frontend/app/knowledge/chunks/page.tsx
@@ -19,7 +19,9 @@ import {
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import {
   type ChunkResult,
+  EMPTY_SEARCH_RESULT,
   type File,
+  type SearchResult,
   useGetSearchQuery,
 } from "../../api/queries/useGetSearchQuery";
 
@@ -55,10 +57,11 @@ function ChunksPageContent() {
   // const [selectAll, setSelectAll] = useState(false);
 
   // Use the same search query as the knowledge page, but we'll filter for the specific file
-  const { data = [], isFetching } = useGetSearchQuery(
+  const { data = EMPTY_SEARCH_RESULT, isFetching } = useGetSearchQuery(
     queryOverride,
     parsedFilterData,
   );
+  const searchFiles = (data as SearchResult).files;
 
   const handleCopy = useCallback((text: string, index: number) => {
     // Trim whitespace and remove new lines/tabs for cleaner copy
@@ -67,13 +70,11 @@ function ChunksPageContent() {
     setTimeout(() => setActiveCopiedChunkIndex(null), 10 * 1000); // 10 seconds
   }, []);
 
-  const fileData = (data as File[]).find(
-    (file: File) => file.filename === filename,
-  );
+  const fileData = searchFiles.find((file: File) => file.filename === filename);
 
   // Extract chunks for the specific file
   useEffect(() => {
-    if (!filename || !(data as File[]).length) {
+    if (!filename || !searchFiles.length) {
       setChunks([]);
       return;
     }
@@ -81,7 +82,7 @@ function ChunksPageContent() {
     setChunks(
       fileData?.chunks?.map((chunk, i) => ({ ...chunk, index: i + 1 })) || [],
     );
-  }, [data, filename]);
+  }, [searchFiles, filename]);
 
   // Set selected state for all checkboxes when selectAll changes
   // useEffect(() => {

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -10,15 +10,21 @@ import {
   type ValueGetterParams,
 } from "ag-grid-community";
 import { AgGridReact, type CustomCellRendererProps } from "ag-grid-react";
-import { Cloud, FileIcon, Globe, RefreshCw } from "lucide-react";
+import { AlertTriangle, Cloud, FileIcon, Globe, RefreshCw } from "lucide-react";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { KnowledgeDropdown } from "@/components/knowledge-dropdown";
 import { ProtectedRoute } from "@/components/protected-route";
+import { Banner, BannerIcon, BannerTitle } from "@/components/ui/banner";
 import { Button } from "@/components/ui/button";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { useTask } from "@/contexts/task-context";
-import { type File, useGetSearchQuery } from "../api/queries/useGetSearchQuery";
+import {
+  EMPTY_SEARCH_RESULT,
+  type File,
+  type SearchResult,
+  useGetSearchQuery,
+} from "../api/queries/useGetSearchQuery";
 import "@/components/AgGrid/registerAgGridModules";
 import "@/components/AgGrid/agGridStyles.css";
 import { toast } from "sonner";
@@ -205,13 +211,15 @@ function SearchPage() {
   ]);
 
   const {
-    data: searchData = [],
+    data: searchData = EMPTY_SEARCH_RESULT,
     isLoading: isSearchLoading,
     error,
     isError,
   } = useGetSearchQuery(queryOverride, parsedFilterData, {
     refetchInterval: 5000,
   });
+  const { files: searchFiles, warnings: searchWarnings } =
+    searchData as SearchResult;
 
   const isOpenragDocsRow = useCallback((file?: File) => {
     return (
@@ -305,7 +313,7 @@ function SearchPage() {
     }
   }, [isError, error]);
   const fileResults = buildKnowledgeTableRows(
-    searchData as File[],
+    searchFiles,
     taskFiles,
     !!parsedFilterData,
   );
@@ -783,6 +791,43 @@ function SearchPage() {
             <div className="ml-auto">
               <KnowledgeDropdown />
             </div>
+          </div>
+        )}
+        {searchWarnings.length > 0 && (
+          <div className="mb-4 flex flex-col gap-2">
+            {searchWarnings.map((warning, idx) => {
+              const isEmbeddingWarning =
+                warning.code === "embedding_unavailable";
+              const semanticDown =
+                isEmbeddingWarning &&
+                warning.semantic_search_available === false;
+              const title = isEmbeddingWarning
+                ? semanticDown
+                  ? "Semantic search degraded — keyword results only"
+                  : "Semantic search partially degraded"
+                : warning.message || "Search warning";
+              const details =
+                warning.models && warning.models.length > 0
+                  ? ` Affected embedding model${warning.models.length > 1 ? "s" : ""}: ${warning.models.join(", ")}.`
+                  : "";
+              return (
+                <Banner
+                  key={`${warning.code}-${idx}`}
+                  inset
+                  className="bg-amber-500/10 text-amber-100 border border-amber-500/30"
+                >
+                  <BannerIcon icon={AlertTriangle} />
+                  <BannerTitle>
+                    <span className="font-medium">{title}.</span>
+                    <span className="ml-1 opacity-90">
+                      {isEmbeddingWarning
+                        ? `The provider for some indexed documents is no longer reachable, so results rely on keyword matching.${details} Re-configure the provider or re-ingest those documents with another embedding model to restore semantic search.`
+                        : warning.message}
+                    </span>
+                  </BannerTitle>
+                </Banner>
+              );
+            })}
           </div>
         )}
         {isCloudBrand ? (

--- a/frontend/app/settings/_components/model-provider-dialog-footer.tsx
+++ b/frontend/app/settings/_components/model-provider-dialog-footer.tsx
@@ -1,3 +1,4 @@
+import type { AffectedEmbeddingModel } from "@/app/api/mutations/useUpdateSettingsMutation";
 import { Button } from "@/components/ui/button";
 import { DialogFooter } from "@/components/ui/dialog";
 import {
@@ -21,6 +22,11 @@ type ModelProviderDialogFooterProps = {
   onCancel: () => void;
   isSavePending: boolean;
   isValidating: boolean;
+
+  // When the backend returned a 409 because the provider's embedding models
+  // are still referenced by indexed documents, pass the list here to render
+  // a force-confirmation state.
+  affectedModels?: AffectedEmbeddingModel[];
 };
 
 const ModelProviderDialogFooter = ({
@@ -35,24 +41,54 @@ const ModelProviderDialogFooter = ({
   onCancel,
   isSavePending,
   isValidating,
+  affectedModels,
 }: ModelProviderDialogFooterProps) => {
   if (showRemoveConfirm) {
+    const hasAffected = !!affectedModels && affectedModels.length > 0;
     return (
-      <DialogFooter className="mt-4 flex items-center gap-2 rounded-lg border border-red-500/10 bg-red-500/5 px-4 py-3 animate-in fade-in-0 slide-in-from-bottom-2 duration-150">
+      <DialogFooter className="mt-4 flex flex-col gap-3 rounded-lg border border-red-500/10 bg-red-500/5 px-4 py-3 animate-in fade-in-0 slide-in-from-bottom-2 duration-150 sm:flex-row sm:items-start">
         <div className="border-l-2 border-destructive pl-3 mr-auto text-sm text-red-100">
-          Remove configuration?
+          {hasAffected ? (
+            <div className="flex flex-col gap-1">
+              <span>
+                Semantic search will break for documents embedded with:
+              </span>
+              <ul className="list-disc pl-5 text-xs text-red-200/80">
+                {affectedModels!.map((m) => (
+                  <li key={m.model}>
+                    <span className="font-mono">{m.model}</span>{" "}
+                    <span className="opacity-70">
+                      ({m.doc_count.toLocaleString()} chunks)
+                    </span>
+                  </li>
+                ))}
+              </ul>
+              <span className="text-xs opacity-80">
+                Re-ingest these with another embedding model, or remove anyway
+                to keep keyword search only.
+              </span>
+            </div>
+          ) : (
+            "Remove configuration?"
+          )}
         </div>
-        <Button variant="ghost" type="button" onClick={onCancelRemove}>
-          Cancel
-        </Button>
-        <Button
-          type="button"
-          variant="destructive"
-          disabled={isRemovePending}
-          onClick={onConfirmRemove}
-        >
-          {isRemovePending ? "Removing..." : "Remove"}
-        </Button>
+        <div className="flex items-center gap-2 sm:self-center">
+          <Button variant="ghost" type="button" onClick={onCancelRemove}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            disabled={isRemovePending}
+            onClick={onConfirmRemove}
+          >
+            {isRemovePending
+              ? "Removing..."
+              : hasAffected
+                ? "Remove anyway"
+                : "Remove"}
+          </Button>
+        </div>
       </DialogFooter>
     );
   }

--- a/frontend/app/settings/_components/ollama-settings-dialog.tsx
+++ b/frontend/app/settings/_components/ollama-settings-dialog.tsx
@@ -4,7 +4,11 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { useUpdateSettingsMutation } from "@/app/api/mutations/useUpdateSettingsMutation";
+import {
+  type AffectedEmbeddingModel,
+  isEmbeddingProviderInUseError,
+  useUpdateSettingsMutation,
+} from "@/app/api/mutations/useUpdateSettingsMutation";
 import { useGetOllamaModelsQuery } from "@/app/api/queries/useGetModelsQuery";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import type { ProviderHealthResponse } from "@/app/api/queries/useProviderHealthQuery";
@@ -35,6 +39,9 @@ const OllamaSettingsDialog = ({
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<Error | null>(null);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+  const [affectedModels, setAffectedModels] = useState<
+    AffectedEmbeddingModel[] | undefined
+  >(undefined);
   const router = useRouter();
 
   const { data: settings = {} } = useGetSettingsQuery({
@@ -107,7 +114,13 @@ const OllamaSettingsDialog = ({
     onSuccess: () => {
       toast.success("Ollama configuration removed");
       setShowRemoveConfirm(false);
+      setAffectedModels(undefined);
       setOpen(false);
+    },
+    onError: (err) => {
+      if (isEmbeddingProviderInUseError(err)) {
+        setAffectedModels(err.affectedModels);
+      }
     },
   });
 
@@ -135,6 +148,7 @@ const OllamaSettingsDialog = ({
       open={open}
       onOpenChange={(o) => {
         setShowRemoveConfirm(false);
+        setAffectedModels(undefined);
         setOpen(o);
       }}
     >
@@ -168,25 +182,32 @@ const OllamaSettingsDialog = ({
                   </p>
                 </motion.div>
               )}
-              {removeMutation.isError && (
-                <motion.div
-                  key="remove-error"
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -10 }}
-                >
-                  <p className="rounded-lg border border-destructive p-4">
-                    {removeMutation.error?.message}
-                  </p>
-                </motion.div>
-              )}
+              {removeMutation.isError &&
+                !isEmbeddingProviderInUseError(removeMutation.error) && (
+                  <motion.div
+                    key="remove-error"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                  >
+                    <p className="rounded-lg border border-destructive p-4">
+                      {removeMutation.error?.message}
+                    </p>
+                  </motion.div>
+                )}
             </AnimatePresence>
 
             <ModelProviderDialogFooter
               showRemoveConfirm={showRemoveConfirm}
-              onCancelRemove={() => setShowRemoveConfirm(false)}
+              onCancelRemove={() => {
+                setShowRemoveConfirm(false);
+                setAffectedModels(undefined);
+              }}
               onConfirmRemove={() =>
-                removeMutation.mutate({ remove_ollama_config: true })
+                removeMutation.mutate({
+                  remove_ollama_config: true,
+                  force_remove: !!affectedModels,
+                })
               }
               isRemovePending={removeMutation.isPending}
               isConfigured={isOllamaConfigured}
@@ -196,6 +217,7 @@ const OllamaSettingsDialog = ({
               onCancel={() => setOpen(false)}
               isSavePending={settingsMutation.isPending}
               isValidating={isValidating}
+              affectedModels={affectedModels}
             />
           </form>
         </FormProvider>

--- a/frontend/app/settings/_components/openai-settings-dialog.tsx
+++ b/frontend/app/settings/_components/openai-settings-dialog.tsx
@@ -4,7 +4,11 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { useUpdateSettingsMutation } from "@/app/api/mutations/useUpdateSettingsMutation";
+import {
+  type AffectedEmbeddingModel,
+  isEmbeddingProviderInUseError,
+  useUpdateSettingsMutation,
+} from "@/app/api/mutations/useUpdateSettingsMutation";
 import { useGetOpenAIModelsQuery } from "@/app/api/queries/useGetModelsQuery";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import type { ProviderHealthResponse } from "@/app/api/queries/useProviderHealthQuery";
@@ -35,6 +39,9 @@ const OpenAISettingsDialog = ({
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<Error | null>(null);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+  const [affectedModels, setAffectedModels] = useState<
+    AffectedEmbeddingModel[] | undefined
+  >(undefined);
   const router = useRouter();
 
   const { data: settings = {} } = useGetSettingsQuery({
@@ -104,7 +111,13 @@ const OpenAISettingsDialog = ({
     onSuccess: () => {
       toast.success("OpenAI configuration removed");
       setShowRemoveConfirm(false);
+      setAffectedModels(undefined);
       setOpen(false);
+    },
+    onError: (err) => {
+      if (isEmbeddingProviderInUseError(err)) {
+        setAffectedModels(err.affectedModels);
+      }
     },
   });
 
@@ -142,6 +155,7 @@ const OpenAISettingsDialog = ({
       open={open}
       onOpenChange={(o) => {
         setShowRemoveConfirm(false);
+        setAffectedModels(undefined);
         setOpen(o);
       }}
     >
@@ -175,25 +189,32 @@ const OpenAISettingsDialog = ({
                   </p>
                 </motion.div>
               )}
-              {removeMutation.isError && (
-                <motion.div
-                  key="remove-error"
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -10 }}
-                >
-                  <p className="rounded-lg border border-destructive p-4">
-                    {removeMutation.error?.message}
-                  </p>
-                </motion.div>
-              )}
+              {removeMutation.isError &&
+                !isEmbeddingProviderInUseError(removeMutation.error) && (
+                  <motion.div
+                    key="remove-error"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                  >
+                    <p className="rounded-lg border border-destructive p-4">
+                      {removeMutation.error?.message}
+                    </p>
+                  </motion.div>
+                )}
             </AnimatePresence>
 
             <ModelProviderDialogFooter
               showRemoveConfirm={showRemoveConfirm}
-              onCancelRemove={() => setShowRemoveConfirm(false)}
+              onCancelRemove={() => {
+                setShowRemoveConfirm(false);
+                setAffectedModels(undefined);
+              }}
               onConfirmRemove={() =>
-                removeMutation.mutate({ remove_openai_config: true })
+                removeMutation.mutate({
+                  remove_openai_config: true,
+                  force_remove: !!affectedModels,
+                })
               }
               isRemovePending={removeMutation.isPending}
               isConfigured={isOpenAIConfigured}
@@ -203,6 +224,7 @@ const OpenAISettingsDialog = ({
               onCancel={() => setOpen(false)}
               isSavePending={settingsMutation.isPending}
               isValidating={isValidating}
+              affectedModels={affectedModels}
             />
           </form>
         </FormProvider>

--- a/frontend/app/settings/_components/watsonx-settings-dialog.tsx
+++ b/frontend/app/settings/_components/watsonx-settings-dialog.tsx
@@ -4,7 +4,11 @@ import { useRouter } from "next/navigation";
 import { useEffect, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
-import { useUpdateSettingsMutation } from "@/app/api/mutations/useUpdateSettingsMutation";
+import {
+  type AffectedEmbeddingModel,
+  isEmbeddingProviderInUseError,
+  useUpdateSettingsMutation,
+} from "@/app/api/mutations/useUpdateSettingsMutation";
 import { useGetIBMModelsQuery } from "@/app/api/queries/useGetModelsQuery";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import type { ProviderHealthResponse } from "@/app/api/queries/useProviderHealthQuery";
@@ -35,6 +39,9 @@ const WatsonxSettingsDialog = ({
   const [isValidating, setIsValidating] = useState(false);
   const [validationError, setValidationError] = useState<Error | null>(null);
   const [showRemoveConfirm, setShowRemoveConfirm] = useState(false);
+  const [affectedModels, setAffectedModels] = useState<
+    AffectedEmbeddingModel[] | undefined
+  >(undefined);
   const router = useRouter();
 
   const { data: settings = {} } = useGetSettingsQuery({
@@ -110,7 +117,13 @@ const WatsonxSettingsDialog = ({
     onSuccess: () => {
       toast.success("IBM watsonx.ai configuration removed");
       setShowRemoveConfirm(false);
+      setAffectedModels(undefined);
       setOpen(false);
+    },
+    onError: (err) => {
+      if (isEmbeddingProviderInUseError(err)) {
+        setAffectedModels(err.affectedModels);
+      }
     },
   });
 
@@ -151,6 +164,7 @@ const WatsonxSettingsDialog = ({
       open={open}
       onOpenChange={(o) => {
         setShowRemoveConfirm(false);
+        setAffectedModels(undefined);
         setOpen(o);
       }}
     >
@@ -184,25 +198,32 @@ const WatsonxSettingsDialog = ({
                   </p>
                 </motion.div>
               )}
-              {removeMutation.isError && (
-                <motion.div
-                  key="remove-error"
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -10 }}
-                >
-                  <p className="rounded-lg border border-destructive p-4">
-                    {removeMutation.error?.message}
-                  </p>
-                </motion.div>
-              )}
+              {removeMutation.isError &&
+                !isEmbeddingProviderInUseError(removeMutation.error) && (
+                  <motion.div
+                    key="remove-error"
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    exit={{ opacity: 0, y: -10 }}
+                  >
+                    <p className="rounded-lg border border-destructive p-4">
+                      {removeMutation.error?.message}
+                    </p>
+                  </motion.div>
+                )}
             </AnimatePresence>
 
             <ModelProviderDialogFooter
               showRemoveConfirm={showRemoveConfirm}
-              onCancelRemove={() => setShowRemoveConfirm(false)}
+              onCancelRemove={() => {
+                setShowRemoveConfirm(false);
+                setAffectedModels(undefined);
+              }}
               onConfirmRemove={() =>
-                removeMutation.mutate({ remove_watsonx_config: true })
+                removeMutation.mutate({
+                  remove_watsonx_config: true,
+                  force_remove: !!affectedModels,
+                })
               }
               isRemovePending={removeMutation.isPending}
               isConfigured={isWatsonxConfigured}
@@ -212,6 +233,7 @@ const WatsonxSettingsDialog = ({
               onCancel={() => setOpen(false)}
               isSavePending={settingsMutation.isPending}
               isValidating={isValidating}
+              affectedModels={affectedModels}
             />
           </form>
         </FormProvider>

--- a/frontend/components/knowledge-filter-panel.tsx
+++ b/frontend/components/knowledge-filter-panel.tsx
@@ -7,7 +7,7 @@ import { useDeleteFilter } from "@/app/api/mutations/useDeleteFilter";
 import { useUpdateFilter } from "@/app/api/mutations/useUpdateFilter";
 import { useGetSearchAggregations } from "@/app/api/queries/useGetSearchAggregations";
 import {
-  type File as SearchFile,
+  EMPTY_SEARCH_RESULT,
   useGetSearchQuery,
 } from "@/app/api/queries/useGetSearchQuery";
 import {
@@ -159,9 +159,10 @@ export function KnowledgeFilterPanel() {
     gcTime: 5 * 60_000,
   });
 
-  const { data: allSearchData = [] } = useGetSearchQuery("*", null, {
+  const { data = EMPTY_SEARCH_RESULT } = useGetSearchQuery("*", null, {
     enabled: isPanelOpen,
   });
+  const allSearchData = data.files;
 
   useEffect(() => {
     if (!aggregations) return;
@@ -174,10 +175,7 @@ export function KnowledgeFilterPanel() {
     setAvailableFacets(facets);
   }, [aggregations]);
 
-  const tableRows = buildKnowledgeTableRows(
-    allSearchData as SearchFile[],
-    taskFiles,
-  );
+  const tableRows = buildKnowledgeTableRows(allSearchData, taskFiles);
   const sourceOptions = buildActiveSourceOptions(tableRows);
 
   // Don't render if panel is closed or we don't have any data

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -64,6 +64,10 @@ class SettingsUpdateBody(BaseModel):
     remove_openai_config: Optional[bool] = None
     remove_anthropic_config: Optional[bool] = None
     remove_watsonx_config: Optional[bool] = None
+    # Explicit confirmation that the caller accepts removing a provider whose
+    # embedding models are still in use by indexed documents. Without this,
+    # the backend returns 409 and the frontend prompts the user.
+    force_remove: Optional[bool] = False
 
 
 class OnboardingBody(BaseModel):
@@ -404,10 +408,107 @@ def _first_configured_embedding_provider(config, excluding: str) -> str:
     return "openai"
 
 
+async def _affected_embedding_models(
+    provider: str,
+    session_manager,
+    user,
+    models_service,
+) -> List[Dict[str, Any]]:
+    """Find embedding models present in the corpus that belong to ``provider``.
+
+    Used to warn users before they remove a provider whose embedding models
+    were used to index documents — otherwise semantic search silently breaks
+    for those docs. Returns a list of ``{"model": str, "doc_count": int}``.
+
+    Conservative on errors (returns empty list) so infra issues don't block
+    provider removal.
+    """
+    from services.models_service import ModelsService
+    from config.settings import get_index_name
+
+    provider_lower = provider.lower()
+    if provider_lower == "anthropic":
+        # Anthropic doesn't serve embedding models — nothing to warn about.
+        return []
+
+    try:
+        # Refresh so the registry reflects currently-configured providers
+        # before we use it to attribute models.
+        await models_service.update_model_registry()
+        registry = ModelsService._model_provider_registry
+
+        # Use the admin client so DLS does not scope the aggregation to the
+        # requesting user's documents. Provider removal is a global operation
+        # that affects all tenants, so we must see every document's embedding
+        # model regardless of ownership.
+        agg_result = await clients.opensearch.search(
+            index=get_index_name(),
+            body={
+                "size": 0,
+                "aggs": {
+                    "embedding_models": {
+                        "terms": {"field": "embedding_model", "size": 50}
+                    }
+                },
+            },
+            params={"terminate_after": 0},
+        )
+        buckets = (
+            agg_result.get("aggregations", {})
+            .get("embedding_models", {})
+            .get("buckets", [])
+        )
+
+        affected: List[Dict[str, Any]] = []
+        for bucket in buckets:
+            model = bucket.get("key")
+            if not model:
+                continue
+            mapped = registry.get(model)
+            # Narrow fallback: the watsonx registry bootstrap requires the
+            # provider still be configured, so models from an about-to-be-
+            # removed watsonx can still be attributed via the "ibm/" prefix.
+            if mapped is None and provider_lower == "watsonx" and model.startswith("ibm/"):
+                mapped = "watsonx"
+            if mapped == provider_lower:
+                affected.append({"model": model, "doc_count": bucket.get("doc_count", 0)})
+        return affected
+    except Exception as e:
+        logger.warning(
+            "Could not determine affected embedding models for provider removal",
+            provider=provider,
+            error=str(e),
+        )
+        return []
+
+
+def _embedding_conflict_response(
+    provider_label: str, provider_key: str, affected: List[Dict[str, Any]]
+) -> JSONResponse:
+    """Shared 409 response when removing a provider whose embedding models are
+    still referenced by indexed documents."""
+    model_names = [a["model"] for a in affected]
+    return JSONResponse(
+        {
+            "error": (
+                f"Removing {provider_label} will disable semantic search on "
+                f"documents indexed with: {', '.join(model_names)}. "
+                f"Re-ingest affected documents with another embedding model, "
+                f"or retry with force_remove=true to proceed anyway."
+            ),
+            "code": "embedding_provider_in_use",
+            "affected_provider": provider_key,
+            "affected_models": affected,
+        },
+        status_code=409,
+    )
+
+
 async def update_settings(
     body: SettingsUpdateBody,
     session_manager=Depends(get_session_manager),
     user: User = Depends(get_current_user),
+    models_service=Depends(get_models_service),
 ) -> SettingsUpdateResponse:
     """Update settings in configuration"""
     try:
@@ -741,6 +842,12 @@ async def update_settings(
                     {"error": "Cannot remove Ollama configuration: configure another model provider first."},
                     status_code=400,
                 )
+            if not body.force_remove:
+                affected = await _affected_embedding_models(
+                    "ollama", session_manager, user, models_service
+                )
+                if affected:
+                    return _embedding_conflict_response("Ollama", "ollama", affected)
             current_config.providers.ollama.endpoint = ""
             current_config.providers.ollama.configured = False
             if current_config.agent.llm_provider == "ollama":
@@ -763,6 +870,12 @@ async def update_settings(
                     {"error": "Cannot remove OpenAI configuration: configure another model provider first."},
                     status_code=400,
                 )
+            if not body.force_remove:
+                affected = await _affected_embedding_models(
+                    "openai", session_manager, user, models_service
+                )
+                if affected:
+                    return _embedding_conflict_response("OpenAI", "openai", affected)
             current_config.providers.openai.api_key = ""
             current_config.providers.openai.configured = False
             if current_config.agent.llm_provider == "openai":
@@ -808,6 +921,14 @@ async def update_settings(
                     {"error": "Cannot remove IBM watsonx.ai configuration: configure another model provider first."},
                     status_code=400,
                 )
+            if not body.force_remove:
+                affected = await _affected_embedding_models(
+                    "watsonx", session_manager, user, models_service
+                )
+                if affected:
+                    return _embedding_conflict_response(
+                        "IBM watsonx.ai", "watsonx", affected
+                    )
             current_config.providers.watsonx.api_key = ""
             current_config.providers.watsonx.endpoint = ""
             current_config.providers.watsonx.project_id = ""
@@ -842,6 +963,12 @@ async def update_settings(
 
         # Refresh patched client immediately so subsequent requests pick up latest config.
         await clients.refresh_patched_client()
+
+        # Refresh model registry so get_litellm_model_name(strict=True) sees the
+        # updated provider list — force_remove skips _affected_embedding_models which
+        # is the usual registry refresh trigger.
+        if provider_updated:
+            await models_service.update_model_registry()
 
         # Run expensive Langflow sync in the background to keep settings updates responsive.
         if should_validate or provider_updated:

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -964,17 +964,12 @@ async def update_settings(
         # Refresh patched client immediately so subsequent requests pick up latest config.
         await clients.refresh_patched_client()
 
-        # Refresh model registry so get_litellm_model_name(strict=True) sees the
-        # updated provider list — force_remove skips _affected_embedding_models which
-        # is the usual registry refresh trigger.
-        if provider_updated:
-            await models_service.update_model_registry()
-
         # Run expensive Langflow sync in the background to keep settings updates responsive.
         if should_validate or provider_updated:
             task = asyncio.create_task(
                 _run_async_post_save_langflow_updates(
                     session_manager=session_manager,
+                    models_service=models_service if provider_updated else None,
                     update_mcp_servers=(
                         body.embedding_provider is not None
                         or body.embedding_model is not None
@@ -1550,11 +1545,18 @@ async def _run_async_post_save_langflow_updates(
     session_manager,
     update_mcp_servers: bool,
     update_model_values: bool,
+    models_service=None,
 ) -> None:
     """Apply post-save Langflow synchronization asynchronously."""
     try:
         current_config = get_openrag_config()
         flows_service = _get_flows_service()
+
+        # Refresh model registry so get_litellm_model_name(strict=True) sees the
+        # updated provider list — force_remove skips _affected_embedding_models which
+        # is the usual registry refresh trigger.
+        if models_service is not None:
+            await models_service.update_model_registry()
 
         # Update global variables
         await _update_langflow_global_variables(

--- a/src/api/v1/settings.py
+++ b/src/api/v1/settings.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from fastapi.responses import JSONResponse
 from utils.logging_config import get_logger
 from config.settings import get_openrag_config
-from dependencies import get_api_key_user_async, get_session_manager
+from dependencies import get_api_key_user_async, get_models_service, get_session_manager
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -66,8 +66,9 @@ async def update_settings_endpoint(
     body: SettingsUpdateBody,
     session_manager=Depends(get_session_manager),
     user: User = Depends(get_api_key_user_async),
+    models_service=Depends(get_models_service),
 ):
     """Update OpenRAG configuration settings. POST /v1/settings"""
     from api.settings import update_settings
 
-    return await update_settings(body=body, session_manager=session_manager, user=user)
+    return await update_settings(body=body, session_manager=session_manager, user=user, models_service=models_service)

--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -16,6 +16,18 @@ logger = get_logger(__name__)
 
 KNOWN_PREFIXES = ["openai", "ollama", "watsonx", "anthropic"]
 
+
+class UnknownEmbeddingProvider(Exception):
+    """Raised when a model's provider can't be resolved and the caller asked
+    for strict routing. Lets callers fail fast instead of dispatching an
+    unroutable request into LiteLLM's retry loop."""
+
+    def __init__(self, model_name: str):
+        super().__init__(
+            f"No configured provider can serve embedding model '{model_name}'"
+        )
+        self.model_name = model_name
+
 class ModelsService:
     """Service for fetching available models from different AI providers and managing a model registry."""
 
@@ -102,23 +114,31 @@ class ModelsService:
             except Exception as e:
                 logger.error(f"Error updating model registry: {str(e)}")
 
-    async def get_litellm_model_name(self, model_name: str, provider: Optional[str] = None) -> str:
-        """Synchronous version of model formatting for when provider is already known.
-        
-        This is useful for synchronous contexts (like properties) where the provider
-        information is already available and doesn't need to be looked up in the registry.
+    async def get_litellm_model_name(
+        self,
+        model_name: str,
+        provider: Optional[str] = None,
+        strict: bool = False,
+    ) -> str:
+        """Resolve ``model_name`` to a LiteLLM-routable string.
+
+        When ``strict`` is True and the provider can't be resolved, raise
+        ``UnknownEmbeddingProvider`` so the caller can short-circuit instead of
+        letting LiteLLM burn a retry loop on an unroutable name. Non-strict
+        callers (e.g. ingestion) keep the original best-effort behavior of
+        returning the raw name.
         """
 
         if not model_name:
             return ""
-            
+
         # Skip formatting if already has a known provider prefix
         if any(model_name.startswith(p + "/") for p in KNOWN_PREFIXES):
             return model_name
-            
+
         # Check if provider is explicitly given and not "openai"
         provider_lower = provider.lower() if provider else None
-        
+
         if provider_lower is None:
             # Try looking in registry
             provider_lower = ModelsService._model_provider_registry.get(model_name)
@@ -127,12 +147,17 @@ class ModelsService:
                 provider_lower = ModelsService._model_provider_registry.get(model_name)
 
         if provider_lower is None:
+            if strict:
+                # Caller wants fail-fast: the model isn't claimed by any
+                # currently-configured provider. Typical trigger: corpus was
+                # embedded with a model whose provider has since been removed.
+                raise UnknownEmbeddingProvider(model_name)
             logger.warning(
                 "Could not determine provider for model; using model name as-is",
                 model_name=model_name,
             )
             return model_name  # OpenAI-compatible models work without a prefix
-            
+
         return f"{provider_lower}/{model_name}" if provider_lower != "openai" else model_name
 
     async def get_openai_models(self, api_key: str, update_index: bool = True) -> Dict[str, List[Dict[str, str]]]:

--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -395,6 +395,18 @@ class ModelsService:
                                     in model_name.lower(),
                                 }
                             )
+                        if not capabilities and not has_embedding:
+                            # Older Ollama versions don't return a capabilities field.
+                            # Register the model as a potential embedding model so
+                            # search can route it through Ollama. If it can't actually
+                            # embed, the LiteLLM call will fail and be caught gracefully.
+                            embedding_models.append(
+                                {
+                                    "value": model_name,
+                                    "label": model_name,
+                                    "default": "nomic-embed-text" in model_name.lower(),
+                                }
+                            )
                     except Exception as e:
                         logger.warning(
                             f"Failed to check capabilities for model {model_name}: {str(e)}"

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -116,6 +116,7 @@ class SearchService:
         # Get available embedding models from corpus
         query_embeddings = {}
         available_models = []
+        failed_models: list = []
 
         opensearch_client = self.session_manager.get_user_opensearch_client(
             user_id, jwt_token
@@ -198,9 +199,15 @@ class SearchService:
                 attempts = 0
                 last_exception = None
 
-                # Use centralized utility for LiteLLM model formatting
+                # Use centralized utility for LiteLLM model formatting.
+                # strict=True: if no configured provider claims this model
+                # (e.g. the provider was removed after ingest), raise
+                # immediately rather than entering a ~3s retry loop on an
+                # unroutable model name.
                 if self.models_service:
-                    formatted_model = await self.models_service.get_litellm_model_name(model_name)
+                    formatted_model = await self.models_service.get_litellm_model_name(
+                        model_name, strict=True
+                    )
                 else:
                     # Fallback if service not injected (tests/etc)
                     formatted_model = model_name
@@ -244,25 +251,33 @@ class SearchService:
                     f"Failed to embed with model {model_name}"
                 ) from last_exception
 
-            # Run all embeddings in parallel
-            try:
-                embedding_results = await asyncio.gather(
-                    *[embed_with_model(model) for model in available_models]
-                )
-            except Exception as e:
-                logger.error("Embedding generation failed", error=str(e))
-                raise
+            # Run all embeddings in parallel, tolerating per-model failures so
+            # one broken model (e.g. provider credentials removed after ingest)
+            # doesn't take down the entire search. If all models fail we fall
+            # back to keyword-only search below.
+            embedding_results = await asyncio.gather(
+                *[embed_with_model(model) for model in available_models],
+                return_exceptions=True,
+            )
 
-            # Collect successful embeddings
-            for result in embedding_results:
+            for model_name, result in zip(available_models, embedding_results):
+                if isinstance(result, BaseException):
+                    failed_models.append(model_name)
+                    logger.warning(
+                        "Skipping model with failed embedding; continuing with others",
+                        model=model_name,
+                        error=str(result),
+                    )
+                    continue
                 if isinstance(result, tuple) and result[1] is not None:
-                    model_name, embedding = result
-                    query_embeddings[model_name] = embedding
+                    successful_model, embedding = result
+                    query_embeddings[successful_model] = embedding
 
             logger.info(
                 "Generated query embeddings",
                 models=list(query_embeddings.keys()),
-                query_preview=query[:50]
+                failed_models=failed_models,
+                query_preview=query[:50],
             )
         else:
             # Wildcard query - no embedding needed
@@ -301,7 +316,8 @@ class SearchService:
             else:
                 query_block = {"match_all": {}}
         else:
-            # Build multi-model KNN queries
+            # Build multi-model KNN queries (only for models that successfully
+            # produced query embeddings)
             knn_queries = []
             embedding_fields_to_check = []
 
@@ -318,61 +334,74 @@ class SearchService:
                     }
                 })
 
-            # Build exists filter - doc must have at least one embedding field
-            exists_any_embedding = {
-                "bool": {
-                    "should": [{"exists": {"field": f}} for f in embedding_fields_to_check],
-                    "minimum_should_match": 1
-                }
-            }
-
-            # Add exists filter to existing filters
-            all_filters = [*filter_clauses, exists_any_embedding]
+            # Only require an embedding field when we actually have embeddings
+            # to match against — otherwise we'd filter out every doc in keyword
+            # fallback mode.
+            all_filters = list(filter_clauses)
+            if knn_queries:
+                exists_should = [{"exists": {"field": f}} for f in embedding_fields_to_check]
+                # Docs indexed under a failed provider have none of the successful
+                # embedding fields, but keyword matching should still surface them.
+                # Allow them through by matching on their embedding_model value.
+                if failed_models:
+                    exists_should.append({"terms": {"embedding_model": failed_models}})
+                all_filters.append({
+                    "bool": {
+                        "should": exists_should,
+                        "minimum_should_match": 1,
+                    }
+                })
 
             logger.debug(
                 "Building hybrid query with filters",
                 user_filters_count=len(filter_clauses),
                 total_filters_count=len(all_filters),
-                filter_types=[type(f).__name__ for f in all_filters]
+                filter_types=[type(f).__name__ for f in all_filters],
+                knn_queries_count=len(knn_queries),
             )
 
-            # Hybrid search query structure (semantic + keyword)
-            # Use dis_max to pick best score across multiple embedding fields
+            # Hybrid search (semantic + keyword) when embeddings are available;
+            # keyword-only fallback when none succeeded. When falling back, bump
+            # the multi_match boost so keyword scoring isn't artificially damped.
+            should_clauses = []
+            if knn_queries:
+                should_clauses.append({
+                    "dis_max": {
+                        "tie_breaker": 0.0,  # Take only the best match, no blending
+                        "boost": 0.7,         # 70% weight for semantic search
+                        "queries": knn_queries,
+                    }
+                })
+            should_clauses.extend([
+                {
+                    "multi_match": {
+                        "query": query,
+                        "fields": ["text^2", "filename^1.5"],
+                        "type": "best_fields",
+                        "operator": "or",
+                        "fuzziness": "AUTO:4,7",
+                        "boost": 0.3 if knn_queries else 1.0,
+                    }
+                },
+                {
+                    # Prefix fallback for partial input (e.g. "vita" -> "vitamin").
+                    # Avoid bool_prefix here because our current mappings are:
+                    # - text: standard "text" (not search_as_you_type / edge-ngram)
+                    # - filename: "keyword"
+                    # match_phrase_prefix with a bounded expansion is safer.
+                    "match_phrase_prefix": {
+                        "text": {
+                            "query": query,
+                            "max_expansions": 50,
+                            "boost": 0.25,
+                        }
+                    }
+                },
+            ])
+
             query_block = {
                 "bool": {
-                    "should": [
-                        {
-                            "dis_max": {
-                                "tie_breaker": 0.0,  # Take only the best match, no blending
-                                "boost": 0.7,         # 70% weight for semantic search
-                                "queries": knn_queries
-                            }
-                        },
-                        {
-                            "multi_match": {
-                                "query": query,
-                                "fields": ["text^2", "filename^1.5"],
-                                "type": "best_fields",
-                                "operator": "or",
-                                "fuzziness": "AUTO:4,7",
-                                "boost": 0.3,  # 30% weight for keyword search
-                            }
-                        },
-                        {
-                            # Prefix fallback for partial input (e.g. "vita" -> "vitamin").
-                            # Avoid bool_prefix here because our current mappings are:
-                            # - text: standard "text" (not search_as_you_type / edge-ngram)
-                            # - filename: "keyword"
-                            # match_phrase_prefix with a bounded expansion is safer.
-                            "match_phrase_prefix": {
-                                "text": {
-                                    "query": query,
-                                    "max_expansions": 50,
-                                    "boost": 0.25,
-                                }
-                            }
-                        },
-                    ],
+                    "should": should_clauses,
                     "minimum_should_match": 1,
                     "filter": all_filters,
                 }
@@ -410,9 +439,10 @@ class SearchService:
         if not is_wildcard_match_all and score_threshold > 0:
             search_body["min_score"] = score_threshold
 
-        # Prepare fallback search body without num_candidates for clusters that don't support it
+        # Prepare fallback search body without num_candidates for clusters that don't support it.
+        # Only relevant when we actually dispatched KNN queries.
         fallback_search_body = None
-        if not is_wildcard_match_all:
+        if not is_wildcard_match_all and query_embeddings:
             try:
                 fallback_search_body = copy.deepcopy(search_body)
                 knn_query_blocks = (
@@ -583,12 +613,30 @@ class SearchService:
                     "embedding_models": _build_terms_agg("embedding_model"),
                 }
 
-        # Return both transformed results and aggregations
-        return {
+        # Return both transformed results and aggregations. Surface degraded
+        # semantic-search signals so the UI can show a non-fatal warning
+        # instead of treating partial-embedding failure as a hard error.
+        response: Dict[str, Any] = {
             "results": chunks,
             "aggregations": aggregations,
             "total": len(chunks),
         }
+        if failed_models:
+            response["warnings"] = [
+                {
+                    "code": "embedding_unavailable",
+                    "models": failed_models,
+                    "semantic_search_available": bool(query_embeddings),
+                    "message": (
+                        "Some documents were embedded with models that are "
+                        "no longer reachable (provider removed or misconfigured). "
+                        "Results shown use keyword matching only for those models."
+                        if not query_embeddings
+                        else "Semantic search is degraded for some embedding models."
+                    ),
+                }
+            ]
+        return response
 
     async def search(
         self,


### PR DESCRIPTION
### Issue

- #69807

### Summary

- Fixed knowledge search failing with an embedding model error when a previously configured provider was removed after documents were ingested.
- Search now degrades gracefully to keyword-only results instead of hard-failing, and the UI surfaces a non-fatal warning banner explaining the degraded state.

### Backend: Graceful Embedding Failure & Provider-Removal Guard

- Added `strict` mode to `get_litellm_model_name` in `models_service.py` that raises `UnknownEmbeddingProvider` immediately when no configured provider claims a model, preventing LiteLLM from entering a costly retry loop on an unroutable model.
- Refactored `search_service.py` to gather embedding results with `return_exceptions=True`, tracking per-model failures in `failed_models` and continuing with the subset of models that succeeded.
- Introduced keyword-only fallback when all embeddings fail: removed the embedding-field `exists` filter from the query so documents without a matching embedding field are still returned, and bumped `multi_match` boost to compensate for the absent semantic signal.
- Added `warnings` to the search response payload (`code: "embedding_unavailable"`) to signal degraded semantic search to the client.
- Added `force_remove` flag to `SettingsUpdateBody` in `settings.py` and a pre-removal check (`_affected_embedding_models`) that returns a structured `409` response listing affected models and chunk counts before allowing a provider to be removed.

### Frontend: 409 Force-Remove Flow & Warning Banner

- Introduced `UpdateSettingsError` typed error class and `isEmbeddingProviderInUseError` type guard in `useUpdateSettingsMutation.ts` to preserve the structured 409 payload from the backend.
- Added `force_remove` to `UpdateSettingsRequest` and wired it through the Ollama, OpenAI, and watsonx settings dialogs; on a 409, `affectedModels` state is populated and the dialog footer switches to a force-confirmation view listing impacted models and chunk counts.
- Updated `useGetSearchQuery.ts` return type from `File[]` to `SearchResult` (`{ files, warnings }`) and propagated the change through `knowledge/page.tsx` and `knowledge/chunks/page.tsx`.
- Rendered `embedding_unavailable` warnings in the knowledge page as amber banner alerts that explain the degraded state and guide users to re-ingest or re-configure the missing provider.

---

### API Changes

- Removed eager `update_model_registry()` call from `update_settings` and passed `models_service` into `_run_async_post_save_langflow_updates` so the registry refresh happens in the background after save completes.
- Added `models_service` parameter to `_run_async_post_save_langflow_updates`; registry refresh only runs when a provider update was detected.

### Model Registry Changes

- Registered Ollama models with no `capabilities` field as potential embedding models, defaulting `nomic-embed-text` variants as the default embedding model.
- Preserved graceful error handling so models that cannot actually embed fail at the LiteLLM call level rather than silently dropping from the registry.


