### PR TITLE
fix: Unable to overwrite documents in Knowledge

### DIFF
--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -393,12 +393,24 @@ export function KnowledgeDropdown() {
 
     if (pendingFile) {
       // Remove the old file from all search query caches before overwriting
-      queryClient.setQueriesData({ queryKey: ["search"] }, (oldData: []) => {
+      queryClient.setQueriesData({ queryKey: ["search"] }, (oldData: any) => {
         if (!oldData) return oldData;
-        // Filter out the file that's being overwritten
-        return oldData.filter(
-          (file: SearchFile) => file.filename !== pendingFile.name,
-        );
+        // Handle SearchResult structure { files: [], warnings: [] }
+        if (oldData.files && Array.isArray(oldData.files)) {
+          return {
+            ...oldData,
+            files: oldData.files.filter(
+              (file: SearchFile) => file.filename !== pendingFile.name,
+            ),
+          };
+        }
+        // Fallback for legacy array format
+        if (Array.isArray(oldData)) {
+          return oldData.filter(
+            (file: SearchFile) => file.filename !== pendingFile.name,
+          );
+        }
+        return oldData;
       });
 
       await uploadFile(pendingFile, true);


### PR DESCRIPTION
### Issue

- #70921

### Summary

- Fixed a bug where overwriting an existing document in Knowledge failed because the query cache invalidation assumed a flat array format but the search results now use a `SearchResult` object structure with a `files` property.

### Frontend

- Updated `queryClient.setQueriesData` callback in `knowledge-dropdown.tsx` to handle the `SearchResult` structure `{ files: [], warnings: [] }` when filtering out the file being overwritten
- Added a fallback path to handle the legacy flat array format for backwards compatibility
- Changed the `oldData` type annotation from `[]` to `any` to accommodate both data shapes