### PR TITLE
fix: changed frontend checks to pass correct embedding model to backend

### DIFF
--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -382,9 +382,7 @@ const OnboardingCard = ({
 
     if (
       !currentProvider ||
-      (isEmbedding &&
-        !settings.embedding_model &&
-        !showProviderConfiguredMessage) ||
+      (isEmbedding && !settings.embedding_model) ||
       (!isEmbedding && !settings.llm_model)
     ) {
       toast.error("Please complete all required fields");
@@ -400,16 +398,15 @@ const OnboardingCard = ({
     // Set the provider field
     if (isEmbedding) {
       onboardingData.embedding_provider = currentProvider;
-      // If provider is already configured, use the existing embedding model from settings
-      // Otherwise, use the embedding model from the form
-      if (
+      if (settings.embedding_model) {
+        onboardingData.embedding_model = settings.embedding_model;
+      } else if (
         showProviderConfiguredMessage &&
-        currentSettings?.knowledge?.embedding_model
+        currentSettings?.knowledge?.embedding_model &&
+        currentProvider === currentSettings?.knowledge?.embedding_provider
       ) {
         onboardingData.embedding_model =
           currentSettings.knowledge.embedding_model;
-      } else {
-        onboardingData.embedding_model = settings.embedding_model;
       }
     } else {
       onboardingData.llm_provider = currentProvider;
@@ -442,8 +439,7 @@ const OnboardingCard = ({
   };
 
   const isComplete =
-    (isEmbedding &&
-      (!!settings.embedding_model || showProviderConfiguredMessage)) ||
+    (isEmbedding && !!settings.embedding_model) ||
     (!isEmbedding && !!settings.llm_model && isDoclingHealthy);
 
   return (

--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -396,22 +396,13 @@ const OnboardingCard = ({
     const onboardingData: OnboardingVariables = {};
 
     // Set the provider field
-    if (isEmbedding) {
-      onboardingData.embedding_provider = currentProvider;
-      if (settings.embedding_model) {
-        onboardingData.embedding_model = settings.embedding_model;
-      } else if (
-        showProviderConfiguredMessage &&
-        currentSettings?.knowledge?.embedding_model &&
-        currentProvider === currentSettings?.knowledge?.embedding_provider
-      ) {
-        onboardingData.embedding_model =
-          currentSettings.knowledge.embedding_model;
-      }
-    } else {
-      onboardingData.llm_provider = currentProvider;
-      onboardingData.llm_model = settings.llm_model;
-    }
+    if (isEmbedding) {  
+      onboardingData.embedding_provider = currentProvider;  
+      onboardingData.embedding_model = settings.embedding_model;  
+    } else {  
+      onboardingData.llm_provider = currentProvider;  
+      onboardingData.llm_model = settings.llm_model;  
+    }  
 
     // Add provider-specific credentials based on the selected provider
     if (currentProvider === "openai" && settings.openai_api_key) {

--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -396,13 +396,13 @@ const OnboardingCard = ({
     const onboardingData: OnboardingVariables = {};
 
     // Set the provider field
-    if (isEmbedding) {  
-      onboardingData.embedding_provider = currentProvider;  
-      onboardingData.embedding_model = settings.embedding_model;  
-    } else {  
-      onboardingData.llm_provider = currentProvider;  
-      onboardingData.llm_model = settings.llm_model;  
-    }  
+    if (isEmbedding) {
+      onboardingData.embedding_provider = currentProvider;
+      onboardingData.embedding_model = settings.embedding_model;
+    } else {
+      onboardingData.llm_provider = currentProvider;
+      onboardingData.llm_model = settings.llm_model;
+    }
 
     // Add provider-specific credentials based on the selected provider
     if (currentProvider === "openai" && settings.openai_api_key) {


### PR DESCRIPTION
This pull request refines the onboarding logic for selecting embedding and LLM models in the `OnboardingCard` component. The changes ensure that model selection and validation are more accurate, especially when handling providers that are already configured.

**Improvements to model selection and validation logic:**

* The validation for required fields now only checks for the presence of `embedding_model` when `isEmbedding` is true, removing the dependency on `showProviderConfiguredMessage` for this check.
* The logic for setting `embedding_model` in the onboarding data now prefers the value from `settings.embedding_model`. It only falls back to the provider-configured model if the provider matches and the model is available, preventing accidental mismatches.
* The condition for marking the onboarding step as complete is simplified to require only `settings.embedding_model` when `isEmbedding` is true, rather than also checking `showProviderConfiguredMessage`.


Duplicate of #1473 