### PR TITLE
fix: removes duplicated dependency from pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,6 @@ dependencies = [
     "litellm==1.83.3",
     "pyyaml>=6.0",
     "tiktoken>=0.7.0",
-    "prometheus-fastapi-instrumentator>=7.1.0",
     "fastmcp>=3.2.3",
     "openai>=2.30.0",
     "tenacity>=9.1.4",


### PR DESCRIPTION
prometheus-fastapi-instrumentator>=7.1.0 was in the list twice