### PR TITLE
fix: make watsonx work in chat

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -44,6 +44,7 @@ function ChatPage() {
     refreshConversations,
     refreshConversationsSilent,
     refreshTrigger,
+    refreshTriggerSilent,
     previousResponseIds,
     setPreviousResponseIds,
     placeholderConversation,
@@ -82,7 +83,7 @@ function ChatPage() {
   // Check if chat history is loading
   const { isLoading: isConversationsLoading } = useGetConversationsQuery(
     endpoint,
-    refreshTrigger,
+    refreshTrigger + refreshTriggerSilent,
   );
 
   // Use conversation-specific filter instead of global filter
@@ -358,15 +359,20 @@ function ChatPage() {
     };
   }, [abortStream, setLoading]);
 
-  // Load conversation only when user explicitly selects a conversation
+  // Load conversation data from context
   useEffect(() => {
     // Only load conversation data when:
     // 1. conversationData exists AND
-    // 2. It's different from the last loaded conversation AND
+    // 2. (It's a different conversation OR we're not streaming and data has changed) AND
     // 3. User is not in the middle of an interaction
+    const isNewConversation =
+      lastLoadedConversationRef.current !== conversationData?.response_id;
+    const hasMessageCountChanged =
+      conversationData?.messages?.length !== messages.length;
+
     if (
       conversationData?.messages &&
-      lastLoadedConversationRef.current !== conversationData.response_id &&
+      (isNewConversation || (!isStreamLoading && hasMessageCountChanged)) &&
       !isUserInteracting &&
       !isForkingInProgress
     ) {
@@ -558,6 +564,8 @@ function ChatPage() {
     isUserInteracting,
     isForkingInProgress,
     setPreviousResponseIds,
+    isStreamLoading,
+    messages.length,
   ]);
 
   // Handle new conversation creation - only reset messages when placeholderConversation is set

--- a/frontend/components/chat-renderer.tsx
+++ b/frontend/components/chat-renderer.tsx
@@ -42,6 +42,7 @@ export function ChatRenderer({
   const {
     endpoint,
     refreshTrigger,
+    refreshTriggerSilent,
     refreshConversations,
     startNewConversation,
     setConversationFilter,
@@ -79,7 +80,7 @@ export function ChatRenderer({
   // Only fetch conversations on chat page
   const isOnChatPage = pathname === "/" || pathname === "/chat";
   const { data: conversations = [], isLoading: isConversationsLoading } =
-    useGetConversationsQuery(endpoint, refreshTrigger, {
+    useGetConversationsQuery(endpoint, refreshTrigger + refreshTriggerSilent, {
       enabled: isOnChatPage && (isAuthenticated || isNoAuthMode),
     }) as { data: ChatConversation[]; isLoading: boolean };
 

--- a/frontend/hooks/useChatStreaming.ts
+++ b/frontend/hooks/useChatStreaming.ts
@@ -152,7 +152,7 @@ export function useChatStreaming({
       }
 
       try {
-        while (true) {
+        streamLoop: while (true) {
           const { done, value } = await reader.read();
           if (controller.signal.aborted || thisStreamId !== streamIdRef.current)
             break;
@@ -460,19 +460,6 @@ export function useChatStreaming({
                   }
                 }
 
-                // Check for error status from Langflow
-                if (
-                  chunk.finish_reason === "error" ||
-                  chunk.status === "failed"
-                ) {
-                  console.error("Error detected in stream");
-
-                  // Mark this as an error message and complete the stream
-                  isError = true;
-
-                  // Exit the streaming loop by throwing so the reader stops promptly on error
-                  throw new Error("Error detected in stream");
-                }
                 // Handle text output streaming (Realtime API)
                 else if (chunk.type === "response.output_text.delta") {
                   currentContent += chunk.delta || "";
@@ -550,6 +537,20 @@ export function useChatStreaming({
                   console.log(
                     "[Heuristic Detection] Created synthetic function call",
                   );
+                }
+
+                // Check for error status from Langflow
+                if (
+                  chunk.finish_reason === "error" ||
+                  chunk.status === "failed"
+                ) {
+                  console.error("Error detected in stream");
+
+                  // Mark this as an error message and complete the stream
+                  isError = true;
+
+                  // Exit the streaming loop by breaking the labeled while loop
+                  break streamLoop;
                 }
 
                 // Update streaming message in real-time

--- a/src/agent.py
+++ b/src/agent.py
@@ -515,25 +515,24 @@ async def async_chat_stream(
         yield chunk
 
     # Add the complete assistant response to message history with response_id and timestamp
-    if full_response:
-        assistant_message = {
-            "role": "assistant",
-            "content": full_response,
-            "response_id": response_id,
-            "timestamp": datetime.now(),
-        }
-        # Store usage data if available (from response.completed event)
-        if usage_data:
-            assistant_message["response_data"] = {"usage": usage_data}
-        conversation_state["messages"].append(assistant_message)
+    assistant_message = {
+        "role": "assistant",
+        "content": full_response,
+        "response_id": response_id,
+        "timestamp": datetime.now(),
+    }
+    # Store usage data if available (from response.completed event)
+    if usage_data:
+        assistant_message["response_data"] = {"usage": usage_data}
+    conversation_state["messages"].append(assistant_message)
 
-        # Store the conversation thread with its response_id
-        if response_id:
-            conversation_state["last_activity"] = datetime.now()
-            await store_conversation_thread(user_id, response_id, conversation_state)
-            logger.debug(
-                f"Stored conversation thread for user {user_id} with response_id: {response_id}"
-            )
+    # Store the conversation thread with its response_id
+    if response_id:
+        conversation_state["last_activity"] = datetime.now()
+        await store_conversation_thread(user_id, response_id, conversation_state)
+        logger.debug(
+            f"Stored conversation thread for user {user_id} with response_id: {response_id}"
+        )
 
 
 # Async langflow function with conversation storage (non-streaming)
@@ -789,16 +788,15 @@ async def async_langflow_chat_stream(
             yield chunk
 
         # Add the complete assistant response to message history with response_id, timestamp, and function call data
-        if full_response:
-            assistant_message = {
-                "role": "assistant",
-                "content": full_response,
-                "response_id": response_id,
-                "timestamp": datetime.now(),
-                "chunks": collected_chunks,  # Store complete chunk data for function calls
-                "error": error_occurred,  # Mark if this was an error response
-            }
-            # Store usage data if available (from response.completed event)
+        assistant_message = {
+            "role": "assistant",
+            "content": full_response,
+            "response_id": response_id,
+            "timestamp": datetime.now(),
+            "chunks": collected_chunks,  # Store complete chunk data for function calls
+            "error": error_occurred,  # Mark if this was an error response
+        }
+        # Store usage data if available (from response.completed event)
         if usage_data:
             assistant_message["response_data"] = {"usage": usage_data}
         conversation_state["messages"].append(assistant_message)


### PR DESCRIPTION
This pull request improves the chat streaming and conversation refresh logic in both the frontend and backend. The main focus is on more robust handling of conversation state updates, improved detection and handling of streaming errors, and minor code cleanups for consistency.

**Frontend Improvements:**

*Conversation Refresh Logic:*
- Updated both `ChatPage` and `ChatRenderer` components to use a combined `refreshTrigger + refreshTriggerSilent` value when fetching conversations, ensuring that silent refreshes also trigger data updates. [[1]](diffhunk://#diff-615aa4bbd13d9ae97f449cdf8676fc363f764660c7ed5cc61684bc8efe2128daR47) [[2]](diffhunk://#diff-615aa4bbd13d9ae97f449cdf8676fc363f764660c7ed5cc61684bc8efe2128daL85-R86) [[3]](diffhunk://#diff-44acdd344e33c38d05fff42c0f55a60bdf3e56f008d496961591938c573268e1R45) [[4]](diffhunk://#diff-44acdd344e33c38d05fff42c0f55a60bdf3e56f008d496961591938c573268e1L82-R83)
- Enhanced logic in `ChatPage` to detect when to reload conversation data, now also considering changes in the message count and streaming state for more accurate updates. [[1]](diffhunk://#diff-615aa4bbd13d9ae97f449cdf8676fc363f764660c7ed5cc61684bc8efe2128daL361-R375) [[2]](diffhunk://#diff-615aa4bbd13d9ae97f449cdf8676fc363f764660c7ed5cc61684bc8efe2128daR567-R568)

*Streaming Error Handling:*
- Refactored the streaming loop in `useChatStreaming` to use a labeled loop, allowing for a clean exit when an error is detected in the stream. Error detection now breaks the loop directly instead of throwing an exception, improving control flow. [[1]](diffhunk://#diff-a6aedb219be8327659bb3e93392885c93ca25f5fdc9d41be83ba2fc6da6d5946L155-R155) [[2]](diffhunk://#diff-a6aedb219be8327659bb3e93392885c93ca25f5fdc9d41be83ba2fc6da6d5946L463-L475) [[3]](diffhunk://#diff-a6aedb219be8327659bb3e93392885c93ca25f5fdc9d41be83ba2fc6da6d5946R542-R555)

**Backend Improvements:**

*Message History Consistency:*
- Cleaned up the logic in both `async_chat_stream` and `async_langflow_chat_stream` by removing unnecessary conditional checks before appending the assistant's message to the conversation history, ensuring consistency. [[1]](diffhunk://#diff-3f21ad1752eea52d46c1770fecd891a347976b44142baa2a02235d239cc6e016L518) [[2]](diffhunk://#diff-3f21ad1752eea52d46c1770fecd891a347976b44142baa2a02235d239cc6e016L792)

Can close #1523 