### PR TITLE
fix: Ensure the list of files deleted doesn't clear before delete finished

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -629,12 +629,6 @@ function SearchPage() {
           } not deleted (0 chunks matched).`,
         );
       }
-      setSelectedRows([]);
-
-      // Clear selection in the grid
-      if (gridRef.current) {
-        gridRef.current.api.deselectAll();
-      }
     } catch (error) {
       toast.error(
         error instanceof Error
@@ -644,6 +638,8 @@ function SearchPage() {
     } finally {
       setIsBulkDeleting(false);
       setShowBulkDeleteDialog(false);
+      setSelectedRows([]);
+      gridRef.current?.api.deselectAll();
     }
   };
 

--- a/frontend/components/knowledge-actions-dropdown.tsx
+++ b/frontend/components/knowledge-actions-dropdown.tsx
@@ -42,6 +42,7 @@ export const KnowledgeActionsDropdown = ({
 }: KnowledgeActionsDropdownProps) => {
   const { refreshTasks } = useTask();
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const deleteDocumentMutation = useDeleteDocument();
   const syncConnectorMutation = useSyncConnector();
   const { data: connectors = [] } = useGetConnectorsQuery();
@@ -58,6 +59,7 @@ export const KnowledgeActionsDropdown = ({
   }, [connectors, connectorType]);
 
   const handleDelete = async () => {
+    setIsDeleting(true);
     try {
       const result = await deleteDocumentMutation.mutateAsync({ filename });
       await refreshTasks();
@@ -70,11 +72,12 @@ export const KnowledgeActionsDropdown = ({
           "No document chunks were deleted. The file may be missing or not deletable in your current context.",
         );
       }
-      setShowDeleteDialog(false);
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to delete document",
       );
+    } finally {
+      setIsDeleting(false);
       setShowDeleteDialog(false);
     }
   };
@@ -181,7 +184,7 @@ export const KnowledgeActionsDropdown = ({
         description="Are you sure you want to delete this document?"
         confirmText="Delete"
         onConfirm={handleDelete}
-        isLoading={deleteDocumentMutation.isPending}
+        isLoading={isDeleting}
       >
         <p className="my-2">
           This will remove all chunks and data associated with this document.


### PR DESCRIPTION
Fixes https://github.ibm.com/lakehouse/tracker/issues/70731

Bulk delete — setSelectedRows([]) and gridRef.current?.api.deselectAll() moved into the finally block so selection clears atomically with the dialog closing, preventing a flash of empty content.

Per-row delete — replaced deleteDocumentMutation.isPending with a dedicated isDeleting state and consolidated dialog close into finally, matching the bulk pattern.