### PR TITLE
fix: adjust patch function for mcp

### DIFF
--- a/src/services/langflow_mcp_service.py
+++ b/src/services/langflow_mcp_service.py
@@ -153,7 +153,7 @@ class LangflowMCPService:
             logger.debug(f"Patched URL: {url}")
         return url
 
-    async def patch_mcp_server_url(self, server_name: str) -> bool:
+    async def patch_mcp_server_url(self, server_name: str) -> str:
         """Patch a single MCP server to update the Langflow URL and convert to streamable HTTP if applicable.
 
         Only updates the URL (replacing localhost references with the configured LANGFLOW_URL).
@@ -182,7 +182,7 @@ class LangflowMCPService:
                         "Could not extract URL from stdio args, skipping",
                         server_name=server_name,
                     )
-                    return True
+                    return "skipped"
             elif self._is_streamable_http_mode(current):
                 # Already streamable HTTP: only patch the URL, keep headers untouched
                 url = current.get("url")
@@ -193,7 +193,7 @@ class LangflowMCPService:
                         "MCP server URL unchanged, skipping patch",
                         server_name=server_name,
                     )
-                    return True
+                    return "skipped"
                 payload = {"url": patched_url}
                 mode = "streamable_http"
             else:


### PR DESCRIPTION
This pull request updates the return value of the `patch_mcp_server_url` method in `src/services/langflow_mcp_service.py` to provide more informative status feedback. Instead of returning a boolean, the method now returns a string status, such as `"skipped"`, to clarify the outcome of the patch operation.

Patch method return value update:

* Changed the return type of `patch_mcp_server_url` from `bool` to `str` to allow returning descriptive status messages instead of just `True`/`False`.
* Updated return values within `patch_mcp_server_url` to return `"skipped"` instead of `True` when the patch operation is not performed, making the method's outcome more explicit and easier to interpret. [[1]](diffhunk://#diff-5709c20045ba762b6893b80b5944afefabf8f6d62ec3473a595db44daf8c032fL185-R185) [[2]](diffhunk://#diff-5709c20045ba762b6893b80b5944afefabf8f6d62ec3473a595db44daf8c032fL196-R196)