### PR TITLE
fix: Validate and prefer user-selected embedding model

### DIFF
--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -382,9 +382,7 @@ const OnboardingCard = ({
 
     if (
       !currentProvider ||
-      (isEmbedding &&
-        !settings.embedding_model &&
-        !showProviderConfiguredMessage) ||
+      (isEmbedding && !settings.embedding_model?.trim()) ||
       (!isEmbedding && !settings.llm_model)
     ) {
       toast.error("Please complete all required fields");
@@ -400,17 +398,12 @@ const OnboardingCard = ({
     // Set the provider field
     if (isEmbedding) {
       onboardingData.embedding_provider = currentProvider;
-      // If provider is already configured, use the existing embedding model from settings
-      // Otherwise, use the embedding model from the form
-      if (
-        showProviderConfiguredMessage &&
-        currentSettings?.knowledge?.embedding_model
-      ) {
-        onboardingData.embedding_model =
-          currentSettings.knowledge.embedding_model;
-      } else {
-        onboardingData.embedding_model = settings.embedding_model;
-      }
+      // Prefer the user's current selection; fall back to the saved config
+      // value only when the user hasn't picked one in this session. This
+      // prevents a stale saved model from overriding a fresh provider switch.
+      const userSelected = settings.embedding_model?.trim();
+      const savedModel = currentSettings?.knowledge?.embedding_model?.trim();
+      onboardingData.embedding_model = userSelected || savedModel || "";
     } else {
       onboardingData.llm_provider = currentProvider;
       onboardingData.llm_model = settings.llm_model;
@@ -442,8 +435,7 @@ const OnboardingCard = ({
   };
 
   const isComplete =
-    (isEmbedding &&
-      (!!settings.embedding_model || showProviderConfiguredMessage)) ||
+    (isEmbedding && !!settings.embedding_model?.trim()) ||
     (!isEmbedding && !!settings.llm_model && isDoclingHealthy);
 
   return (

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -25,6 +25,7 @@ from config.settings import (
 from typing import List, Optional, Any, Dict
 
 from api.provider_validation import validate_provider_setup
+from config.embedding_constants import OPENAI_EMBEDDING_MODEL_PREFIX
 from utils.langflow_utils import LangflowNotReadyError, wait_for_langflow
 from dependencies import (
     get_session_manager,
@@ -945,6 +946,36 @@ async def onboarding(
         embedding_model_selected = None
         embedding_provider_selected = None
 
+        # Pre-validate the embedding provider/model pair before any cascading
+        # writes. Empty model + saved-empty config previously leaked an empty
+        # string to OpenAI and surfaced as a confusing "invalid model ID" error.
+        if body.embedding_provider or body.embedding_model:
+            final_provider = (
+                body.embedding_provider
+                or current_config.knowledge.embedding_provider
+                or ""
+            ).strip().lower()
+            final_model = (
+                body.embedding_model
+                or current_config.knowledge.embedding_model
+                or ""
+            ).strip()
+            if not final_model:
+                return JSONResponse(
+                    {"error": "Embedding model is required. Please select a model from the dropdown."},
+                    status_code=400,
+                )
+            if final_provider == "openai" and not final_model.startswith(OPENAI_EMBEDDING_MODEL_PREFIX):
+                return JSONResponse(
+                    {
+                        "error": (
+                            f"Model '{final_model}' is not a valid OpenAI embedding model. "
+                            f"Expected a model starting with '{OPENAI_EMBEDDING_MODEL_PREFIX}'."
+                        )
+                    },
+                    status_code=400,
+                )
+
         if body.embedding_model:
             embedding_model_selected = body.embedding_model.strip()
             current_config.knowledge.embedding_model = embedding_model_selected
@@ -958,6 +989,15 @@ async def onboarding(
 
         if body.embedding_provider:
             embedding_provider_selected = body.embedding_provider.strip()
+            # Switching provider without a fresh model would silently carry the
+            # old provider's model forward — clear it so the request fails fast
+            # via the pre-validation above on the next attempt.
+            if (
+                embedding_provider_selected.lower()
+                != current_config.knowledge.embedding_provider.lower()
+                and not body.embedding_model
+            ):
+                current_config.knowledge.embedding_model = ""
             current_config.knowledge.embedding_provider = embedding_provider_selected
             config_updated = True
             await TelemetryClient.send_event(


### PR DESCRIPTION
Frontend: Simplify and harden embedding checks in onboarding-card.tsx — use trimmed values, prefer the user's current embedding_model selection over a saved config to avoid a stale saved model overriding a fresh provider switch, and update the isComplete check accordingly. Backend: Add OPENAI_EMBEDDING_MODEL_PREFIX import and pre-validate embedding provider/model pairs in src/api/settings.py — require a non-empty model when a provider/model is supplied, enforce OpenAI embedding model name prefix, and clear the saved embedding_model when switching providers without a new model to fail fast. These changes prevent empty-string leaks and confusing "invalid model ID" errors and make onboarding validation more robust.