### PR TITLE
feat: RBAC + database migration layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -275,3 +275,9 @@ CACHE_BACKEND=memory
 #   - hybrid          DB + JSON dual-write (Phase B fallback)
 #   - files           legacy JSON-only path; DB untouched
 OPENRAG_STORAGE_MODE=db
+
+# RBAC kill switch. Default OFF — the system behaves like the pre-RBAC
+# release: any authenticated user has full access; API-key role
+# overrides are also bypassed. Set to `true` to turn the permissions
+# system on for multi-user deployments. Available in all run modes.
+# OPENRAG_RBAC_ENFORCE=true

--- a/.env.example
+++ b/.env.example
@@ -258,3 +258,11 @@ SESSION_SECRET=
 # - "saas": Public Cloud
 # - "on_prem": Private Cloud
 OPENRAG_RUN_MODE=oss
+
+# Permission/identity cache backend. Only "memory" is currently wired.
+# When CACHE_BACKEND=memory the RBAC permission cache and OAuth-subject
+# cache are per-process, so OpenRAG must run with UVICORN_WORKERS=1 (and
+# replicaCount=1 in helm). Anything >1 hard-fails at startup until cache
+# is shared across processes (planned: Redis).
+CACHE_BACKEND=memory
+# UVICORN_WORKERS=1

--- a/.env.example
+++ b/.env.example
@@ -266,3 +266,12 @@ OPENRAG_RUN_MODE=oss
 # is shared across processes (planned: Redis).
 CACHE_BACKEND=memory
 # UVICORN_WORKERS=1
+
+# Storage mode. Default `db` — workspace config + chat history live in
+# the SQL DB only; no `config.yaml`, `conversations.json`, or
+# `session_ownership.json` are ever written. Pre-existing JSON files
+# are imported once on first boot, then ignored.
+#   - db     (default) DB-only, no JSON written
+#   - hybrid          DB + JSON dual-write (Phase B fallback)
+#   - files           legacy JSON-only path; DB untouched
+OPENRAG_STORAGE_MODE=db

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,7 @@ documents/ibm_anthropic.pdf
 documents/docling.pdf
 /opensearch-data-new-lf
 /opensearch-data2
+data/openrag.db
+data/openrag.db
+*.db
+/data

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,5 @@ Read the `SKILL.md` files directly. The frontmatter `description` tells you when
 ## Operational constraints
 
 **Single-worker only (until Redis cache lands).** The RBAC permission cache and OAuth-subject→DB-id cache are both per-process (`cachetools.TTLCache`). Running with multiple uvicorn workers or multiple helm replicas means a role grant or revoke takes effect in only one process; the others serve stale permissions for up to `OPENRAG_PERM_CACHE_TTL` seconds (default 60). The startup event in `src/main.py` enforces `UVICORN_WORKERS<=1` and `CACHE_BACKEND=memory` and hard-fails otherwise. To horizontally scale, swap the cache to Redis first.
+
+**RBAC is opt-in.** `OPENRAG_RBAC_ENFORCE` defaults to `false`, which makes OpenRAG behave like the pre-RBAC release: every authenticated user has full access; API-key role overrides are also bypassed. To turn the permissions system on (admin/developer/user/viewer roles, `require_permission` gates, audit denials), set `OPENRAG_RBAC_ENFORCE=true`. Available in all `OPENRAG_RUN_MODE` values — operators own the trade-off. The startup event logs the enforcement state on every boot.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,3 +37,7 @@ Read the `SKILL.md` files directly. The frontmatter `description` tells you when
 - Skill bodies are intentionally kept agent-neutral. Do not add references to tools or features that only exist in one runtime (for example, do not name specific slash commands, hook systems, or task-tracking tools).
 - Claude-Code-specific plumbing belongs in `plugin.json` or `.claude/`, not in `SKILL.md`.
 - See `plugins/README.md` for the full layout and distribution model.
+
+## Operational constraints
+
+**Single-worker only (until Redis cache lands).** The RBAC permission cache and OAuth-subject→DB-id cache are both per-process (`cachetools.TTLCache`). Running with multiple uvicorn workers or multiple helm replicas means a role grant or revoke takes effect in only one process; the others serve stale permissions for up to `OPENRAG_PERM_CACHE_TTL` seconds (default 60). The startup event in `src/main.py` enforces `UVICORN_WORKERS<=1` and `CACHE_BACKEND=memory` and hard-fails otherwise. To horizontally scale, swap the cache to Redis first.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,3 +43,13 @@ Read the `SKILL.md` files directly. The frontmatter `description` tells you when
 **Single-worker only (until Redis cache lands).** The RBAC permission cache and OAuth-subject→DB-id cache are both per-process (`cachetools.TTLCache`). Running with multiple uvicorn workers or multiple helm replicas means a role grant or revoke takes effect in only one process; the others serve stale permissions for up to `OPENRAG_PERM_CACHE_TTL` seconds (default 60). The startup event in `src/main.py` enforces `UVICORN_WORKERS<=1` and `CACHE_BACKEND=memory` and hard-fails otherwise. To horizontally scale, swap the cache to Redis first.
 
 **RBAC is opt-in.** `OPENRAG_RBAC_ENFORCE` defaults to `false`, which makes OpenRAG behave like the pre-RBAC release: every authenticated user has full access; API-key role overrides are also bypassed. To turn the permissions system on (admin/developer/user/viewer roles, `require_permission` gates, audit denials), set `OPENRAG_RBAC_ENFORCE=true`. Available in all `OPENRAG_RUN_MODE` values — operators own the trade-off. The startup event logs the enforcement state on every boot.
+
+**Dev-local with backend on host.** When you run `make dev-local-cpu` (or `dev-local`) and then `make backend` on the host, OpenSearch needs to resolve `openrag-backend` to the host machine so it can fetch JWKS for OIDC validation. The base `docker-compose.yml` does NOT add this alias — it would break CI, where the backend is a docker-compose service. To enable the host-backend mode, layer the override file:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.host-backend.yml up -d opensearch dashboards langflow
+make backend     # in another terminal
+make frontend    # in another terminal
+```
+
+The override only adds `extra_hosts: openrag-backend:host-gateway` to the OpenSearch service. Without it, OIDC works because docker DNS routes `openrag-backend` to the in-compose backend container.

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -41,6 +41,12 @@ COPY src/ ./src/
 COPY flows/ ./flows/
 COPY securityconfig/ ./securityconfig/
 COPY cloud_securityconfig/ ./cloud_securityconfig/
+# Alembic migrations — the runtime calls run_alembic_upgrade("head") on
+# startup. Without these the migration silently no-ops with
+# "alembic.ini not found; skipping schema upgrade", and the SQL DB
+# starts empty (no users / conversations / session_ownership tables).
+COPY alembic.ini ./
+COPY alembic/ ./alembic/
 
 # -----------------------------------------------------------------------------
 # Stage: runtime (minimal image)

--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,42 @@
+[alembic]
+script_location = alembic
+prepend_sys_path = . src
+version_path_separator = os
+file_template = %%(rev)s_%%(slug)s
+
+# DATABASE_URL is resolved at runtime in env.py — do not set sqlalchemy.url here
+sqlalchemy.url =
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARN
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,90 @@
+"""Alembic env — supports both sync (offline / CLI) and async runtimes.
+
+DATABASE_URL is resolved via db.engine.get_database_url so the same code
+path applies whether you run alembic from the CLI or programmatically
+during app startup.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+from logging.config import fileConfig
+from pathlib import Path
+
+from alembic import context
+from sqlalchemy import engine_from_config, pool
+from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
+
+# Make `src/` importable
+ROOT = Path(__file__).resolve().parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from db.base import metadata as base_metadata  # noqa: E402
+from db.engine import get_database_url  # noqa: E402
+import db.models  # noqa: E402,F401  (registers tables on metadata)
+from sqlmodel import SQLModel  # noqa: E402
+
+config = context.config
+
+if config.config_file_name is not None:
+    try:
+        fileConfig(config.config_file_name)
+    except Exception:
+        pass
+
+target_metadata = SQLModel.metadata
+
+
+def _sync_url() -> str:
+    """Alembic prefers a sync URL for offline mode. Convert async drivers."""
+    url = get_database_url()
+    return (
+        url.replace("+aiosqlite", "")
+        .replace("postgresql+asyncpg", "postgresql+psycopg")
+        .replace("mysql+aiomysql", "mysql+pymysql")
+    )
+
+
+def run_migrations_offline() -> None:
+    context.configure(
+        url=_sync_url(),
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+        render_as_batch=True,  # SQLite-friendly
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection) -> None:
+    context.configure(
+        connection=connection,
+        target_metadata=target_metadata,
+        render_as_batch=True,
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    connectable: AsyncEngine = create_async_engine(
+        get_database_url(), poolclass=pool.NullPool, future=True
+    )
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,26 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/0001_initial.py
+++ b/alembic/versions/0001_initial.py
@@ -1,0 +1,172 @@
+"""initial RBAC schema
+
+Revision ID: 0001_initial
+Revises:
+Create Date: 2026-05-01 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0001_initial"
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "users",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column("oauth_provider", sa.String(length=32), nullable=False),
+        sa.Column("oauth_subject", sa.String(length=255), nullable=False),
+        sa.Column("email", sa.String(), nullable=True),
+        sa.Column("email_lookup_hash", sa.String(length=64), nullable=True),
+        sa.Column("display_name", sa.String(), nullable=True),
+        sa.Column("picture_url", sa.String(length=2048), nullable=True),
+        sa.Column("is_active", sa.Boolean(), nullable=False, server_default=sa.true()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("last_login", sa.DateTime(), nullable=True),
+        sa.UniqueConstraint("oauth_provider", "oauth_subject", name="uq_users_oauth"),
+        sa.UniqueConstraint("email_lookup_hash", name="uq_users_email_lookup_hash"),
+    )
+    op.create_index("ix_users_oauth_provider", "users", ["oauth_provider"])
+    op.create_index("ix_users_oauth_subject", "users", ["oauth_subject"])
+    op.create_index("ix_users_email_lookup_hash", "users", ["email_lookup_hash"])
+
+    op.create_table(
+        "roles",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column("name", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.String(length=512), nullable=True),
+        sa.Column("is_system", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.UniqueConstraint("name", name="uq_roles_name"),
+    )
+    op.create_index("ix_roles_name", "roles", ["name"])
+
+    op.create_table(
+        "permissions",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("resource", sa.String(length=64), nullable=False),
+        sa.Column("action", sa.String(length=64), nullable=False),
+        sa.Column("description", sa.String(length=512), nullable=True),
+        sa.UniqueConstraint("name", name="uq_permissions_name"),
+    )
+    op.create_index("ix_permissions_name", "permissions", ["name"])
+    op.create_index("ix_permissions_resource", "permissions", ["resource"])
+
+    op.create_table(
+        "role_permissions",
+        sa.Column("role_id", sa.String(length=64), nullable=False),
+        sa.Column("permission_id", sa.String(length=64), nullable=False),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"], name="fk_role_permissions_role_id_roles"),
+        sa.ForeignKeyConstraint(
+            ["permission_id"], ["permissions.id"],
+            name="fk_role_permissions_permission_id_permissions",
+        ),
+        sa.PrimaryKeyConstraint("role_id", "permission_id", name="pk_role_permissions"),
+    )
+
+    op.create_table(
+        "user_roles",
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("role_id", sa.String(length=64), nullable=False),
+        sa.Column("granted_by", sa.String(length=64), nullable=True),
+        sa.Column("granted_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_user_roles_user_id_users"),
+        sa.ForeignKeyConstraint(["role_id"], ["roles.id"], name="fk_user_roles_role_id_roles"),
+        sa.ForeignKeyConstraint(
+            ["granted_by"], ["users.id"], name="fk_user_roles_granted_by_users"
+        ),
+        sa.PrimaryKeyConstraint("user_id", "role_id", name="pk_user_roles"),
+    )
+
+    op.create_table(
+        "user_preferences",
+        sa.Column("user_id", sa.String(length=64), primary_key=True),
+        sa.Column("agent_system_prompt_override", sa.String(), nullable=True),
+        sa.Column("default_kf_id", sa.String(length=128), nullable=True),
+        sa.Column("theme", sa.String(length=32), nullable=True),
+        sa.Column("language", sa.String(length=16), nullable=True),
+        sa.Column("provider_overrides", sa.String(), nullable=True),
+        sa.Column("preferences_json", sa.String(), nullable=True),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["user_id"], ["users.id"], name="fk_user_preferences_user_id_users"
+        ),
+    )
+
+    op.create_table(
+        "api_keys",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("name", sa.String(length=128), nullable=False),
+        sa.Column("key_hash", sa.String(length=128), nullable=False),
+        sa.Column("key_prefix", sa.String(length=32), nullable=False),
+        sa.Column("scope_role_ids", sa.JSON(), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("revoked_at", sa.DateTime(), nullable=True),
+        sa.Column("revoked", sa.Boolean(), nullable=False, server_default=sa.false()),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_api_keys_user_id_users"),
+        sa.UniqueConstraint("key_hash", name="uq_api_keys_key_hash"),
+    )
+    op.create_index("ix_api_keys_user_id", "api_keys", ["user_id"])
+    op.create_index("ix_api_keys_key_hash", "api_keys", ["key_hash"])
+
+    op.create_table(
+        "audit_log",
+        sa.Column("id", sa.String(length=64), primary_key=True),
+        sa.Column("ts", sa.DateTime(), nullable=False),
+        sa.Column("actor_user_id", sa.String(length=64), nullable=True),
+        sa.Column("actor_api_key_id", sa.String(length=64), nullable=True),
+        sa.Column("event", sa.String(length=128), nullable=False),
+        sa.Column("target_type", sa.String(length=64), nullable=True),
+        sa.Column("target_id", sa.String(length=128), nullable=True),
+        sa.Column("metadata", sa.JSON(), nullable=True),
+        sa.Column("ip", sa.String(length=64), nullable=True),
+        sa.Column("user_agent", sa.String(length=512), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["actor_user_id"], ["users.id"], name="fk_audit_log_actor_user_id_users"
+        ),
+    )
+    op.create_index("ix_audit_log_ts", "audit_log", ["ts"])
+    op.create_index("ix_audit_log_event", "audit_log", ["event"])
+    op.create_index("ix_audit_log_actor_user_id", "audit_log", ["actor_user_id"])
+
+    op.create_table(
+        "migration_status",
+        sa.Column("name", sa.String(length=128), primary_key=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=False),
+        sa.Column("notes", sa.String(length=2048), nullable=False, server_default=""),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("migration_status")
+    op.drop_index("ix_audit_log_actor_user_id", table_name="audit_log")
+    op.drop_index("ix_audit_log_event", table_name="audit_log")
+    op.drop_index("ix_audit_log_ts", table_name="audit_log")
+    op.drop_table("audit_log")
+    op.drop_index("ix_api_keys_key_hash", table_name="api_keys")
+    op.drop_index("ix_api_keys_user_id", table_name="api_keys")
+    op.drop_table("api_keys")
+    op.drop_table("user_preferences")
+    op.drop_table("user_roles")
+    op.drop_table("role_permissions")
+    op.drop_index("ix_permissions_resource", table_name="permissions")
+    op.drop_index("ix_permissions_name", table_name="permissions")
+    op.drop_table("permissions")
+    op.drop_index("ix_roles_name", table_name="roles")
+    op.drop_table("roles")
+    op.drop_index("ix_users_email_lookup_hash", table_name="users")
+    op.drop_index("ix_users_oauth_subject", table_name="users")
+    op.drop_index("ix_users_oauth_provider", table_name="users")
+    op.drop_table("users")

--- a/alembic/versions/0002_seed_roles_permissions.py
+++ b/alembic/versions/0002_seed_roles_permissions.py
@@ -1,0 +1,150 @@
+"""seed built-in roles and permissions
+
+Revision ID: 0002_seed_roles_permissions
+Revises: 0001_initial
+Create Date: 2026-05-01 00:00:01.000000
+
+Idempotent: re-running this migration on a database that already has rows
+inserts only what's missing. Implementation lives in db.seed so the
+catalog has a single source of truth.
+
+"""
+from datetime import datetime
+from typing import Sequence, Union
+import uuid
+
+from alembic import op
+import sqlalchemy as sa
+
+from db.seed import BUILTIN_ROLES, PERMISSIONS, ROLE_PERMISSION_MAP, permission_name
+
+
+revision: str = "0002_seed_roles_permissions"
+down_revision: Union[str, Sequence[str], None] = "0001_initial"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    now = datetime.utcnow()
+
+    # Permissions
+    perms_table = sa.table(
+        "permissions",
+        sa.column("id", sa.String),
+        sa.column("name", sa.String),
+        sa.column("resource", sa.String),
+        sa.column("action", sa.String),
+        sa.column("description", sa.String),
+    )
+    existing_perm_names = {
+        row[0] for row in bind.execute(sa.text("SELECT name FROM permissions")).fetchall()
+    }
+    perm_rows = []
+    for resource, action, description in PERMISSIONS:
+        name = permission_name(resource, action)
+        if name in existing_perm_names:
+            continue
+        perm_rows.append(
+            {
+                "id": str(uuid.uuid4()),
+                "name": name,
+                "resource": resource,
+                "action": action,
+                "description": description,
+            }
+        )
+    if perm_rows:
+        op.bulk_insert(perms_table, perm_rows)
+
+    # Roles
+    roles_table = sa.table(
+        "roles",
+        sa.column("id", sa.String),
+        sa.column("name", sa.String),
+        sa.column("description", sa.String),
+        sa.column("is_system", sa.Boolean),
+        sa.column("created_at", sa.DateTime),
+        sa.column("updated_at", sa.DateTime),
+    )
+    existing_role_names = {
+        row[0] for row in bind.execute(sa.text("SELECT name FROM roles")).fetchall()
+    }
+    role_rows = []
+    for role_id, role_name, description in BUILTIN_ROLES:
+        if role_name in existing_role_names:
+            continue
+        role_rows.append(
+            {
+                "id": role_id,
+                "name": role_name,
+                "description": description,
+                "is_system": True,
+                "created_at": now,
+                "updated_at": now,
+            }
+        )
+    if role_rows:
+        op.bulk_insert(roles_table, role_rows)
+
+    # Lookups for the join table
+    perm_id_by_name = {
+        row[1]: row[0]
+        for row in bind.execute(sa.text("SELECT id, name FROM permissions")).fetchall()
+    }
+    role_id_by_name = {
+        row[1]: row[0]
+        for row in bind.execute(sa.text("SELECT id, name FROM roles")).fetchall()
+    }
+    existing_rp = {
+        (row[0], row[1])
+        for row in bind.execute(
+            sa.text("SELECT role_id, permission_id FROM role_permissions")
+        ).fetchall()
+    }
+
+    rp_table = sa.table(
+        "role_permissions",
+        sa.column("role_id", sa.String),
+        sa.column("permission_id", sa.String),
+    )
+    rp_rows = []
+    for role_name, perm_names in ROLE_PERMISSION_MAP.items():
+        rid = role_id_by_name.get(role_name)
+        if not rid:
+            continue
+        for pname in perm_names:
+            pid = perm_id_by_name.get(pname)
+            if not pid:
+                continue
+            if (rid, pid) in existing_rp:
+                continue
+            rp_rows.append({"role_id": rid, "permission_id": pid})
+    if rp_rows:
+        op.bulk_insert(rp_table, rp_rows)
+
+
+def downgrade() -> None:
+    # Best-effort: delete only the rows this migration would have inserted.
+    bind = op.get_bind()
+    role_names = [r[1] for r in BUILTIN_ROLES]
+    perm_names = [permission_name(r, a) for r, a, _ in PERMISSIONS]
+    if role_names:
+        bind.execute(
+            sa.text("DELETE FROM role_permissions WHERE role_id IN "
+                    "(SELECT id FROM roles WHERE name IN :names)")
+            .bindparams(sa.bindparam("names", expanding=True)),
+            {"names": role_names},
+        )
+        bind.execute(
+            sa.text("DELETE FROM roles WHERE name IN :names AND is_system = 1")
+            .bindparams(sa.bindparam("names", expanding=True)),
+            {"names": role_names},
+        )
+    if perm_names:
+        bind.execute(
+            sa.text("DELETE FROM permissions WHERE name IN :names")
+            .bindparams(sa.bindparam("names", expanding=True)),
+            {"names": perm_names},
+        )

--- a/alembic/versions/0003_workspace_config.py
+++ b/alembic/versions/0003_workspace_config.py
@@ -1,0 +1,35 @@
+"""workspace_config table
+
+Revision ID: 0003_workspace_config
+Revises: 0002_seed_roles_permissions
+Create Date: 2026-05-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0003_workspace_config"
+down_revision: Union[str, Sequence[str], None] = "0002_seed_roles_permissions"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "workspace_config",
+        sa.Column("section", sa.String(length=64), primary_key=True),
+        sa.Column("value", sa.JSON(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_by", sa.String(length=64), nullable=True),
+        sa.ForeignKeyConstraint(
+            ["updated_by"], ["users.id"],
+            name="fk_workspace_config_updated_by_users",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("workspace_config")

--- a/alembic/versions/0004_chat_history_tables.py
+++ b/alembic/versions/0004_chat_history_tables.py
@@ -1,0 +1,57 @@
+"""chat history tables (session_ownership + conversations)
+
+Revision ID: 0004_chat_history_tables
+Revises: 0003_workspace_config
+Create Date: 2026-05-05 00:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "0004_chat_history_tables"
+down_revision: Union[str, Sequence[str], None] = "0003_workspace_config"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "session_ownership",
+        sa.Column("response_id", sa.String(length=64), primary_key=True),
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_accessed", sa.DateTime(), nullable=True),
+    )
+    op.create_index(
+        "ix_session_ownership_user_id", "session_ownership", ["user_id"]
+    )
+
+    op.create_table(
+        "conversations",
+        sa.Column("response_id", sa.String(length=64), primary_key=True),
+        sa.Column("user_id", sa.String(length=64), nullable=False),
+        sa.Column("title", sa.String(length=512), nullable=True),
+        sa.Column("endpoint", sa.String(length=64), nullable=True),
+        sa.Column("previous_response_id", sa.String(length=64), nullable=True),
+        sa.Column("filter_id", sa.String(length=128), nullable=True),
+        sa.Column("total_messages", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("last_activity", sa.DateTime(), nullable=False),
+    )
+    op.create_index("ix_conversations_user_id", "conversations", ["user_id"])
+    op.create_index(
+        "ix_conversations_user_recent",
+        "conversations",
+        ["user_id", "last_activity"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_conversations_user_recent", table_name="conversations")
+    op.drop_index("ix_conversations_user_id", table_name="conversations")
+    op.drop_table("conversations")
+    op.drop_index("ix_session_ownership_user_id", table_name="session_ownership")
+    op.drop_table("session_ownership")

--- a/alembic/versions/0005_user_fk_ondelete.py
+++ b/alembic/versions/0005_user_fk_ondelete.py
@@ -1,0 +1,71 @@
+"""apply ondelete= policy to user FKs
+
+Revision ID: 0005_user_fk_ondelete
+Revises: 0004_chat_history_tables
+Create Date: 2026-05-05 00:00:00.000000
+
+Background:
+    The initial schema (0001_initial) declared FKs to ``users.id`` from
+    ``user_roles``, ``user_preferences``, ``api_keys``, ``audit_log``,
+    and ``workspace_config`` (added in 0003) — all without an
+    ``ondelete=`` clause. SQLite doesn't enforce FKs by default so this
+    is invisible there, but Postgres enforces RESTRICT, so a
+    ``DELETE FROM users WHERE id = ?`` raises an IntegrityError on the
+    very first admin-deletes-user request.
+
+Policy applied here:
+    user_roles.user_id           CASCADE   (owned membership)
+    user_roles.granted_by        SET NULL  (audit ref — keep the row)
+    user_preferences.user_id     CASCADE   (owned data)
+    api_keys.user_id             CASCADE   (owned credential)
+    audit_log.actor_user_id      SET NULL  (preserve audit trail)
+    workspace_config.updated_by  SET NULL  (preserve change history)
+
+Implementation note:
+    Uses batch_alter_table for SQLite compatibility (recreates the
+    table with the new FK definitions). Postgres applies the change in
+    place via ALTER TABLE inside the same op.
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "0005_user_fk_ondelete"
+down_revision: Union[str, Sequence[str], None] = "0004_chat_history_tables"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+_FK_POLICY = [
+    # (table, fk_name, local_cols, remote_table, remote_cols, ondelete)
+    ("user_roles", "fk_user_roles_user_id_users",
+     ["user_id"], "users", ["id"], "CASCADE"),
+    ("user_roles", "fk_user_roles_granted_by_users",
+     ["granted_by"], "users", ["id"], "SET NULL"),
+    ("user_preferences", "fk_user_preferences_user_id_users",
+     ["user_id"], "users", ["id"], "CASCADE"),
+    ("api_keys", "fk_api_keys_user_id_users",
+     ["user_id"], "users", ["id"], "CASCADE"),
+    ("audit_log", "fk_audit_log_actor_user_id_users",
+     ["actor_user_id"], "users", ["id"], "SET NULL"),
+    ("workspace_config", "fk_workspace_config_updated_by_users",
+     ["updated_by"], "users", ["id"], "SET NULL"),
+]
+
+
+def upgrade() -> None:
+    for table, name, cols, ref_table, ref_cols, ondelete in _FK_POLICY:
+        with op.batch_alter_table(table) as batch:
+            batch.drop_constraint(name, type_="foreignkey")
+            batch.create_foreign_key(
+                name, ref_table, cols, ref_cols, ondelete=ondelete
+            )
+
+
+def downgrade() -> None:
+    for table, name, cols, ref_table, ref_cols, _ondelete in _FK_POLICY:
+        with op.batch_alter_table(table) as batch:
+            batch.drop_constraint(name, type_="foreignkey")
+            batch.create_foreign_key(name, ref_table, cols, ref_cols)

--- a/docker-compose.host-backend.yml
+++ b/docker-compose.host-backend.yml
@@ -1,0 +1,30 @@
+# docker-compose.host-backend.yml
+#
+# Layered override for the dev-local mode where the OpenRAG backend
+# runs on the HOST machine via `make backend` (not as a compose
+# service). In that mode OpenSearch — running inside its container —
+# needs to reach the host's port 8000 to fetch the OIDC discovery /
+# JWKS for JWT validation. This override adds the alias that routes
+# `openrag-backend` from inside the OpenSearch container to the host
+# gateway.
+#
+# Do NOT merge this into the base `docker-compose.yml`: `extra_hosts`
+# writes to /etc/hosts, which libc resolves before DNS, so adding the
+# alias unconditionally overrides the docker-compose service-name
+# resolution in any deployment where the backend runs as a service
+# (e.g. CI integration tests, e2e tests). That broke every
+# `/search` call with `AuthenticationException(401, 'Unauthorized')`
+# until this file existed.
+#
+# Usage:
+#     docker compose \
+#         -f docker-compose.yml \
+#         -f docker-compose.host-backend.yml \
+#         up -d opensearch dashboards langflow
+#     make backend     # in another terminal — listens on host:8000
+#     make frontend    # in another terminal
+
+services:
+  opensearch:
+    extra_hosts:
+      - "openrag-backend:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,11 @@ services:
       - discovery.type=single-node
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD}
       - OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
+    extra_hosts:
+      # Lets the security plugin reach a host-side `make backend` for
+      # OIDC discovery / JWKS. Inside compose the service DNS already
+      # resolves; this alias is only used when the backend runs on the host.
+      - "openrag-backend:host-gateway"
     ports:
       - "9200:9200"
       - "9600:9600"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,11 +11,14 @@ services:
       - discovery.type=single-node
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD}
       - OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
-    extra_hosts:
-      # Lets the security plugin reach a host-side `make backend` for
-      # OIDC discovery / JWKS. Inside compose the service DNS already
-      # resolves; this alias is only used when the backend runs on the host.
-      - "openrag-backend:host-gateway"
+    # NOTE: do NOT add `extra_hosts: openrag-backend:host-gateway` here.
+    # `extra_hosts` writes to /etc/hosts, which libc resolves BEFORE
+    # docker DNS — so the alias overrides docker-compose service-name
+    # resolution unconditionally and routes OpenSearch's JWKS lookup to
+    # the host gateway. In CI the host has nothing on port 8000, so JWT
+    # validation breaks (every /search returns 401). Dev-local users who
+    # run `make backend` on the host need the alias and should add it via
+    # an override file (see AGENTS.md → Operational constraints).
     ports:
       - "9200:9200"
       - "9600:9600"

--- a/frontend/app/api/mutations/useAssignRoleMutation.ts
+++ b/frontend/app/api/mutations/useAssignRoleMutation.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+interface AssignRoleVariables {
+  user_id: string;
+  role_id: string;
+}
+
+export const useAssignRoleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ user_id, role_id }: AssignRoleVariables) => {
+      const response = await fetch(`/api/admin/users/${user_id}/roles`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ role_id }),
+      });
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err?.detail?.error || "Failed to assign role");
+      }
+      return await response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+  });
+};

--- a/frontend/app/api/mutations/useRevokeRoleMutation.ts
+++ b/frontend/app/api/mutations/useRevokeRoleMutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+interface RevokeRoleVariables {
+  user_id: string;
+  role_id: string;
+}
+
+export const useRevokeRoleMutation = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ user_id, role_id }: RevokeRoleVariables) => {
+      const response = await fetch(
+        `/api/admin/users/${user_id}/roles/${role_id}`,
+        { method: "DELETE" },
+      );
+      if (!response.ok) {
+        const err = await response.json().catch(() => ({}));
+        throw new Error(err?.detail?.error || "Failed to revoke role");
+      }
+      return await response.json();
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["admin-users"] });
+    },
+  });
+};

--- a/frontend/app/api/queries/useGetAdminPermissionsQuery.ts
+++ b/frontend/app/api/queries/useGetAdminPermissionsQuery.ts
@@ -1,0 +1,26 @@
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+export interface AdminPermission {
+  id: string;
+  name: string;
+  resource: string;
+  action: string;
+  description: string | null;
+}
+
+export const useGetAdminPermissionsQuery = (
+  options?: Omit<UseQueryOptions<AdminPermission[]>, "queryKey" | "queryFn">,
+) => {
+  async function fetchPermissions(): Promise<AdminPermission[]> {
+    const response = await fetch("/api/admin/permissions");
+    if (response.ok) return await response.json();
+    if (response.status === 403) return [];
+    throw new Error(`Failed to fetch permissions (${response.status})`);
+  }
+
+  return useQuery({
+    queryKey: ["admin-permissions"],
+    queryFn: fetchPermissions,
+    ...options,
+  });
+};

--- a/frontend/app/api/queries/useGetAdminRolesQuery.ts
+++ b/frontend/app/api/queries/useGetAdminRolesQuery.ts
@@ -1,0 +1,26 @@
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+export interface AdminRole {
+  id: string;
+  name: string;
+  description: string | null;
+  is_system: boolean;
+  permissions: string[];
+}
+
+export const useGetAdminRolesQuery = (
+  options?: Omit<UseQueryOptions<AdminRole[]>, "queryKey" | "queryFn">,
+) => {
+  async function fetchRoles(): Promise<AdminRole[]> {
+    const response = await fetch("/api/admin/roles");
+    if (response.ok) return await response.json();
+    if (response.status === 403) return [];
+    throw new Error(`Failed to fetch roles (${response.status})`);
+  }
+
+  return useQuery({
+    queryKey: ["admin-roles"],
+    queryFn: fetchRoles,
+    ...options,
+  });
+};

--- a/frontend/app/api/queries/useGetAdminUsersQuery.ts
+++ b/frontend/app/api/queries/useGetAdminUsersQuery.ts
@@ -1,0 +1,31 @@
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+export interface AdminUser {
+  id: string;
+  oauth_provider: string;
+  oauth_subject: string;
+  email: string | null;
+  display_name: string | null;
+  picture_url: string | null;
+  is_active: boolean;
+  roles: string[];
+  created_at: string | null;
+  last_login: string | null;
+}
+
+export const useGetAdminUsersQuery = (
+  options?: Omit<UseQueryOptions<AdminUser[]>, "queryKey" | "queryFn">,
+) => {
+  async function fetchUsers(): Promise<AdminUser[]> {
+    const response = await fetch("/api/admin/users");
+    if (response.ok) return await response.json();
+    if (response.status === 403) return [];
+    throw new Error(`Failed to fetch users (${response.status})`);
+  }
+
+  return useQuery({
+    queryKey: ["admin-users"],
+    queryFn: fetchUsers,
+    ...options,
+  });
+};

--- a/frontend/app/api/queries/useGetAuditEventsQuery.ts
+++ b/frontend/app/api/queries/useGetAuditEventsQuery.ts
@@ -1,0 +1,40 @@
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+export interface AuditEvent {
+  id: string;
+  ts: string;
+  actor_user_id: string | null;
+  event: string;
+  target_type: string | null;
+  target_id: string | null;
+  audit_metadata: Record<string, unknown> | null;
+}
+
+interface AuditQueryParams {
+  limit?: number;
+  offset?: number;
+}
+
+export const useGetAuditEventsQuery = (
+  params: AuditQueryParams = {},
+  options?: Omit<UseQueryOptions<AuditEvent[]>, "queryKey" | "queryFn">,
+) => {
+  const { limit = 20, offset = 0 } = params;
+
+  async function fetchAudit(): Promise<AuditEvent[]> {
+    const qs = new URLSearchParams({
+      limit: String(limit),
+      offset: String(offset),
+    });
+    const response = await fetch(`/api/admin/audit?${qs.toString()}`);
+    if (response.ok) return await response.json();
+    if (response.status === 403) return [];
+    throw new Error(`Failed to fetch audit log (${response.status})`);
+  }
+
+  return useQuery({
+    queryKey: ["admin-audit", limit, offset],
+    queryFn: fetchAudit,
+    ...options,
+  });
+};

--- a/frontend/app/api/queries/useGetOnboardingStatusQuery.ts
+++ b/frontend/app/api/queries/useGetOnboardingStatusQuery.ts
@@ -1,0 +1,34 @@
+import { type UseQueryOptions, useQuery } from "@tanstack/react-query";
+
+export interface OnboardingStatus {
+  onboarded: boolean;
+  /** Step indicator from OnboardingState — historically an integer
+   * index, may become a named step in future. Treat as opaque. */
+  current_step: number | string | null;
+}
+
+/**
+ * Public query — hits GET /api/onboarding-status. The endpoint is
+ * unauthenticated so this works pre-login and is used by the auth
+ * context to decide between rendering the onboarding wizard and the
+ * login flow.
+ */
+export const useGetOnboardingStatusQuery = (
+  options?: Omit<UseQueryOptions<OnboardingStatus>, "queryKey" | "queryFn">,
+) => {
+  async function fetchStatus(): Promise<OnboardingStatus> {
+    const response = await fetch("/api/onboarding-status");
+    if (response.ok) return await response.json();
+    // Conservative fallback: assume NOT onboarded if the endpoint is
+    // unreachable. Avoids accidentally hiding the wizard on a brand-new
+    // install whose backend is still booting.
+    return { onboarded: false, current_step: null };
+  }
+
+  return useQuery({
+    queryKey: ["onboarding-status"],
+    queryFn: fetchStatus,
+    staleTime: Infinity, // doesn't change during a session
+    ...options,
+  });
+};

--- a/frontend/app/settings/_components/audit-log-feed.tsx
+++ b/frontend/app/settings/_components/audit-log-feed.tsx
@@ -1,0 +1,225 @@
+"use client";
+
+import { Activity, Loader2, RefreshCw } from "lucide-react";
+import { useMemo } from "react";
+
+import { useGetAdminUsersQuery } from "@/app/api/queries/useGetAdminUsersQuery";
+import {
+  type AuditEvent,
+  useGetAuditEventsQuery,
+} from "@/app/api/queries/useGetAuditEventsQuery";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { useIsCloudBrand } from "@/contexts/brand-context";
+import { cn } from "@/lib/utils";
+
+/** Colored dot + label for an event. No pill chrome — pills are reserved for roles. */
+const EVENT_PRESENTATION: Record<string, { label: string; dot: string }> = {
+  // Greens — additive, healthy
+  "user.bootstrap_admin": {
+    label: "Bootstrap admin",
+    dot: "bg-emerald-500",
+  },
+  "user.created": { label: "User created", dot: "bg-emerald-500" },
+  "user.role.assigned": { label: "Role assigned", dot: "bg-emerald-500" },
+  "role.created": { label: "Role created", dot: "bg-emerald-500" },
+
+  // Blues — informational, neutral mutations
+  "user.updated": { label: "User updated", dot: "bg-blue-500" },
+  "role.updated": { label: "Role updated", dot: "bg-blue-500" },
+  "user.merged_legacy": { label: "Merged legacy", dot: "bg-blue-500" },
+
+  // Reds — destructive
+  "user.deleted": { label: "User deleted", dot: "bg-red-500" },
+  "user.role.revoked": { label: "Role revoked", dot: "bg-red-500" },
+  "role.deleted": { label: "Role deleted", dot: "bg-red-500" },
+
+  // Amber — warnings / denials
+  "permission.denied": { label: "Permission denied", dot: "bg-amber-500" },
+};
+
+function formatHumanRelative(iso: string): string {
+  const ts = new Date(iso).getTime();
+  const diffMs = Date.now() - ts;
+  const sec = Math.round(diffMs / 1000);
+  if (sec < 5) return "just now";
+  if (sec < 60) return `${sec} seconds ago`;
+  const min = Math.round(sec / 60);
+  if (min === 1) return "a minute ago";
+  if (min < 60) return `${min} minutes ago`;
+  const hr = Math.round(min / 60);
+  if (hr === 1) return "an hour ago";
+  if (hr < 24) return `${hr} hours ago`;
+  const day = Math.round(hr / 24);
+  if (day === 1) return "yesterday";
+  if (day < 7) return `${day} days ago`;
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+function summarizeMetadata(e: AuditEvent): string | null {
+  const m = e.audit_metadata;
+  if (!m) return null;
+  if (typeof m.role_name === "string") return m.role_name;
+  if (typeof m.role === "string") return m.role;
+  if (typeof m.required === "string") return m.required;
+  if (typeof m.name === "string") return m.name;
+  return null;
+}
+
+export function AuditLogFeed() {
+  const isCloudBrand = useIsCloudBrand();
+  const auditQuery = useGetAuditEventsQuery({ limit: 20 });
+  const usersQuery = useGetAdminUsersQuery();
+
+  const events = auditQuery.data ?? [];
+  const users = usersQuery.data ?? [];
+
+  // Build a map: db_user_id -> display label (name or email).
+  const userLabel = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const u of users) {
+      const label = u.display_name || u.email || u.oauth_subject;
+      map.set(u.id, label);
+      // Also key by oauth_subject so legacy events whose actor_user_id is
+      // the OAuth sub still resolve.
+      if (u.oauth_subject) map.set(u.oauth_subject, label);
+    }
+    return map;
+  }, [users]);
+
+  const labelFor = (id: string | null): string => {
+    if (!id) return "—";
+    return userLabel.get(id) ?? `${id.slice(0, 8)}…`;
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-center justify-between mb-3">
+          <CardTitle
+            className={cn(
+              "text-lg flex items-center gap-2",
+              isCloudBrand && "ibm-settings-section-title",
+            )}
+          >
+            <Activity className="h-5 w-5" /> Recent Activity
+          </CardTitle>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => auditQuery.refetch()}
+            disabled={auditQuery.isFetching}
+          >
+            <RefreshCw
+              className={cn(
+                "h-4 w-4 mr-2",
+                auditQuery.isFetching && "animate-spin",
+              )}
+            />
+            Refresh
+          </Button>
+        </div>
+        <CardDescription>
+          Last 20 RBAC events. Backend writes one row per role assignment,
+          revocation, or permission denial.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {auditQuery.isLoading ? (
+          <div className="flex items-center justify-center py-8">
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        ) : auditQuery.isError ? (
+          <div className="text-sm text-destructive py-4">
+            Failed to load audit log: {(auditQuery.error as Error).message}
+          </div>
+        ) : events.length === 0 ? (
+          <div className="text-center py-8">
+            <Activity className="h-12 w-12 mx-auto text-muted-foreground/50 mb-4" />
+            <p className="text-muted-foreground text-sm">
+              No events yet, or you do not have{" "}
+              <code className="text-xs bg-muted px-1 py-0.5 rounded">
+                audit:read
+              </code>
+              .
+            </p>
+          </div>
+        ) : (
+          <div className="border rounded-lg overflow-hidden">
+            <table className="w-full">
+              <thead className="bg-muted/50">
+                <tr>
+                  <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3 w-[200px]">
+                    Event
+                  </th>
+                  <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">
+                    Actor
+                  </th>
+                  <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">
+                    Target
+                  </th>
+                  <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">
+                    Detail
+                  </th>
+                  <th className="text-right text-sm font-medium text-muted-foreground px-4 py-3 w-[140px]">
+                    When
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {events.map((e) => {
+                  const meta = EVENT_PRESENTATION[e.event] ?? {
+                    label: e.event,
+                    dot: "bg-muted-foreground",
+                  };
+                  const summary = summarizeMetadata(e);
+                  return (
+                    <tr key={e.id} className="border-t">
+                      <td className="px-4 py-3">
+                        <span className="inline-flex items-center gap-2 text-sm">
+                          <span
+                            className={cn(
+                              "h-1.5 w-1.5 rounded-full shrink-0",
+                              meta.dot,
+                            )}
+                            aria-hidden
+                          />
+                          <span>{meta.label}</span>
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {labelFor(e.actor_user_id)}
+                      </td>
+                      <td className="px-4 py-3 text-sm">
+                        {labelFor(e.target_id)}
+                      </td>
+                      <td className="px-4 py-3 text-sm text-muted-foreground capitalize">
+                        {summary ?? "—"}
+                      </td>
+                      <td
+                        className="px-4 py-3 text-sm text-muted-foreground text-right whitespace-nowrap"
+                        title={new Date(e.ts).toLocaleString()}
+                      >
+                        {formatHumanRelative(e.ts)}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/app/settings/_components/connector-card.tsx
+++ b/frontend/app/settings/_components/connector-card.tsx
@@ -11,6 +11,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useIsCloudBrand } from "@/contexts/brand-context";
+import { usePermissions } from "@/hooks/use-permissions";
 import { cn } from "@/lib/utils";
 import CardIcon from "./card-icon";
 
@@ -45,6 +46,13 @@ export default function ConnectorCard({
   onConfigure,
 }: ConnectorCardProps) {
   const isCloudBrand = useIsCloudBrand();
+  const { can, canAny } = usePermissions();
+  const canCreate = can("connectors:create");
+  const canDisconnect = canAny([
+    "connectors:delete:own",
+    "connectors:delete:any",
+  ]);
+  const canUpload = can("knowledge:upload");
   const isConnected =
     connector.status === "connected" && connector.connectionId;
 
@@ -109,7 +117,12 @@ export default function ConnectorCard({
                 <Button
                   variant="default"
                   onClick={() => onNavigateToKnowledge(connector)}
-                  disabled={isDisconnecting || isConnecting}
+                  disabled={isDisconnecting || isConnecting || !canUpload}
+                  title={
+                    canUpload
+                      ? undefined
+                      : "You do not have permission to add knowledge"
+                  }
                   className={cn(
                     "cursor-pointer !text-sm truncate flex-1 text-primary-foreground [&_svg]:text-primary-foreground",
                     isCloudBrand ? "rounded-none" : "rounded-md",
@@ -119,48 +132,59 @@ export default function ConnectorCard({
                   <Plus className="h-4 w-4" />
                   <span className="text-mmd truncate">Add Knowledge</span>
                 </Button>
-                <Button
-                  variant="outline"
-                  onClick={() =>
-                    onConfigure ? onConfigure(connector) : onConnect(connector)
-                  }
-                  disabled={isConnecting || isDisconnecting}
-                  className={cn(
-                    "cursor-pointer",
-                    isCloudBrand &&
-                      "rounded-none border-button-tertiary text-layer-contextual-foreground hover:bg-black/5 hover:text-layer-contextual-foreground dark:hover:bg-white/5",
-                  )}
-                  size="iconMd"
-                >
-                  {isConnecting ? (
-                    <RefreshCcw className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Settings2 className="h-4 w-4" />
-                  )}
-                </Button>
-                <Button
-                  variant="outline"
-                  onClick={() => onDisconnect(connector)}
-                  disabled={isDisconnecting || isConnecting}
-                  className={cn(
-                    "cursor-pointer text-destructive hover:text-destructive",
-                    isCloudBrand && "rounded-none",
-                  )}
-                  size="iconMd"
-                >
-                  {isDisconnecting ? (
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                  ) : (
-                    <Trash2 className="h-4 w-4" />
-                  )}
-                </Button>
+                {canCreate && (
+                  <Button
+                    variant="outline"
+                    onClick={() =>
+                      onConfigure
+                        ? onConfigure(connector)
+                        : onConnect(connector)
+                    }
+                    disabled={isConnecting || isDisconnecting}
+                    className={cn(
+                      "cursor-pointer",
+                      isCloudBrand &&
+                        "rounded-none border-button-tertiary text-layer-contextual-foreground hover:bg-black/5 hover:text-layer-contextual-foreground dark:hover:bg-white/5",
+                    )}
+                    size="iconMd"
+                  >
+                    {isConnecting ? (
+                      <RefreshCcw className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Settings2 className="h-4 w-4" />
+                    )}
+                  </Button>
+                )}
+                {canDisconnect && (
+                  <Button
+                    variant="outline"
+                    onClick={() => onDisconnect(connector)}
+                    disabled={isDisconnecting || isConnecting}
+                    className={cn(
+                      "cursor-pointer text-destructive hover:text-destructive",
+                      isCloudBrand && "rounded-none",
+                    )}
+                    size="iconMd"
+                  >
+                    {isDisconnecting ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : (
+                      <Trash2 className="h-4 w-4" />
+                    )}
+                  </Button>
+                )}
               </div>
             ) : (
               <Button
                 onClick={() =>
                   onConfigure ? onConfigure(connector) : onConnect(connector)
                 }
-                disabled={isConnecting}
+                disabled={isConnecting || !canCreate}
+                title={
+                  canCreate
+                    ? undefined
+                    : "You do not have permission to create connectors"
+                }
                 variant={isCloudBrand ? "outline" : "default"}
                 className={cn(
                   "w-full cursor-pointer",

--- a/frontend/app/settings/_components/role-permissions-matrix.tsx
+++ b/frontend/app/settings/_components/role-permissions-matrix.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import { Check, ChevronDown, Minus } from "lucide-react";
+import { Fragment, useState } from "react";
+
+import {
+  type AdminPermission,
+  useGetAdminPermissionsQuery,
+} from "@/app/api/queries/useGetAdminPermissionsQuery";
+import {
+  type AdminRole,
+  useGetAdminRolesQuery,
+} from "@/app/api/queries/useGetAdminRolesQuery";
+import { Button } from "@/components/ui/button";
+import { getRolePillClass } from "@/lib/role-styles";
+import { cn } from "@/lib/utils";
+
+/**
+ * Friendly description mapping for what each permission *actually* gates
+ * in the live system. Curated alongside the backend `require_permission`
+ * sites and the frontend `<RequirePermission>` wrappers, so admins can
+ * see at a glance which permission unlocks which UI / API surface.
+ *
+ * Anything not in this map falls back to the backend's free-form
+ * `description` column from the permissions table — there's always a
+ * description, this just adds a "where it bites" hint for the built-ins.
+ */
+const PERMISSION_GATES: Record<string, { ui: string; api: string }> = {
+  // Config / Infra
+  "config:read": {
+    ui: "Settings page reads",
+    api: "GET /settings",
+  },
+  "config:write": {
+    ui: "Knowledge Ingest, Onboarding, Docling preset",
+    api: "POST /settings, /onboarding, /onboarding/state, /onboarding/rollback, /settings/docling-preset",
+  },
+  "providers:read": {
+    ui: "Model Providers section (read)",
+    api: "GET /models, /providers",
+  },
+  "providers:write": {
+    ui: "Model Providers section (edit)",
+    api: "POST /settings (provider fields)",
+  },
+  "providers:override:self": {
+    ui: "Per-user provider key override (Phase 4)",
+    api: "PATCH /api/users/me/preferences",
+  },
+  "opensearch:admin": {
+    ui: "(internal)",
+    api: "OpenSearch security setup at startup",
+  },
+
+  // Users / RBAC
+  "users:list": {
+    ui: "Users & Roles table",
+    api: "GET /api/admin/users",
+  },
+  "users:read": {
+    ui: "User detail",
+    api: "GET /api/admin/users/{id}",
+  },
+  "users:invite": {
+    ui: "Activate / deactivate user",
+    api: "PATCH /api/admin/users/{id}",
+  },
+  "users:delete": {
+    ui: "Delete user (admin)",
+    api: "DELETE /api/admin/users/{id}",
+  },
+  "roles:list": {
+    ui: "Available Roles + this matrix",
+    api: "GET /api/admin/roles, /api/admin/permissions",
+  },
+  "roles:assign": {
+    ui: "+ Assign role / × Revoke role",
+    api: "POST /api/admin/users/{id}/roles, DELETE /api/admin/users/{id}/roles/{role_id}",
+  },
+  "roles:create": {
+    ui: "Create custom role (planned)",
+    api: "POST /api/admin/roles",
+  },
+  "roles:edit": {
+    ui: "Edit role permissions (planned)",
+    api: "PATCH /api/admin/roles/{id}",
+  },
+  "roles:delete": {
+    ui: "Delete custom role (planned)",
+    api: "DELETE /api/admin/roles/{id}",
+  },
+  "audit:read": {
+    ui: "Recent Activity table",
+    api: "GET /api/admin/audit",
+  },
+
+  // Connectors
+  "connectors:list:own": {
+    ui: "List own connectors",
+    api: "GET /connectors (filtered to user)",
+  },
+  "connectors:list:all": {
+    ui: "List all users' connectors (admin)",
+    api: "GET /connectors (no filter)",
+  },
+  "connectors:create": {
+    ui: "Connect / Configure buttons in Settings",
+    api: "POST /connectors/{type}/sync, OAuth init",
+  },
+  "connectors:delete:own": {
+    ui: "Disconnect button on own connector",
+    api: "DELETE /connectors/{type}/disconnect",
+  },
+  "connectors:delete:any": {
+    ui: "Disconnect any user's connector (admin)",
+    api: "DELETE /connectors/{type}/disconnect (any user)",
+  },
+  "connectors:use": {
+    ui: "Sync, browse buckets, OAuth callback",
+    api: "POST /connectors/{type}/sync, /connectors/sync-all",
+  },
+
+  // Knowledge
+  "knowledge:upload": {
+    ui: "Add Knowledge dropdown, file picker, folder ingest",
+    api: "POST /upload, /upload_path, /upload_context, /upload_bucket",
+  },
+  "knowledge:delete:own": {
+    ui: "Delete own document (row + bulk)",
+    api: "POST /documents/delete-by-filename (own)",
+  },
+  "knowledge:delete:any": {
+    ui: "Delete any document (admin)",
+    api: "POST /documents/delete-by-filename (any)",
+  },
+  "knowledge:read:own": {
+    ui: "Knowledge tab visibility, browse own docs",
+    api: "GET /search, /knowledge/* (own scope)",
+  },
+  "knowledge:read:all": {
+    ui: "Browse all users' docs (admin)",
+    api: "GET /search, /knowledge/* (no scope)",
+  },
+  "kf:create": {
+    ui: "Create Filter button",
+    api: "POST /knowledge-filter",
+  },
+  "kf:edit:own": {
+    ui: "Edit/Delete own KF (Save/Update/Delete buttons)",
+    api: "PUT/DELETE /knowledge-filter/{id} (own)",
+  },
+  "kf:edit:any": {
+    ui: "Edit/Delete any KF (admin)",
+    api: "PUT/DELETE /knowledge-filter/{id} (any)",
+  },
+  "kf:share": {
+    ui: "Share KF (planned)",
+    api: "(planned)",
+  },
+
+  // Chat / search
+  "chat:use": {
+    ui: "Chat tab + send message + New Conversation",
+    api: "POST /chat, /langflow",
+  },
+  "search:use": {
+    ui: "Search bar",
+    api: "POST /search",
+  },
+  "conversations:read:own": {
+    ui: "Own chat history",
+    api: "GET /chat/history, /langflow/history",
+  },
+  "conversations:read:all": {
+    ui: "All users' history (admin)",
+    api: "(planned)",
+  },
+  "conversations:delete:own": {
+    ui: "Delete conversation menu item",
+    api: "DELETE /sessions/{id} (own)",
+  },
+  "conversations:delete:any": {
+    ui: "Delete any conversation (admin)",
+    api: "DELETE /sessions/{id} (any)",
+  },
+
+  // Flows / agent
+  "flows:read": {
+    ui: "View Langflow",
+    api: "GET /flows/*",
+  },
+  "flows:edit": {
+    ui: "Edit in Langflow + Restore flow buttons",
+    api: "POST /reset-flow/{type}",
+  },
+  "agent:prompt:override": {
+    ui: "Per-user agent prompt (Phase 4)",
+    api: "PATCH /api/users/me/preferences",
+  },
+  "agent:prompt:global": {
+    ui: "Workspace agent system prompt textarea",
+    api: "POST /settings (agent.system_prompt)",
+  },
+
+  // API keys
+  "apikeys:create:self": {
+    ui: "Create Key button",
+    api: "POST /keys",
+  },
+  "apikeys:revoke:self": {
+    ui: "Revoke own key (trash icon)",
+    api: "DELETE /keys/{id}, /keys/{id}/permanent",
+  },
+  "apikeys:revoke:any": {
+    ui: "Revoke any user's key (admin)",
+    api: "(planned)",
+  },
+  "apikeys:list:any": {
+    ui: "List all users' keys (admin)",
+    api: "(planned)",
+  },
+};
+
+interface MatrixRowProps {
+  perm: AdminPermission;
+  roles: AdminRole[];
+}
+
+function MatrixRow({ perm, roles }: MatrixRowProps) {
+  const gate = PERMISSION_GATES[perm.name];
+  return (
+    <tr className="border-t hover:bg-muted/30">
+      <td className="px-4 py-2.5 align-top">
+        <div className="flex flex-col gap-0.5">
+          <code className="text-xs font-mono text-foreground">{perm.name}</code>
+          {perm.description && (
+            <span className="text-xs text-muted-foreground">
+              {perm.description}
+            </span>
+          )}
+          {gate && (
+            <div className="flex flex-col gap-0.5 mt-1">
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                UI:{" "}
+                <span className="normal-case text-muted-foreground/80">
+                  {gate.ui}
+                </span>
+              </span>
+              <span className="text-[10px] uppercase tracking-wide text-muted-foreground">
+                API:{" "}
+                <code className="normal-case text-muted-foreground/80 font-mono">
+                  {gate.api}
+                </code>
+              </span>
+            </div>
+          )}
+        </div>
+      </td>
+      {roles.map((r) => {
+        const has = r.permissions.includes(perm.name);
+        return (
+          <td key={r.id} className="px-3 py-2.5 text-center align-top">
+            {has ? (
+              <Check
+                className="h-4 w-4 mx-auto text-emerald-600 dark:text-emerald-400"
+                aria-label={`${r.name} has ${perm.name}`}
+              />
+            ) : (
+              <Minus
+                className="h-4 w-4 mx-auto text-muted-foreground/30"
+                aria-label={`${r.name} does not have ${perm.name}`}
+              />
+            )}
+          </td>
+        );
+      })}
+    </tr>
+  );
+}
+
+export function RolePermissionsMatrix() {
+  const [open, setOpen] = useState(false);
+  const rolesQuery = useGetAdminRolesQuery();
+  const permsQuery = useGetAdminPermissionsQuery({
+    enabled: open, // lazy fetch — only when the matrix is expanded
+  });
+
+  const roles = rolesQuery.data ?? [];
+  const perms = permsQuery.data ?? [];
+
+  // Group permissions by resource for readable section headers.
+  const groupedPerms = perms.reduce<Record<string, AdminPermission[]>>(
+    (acc, p) => {
+      if (!acc[p.resource]) acc[p.resource] = [];
+      acc[p.resource].push(p);
+      return acc;
+    },
+    {},
+  );
+  const sortedGroups = Object.entries(groupedPerms).sort(([a], [b]) =>
+    a.localeCompare(b),
+  );
+
+  return (
+    <div className="border rounded-lg overflow-hidden">
+      <Button
+        type="button"
+        variant="ghost"
+        onClick={() => setOpen((v) => !v)}
+        className="w-full justify-between h-auto px-4 py-3 rounded-none hover:bg-muted/30"
+      >
+        <span className="flex items-center gap-2 text-sm font-medium">
+          Role × Permission matrix
+          <span className="text-xs text-muted-foreground">
+            ({perms.length || roles.length} permissions
+            {roles.length > 0 ? ` × ${roles.length} roles` : ""})
+          </span>
+        </span>
+        <ChevronDown
+          className={cn(
+            "h-4 w-4 text-muted-foreground transition-transform",
+            open && "rotate-180",
+          )}
+        />
+      </Button>
+
+      {open && (
+        <div className="border-t">
+          {permsQuery.isLoading ? (
+            <div className="px-4 py-6 text-center text-sm text-muted-foreground">
+              Loading…
+            </div>
+          ) : permsQuery.isError ? (
+            <div className="px-4 py-6 text-sm text-destructive">
+              Failed to load permission catalog:{" "}
+              {(permsQuery.error as Error).message}
+            </div>
+          ) : perms.length === 0 ? (
+            <div className="px-4 py-6 text-center text-sm text-muted-foreground italic">
+              No permissions returned (need <code>roles:list</code>).
+            </div>
+          ) : (
+            <div className="overflow-x-auto">
+              <table className="w-full">
+                <thead className="bg-muted/50 sticky top-0">
+                  <tr>
+                    <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">
+                      Permission
+                    </th>
+                    {roles.map((r) => (
+                      <th
+                        key={r.id}
+                        className="text-center text-sm font-medium px-3 py-3 min-w-[100px]"
+                      >
+                        <span className={getRolePillClass(r.name)}>
+                          {r.name}
+                        </span>
+                      </th>
+                    ))}
+                  </tr>
+                </thead>
+                <tbody>
+                  {sortedGroups.map(([resource, resourcePerms]) => (
+                    <Fragment key={`group-${resource}`}>
+                      <tr className="bg-muted/20">
+                        <td
+                          colSpan={1 + roles.length}
+                          className="px-4 py-1.5 text-[10px] uppercase tracking-wide text-muted-foreground font-semibold"
+                        >
+                          {resource}
+                        </td>
+                      </tr>
+                      {resourcePerms
+                        .sort((a, b) => a.action.localeCompare(b.action))
+                        .map((p) => (
+                          <MatrixRow key={p.id} perm={p} roles={roles} />
+                        ))}
+                    </Fragment>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/app/settings/_components/users-and-roles-section.tsx
+++ b/frontend/app/settings/_components/users-and-roles-section.tsx
@@ -1,0 +1,415 @@
+"use client";
+
+import { Loader2, RefreshCw, Search, ShieldCheck, X } from "lucide-react";
+import { useMemo, useState } from "react";
+import { toast } from "sonner";
+import { useAssignRoleMutation } from "@/app/api/mutations/useAssignRoleMutation";
+import { useRevokeRoleMutation } from "@/app/api/mutations/useRevokeRoleMutation";
+import {
+  type AdminRole,
+  useGetAdminRolesQuery,
+} from "@/app/api/queries/useGetAdminRolesQuery";
+import {
+  type AdminUser,
+  useGetAdminUsersQuery,
+} from "@/app/api/queries/useGetAdminUsersQuery";
+import { RolePermissionsPreview } from "@/components/role-permissions-preview";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAuth } from "@/contexts/auth-context";
+import { useIsCloudBrand } from "@/contexts/brand-context";
+import { getRolePillClass } from "@/lib/role-styles";
+import { cn } from "@/lib/utils";
+
+import { AuditLogFeed } from "./audit-log-feed";
+import { RolePermissionsMatrix } from "./role-permissions-matrix";
+
+interface UserRowProps {
+  u: AdminUser;
+  roles: AdminRole[];
+  onAssign: (userId: string, roleId: string) => void;
+  onRevoke: (userId: string, roleId: string, roleName: string) => void;
+  pending: boolean;
+  selfDbId?: string;
+}
+
+function UserRow({
+  u,
+  roles,
+  onAssign,
+  onRevoke,
+  pending,
+  selfDbId,
+}: UserRowProps) {
+  const [selectedRole, setSelectedRole] = useState<string>("");
+  const isSelf = selfDbId && selfDbId === u.id;
+  const availableRoles = roles.filter((r) => !u.roles.includes(r.name));
+
+  return (
+    <tr className="border-t">
+      <td className="px-4 py-3">
+        <div className="flex items-center gap-3 min-w-0">
+          <Avatar className="rounded-md w-8 h-8 shrink-0">
+            {u.picture_url && (
+              <AvatarImage src={u.picture_url} alt={u.display_name ?? ""} />
+            )}
+            <AvatarFallback className="text-xs rounded-md">
+              {(u.display_name ?? u.email ?? "?").charAt(0).toUpperCase()}
+            </AvatarFallback>
+          </Avatar>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <p className="text-sm font-medium truncate">
+                {u.display_name ?? "(unnamed)"}
+              </p>
+              {isSelf && (
+                <Badge variant="outline" className="text-[10px] py-0 px-1.5">
+                  you
+                </Badge>
+              )}
+            </div>
+            <p className="text-xs text-muted-foreground truncate">
+              {u.email ?? u.oauth_subject}
+            </p>
+          </div>
+        </div>
+      </td>
+      <td className="px-4 py-3">
+        <div className="flex flex-wrap items-center gap-1.5">
+          {u.roles.length === 0 ? (
+            <span className="text-xs text-muted-foreground italic">
+              no roles
+            </span>
+          ) : (
+            u.roles.map((r) => {
+              const role = roles.find((rr) => rr.name === r);
+              return (
+                <span key={r} className={getRolePillClass(r)}>
+                  {r}
+                  {role && (
+                    <RolePermissionsPreview
+                      name={role.name}
+                      description={role.description}
+                      permissions={role.permissions}
+                    />
+                  )}
+                  {role && (
+                    <button
+                      type="button"
+                      aria-label={`Remove ${r}`}
+                      disabled={pending}
+                      onClick={() => onRevoke(u.id, role.id, role.name)}
+                      className="inline-flex h-5 w-5 items-center justify-center rounded-full hover:bg-foreground/10 transition-colors -mr-1 disabled:opacity-50"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  )}
+                </span>
+              );
+            })
+          )}
+        </div>
+      </td>
+      <td className="px-4 py-3 text-right">
+        <Select
+          value={selectedRole}
+          onValueChange={(v) => {
+            setSelectedRole("");
+            const role = roles.find((rr) => rr.id === v);
+            if (role) onAssign(u.id, role.id);
+          }}
+          disabled={pending || availableRoles.length === 0}
+        >
+          <SelectTrigger className="h-9 w-[160px] text-sm ml-auto">
+            <SelectValue placeholder="+ Assign role" />
+          </SelectTrigger>
+          <SelectContent>
+            {availableRoles.map((r) => (
+              <SelectItem key={r.id} value={r.id} className="text-sm py-2">
+                <span className="capitalize font-medium">{r.name}</span>
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </td>
+    </tr>
+  );
+}
+
+export function UsersAndRolesSection() {
+  const isCloudBrand = useIsCloudBrand();
+  const { user: currentUser } = useAuth();
+  const usersQuery = useGetAdminUsersQuery();
+  const rolesQuery = useGetAdminRolesQuery();
+  const assignMutation = useAssignRoleMutation();
+  const revokeMutation = useRevokeRoleMutation();
+
+  const [search, setSearch] = useState("");
+  const [filterRole, setFilterRole] = useState<string>("__all");
+
+  const [pendingRevoke, setPendingRevoke] = useState<{
+    user_id: string;
+    role_id: string;
+    role_name: string;
+  } | null>(null);
+
+  const onAssign = (user_id: string, role_id: string) => {
+    assignMutation.mutate(
+      { user_id, role_id },
+      {
+        onSuccess: () => toast.success("Role assigned"),
+        onError: (err: Error) => toast.error(err.message),
+      },
+    );
+  };
+
+  const performRevoke = (user_id: string, role_id: string) => {
+    revokeMutation.mutate(
+      { user_id, role_id },
+      {
+        onSuccess: () => toast.success("Role revoked"),
+        onError: (err: Error) => toast.error(err.message),
+      },
+    );
+  };
+
+  const onRevoke = (user_id: string, role_id: string, role_name: string) => {
+    if (role_name === "admin") {
+      setPendingRevoke({ user_id, role_id, role_name });
+      return;
+    }
+    performRevoke(user_id, role_id);
+  };
+
+  const isLoading = usersQuery.isLoading || rolesQuery.isLoading;
+  const isMutating = assignMutation.isPending || revokeMutation.isPending;
+  const users = usersQuery.data ?? [];
+  const roles = rolesQuery.data ?? [];
+
+  const filteredUsers = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return users.filter((u) => {
+      if (filterRole !== "__all" && !u.roles.includes(filterRole)) return false;
+      if (!q) return true;
+      const hay =
+        `${u.email ?? ""} ${u.display_name ?? ""} ${u.oauth_subject}`.toLowerCase();
+      return hay.includes(q);
+    });
+  }, [users, search, filterRole]);
+
+  const selfDbId = useMemo(() => {
+    if (!currentUser) return undefined;
+    const match = users.find(
+      (u) =>
+        u.oauth_subject === currentUser.user_id || u.id === currentUser.user_id,
+    );
+    return match?.id;
+  }, [users, currentUser]);
+
+  return (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between mb-3">
+            <CardTitle
+              className={cn(
+                "text-lg flex items-center gap-2",
+                isCloudBrand && "ibm-settings-section-title",
+              )}
+            >
+              <ShieldCheck className="h-5 w-5" /> Users & Roles
+            </CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                usersQuery.refetch();
+                rolesQuery.refetch();
+              }}
+              disabled={usersQuery.isFetching || rolesQuery.isFetching}
+            >
+              <RefreshCw
+                className={cn(
+                  "h-4 w-4 mr-2",
+                  (usersQuery.isFetching || rolesQuery.isFetching) &&
+                    "animate-spin",
+                )}
+              />
+              Refresh
+            </Button>
+          </div>
+          <CardDescription>
+            Assign or revoke roles for users in your workspace. Backend enforces
+            all permission checks; this UI mirrors the live state.
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          {/* Search + filter row — heights match Settings primitives (h-9) */}
+          <div className="flex items-center gap-2">
+            <div className="relative flex-1">
+              <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                placeholder="Search by name, email, or ID"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                className="pl-9"
+              />
+            </div>
+            <Select value={filterRole} onValueChange={setFilterRole}>
+              <SelectTrigger className="w-[180px]">
+                <SelectValue placeholder="All roles" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="__all">All roles</SelectItem>
+                {roles.map((r) => (
+                  <SelectItem key={r.id} value={r.name}>
+                    <span className="capitalize">{r.name}</span>
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {/* User table — matches API Keys table styling */}
+          {isLoading ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            </div>
+          ) : usersQuery.isError ? (
+            <div className="text-sm text-destructive py-4">
+              Failed to load users: {(usersQuery.error as Error).message}
+            </div>
+          ) : filteredUsers.length === 0 ? (
+            <div className="text-sm text-muted-foreground italic py-8 text-center">
+              {users.length === 0
+                ? "No users found, or you do not have permission to list users."
+                : "No users match your search."}
+            </div>
+          ) : (
+            <div className="border rounded-lg overflow-hidden">
+              <table className="w-full">
+                <thead className="bg-muted/50">
+                  <tr>
+                    <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">
+                      User
+                    </th>
+                    <th className="text-left text-sm font-medium text-muted-foreground px-4 py-3">
+                      Roles
+                    </th>
+                    <th className="text-right text-sm font-medium text-muted-foreground px-4 py-3 w-[180px]">
+                      Actions
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filteredUsers.map((u) => (
+                    <UserRow
+                      key={u.id}
+                      u={u}
+                      roles={roles}
+                      onAssign={onAssign}
+                      onRevoke={onRevoke}
+                      pending={isMutating}
+                      selfDbId={selfDbId}
+                    />
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
+
+          {/* Available Roles strip + collapsible matrix */}
+          {roles.length > 0 && (
+            <div className="pt-2 space-y-3">
+              <div>
+                <p className="text-xs uppercase tracking-wide text-muted-foreground mb-2">
+                  Available Roles
+                </p>
+                <div className="flex flex-wrap gap-1.5">
+                  {roles.map((r) => (
+                    <span key={r.id} className={getRolePillClass(r.name)}>
+                      {r.name}
+                      <RolePermissionsPreview
+                        name={r.name}
+                        description={r.description}
+                        permissions={r.permissions}
+                      />
+                    </span>
+                  ))}
+                </div>
+              </div>
+              <RolePermissionsMatrix />
+            </div>
+          )}
+        </CardContent>
+      </Card>
+
+      <AuditLogFeed />
+
+      <Dialog
+        open={pendingRevoke !== null}
+        onOpenChange={(open) => !open && setPendingRevoke(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle className="mb-4">Revoke admin role?</DialogTitle>
+            <DialogDescription className="text-left">
+              <span className="block mb-2">
+                You are about to remove the <strong>admin</strong> role from
+                this user. They will lose all admin permissions immediately.
+              </span>
+              <span className="block text-xs text-muted-foreground">
+                The backend prevents removing the last admin in the workspace.
+              </span>
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="ghost"
+              onClick={() => setPendingRevoke(null)}
+              size="sm"
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                if (pendingRevoke) {
+                  performRevoke(pendingRevoke.user_id, pendingRevoke.role_id);
+                  setPendingRevoke(null);
+                }
+              }}
+              size="sm"
+            >
+              Revoke admin
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/frontend/app/settings/settings-client.tsx
+++ b/frontend/app/settings/settings-client.tsx
@@ -58,15 +58,18 @@ import { deriveCloudLangflowUrl } from "@/lib/url-utils";
 import { cn } from "@/lib/utils";
 import { useUpdateSettingsMutation } from "../api/mutations/useUpdateSettingsMutation";
 import { ModelSelector } from "../onboarding/_components/model-selector";
+import { RequirePermission } from "@/components/require-permission";
 import ConnectorCards from "./_components/connector-cards";
 import ModelProviders from "./_components/model-providers";
+import { UsersAndRolesSection } from "./_components/users-and-roles-section";
 import { getModelLogo, type ModelProvider } from "./_helpers/model-helpers";
 
 const { MAX_SYSTEM_PROMPT_CHARS } = UI_CONSTANTS;
 
 function KnowledgeSourcesPage() {
   const isCloudBrand = useIsCloudBrand();
-  const { isAuthenticated, isNoAuthMode, isIbmAuthMode } = useAuth();
+  const { isAuthenticated, isNoAuthMode, isIbmAuthMode, rbacEnforced } =
+    useAuth();
   const { addTask, tasks } = useTask();
   const searchParams = useSearchParams();
   const router = useRouter();
@@ -690,20 +693,22 @@ function KnowledgeSourcesPage() {
         <ConnectorCards />
       </div>
 
-      {/* Model Providers Section */}
-      <div className="space-y-6">
-        <div>
-          <h2
-            className={cn(
-              "mb-2 text-lg font-semibold tracking-tight",
-              isCloudBrand && "ibm-settings-section-title",
-            )}
-          >
-            Model Providers
-          </h2>
+      {/* Model Providers Section — admin only (workspace-level provider keys) */}
+      <RequirePermission perm="providers:write">
+        <div className="space-y-6">
+          <div>
+            <h2
+              className={cn(
+                "mb-2 text-lg font-semibold tracking-tight",
+                isCloudBrand && "ibm-settings-section-title",
+              )}
+            >
+              Model Providers
+            </h2>
+          </div>
+          <ModelProviders />
         </div>
-        <ModelProviders />
-      </div>
+      </RequirePermission>
 
       {/* Agent Behavior Section */}
       <Card id="agent-card">
@@ -717,6 +722,7 @@ function KnowledgeSourcesPage() {
             >
               Agent
             </CardTitle>
+            <RequirePermission perm="flows:edit">
             <div className="flex gap-2">
               <ConfirmationDialog
                 trigger={
@@ -782,6 +788,7 @@ function KnowledgeSourcesPage() {
                 variant="warning"
               />
             </div>
+            </RequirePermission>
           </div>
           <CardDescription>
             This Agent retrieves from your knowledge and generates chat
@@ -872,6 +879,7 @@ function KnowledgeSourcesPage() {
             >
               Knowledge Ingest
             </CardTitle>
+            <RequirePermission perm="flows:edit">
             <div className="flex gap-2">
               <ConfirmationDialog
                 trigger={
@@ -937,6 +945,7 @@ function KnowledgeSourcesPage() {
                 }
               />
             </div>
+            </RequirePermission>
           </div>
           <CardDescription>
             Configure how files are ingested and stored for retrieval. The

--- a/frontend/app/settings/settings-client.tsx
+++ b/frontend/app/settings/settings-client.tsx
@@ -26,6 +26,7 @@ import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import { ConfirmationDialog } from "@/components/confirmation-dialog";
 import { LabelWrapper } from "@/components/label-wrapper";
 import { ProtectedRoute } from "@/components/protected-route";
+import { RequirePermission } from "@/components/require-permission";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -58,7 +59,6 @@ import { deriveCloudLangflowUrl } from "@/lib/url-utils";
 import { cn } from "@/lib/utils";
 import { useUpdateSettingsMutation } from "../api/mutations/useUpdateSettingsMutation";
 import { ModelSelector } from "../onboarding/_components/model-selector";
-import { RequirePermission } from "@/components/require-permission";
 import ConnectorCards from "./_components/connector-cards";
 import ModelProviders from "./_components/model-providers";
 import { UsersAndRolesSection } from "./_components/users-and-roles-section";
@@ -723,71 +723,72 @@ function KnowledgeSourcesPage() {
               Agent
             </CardTitle>
             <RequirePermission perm="flows:edit">
-            <div className="flex gap-2">
-              <ConfirmationDialog
-                trigger={
-                  <Button ignoreTitleCase={true} variant="outline">
-                    Restore flow
-                  </Button>
-                }
-                title="Restore default Agent flow"
-                description="This restores defaults and discards all custom settings and overrides. This can’t be undone."
-                confirmText="Restore"
-                variant="destructive"
-                onConfirm={handleRestoreRetrievalFlow}
-              />
-              <ConfirmationDialog
-                trigger={
-                  <Button>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="24"
-                      height="22"
-                      viewBox="0 0 24 22"
-                      className="h-4 w-4 mr-2"
-                      aria-label="Langflow icon"
-                    >
-                      <title>Langflow icon</title>
-                      <path
-                        fill="currentColor"
-                        d="M13.0486 0.462158H9.75399C9.44371 0.462158 9.14614 0.586082 8.92674 0.806667L4.03751 5.72232C3.81811 5.9429 3.52054 6.06682 3.21026 6.06682H1.16992C0.511975 6.06682 -0.0165756 6.61212 0.000397655 7.2734L0.0515933 9.26798C0.0679586 9.90556 0.586745 10.4139 1.22111 10.4139H3.59097C3.90124 10.4139 4.19881 10.2899 4.41821 10.0694L9.34823 5.11269C9.56763 4.89211 9.8652 4.76818 10.1755 4.76818H13.0486C13.6947 4.76818 14.2185 4.24157 14.2185 3.59195V1.63839C14.2185 0.988773 13.6947 0.462158 13.0486 0.462158Z"
-                      ></path>
-                      <path
-                        fill="currentColor"
-                        d="M19.5355 11.5862H22.8301C23.4762 11.5862 24 12.1128 24 12.7624V14.716C24 15.3656 23.4762 15.8922 22.8301 15.8922H19.957C19.6467 15.8922 19.3491 16.0161 19.1297 16.2367L14.1997 21.1934C13.9803 21.414 13.6827 21.5379 13.3725 21.5379H11.0026C10.3682 21.5379 9.84945 21.0296 9.83309 20.392L9.78189 18.3974C9.76492 17.7361 10.2935 17.1908 10.9514 17.1908H12.9918C13.302 17.1908 13.5996 17.0669 13.819 16.8463L18.7082 11.9307C18.9276 11.7101 19.2252 11.5862 19.5355 11.5862Z"
-                      ></path>
-                      <path
-                        fill="currentColor"
-                        d="M19.5355 2.9796L22.8301 2.9796C23.4762 2.9796 24 3.50622 24 4.15583V6.1094C24 6.75901 23.4762 7.28563 22.8301 7.28563H19.957C19.6467 7.28563 19.3491 7.40955 19.1297 7.63014L14.1997 12.5868C13.9803 12.8074 13.6827 12.9313 13.3725 12.9313H10.493C10.1913 12.9313 9.90126 13.0485 9.68346 13.2583L4.14867 18.5917C3.93087 18.8016 3.64085 18.9187 3.33917 18.9187H1.32174C0.675616 18.9187 0.151832 18.3921 0.151832 17.7425V15.7343C0.151832 15.0846 0.675616 14.558 1.32174 14.558H3.32468C3.63496 14.558 3.93253 14.4341 4.15193 14.2135L9.40827 8.92878C9.62767 8.70819 9.92524 8.58427 10.2355 8.58427H12.9918C13.302 8.58427 13.5996 8.46034 13.819 8.23976L18.7082 3.32411C18.9276 3.10353 19.2252 2.9796 19.5355 2.9796Z"
-                      ></path>
-                    </svg>
-                    Edit in Langflow
-                  </Button>
-                }
-                title="Edit Agent flow in Langflow"
-                description={
-                  <>
-                    <p className="mb-2">
-                      You&apos;re entering Langflow. You can edit the{" "}
-                      <b>Agent flow</b> and other underlying flows. Manual
-                      changes to components, wiring, or I/O can break this
-                      experience.
-                    </p>
-                    <p className="mb-2">
-                      To enable editing, you need to unlock the flow by clicking
-                      on its name and disabling the <b>Lock flow</b> option.
-                    </p>
-                    <p>You can restore this flow from Settings.</p>
-                  </>
-                }
-                confirmText="Proceed"
-                confirmIcon={<ArrowUpRight />}
-                onConfirm={(closeDialog) =>
-                  handleEditInLangflow("chat", closeDialog)
-                }
-                variant="warning"
-              />
-            </div>
+              <div className="flex gap-2">
+                <ConfirmationDialog
+                  trigger={
+                    <Button ignoreTitleCase={true} variant="outline">
+                      Restore flow
+                    </Button>
+                  }
+                  title="Restore default Agent flow"
+                  description="This restores defaults and discards all custom settings and overrides. This can’t be undone."
+                  confirmText="Restore"
+                  variant="destructive"
+                  onConfirm={handleRestoreRetrievalFlow}
+                />
+                <ConfirmationDialog
+                  trigger={
+                    <Button>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="22"
+                        viewBox="0 0 24 22"
+                        className="h-4 w-4 mr-2"
+                        aria-label="Langflow icon"
+                      >
+                        <title>Langflow icon</title>
+                        <path
+                          fill="currentColor"
+                          d="M13.0486 0.462158H9.75399C9.44371 0.462158 9.14614 0.586082 8.92674 0.806667L4.03751 5.72232C3.81811 5.9429 3.52054 6.06682 3.21026 6.06682H1.16992C0.511975 6.06682 -0.0165756 6.61212 0.000397655 7.2734L0.0515933 9.26798C0.0679586 9.90556 0.586745 10.4139 1.22111 10.4139H3.59097C3.90124 10.4139 4.19881 10.2899 4.41821 10.0694L9.34823 5.11269C9.56763 4.89211 9.8652 4.76818 10.1755 4.76818H13.0486C13.6947 4.76818 14.2185 4.24157 14.2185 3.59195V1.63839C14.2185 0.988773 13.6947 0.462158 13.0486 0.462158Z"
+                        ></path>
+                        <path
+                          fill="currentColor"
+                          d="M19.5355 11.5862H22.8301C23.4762 11.5862 24 12.1128 24 12.7624V14.716C24 15.3656 23.4762 15.8922 22.8301 15.8922H19.957C19.6467 15.8922 19.3491 16.0161 19.1297 16.2367L14.1997 21.1934C13.9803 21.414 13.6827 21.5379 13.3725 21.5379H11.0026C10.3682 21.5379 9.84945 21.0296 9.83309 20.392L9.78189 18.3974C9.76492 17.7361 10.2935 17.1908 10.9514 17.1908H12.9918C13.302 17.1908 13.5996 17.0669 13.819 16.8463L18.7082 11.9307C18.9276 11.7101 19.2252 11.5862 19.5355 11.5862Z"
+                        ></path>
+                        <path
+                          fill="currentColor"
+                          d="M19.5355 2.9796L22.8301 2.9796C23.4762 2.9796 24 3.50622 24 4.15583V6.1094C24 6.75901 23.4762 7.28563 22.8301 7.28563H19.957C19.6467 7.28563 19.3491 7.40955 19.1297 7.63014L14.1997 12.5868C13.9803 12.8074 13.6827 12.9313 13.3725 12.9313H10.493C10.1913 12.9313 9.90126 13.0485 9.68346 13.2583L4.14867 18.5917C3.93087 18.8016 3.64085 18.9187 3.33917 18.9187H1.32174C0.675616 18.9187 0.151832 18.3921 0.151832 17.7425V15.7343C0.151832 15.0846 0.675616 14.558 1.32174 14.558H3.32468C3.63496 14.558 3.93253 14.4341 4.15193 14.2135L9.40827 8.92878C9.62767 8.70819 9.92524 8.58427 10.2355 8.58427H12.9918C13.302 8.58427 13.5996 8.46034 13.819 8.23976L18.7082 3.32411C18.9276 3.10353 19.2252 2.9796 19.5355 2.9796Z"
+                        ></path>
+                      </svg>
+                      Edit in Langflow
+                    </Button>
+                  }
+                  title="Edit Agent flow in Langflow"
+                  description={
+                    <>
+                      <p className="mb-2">
+                        You&apos;re entering Langflow. You can edit the{" "}
+                        <b>Agent flow</b> and other underlying flows. Manual
+                        changes to components, wiring, or I/O can break this
+                        experience.
+                      </p>
+                      <p className="mb-2">
+                        To enable editing, you need to unlock the flow by
+                        clicking on its name and disabling the <b>Lock flow</b>{" "}
+                        option.
+                      </p>
+                      <p>You can restore this flow from Settings.</p>
+                    </>
+                  }
+                  confirmText="Proceed"
+                  confirmIcon={<ArrowUpRight />}
+                  onConfirm={(closeDialog) =>
+                    handleEditInLangflow("chat", closeDialog)
+                  }
+                  variant="warning"
+                />
+              </div>
             </RequirePermission>
           </div>
           <CardDescription>
@@ -880,71 +881,72 @@ function KnowledgeSourcesPage() {
               Knowledge Ingest
             </CardTitle>
             <RequirePermission perm="flows:edit">
-            <div className="flex gap-2">
-              <ConfirmationDialog
-                trigger={
-                  <Button ignoreTitleCase={true} variant="outline">
-                    Restore flow
-                  </Button>
-                }
-                title="Restore default Ingest flow"
-                description="This restores defaults and discards all custom settings and overrides. This can't be undone."
-                confirmText="Restore"
-                variant="destructive"
-                onConfirm={handleRestoreIngestFlow}
-              />
-              <ConfirmationDialog
-                trigger={
-                  <Button>
-                    <svg
-                      xmlns="http://www.w3.org/2000/svg"
-                      width="24"
-                      height="22"
-                      viewBox="0 0 24 22"
-                      className="h-4 w-4 mr-2"
-                      aria-label="Langflow icon"
-                    >
-                      <title>Langflow icon</title>
-                      <path
-                        fill="currentColor"
-                        d="M13.0486 0.462158H9.75399C9.44371 0.462158 9.14614 0.586082 8.92674 0.806667L4.03751 5.72232C3.81811 5.9429 3.52054 6.06682 3.21026 6.06682H1.16992C0.511975 6.06682 -0.0165756 6.61212 0.000397655 7.2734L0.0515933 9.26798C0.0679586 9.90556 0.586745 10.4139 1.22111 10.4139H3.59097C3.90124 10.4139 4.19881 10.2899 4.41821 10.0694L9.34823 5.11269C9.56763 4.89211 9.8652 4.76818 10.1755 4.76818H13.0486C13.6947 4.76818 14.2185 4.24157 14.2185 3.59195V1.63839C14.2185 0.988773 13.6947 0.462158 13.0486 0.462158Z"
-                      ></path>
-                      <path
-                        fill="currentColor"
-                        d="M19.5355 11.5862H22.8301C23.4762 11.5862 24 12.1128 24 12.7624V14.716C24 15.3656 23.4762 15.8922 22.8301 15.8922H19.957C19.6467 15.8922 19.3491 16.0161 19.1297 16.2367L14.1997 21.1934C13.9803 21.414 13.6827 21.5379 13.3725 21.5379H11.0026C10.3682 21.5379 9.84945 21.0296 9.83309 20.392L9.78189 18.3974C9.76492 17.7361 10.2935 17.1908 10.9514 17.1908H12.9918C13.302 17.1908 13.5996 17.0669 13.819 16.8463L18.7082 11.9307C18.9276 11.7101 19.2252 11.5862 19.5355 11.5862Z"
-                      ></path>
-                      <path
-                        fill="currentColor"
-                        d="M19.5355 2.9796L22.8301 2.9796C23.4762 2.9796 24 3.50622 24 4.15583V6.1094C24 6.75901 23.4762 7.28563 22.8301 7.28563H19.957C19.6467 7.28563 19.3491 7.40955 19.1297 7.63014L14.1997 12.5868C13.9803 12.8074 13.6827 12.9313 13.3725 12.9313H10.493C10.1913 12.9313 9.90126 13.0485 9.68346 13.2583L4.14867 18.5917C3.93087 18.8016 3.64085 18.9187 3.33917 18.9187H1.32174C0.675616 18.9187 0.151832 18.3921 0.151832 17.7425V15.7343C0.151832 15.0846 0.675616 14.558 1.32174 14.558H3.32468C3.63496 14.558 3.93253 14.4341 4.15193 14.2135L9.40827 8.92878C9.62767 8.70819 9.92524 8.58427 10.2355 8.58427H12.9918C13.302 8.58427 13.5996 8.46034 13.819 8.23976L18.7082 3.32411C18.9276 3.10353 19.2252 2.9796 19.5355 2.9796Z"
-                      ></path>
-                    </svg>
-                    Edit in Langflow
-                  </Button>
-                }
-                title="Edit Ingest flow in Langflow"
-                description={
-                  <>
-                    <p className="mb-2">
-                      You&apos;re entering Langflow. You can edit the{" "}
-                      <b>Ingest flow</b> and other underlying flows. Manual
-                      changes to components, wiring, or I/O can break this
-                      experience.
-                    </p>
-                    <p className="mb-2">
-                      To enable editing, you need to unlock the flow by clicking
-                      on its name and disabling the <b>Lock flow</b> option.
-                    </p>
-                    <p>You can restore this flow from Settings.</p>
-                  </>
-                }
-                confirmText="Proceed"
-                confirmIcon={<ArrowUpRight />}
-                variant="warning"
-                onConfirm={(closeDialog) =>
-                  handleEditInLangflow("ingest", closeDialog)
-                }
-              />
-            </div>
+              <div className="flex gap-2">
+                <ConfirmationDialog
+                  trigger={
+                    <Button ignoreTitleCase={true} variant="outline">
+                      Restore flow
+                    </Button>
+                  }
+                  title="Restore default Ingest flow"
+                  description="This restores defaults and discards all custom settings and overrides. This can't be undone."
+                  confirmText="Restore"
+                  variant="destructive"
+                  onConfirm={handleRestoreIngestFlow}
+                />
+                <ConfirmationDialog
+                  trigger={
+                    <Button>
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        width="24"
+                        height="22"
+                        viewBox="0 0 24 22"
+                        className="h-4 w-4 mr-2"
+                        aria-label="Langflow icon"
+                      >
+                        <title>Langflow icon</title>
+                        <path
+                          fill="currentColor"
+                          d="M13.0486 0.462158H9.75399C9.44371 0.462158 9.14614 0.586082 8.92674 0.806667L4.03751 5.72232C3.81811 5.9429 3.52054 6.06682 3.21026 6.06682H1.16992C0.511975 6.06682 -0.0165756 6.61212 0.000397655 7.2734L0.0515933 9.26798C0.0679586 9.90556 0.586745 10.4139 1.22111 10.4139H3.59097C3.90124 10.4139 4.19881 10.2899 4.41821 10.0694L9.34823 5.11269C9.56763 4.89211 9.8652 4.76818 10.1755 4.76818H13.0486C13.6947 4.76818 14.2185 4.24157 14.2185 3.59195V1.63839C14.2185 0.988773 13.6947 0.462158 13.0486 0.462158Z"
+                        ></path>
+                        <path
+                          fill="currentColor"
+                          d="M19.5355 11.5862H22.8301C23.4762 11.5862 24 12.1128 24 12.7624V14.716C24 15.3656 23.4762 15.8922 22.8301 15.8922H19.957C19.6467 15.8922 19.3491 16.0161 19.1297 16.2367L14.1997 21.1934C13.9803 21.414 13.6827 21.5379 13.3725 21.5379H11.0026C10.3682 21.5379 9.84945 21.0296 9.83309 20.392L9.78189 18.3974C9.76492 17.7361 10.2935 17.1908 10.9514 17.1908H12.9918C13.302 17.1908 13.5996 17.0669 13.819 16.8463L18.7082 11.9307C18.9276 11.7101 19.2252 11.5862 19.5355 11.5862Z"
+                        ></path>
+                        <path
+                          fill="currentColor"
+                          d="M19.5355 2.9796L22.8301 2.9796C23.4762 2.9796 24 3.50622 24 4.15583V6.1094C24 6.75901 23.4762 7.28563 22.8301 7.28563H19.957C19.6467 7.28563 19.3491 7.40955 19.1297 7.63014L14.1997 12.5868C13.9803 12.8074 13.6827 12.9313 13.3725 12.9313H10.493C10.1913 12.9313 9.90126 13.0485 9.68346 13.2583L4.14867 18.5917C3.93087 18.8016 3.64085 18.9187 3.33917 18.9187H1.32174C0.675616 18.9187 0.151832 18.3921 0.151832 17.7425V15.7343C0.151832 15.0846 0.675616 14.558 1.32174 14.558H3.32468C3.63496 14.558 3.93253 14.4341 4.15193 14.2135L9.40827 8.92878C9.62767 8.70819 9.92524 8.58427 10.2355 8.58427H12.9918C13.302 8.58427 13.5996 8.46034 13.819 8.23976L18.7082 3.32411C18.9276 3.10353 19.2252 2.9796 19.5355 2.9796Z"
+                        ></path>
+                      </svg>
+                      Edit in Langflow
+                    </Button>
+                  }
+                  title="Edit Ingest flow in Langflow"
+                  description={
+                    <>
+                      <p className="mb-2">
+                        You&apos;re entering Langflow. You can edit the{" "}
+                        <b>Ingest flow</b> and other underlying flows. Manual
+                        changes to components, wiring, or I/O can break this
+                        experience.
+                      </p>
+                      <p className="mb-2">
+                        To enable editing, you need to unlock the flow by
+                        clicking on its name and disabling the <b>Lock flow</b>{" "}
+                        option.
+                      </p>
+                      <p>You can restore this flow from Settings.</p>
+                    </>
+                  }
+                  confirmText="Proceed"
+                  confirmIcon={<ArrowUpRight />}
+                  variant="warning"
+                  onConfirm={(closeDialog) =>
+                    handleEditInLangflow("ingest", closeDialog)
+                  }
+                />
+              </div>
             </RequirePermission>
           </div>
           <CardDescription>
@@ -1274,6 +1276,18 @@ function KnowledgeSourcesPage() {
             )}
           </CardContent>
         </Card>
+      )}
+
+      {/* Users & Roles — admin-only, AND only when RBAC is enforced.
+          When OPENRAG_RBAC_ENFORCE=false the system has no real role
+          model (every authenticated user is effectively admin), so
+          rendering this UI would be misleading. */}
+      {rbacEnforced && (
+        <RequirePermission perm="users:list">
+          <div className="space-y-4">
+            <UsersAndRolesSection />
+          </div>
+        </RequirePermission>
       )}
 
       {/* Create API Key Dialog */}

--- a/frontend/app/settings/settings-client.tsx
+++ b/frontend/app/settings/settings-client.tsx
@@ -1165,10 +1165,12 @@ function KnowledgeSourcesPage() {
               >
                 API Keys
               </CardTitle>
-              <Button onClick={() => setCreateKeyDialogOpen(true)} size="sm">
-                <Plus className="h-4 w-4 mr-2" />
-                Create Key
-              </Button>
+              <RequirePermission perm="apikeys:create:self">
+                <Button onClick={() => setCreateKeyDialogOpen(true)} size="sm">
+                  <Plus className="h-4 w-4 mr-2" />
+                  Create Key
+                </Button>
+              </RequirePermission>
             </div>
             <CardDescription>
               API keys allow programmatic access to OpenRAG via the public API.
@@ -1258,14 +1260,16 @@ function KnowledgeSourcesPage() {
                 <p className="text-muted-foreground mb-4">
                   No API keys yet. Create one to get started.
                 </p>
-                <Button
-                  variant="outline"
-                  onClick={() => setCreateKeyDialogOpen(true)}
-                  size="sm"
-                >
-                  <Plus className="h-4 w-4 mr-2" />
-                  Create your first API key
-                </Button>
+                <RequirePermission perm="apikeys:create:self">
+                  <Button
+                    variant="outline"
+                    onClick={() => setCreateKeyDialogOpen(true)}
+                    size="sm"
+                  >
+                    <Plus className="h-4 w-4 mr-2" />
+                    Create your first API key
+                  </Button>
+                </RequirePermission>
               </div>
             )}
           </CardContent>

--- a/frontend/components/knowledge-actions-dropdown.tsx
+++ b/frontend/components/knowledge-actions-dropdown.tsx
@@ -20,8 +20,10 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { useTask } from "@/contexts/task-context";
+import { usePermissions } from "@/hooks/use-permissions";
 import { formatFilesToDelete } from "@/lib/format-files-to-delete";
 import { DeleteConfirmationDialog } from "./delete-confirmation-dialog";
+import { RequirePermission } from "./require-permission";
 import { Button } from "./ui/button";
 
 interface KnowledgeActionsDropdownProps {
@@ -165,12 +167,16 @@ export const KnowledgeActionsDropdown = ({
               </Tooltip>
             </TooltipProvider>
           )}
-          <DropdownMenuItem
-            className="text-destructive focus:text-destructive cursor-pointer"
-            onClick={() => setShowDeleteDialog(true)}
+          <RequirePermission
+            anyOf={["knowledge:delete:own", "knowledge:delete:any"]}
           >
-            Delete
-          </DropdownMenuItem>
+            <DropdownMenuItem
+              className="text-destructive focus:text-destructive cursor-pointer"
+              onClick={() => setShowDeleteDialog(true)}
+            >
+              Delete
+            </DropdownMenuItem>
+          </RequirePermission>
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/frontend/components/knowledge-batch-actions-bar.tsx
+++ b/frontend/components/knowledge-batch-actions-bar.tsx
@@ -1,5 +1,7 @@
 import { X } from "lucide-react";
 
+import { usePermissions } from "@/hooks/use-permissions";
+
 interface KnowledgeBatchActionsBarProps {
   selectedCount: number;
   onDelete: () => void;
@@ -11,6 +13,8 @@ export const KnowledgeBatchActionsBar = ({
   onDelete,
   onCancel,
 }: KnowledgeBatchActionsBarProps) => {
+  const { canAny } = usePermissions();
+  const canDelete = canAny(["knowledge:delete:own", "knowledge:delete:any"]);
   return (
     <div className="flex h-12 w-full items-stretch bg-primary text-primary-foreground">
       <span className="flex items-center px-4 text-sm font-medium">
@@ -20,7 +24,13 @@ export const KnowledgeBatchActionsBar = ({
         <button
           type="button"
           onClick={onDelete}
-          className="flex h-full items-center px-4 text-sm font-medium transition-colors hover:bg-primary-foreground/10"
+          disabled={!canDelete}
+          title={
+            canDelete
+              ? undefined
+              : "You do not have permission to delete documents"
+          }
+          className="flex h-full items-center px-4 text-sm font-medium transition-colors hover:bg-primary-foreground/10 disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Delete
         </button>

--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -39,6 +39,7 @@ import { Label } from "@/components/ui/label";
 import { useAuth } from "@/contexts/auth-context";
 import { useIsCloudBrand } from "@/contexts/brand-context";
 import { useTask } from "@/contexts/task-context";
+import { usePermissions } from "@/hooks/use-permissions";
 import {
   duplicateCheck,
   uploadFiles,
@@ -118,6 +119,8 @@ const FolderIconWithColor = ({ className }: { className?: string }) => (
 
 export function KnowledgeDropdown() {
   const { isIbmAuthMode } = useAuth();
+  const { can } = usePermissions();
+  const canUpload = can("knowledge:upload");
   const isCloudBrand = useIsCloudBrand();
   const { addTask } = useTask();
   const { refetch: refetchTasks } = useGetTasksQuery();
@@ -698,6 +701,11 @@ export function KnowledgeDropdown() {
         </Button>
       </div>
     );
+  }
+
+  if (!canUpload) {
+    // Viewer / restricted users see no entry point at all.
+    return null;
   }
 
   return (

--- a/frontend/components/knowledge-filter-panel.tsx
+++ b/frontend/components/knowledge-filter-panel.tsx
@@ -30,6 +30,7 @@ import { Slider } from "@/components/ui/slider";
 import { Textarea } from "@/components/ui/textarea";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { useTask } from "@/contexts/task-context";
+import { usePermissions } from "@/hooks/use-permissions";
 import {
   buildActiveSourceOptions,
   buildKnowledgeTableRows,
@@ -72,6 +73,9 @@ export function KnowledgeFilterPanel() {
   const deleteFilterMutation = useDeleteFilter();
   const updateFilterMutation = useUpdateFilter();
   const createFilterMutation = useCreateFilter();
+  const { can, canAny } = usePermissions();
+  const canCreate = can("kf:create");
+  const canEdit = canAny(["kf:edit:own", "kf:edit:any"]);
 
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -492,7 +496,7 @@ export function KnowledgeFilterPanel() {
               Cancel
             </Button>
           )}
-          {!createMode && (
+          {!createMode && canEdit && (
             <Button
               variant="destructive"
               size="sm"
@@ -505,7 +509,12 @@ export function KnowledgeFilterPanel() {
           )}
           <Button
             onClick={handleSaveConfiguration}
-            disabled={isSaving}
+            disabled={isSaving || (createMode ? !canCreate : !canEdit)}
+            title={
+              (createMode ? canCreate : canEdit)
+                ? undefined
+                : "You do not have permission to modify this filter"
+            }
             size="sm"
             className="relative z-10"
           >

--- a/frontend/components/navigation.tsx
+++ b/frontend/components/navigation.tsx
@@ -23,6 +23,7 @@ import {
 import { useIsCloudBrand } from "@/contexts/brand-context";
 import { type EndpointType, useChat } from "@/contexts/chat-context";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
+import { usePermissions } from "@/hooks/use-permissions";
 import { FILES_REGEX } from "@/lib/constants";
 import { cn } from "@/lib/utils";
 import { useLoadingStore } from "@/stores/loadingStore";
@@ -193,26 +194,35 @@ export function Navigation({
     }
   };
 
-  const routes = [
+  const { can, canAny } = usePermissions();
+  const allRoutes = [
     {
       label: "Chat",
       icon: MessageSquare,
       href: "/chat",
       active: pathname === "/" || pathname.startsWith("/chat"),
+      visible: can("chat:use"),
     },
     {
       label: "Knowledge",
       icon: Library,
       href: "/knowledge",
       active: pathname.startsWith("/knowledge"),
+      visible: canAny([
+        "knowledge:read:own",
+        "knowledge:read:all",
+        "knowledge:upload",
+      ]),
     },
     {
       label: "Settings",
       icon: Settings2,
       href: "/settings",
       active: pathname.startsWith("/settings"),
+      visible: true, // always — content inside is gated
     },
   ];
+  const routes = allRoutes.filter((r) => r.visible);
 
   const isOnChatPage = pathname === "/" || pathname === "/chat";
   const isOnKnowledgePage = pathname.startsWith("/knowledge");

--- a/frontend/components/require-permission.tsx
+++ b/frontend/components/require-permission.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { ReactNode } from "react";
+
+import { usePermissions } from "@/hooks/use-permissions";
+
+interface RequirePermissionProps {
+  /** Single permission to require. */
+  perm?: string;
+  /** Multiple permissions: user must have any one of these. */
+  anyOf?: string[];
+  /** Multiple permissions: user must have all of these. */
+  allOf?: string[];
+  /** Rendered when the user has the permission(s). */
+  children: ReactNode;
+  /** Rendered when the user does not. Defaults to null (hidden). */
+  fallback?: ReactNode;
+}
+
+/**
+ * Conditionally render children based on the current user's permissions.
+ *
+ * Backend remains the source of truth — this is a pure UX wrapper that
+ * hides affordances the backend would 403 on anyway.
+ *
+ * Usage:
+ *   <RequirePermission perm="users:list">
+ *     <UsersAndRolesTab />
+ *   </RequirePermission>
+ *
+ *   <RequirePermission anyOf={["kf:edit:own", "kf:edit:any"]}>
+ *     <EditButton />
+ *   </RequirePermission>
+ */
+export function RequirePermission({
+  perm,
+  anyOf,
+  allOf,
+  children,
+  fallback = null,
+}: RequirePermissionProps) {
+  const { can, canAny, canAll, isLoading } = usePermissions();
+
+  if (isLoading) return null;
+
+  let allowed = true;
+  if (perm) allowed = allowed && can(perm);
+  if (anyOf && anyOf.length > 0) allowed = allowed && canAny(anyOf);
+  if (allOf && allOf.length > 0) allowed = allowed && canAll(allOf);
+
+  return <>{allowed ? children : fallback}</>;
+}

--- a/frontend/components/require-permission.tsx
+++ b/frontend/components/require-permission.tsx
@@ -4,18 +4,34 @@ import { ReactNode } from "react";
 
 import { usePermissions } from "@/hooks/use-permissions";
 
-interface RequirePermissionProps {
-  /** Single permission to require. */
-  perm?: string;
-  /** Multiple permissions: user must have any one of these. */
-  anyOf?: string[];
-  /** Multiple permissions: user must have all of these. */
-  allOf?: string[];
+interface RequirePermissionBaseProps {
   /** Rendered when the user has the permission(s). */
   children: ReactNode;
   /** Rendered when the user does not. Defaults to null (hidden). */
   fallback?: ReactNode;
 }
+
+type RequirePermissionProps = RequirePermissionBaseProps &
+  (
+    | {
+        /** Single permission to require. */
+        perm: string;
+        /** Multiple permissions: user must have any one of these. */
+        anyOf?: string[];
+        /** Multiple permissions: user must have all of these. */
+        allOf?: string[];
+      }
+    | {
+        perm?: string;
+        anyOf: string[];
+        allOf?: string[];
+      }
+    | {
+        perm?: string;
+        anyOf?: string[];
+        allOf: string[];
+      }
+  );
 
 /**
  * Conditionally render children based on the current user's permissions.
@@ -42,6 +58,10 @@ export function RequirePermission({
   const { can, canAny, canAll, isLoading } = usePermissions();
 
   if (isLoading) return null;
+
+  const hasCriterion =
+    Boolean(perm) || Boolean(anyOf?.length) || Boolean(allOf?.length);
+  if (!hasCriterion) return <>{fallback}</>;
 
   let allowed = true;
   if (perm) allowed = allowed && can(perm);

--- a/frontend/components/role-permissions-preview.tsx
+++ b/frontend/components/role-permissions-preview.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { ChevronDown, Info } from "lucide-react";
+import { useState } from "react";
+
+import { Badge } from "@/components/ui/badge";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { cn } from "@/lib/utils";
+
+interface RolePermissionsPreviewProps {
+  /** Role name (display only). */
+  name: string;
+  /** Optional description shown above the permissions list. */
+  description?: string | null;
+  /** Full permission set granted by this role. */
+  permissions: string[];
+  /** Optional trigger override. Defaults to a small info icon. */
+  trigger?: React.ReactNode;
+  /** Visual size of the trigger icon. */
+  size?: "sm" | "md";
+}
+
+/**
+ * Hover/click-to-open popover showing every permission a role grants.
+ * Used inline next to a role badge or in the role-assign dropdown.
+ */
+export function RolePermissionsPreview({
+  name,
+  description,
+  permissions,
+  trigger,
+  size = "sm",
+}: RolePermissionsPreviewProps) {
+  const [open, setOpen] = useState(false);
+
+  // Group permissions by resource for readability:
+  //   connectors:create / connectors:list:own / kf:create / ...
+  const grouped = permissions.reduce<Record<string, string[]>>((acc, p) => {
+    const [resource] = p.split(":");
+    if (!acc[resource]) acc[resource] = [];
+    acc[resource].push(p);
+    return acc;
+  }, {});
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        {trigger ?? (
+          <button
+            type="button"
+            aria-label={`Show permissions for ${name}`}
+            className={cn(
+              "inline-flex items-center justify-center rounded hover:bg-foreground/10 transition-colors -mr-0.5",
+              size === "sm" ? "h-5 w-5" : "h-6 w-6",
+            )}
+          >
+            <Info className={size === "sm" ? "h-3.5 w-3.5" : "h-4 w-4"} />
+          </button>
+        )}
+      </PopoverTrigger>
+      <PopoverContent className="w-80 p-0" align="end" sideOffset={4}>
+        <div className="px-3 pt-3 pb-2 border-b">
+          <p className="text-sm font-medium leading-none capitalize">{name}</p>
+          {description && (
+            <p className="text-xs text-muted-foreground mt-1">{description}</p>
+          )}
+          <p className="text-xs text-muted-foreground mt-1.5">
+            {permissions.length} permission{permissions.length === 1 ? "" : "s"}
+          </p>
+        </div>
+        <ScrollArea className="max-h-72">
+          <div className="px-3 py-2 space-y-3">
+            {Object.entries(grouped)
+              .sort(([a], [b]) => a.localeCompare(b))
+              .map(([resource, perms]) => (
+                <div key={resource}>
+                  <p className="text-xs uppercase tracking-wide text-muted-foreground mb-1">
+                    {resource}
+                  </p>
+                  <div className="flex flex-wrap gap-1">
+                    {perms.sort().map((p) => (
+                      <Badge
+                        key={p}
+                        variant="outline"
+                        className="text-[10px] font-mono py-0 px-1.5 leading-4"
+                      >
+                        {p.split(":").slice(1).join(":")}
+                      </Badge>
+                    ))}
+                  </div>
+                </div>
+              ))}
+          </div>
+        </ScrollArea>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/frontend/components/user-nav.tsx
+++ b/frontend/components/user-nav.tsx
@@ -25,8 +25,13 @@ export function UserNav() {
     login,
     logout,
     version,
+    roles,
   } = useAuth();
   const { theme, setTheme } = useTheme();
+
+  const roleLabel = roles.length
+    ? roles.map((r) => r.charAt(0).toUpperCase() + r.slice(1)).join(", ")
+    : null;
 
   if (isLoading) {
     return <div className="h-8 w-8 rounded-full bg-muted animate-pulse" />;
@@ -113,6 +118,17 @@ export function UserNav() {
           </div>
         </DropdownMenuLabel>
         <DropdownMenuSeparator className="m-0" />
+        {roleLabel && (
+          <>
+            <div className="flex items-center justify-between pl-3 pr-2 h-9">
+              <span className="text-sm">Role</span>
+              <p className="text-xs leading-none text-muted-foreground">
+                {roleLabel}
+              </p>
+            </div>
+            <DropdownMenuSeparator className="m-0" />
+          </>
+        )}
         {version && (
           <>
             <div className="flex items-center justify-between pl-3 pr-2 h-9">

--- a/frontend/components/user-nav.tsx
+++ b/frontend/components/user-nav.tsx
@@ -26,12 +26,18 @@ export function UserNav() {
     logout,
     version,
     roles,
+    rbacEnforced,
   } = useAuth();
   const { theme, setTheme } = useTheme();
 
-  const roleLabel = roles.length
-    ? roles.map((r) => r.charAt(0).toUpperCase() + r.slice(1)).join(", ")
-    : null;
+  // Suppress the role row entirely when RBAC is off — the user
+  // technically still has DB-assigned roles (admin from bootstrap),
+  // but those roles have no operational effect, so showing them is
+  // confusing.
+  const roleLabel =
+    rbacEnforced && roles.length
+      ? roles.map((r) => r.charAt(0).toUpperCase() + r.slice(1)).join(", ")
+      : null;
 
   if (isLoading) {
     return <div className="h-8 w-8 rounded-full bg-muted animate-pulse" />;

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -17,6 +17,8 @@ interface User {
   picture?: string;
   provider: string;
   last_login?: string;
+  roles?: string[];
+  permissions?: string[];
 }
 
 interface AuthContextType {
@@ -26,10 +28,14 @@ interface AuthContextType {
   isNoAuthMode: boolean;
   isIbmAuthMode: boolean;
   version: string | null;
+  permissions: Set<string>;
+  roles: string[];
+  can: (perm: string) => boolean;
   login: () => void;
   loginWithIbm: (username: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   refreshAuth: () => Promise<void>;
+  refreshPermissions: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -228,9 +234,54 @@ export function AuthProvider({ children }: AuthProviderProps) {
     await checkAuth();
   };
 
+  const [permissions, setPermissions] = useState<Set<string>>(new Set());
+  const [roles, setRoles] = useState<string[]>([]);
+
+  const fetchPermissions = useCallback(async () => {
+    try {
+      const r = await fetch("/api/users/me");
+      if (!r.ok) {
+        setPermissions(new Set());
+        setRoles([]);
+        return;
+      }
+      const data = await r.json();
+      const perms: string[] = Array.isArray(data?.permissions)
+        ? data.permissions
+        : [];
+      const userRoles: string[] = Array.isArray(data?.roles) ? data.roles : [];
+      setPermissions(new Set(perms));
+      setRoles(userRoles);
+    } catch {
+      setPermissions(new Set());
+      setRoles([]);
+    }
+  }, []);
+
+  const refreshPermissions = useCallback(async () => {
+    await fetchPermissions();
+  }, [fetchPermissions]);
+
+  useEffect(() => {
+    if (user || isNoAuthMode || isIbmAuthMode) {
+      fetchPermissions();
+    } else {
+      setPermissions(new Set());
+      setRoles([]);
+    }
+  }, [user, isNoAuthMode, isIbmAuthMode, fetchPermissions]);
+
   useEffect(() => {
     checkAuth();
   }, [checkAuth]);
+
+  const can = useCallback(
+    (perm: string): boolean => {
+      if (isNoAuthMode) return true;
+      return permissions.has(perm);
+    },
+    [permissions, isNoAuthMode],
+  );
 
   const value: AuthContextType = {
     user,
@@ -239,10 +290,14 @@ export function AuthProvider({ children }: AuthProviderProps) {
     isNoAuthMode,
     isIbmAuthMode,
     version,
+    permissions,
+    roles,
+    can,
     login,
     loginWithIbm,
     logout,
     refreshAuth,
+    refreshPermissions,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -30,6 +30,14 @@ interface AuthContextType {
   version: string | null;
   permissions: Set<string>;
   roles: string[];
+  /**
+   * Whether the backend is enforcing RBAC (mirrors `OPENRAG_RBAC_ENFORCE`).
+   * When false, the system behaves like the pre-RBAC release: any
+   * authenticated user has full access. The UI hides RBAC-only
+   * sections (Users & Roles, audit log, role pills) so the experience
+   * matches the backend behavior.
+   */
+  rbacEnforced: boolean;
   /** True iff the workspace has been onboarded. Sourced from the public
    * GET /api/onboarding-status endpoint (no auth needed). */
   isOnboarded: boolean | null;
@@ -242,6 +250,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
 
   const [permissions, setPermissions] = useState<Set<string>>(new Set());
   const [roles, setRoles] = useState<string[]>([]);
+  // Default to true so RBAC-only UI doesn't briefly flash on first
+  // load before /api/users/me responds. The backend is authoritative;
+  // this is just a UI affordance.
+  const [rbacEnforced, setRbacEnforced] = useState<boolean>(true);
 
   const fetchPermissions = useCallback(async () => {
     try {
@@ -258,6 +270,10 @@ export function AuthProvider({ children }: AuthProviderProps) {
       const userRoles: string[] = Array.isArray(data?.roles) ? data.roles : [];
       setPermissions(new Set(perms));
       setRoles(userRoles);
+      // Field is optional from older backends — default to true.
+      setRbacEnforced(
+        typeof data?.rbac_enforced === "boolean" ? data.rbac_enforced : true,
+      );
     } catch {
       setPermissions(new Set());
       setRoles([]);
@@ -328,6 +344,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
     version,
     permissions,
     roles,
+    rbacEnforced,
     isOnboarded,
     onboardingStep,
     can,

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -30,12 +30,18 @@ interface AuthContextType {
   version: string | null;
   permissions: Set<string>;
   roles: string[];
+  /** True iff the workspace has been onboarded. Sourced from the public
+   * GET /api/onboarding-status endpoint (no auth needed). */
+  isOnboarded: boolean | null;
+  /** Current onboarding step indicator (int index or named step). */
+  onboardingStep: number | string | null;
   can: (perm: string) => boolean;
   login: () => void;
   loginWithIbm: (username: string, password: string) => Promise<void>;
   logout: () => Promise<void>;
   refreshAuth: () => Promise<void>;
   refreshPermissions: () => Promise<void>;
+  refreshOnboardingStatus: () => Promise<void>;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -262,6 +268,36 @@ export function AuthProvider({ children }: AuthProviderProps) {
     await fetchPermissions();
   }, [fetchPermissions]);
 
+  // Public onboarding-status — fetched once on mount, no auth required.
+  // The frontend uses this to decide between the wizard and the login flow.
+  const [isOnboarded, setIsOnboarded] = useState<boolean | null>(null);
+  const [onboardingStep, setOnboardingStep] = useState<number | string | null>(
+    null,
+  );
+
+  const fetchOnboardingStatus = useCallback(async () => {
+    try {
+      const r = await fetch("/api/onboarding-status");
+      if (!r.ok) return;
+      const data = await r.json();
+      setIsOnboarded(Boolean(data?.onboarded));
+      const step = data?.current_step;
+      setOnboardingStep(
+        typeof step === "string" || typeof step === "number" ? step : null,
+      );
+    } catch {
+      // Conservative: don't flip the flag if the call fails.
+    }
+  }, []);
+
+  const refreshOnboardingStatus = useCallback(async () => {
+    await fetchOnboardingStatus();
+  }, [fetchOnboardingStatus]);
+
+  useEffect(() => {
+    fetchOnboardingStatus();
+  }, [fetchOnboardingStatus]);
+
   useEffect(() => {
     if (user || isNoAuthMode || isIbmAuthMode) {
       fetchPermissions();
@@ -292,12 +328,15 @@ export function AuthProvider({ children }: AuthProviderProps) {
     version,
     permissions,
     roles,
+    isOnboarded,
+    onboardingStep,
     can,
     login,
     loginWithIbm,
     logout,
     refreshAuth,
     refreshPermissions,
+    refreshOnboardingStatus,
   };
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/frontend/hooks/use-permissions.ts
+++ b/frontend/hooks/use-permissions.ts
@@ -1,0 +1,49 @@
+"use client";
+
+import { useAuth } from "@/contexts/auth-context";
+
+export interface UsePermissionsResult {
+  /** All permission strings granted to the current user. */
+  permissions: Set<string>;
+  /** True if the user has every listed permission. */
+  can: (perm: string) => boolean;
+  /** True if the user has at least one of the listed permissions. */
+  canAny: (perms: string[]) => boolean;
+  /** True if the user has all of the listed permissions. */
+  canAll: (perms: string[]) => boolean;
+  /** Force a refetch from /api/users/me/permissions. */
+  refresh: () => Promise<void>;
+  /** True while the auth context is still resolving. */
+  isLoading: boolean;
+}
+
+/**
+ * Single source of truth for permission checks in the UI.
+ *
+ * Pulls from auth-context (which fetched /api/users/me/permissions on
+ * sign-in). The backend is the authoritative gate; this hook only drives
+ * UI affordances (hide tabs, disable buttons, etc).
+ */
+export function usePermissions(): UsePermissionsResult {
+  const { permissions, can, isLoading, refreshPermissions, isNoAuthMode } =
+    useAuth();
+
+  const canAny = (perms: string[]) => {
+    if (isNoAuthMode) return true;
+    return perms.some((p) => permissions.has(p));
+  };
+
+  const canAll = (perms: string[]) => {
+    if (isNoAuthMode) return true;
+    return perms.every((p) => permissions.has(p));
+  };
+
+  return {
+    permissions,
+    can,
+    canAny,
+    canAll,
+    refresh: refreshPermissions,
+    isLoading,
+  };
+}

--- a/frontend/hooks/use-permissions.ts
+++ b/frontend/hooks/use-permissions.ts
@@ -15,6 +15,12 @@ export interface UsePermissionsResult {
   refresh: () => Promise<void>;
   /** True while the auth context is still resolving. */
   isLoading: boolean;
+  /**
+   * Whether the backend is enforcing RBAC. When false, the system
+   * runs in pre-RBAC mode — components that render only when RBAC is
+   * meaningful (Users & Roles, audit log, role pills) should hide.
+   */
+  rbacEnforced: boolean;
 }
 
 /**
@@ -25,8 +31,14 @@ export interface UsePermissionsResult {
  * UI affordances (hide tabs, disable buttons, etc).
  */
 export function usePermissions(): UsePermissionsResult {
-  const { permissions, can, isLoading, refreshPermissions, isNoAuthMode } =
-    useAuth();
+  const {
+    permissions,
+    can,
+    isLoading,
+    refreshPermissions,
+    isNoAuthMode,
+    rbacEnforced,
+  } = useAuth();
 
   const canAny = (perms: string[]) => {
     if (isNoAuthMode) return true;
@@ -45,5 +57,6 @@ export function usePermissions(): UsePermissionsResult {
     canAll,
     refresh: refreshPermissions,
     isLoading,
+    rbacEnforced,
   };
 }

--- a/frontend/lib/role-styles.ts
+++ b/frontend/lib/role-styles.ts
@@ -1,0 +1,42 @@
+/**
+ * Single source of truth for role visuals.
+ *
+ * One pill SHAPE/SIZE — only the COLOR tint changes by role. The tint
+ * is applied as a TRANSPARENT overlay (`bg-{color}/10`,
+ * `border-{color}/30`) so the underlying card/page background shows
+ * through. No white is pre-mixed into the colors — that means the same
+ * classes work correctly on light AND dark themes:
+ *   light theme: red-500 at 10% over white  → soft pink
+ *   dark theme:  red-500 at 10% over slate  → muted red ember
+ *
+ * Sizing matches the modern admin "chip" pattern (Vercel / Linear /
+ * Stripe / GitHub): `px-3 py-1 text-sm` ≈ 32px tall, big enough to read
+ * without competing with primary action buttons (h-9 / 36px).
+ *
+ * Industry-standard role colors:
+ *   admin     -> red    (high privilege, danger zone — Discord, Auth0)
+ *   developer -> blue   (technical/builder — GitHub, VS Code)
+ *   user      -> neutral foreground (default, no special status)
+ *   viewer    -> emerald (read-only, safe — Slack guest)
+ *   custom    -> amber  (visually distinguishable from built-ins)
+ */
+
+export const ROLE_PILL_BASE =
+  "inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-sm font-medium capitalize transition-colors";
+
+const ROLE_TINTS: Record<string, string> = {
+  admin: "bg-red-500/10 text-red-600 border-red-500/30 dark:text-red-400",
+  developer:
+    "bg-blue-500/10 text-blue-600 border-blue-500/30 dark:text-blue-400",
+  user: "bg-foreground/5 text-foreground/80 border-foreground/15",
+  viewer:
+    "bg-emerald-500/10 text-emerald-600 border-emerald-500/30 dark:text-emerald-400",
+};
+
+const CUSTOM_ROLE_TINT =
+  "bg-amber-500/10 text-amber-600 border-amber-500/30 dark:text-amber-400";
+
+export function getRolePillClass(roleName: string): string {
+  const tint = ROLE_TINTS[roleName] ?? CUSTOM_ROLE_TINT;
+  return `${ROLE_PILL_BASE} ${tint}`;
+}

--- a/frontend/tailwind.config.ts
+++ b/frontend/tailwind.config.ts
@@ -11,6 +11,7 @@ const config = {
     "./pages/**/*.{ts,tsx}",
     "./components/**/*.{ts,tsx}",
     "./app/**/*.{ts,tsx}",
+    "./lib/**/*.{ts,tsx}",
   ],
   theme: {
     container: {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -11,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -29,5 +35,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -15,7 +11,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,11 @@ dev = ["pytest>=9.0.3", "pytest-asyncio>=0.21.0", "pytest-mock>=3.12.0", "pytest
 [project.scripts]
 openrag = "tui.main:run_tui"
 
+[tool.pytest.ini_options]
+filterwarnings = [
+    "error::RuntimeWarning",
+]
+
 [tool.uv]
 package = true
 override-dependencies = ["python-dotenv>=1.1.0"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,12 @@ dependencies = [
     "pygments>=2.20.0",
     "pyasn1>=0.6.3",
     "requests>=2.33.0",
+    "sqlmodel>=0.0.22",
+    "sqlalchemy[asyncio]>=2.0.36",
+    "aiosqlite>=0.20.0",
+    "alembic>=1.13.0",
+    "asyncpg>=0.30.0",
+    "cachetools>=5.5.0",
 ]
 
 [dependency-groups]

--- a/src/agent.py
+++ b/src/agent.py
@@ -11,9 +11,9 @@ from services.conversation_persistence_service import conversation_persistence
 active_conversations = {}
 
 
-def get_user_conversations(user_id: str):
-    """Get conversation metadata for a user from persistent storage"""
-    return conversation_persistence.get_user_conversations(user_id)
+async def get_user_conversations(user_id: str):
+    """Get conversation metadata for a user from persistent storage."""
+    return await conversation_persistence.get_user_conversations(user_id)
 
 
 def get_conversation_thread(user_id: str, previous_response_id: str = None):
@@ -688,7 +688,7 @@ async def async_langflow_chat(
         try:
             from services.session_ownership_service import session_ownership_service
 
-            session_ownership_service.claim_session(user_id, response_id)
+            await session_ownership_service.claim_session(user_id, response_id)
             logger.debug(f"Claimed session {response_id} for user {user_id}")
         except Exception as e:
             logger.warning(f"Failed to claim session ownership: {e}")
@@ -810,7 +810,7 @@ async def async_langflow_chat_stream(
         try:
             from services.session_ownership_service import session_ownership_service
 
-            session_ownership_service.claim_session(user_id, response_id)
+            await session_ownership_service.claim_session(user_id, response_id)
             logger.debug(f"Claimed session {response_id} for user {user_id}")
         except Exception as e:
             logger.warning(f"Failed to claim session ownership: {e}")
@@ -876,7 +876,7 @@ async def delete_user_conversation(user_id: str, response_id: str) -> bool:
     # Release session ownership (best-effort; never masks storage errors above)
     try:
         from services.session_ownership_service import session_ownership_service
-        session_ownership_service.release_session(user_id, response_id)
+        await session_ownership_service.release_session(user_id, response_id)
         logger.debug(f"Released session ownership for {response_id} for user {user_id}")
     except Exception as e:
         logger.warning(f"Failed to release session ownership: {e}")

--- a/src/agent.py
+++ b/src/agent.py
@@ -92,8 +92,12 @@ def get_user_conversation(user_id: str):
         )
         return active_conversations[user_id][latest_response_id]
 
-    # Fallback to metadata-only conversations
-    conversations = get_user_conversations(user_id)
+    # Fallback to metadata-only conversations. This is a SYNC legacy
+    # caller, so we read the eagerly-loaded JSON cache directly instead
+    # of awaiting the async service. The dict is populated in the
+    # service's __init__ for all storage modes; in `db` mode it stays
+    # empty but `active_conversations` above already covered fresh data.
+    conversations = conversation_persistence._conversations.get(user_id, {})
     if not conversations:
         return get_conversation_thread(user_id)
 
@@ -449,7 +453,7 @@ async def async_chat(
         )
 
         # Debug: Check what's in user_conversations now
-        conversations = get_user_conversations(user_id)
+        conversations = await get_user_conversations(user_id)
         logger.debug(
             "User conversations updated",
             user_id=user_id,
@@ -703,7 +707,7 @@ async def async_langflow_chat(
         )
 
         # Debug: Check what's in user_conversations now
-        conversations = get_user_conversations(user_id)
+        conversations = await get_user_conversations(user_id)
         logger.debug(
             "User conversations updated",
             user_id=user_id,
@@ -788,32 +792,31 @@ async def async_langflow_chat_stream(
             yield chunk
 
         # Add the complete assistant response to message history with response_id, timestamp, and function call data
-        assistant_message = {
-            "role": "assistant",
-            "content": full_response,
-            "response_id": response_id,
-            "timestamp": datetime.now(),
-            "chunks": collected_chunks,  # Store complete chunk data for function calls
-            "error": error_occurred,  # Mark if this was an error response
-        }
-        # Store usage data if available (from response.completed event)
-        if usage_data:
-            assistant_message["response_data"] = {"usage": usage_data}
-        conversation_state["messages"].append(assistant_message)
+        if full_response:
+            assistant_message = {
+                "role": "assistant",
+                "content": full_response,
+                "response_id": response_id,
+                "timestamp": datetime.now(),
+                "chunks": collected_chunks,
+                "error": error_occurred,
+            }
+            if usage_data:
+                assistant_message["response_data"] = {"usage": usage_data}
+            conversation_state["messages"].append(assistant_message)
 
         # Store the conversation thread with its response_id
         if response_id:
             conversation_state["last_activity"] = datetime.now()
             await store_conversation_thread(user_id, response_id, conversation_state)
 
-            # Claim session ownership for this user
-        try:
-            from services.session_ownership_service import session_ownership_service
+            try:
+                from services.session_ownership_service import session_ownership_service
 
-            await session_ownership_service.claim_session(user_id, response_id)
-            logger.debug(f"Claimed session {response_id} for user {user_id}")
-        except Exception as e:
-            logger.warning(f"Failed to claim session ownership: {e}")
+                await session_ownership_service.claim_session(user_id, response_id)
+                logger.debug(f"Claimed session {response_id} for user {user_id}")
+            except Exception as e:
+                logger.warning(f"Failed to claim session ownership: {e}")
 
             logger.debug(
                 f"Stored langflow conversation thread for user {user_id} with response_id: {response_id}"

--- a/src/api/admin/__init__.py
+++ b/src/api/admin/__init__.py
@@ -1,0 +1,5 @@
+"""Admin-only API surface (RBAC management).
+
+Every endpoint in this package is gated by `require_permission(...)` and
+writes an `audit_log` row in the same transaction as its mutation.
+"""

--- a/src/api/admin/rbac.py
+++ b/src/api/admin/rbac.py
@@ -228,7 +228,7 @@ async def update_user(
         )
         await session.commit()
         rbac.invalidate(row.id)
-        invalidate_user_ensured_cache(row.id)
+        invalidate_user_ensured_cache(row.oauth_provider, row.oauth_subject)
 
     return await _user_to_out(session, row)
 
@@ -247,6 +247,12 @@ async def delete_user(
     row = await UserRepo(session).get_by_id(user_id)
     if row is None:
         raise HTTPException(404, {"error": "user_not_found"})
+
+    # Capture identity for the post-commit cache invalidation; after
+    # session.delete(row) + commit the row is expunged and these
+    # attributes become unavailable.
+    deleted_provider = row.oauth_provider
+    deleted_subject = row.oauth_subject
 
     # Don't let the operator delete the last admin.
     role_repo = RoleRepo(session)
@@ -290,7 +296,7 @@ async def delete_user(
     )
     await session.commit()
     rbac.invalidate(user_id)
-    invalidate_user_ensured_cache(user_id)
+    invalidate_user_ensured_cache(deleted_provider, deleted_subject)
     return {"success": True}
 
 

--- a/src/api/admin/rbac.py
+++ b/src/api/admin/rbac.py
@@ -29,7 +29,7 @@ from typing import List, Optional
 
 from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import (
@@ -201,6 +201,16 @@ async def update_user(
     if row is None:
         raise HTTPException(404, {"error": "user_not_found"})
 
+    # Don't let the operator deactivate the last active admin.
+    if body.is_active is False and row.is_active:
+        role_repo = RoleRepo(session)
+        roles = await role_repo.list_user_roles(user_id)
+        if any(r.name == "admin" for r in roles):
+            if await role_repo.count_admins() <= 1:
+                raise HTTPException(
+                    400, {"error": "cannot_deactivate_last_admin"}
+                )
+
     changed: dict = {}
     if body.is_active is not None and body.is_active != row.is_active:
         row.is_active = body.is_active
@@ -238,7 +248,30 @@ async def delete_user(
     if row is None:
         raise HTTPException(404, {"error": "user_not_found"})
 
-    # Tear down user_roles + preferences then the user row.
+    # Don't let the operator delete the last admin.
+    role_repo = RoleRepo(session)
+    roles = await role_repo.list_user_roles(user_id)
+    if any(r.name == "admin" for r in roles):
+        if await role_repo.count_admins() <= 1:
+            raise HTTPException(400, {"error": "cannot_delete_last_admin"})
+
+    # Pre-null audit_log.actor_user_id so the audit row written below
+    # for the delete event survives even after the deleted user's other
+    # historical audit rows are nulled by the SET NULL FK policy. (The
+    # FK migration handles the cascade from the DB side; this explicit
+    # nulling is belt-and-suspenders for older deployments where the
+    # 0005_user_fk_ondelete migration hasn't run yet.)
+    await session.execute(
+        update(AuditLog)
+        .where(AuditLog.actor_user_id == user_id)
+        .values(actor_user_id=None)
+    )
+    # The 0005 migration sets ON DELETE CASCADE for user_roles and
+    # user_preferences and ON DELETE SET NULL for granted_by /
+    # workspace_config.updated_by, so a single delete of the user row
+    # propagates correctly. Keep the explicit deletes for the legacy
+    # path (deployments that haven't applied 0005 yet); they're no-ops
+    # under the new FK policy.
     await session.execute(
         UserRole.__table__.delete().where(UserRole.user_id == user_id)
     )

--- a/src/api/admin/rbac.py
+++ b/src/api/admin/rbac.py
@@ -1,0 +1,529 @@
+"""Admin RBAC endpoints.
+
+Owns:
+  GET    /api/admin/users
+  GET    /api/admin/users/{id}
+  PATCH  /api/admin/users/{id}
+  DELETE /api/admin/users/{id}
+  POST   /api/admin/users/{id}/roles            body: {role_id}
+  DELETE /api/admin/users/{id}/roles/{role_id}
+
+  GET    /api/admin/roles
+  POST   /api/admin/roles                        body: {name, description, permissions[]}
+  PATCH  /api/admin/roles/{id}                   body: {description?, permissions?[]}
+  DELETE /api/admin/roles/{id}
+  GET    /api/admin/permissions
+
+  GET    /api/admin/audit                        ?limit=100&offset=0
+
+Every mutation writes an audit_log row inside the same DB transaction.
+Cache invalidation: any role/permission mutation calls
+`rbac.invalidate(user_id)` for the affected user (or `invalidate_all()`
+for permission-catalog changes).
+"""
+
+from __future__ import annotations
+
+import uuid
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from pydantic import BaseModel
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import (
+    AuditLog,
+    Permission,
+    Role,
+    RolePermission,
+    User as UserRow,
+    UserRole,
+)
+from db.repositories import (
+    AuditRepo,
+    PermissionRepo,
+    RoleRepo,
+    UserRepo,
+)
+from dependencies import (
+    get_current_user,
+    get_db_session,
+    get_rbac_service,
+    invalidate_user_ensured_cache,
+    require_permission,
+)
+from session_manager import User
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# See note in api/users.py — Next.js proxy strips /api before forwarding,
+# so we mount under /admin and the frontend reaches us at /api/admin/...
+router = APIRouter(prefix="/admin", tags=["admin"])
+
+
+# ---------------------------------------------------------------------------
+# Pydantic shapes
+# ---------------------------------------------------------------------------
+
+class UserOut(BaseModel):
+    id: str
+    oauth_provider: str
+    oauth_subject: str
+    email: Optional[str] = None
+    display_name: Optional[str] = None
+    picture_url: Optional[str] = None
+    is_active: bool
+    roles: List[str]
+    created_at: Optional[str] = None
+    last_login: Optional[str] = None
+
+
+class UserPatch(BaseModel):
+    is_active: Optional[bool] = None
+
+
+class AssignRoleBody(BaseModel):
+    role_id: str
+
+
+class RoleOut(BaseModel):
+    id: str
+    name: str
+    description: Optional[str] = None
+    is_system: bool
+    permissions: List[str]
+
+
+class RoleCreateBody(BaseModel):
+    name: str
+    description: Optional[str] = None
+    permissions: List[str] = []
+
+
+class RolePatchBody(BaseModel):
+    description: Optional[str] = None
+    permissions: Optional[List[str]] = None
+
+
+class PermissionOut(BaseModel):
+    id: str
+    name: str
+    resource: str
+    action: str
+    description: Optional[str] = None
+
+
+class AuditOut(BaseModel):
+    id: str
+    ts: str
+    actor_user_id: Optional[str] = None
+    event: str
+    target_type: Optional[str] = None
+    target_id: Optional[str] = None
+    audit_metadata: Optional[dict] = None
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _user_to_out(session: AsyncSession, row: UserRow) -> UserOut:
+    role_repo = RoleRepo(session)
+    roles = await role_repo.list_user_roles(row.id)
+    return UserOut(
+        id=row.id,
+        oauth_provider=row.oauth_provider,
+        oauth_subject=row.oauth_subject,
+        email=row.email,
+        display_name=row.display_name,
+        picture_url=row.picture_url,
+        is_active=row.is_active,
+        roles=[r.name for r in roles],
+        created_at=row.created_at.isoformat() if row.created_at else None,
+        last_login=row.last_login.isoformat() if row.last_login else None,
+    )
+
+
+def _audit_to_out(row: AuditLog) -> AuditOut:
+    return AuditOut(
+        id=row.id,
+        ts=row.ts.isoformat() if row.ts else "",
+        actor_user_id=row.actor_user_id,
+        event=row.event,
+        target_type=row.target_type,
+        target_id=row.target_id,
+        audit_metadata=row.audit_metadata,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Users
+# ---------------------------------------------------------------------------
+
+
+@router.get("/users", response_model=List[UserOut])
+async def list_users(
+    limit: int = 100,
+    offset: int = 0,
+    actor: User = Depends(require_permission("users:list")),
+    session: AsyncSession = Depends(get_db_session),
+) -> List[UserOut]:
+    user_repo = UserRepo(session)
+    rows = await user_repo.list_all(limit=limit, offset=offset)
+    return [await _user_to_out(session, r) for r in rows]
+
+
+@router.get("/users/{user_id}", response_model=UserOut)
+async def get_user(
+    user_id: str,
+    actor: User = Depends(require_permission("users:read")),
+    session: AsyncSession = Depends(get_db_session),
+) -> UserOut:
+    row = await UserRepo(session).get_by_id(user_id)
+    if row is None:
+        raise HTTPException(404, {"error": "user_not_found"})
+    return await _user_to_out(session, row)
+
+
+@router.patch("/users/{user_id}", response_model=UserOut)
+async def update_user(
+    user_id: str,
+    body: UserPatch,
+    request: Request,
+    actor: User = Depends(require_permission("users:invite")),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> UserOut:
+    row = await UserRepo(session).get_by_id(user_id)
+    if row is None:
+        raise HTTPException(404, {"error": "user_not_found"})
+
+    changed: dict = {}
+    if body.is_active is not None and body.is_active != row.is_active:
+        row.is_active = body.is_active
+        changed["is_active"] = body.is_active
+
+    if changed:
+        session.add(row)
+        await AuditRepo(session).write(
+            event="user.updated",
+            actor_user_id=actor.user_id,
+            target_type="user",
+            target_id=row.id,
+            audit_metadata={"changes": changed},
+            ip=request.client.host if request.client else None,
+        )
+        await session.commit()
+        rbac.invalidate(row.id)
+        invalidate_user_ensured_cache(row.id)
+
+    return await _user_to_out(session, row)
+
+
+@router.delete("/users/{user_id}")
+async def delete_user(
+    user_id: str,
+    request: Request,
+    actor: User = Depends(require_permission("users:delete")),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+):
+    if actor.user_id == user_id:
+        raise HTTPException(400, {"error": "cannot_delete_self"})
+
+    row = await UserRepo(session).get_by_id(user_id)
+    if row is None:
+        raise HTTPException(404, {"error": "user_not_found"})
+
+    # Tear down user_roles + preferences then the user row.
+    await session.execute(
+        UserRole.__table__.delete().where(UserRole.user_id == user_id)
+    )
+    from db.models import UserPreferences
+    await session.execute(
+        UserPreferences.__table__.delete().where(UserPreferences.user_id == user_id)
+    )
+    await session.delete(row)
+
+    await AuditRepo(session).write(
+        event="user.deleted",
+        actor_user_id=actor.user_id,
+        target_type="user",
+        target_id=user_id,
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate(user_id)
+    invalidate_user_ensured_cache(user_id)
+    return {"success": True}
+
+
+@router.post("/users/{user_id}/roles", response_model=UserOut)
+async def assign_role(
+    user_id: str,
+    body: AssignRoleBody,
+    request: Request,
+    actor: User = Depends(require_permission("roles:assign")),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> UserOut:
+    user_repo = UserRepo(session)
+    role_repo = RoleRepo(session)
+
+    user = await user_repo.get_by_id(user_id)
+    if user is None:
+        raise HTTPException(404, {"error": "user_not_found"})
+    role = await role_repo.get_by_id(body.role_id)
+    if role is None:
+        raise HTTPException(404, {"error": "role_not_found"})
+
+    await role_repo.assign_role(user_id, body.role_id, granted_by=actor.user_id)
+    await AuditRepo(session).write(
+        event="user.role.assigned",
+        actor_user_id=actor.user_id,
+        target_type="user",
+        target_id=user_id,
+        audit_metadata={"role_id": body.role_id, "role_name": role.name},
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate(user_id)
+    return await _user_to_out(session, user)
+
+
+@router.delete("/users/{user_id}/roles/{role_id}", response_model=UserOut)
+async def revoke_role(
+    user_id: str,
+    role_id: str,
+    request: Request,
+    actor: User = Depends(require_permission("roles:assign")),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> UserOut:
+    user_repo = UserRepo(session)
+    role_repo = RoleRepo(session)
+    user = await user_repo.get_by_id(user_id)
+    if user is None:
+        raise HTTPException(404, {"error": "user_not_found"})
+    role = await role_repo.get_by_id(role_id)
+
+    # Don't let the operator strip the last admin.
+    if role and role.name == "admin":
+        admin_count = await role_repo.count_admins()
+        if admin_count <= 1:
+            raise HTTPException(400, {"error": "cannot_remove_last_admin"})
+
+    await role_repo.revoke_role(user_id, role_id)
+    await AuditRepo(session).write(
+        event="user.role.revoked",
+        actor_user_id=actor.user_id,
+        target_type="user",
+        target_id=user_id,
+        audit_metadata={"role_id": role_id, "role_name": role.name if role else None},
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate(user_id)
+    return await _user_to_out(session, user)
+
+
+# ---------------------------------------------------------------------------
+# Roles
+# ---------------------------------------------------------------------------
+
+
+async def _role_to_out(session: AsyncSession, role: Role) -> RoleOut:
+    perms = await RoleRepo(session).list_permissions_for_role(role.id)
+    return RoleOut(
+        id=role.id,
+        name=role.name,
+        description=role.description,
+        is_system=role.is_system,
+        permissions=[p.name for p in perms],
+    )
+
+
+@router.get("/roles", response_model=List[RoleOut])
+async def list_roles(
+    actor: User = Depends(require_permission("roles:list")),
+    session: AsyncSession = Depends(get_db_session),
+) -> List[RoleOut]:
+    roles = await RoleRepo(session).list_all()
+    return [await _role_to_out(session, r) for r in roles]
+
+
+@router.post("/roles", response_model=RoleOut)
+async def create_role(
+    body: RoleCreateBody,
+    request: Request,
+    actor: User = Depends(require_permission("roles:create")),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> RoleOut:
+    role_repo = RoleRepo(session)
+    perm_repo = PermissionRepo(session)
+
+    if not body.name or len(body.name) > 64:
+        raise HTTPException(400, {"error": "invalid_role_name"})
+
+    existing = await role_repo.get_by_name(body.name)
+    if existing is not None:
+        raise HTTPException(409, {"error": "role_exists"})
+
+    role = Role(
+        id=str(uuid.uuid4()),
+        name=body.name,
+        description=body.description,
+        is_system=False,
+    )
+    session.add(role)
+    await session.flush()
+
+    # Resolve permissions by name → id
+    if body.permissions:
+        for pname in body.permissions:
+            perm = await perm_repo.get_by_name(pname)
+            if perm is None:
+                raise HTTPException(400, {"error": "unknown_permission", "name": pname})
+            session.add(RolePermission(role_id=role.id, permission_id=perm.id))
+
+    await AuditRepo(session).write(
+        event="role.created",
+        actor_user_id=actor.user_id,
+        target_type="role",
+        target_id=role.id,
+        audit_metadata={"name": role.name, "permissions": body.permissions},
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate_all()
+    return await _role_to_out(session, role)
+
+
+@router.patch("/roles/{role_id}", response_model=RoleOut)
+async def update_role(
+    role_id: str,
+    body: RolePatchBody,
+    request: Request,
+    actor: User = Depends(require_permission("roles:edit")),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> RoleOut:
+    role_repo = RoleRepo(session)
+    perm_repo = PermissionRepo(session)
+
+    role = await role_repo.get_by_id(role_id)
+    if role is None:
+        raise HTTPException(404, {"error": "role_not_found"})
+
+    changed: dict = {}
+    if body.description is not None and body.description != role.description:
+        role.description = body.description
+        changed["description"] = body.description
+        session.add(role)
+
+    if body.permissions is not None:
+        # Resolve names; fail fast on any unknown.
+        new_perm_ids: list[str] = []
+        for pname in body.permissions:
+            perm = await perm_repo.get_by_name(pname)
+            if perm is None:
+                raise HTTPException(400, {"error": "unknown_permission", "name": pname})
+            new_perm_ids.append(perm.id)
+
+        # Replace the role's permission set. For is_system roles we still
+        # allow this so admins can adjust defaults — they just can't rename
+        # or delete the role.
+        await session.execute(
+            RolePermission.__table__.delete().where(RolePermission.role_id == role.id)
+        )
+        for pid in new_perm_ids:
+            session.add(RolePermission(role_id=role.id, permission_id=pid))
+        changed["permissions"] = body.permissions
+
+    if changed:
+        await AuditRepo(session).write(
+            event="role.updated",
+            actor_user_id=actor.user_id,
+            target_type="role",
+            target_id=role.id,
+            audit_metadata={"changes": changed},
+            ip=request.client.host if request.client else None,
+        )
+        await session.commit()
+        rbac.invalidate_all()
+    return await _role_to_out(session, role)
+
+
+@router.delete("/roles/{role_id}")
+async def delete_role(
+    role_id: str,
+    request: Request,
+    actor: User = Depends(require_permission("roles:delete")),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+):
+    role_repo = RoleRepo(session)
+    role = await role_repo.get_by_id(role_id)
+    if role is None:
+        raise HTTPException(404, {"error": "role_not_found"})
+    if role.is_system:
+        raise HTTPException(400, {"error": "cannot_delete_system_role"})
+
+    await session.execute(
+        RolePermission.__table__.delete().where(RolePermission.role_id == role.id)
+    )
+    await session.execute(
+        UserRole.__table__.delete().where(UserRole.role_id == role.id)
+    )
+    await session.delete(role)
+    await AuditRepo(session).write(
+        event="role.deleted",
+        actor_user_id=actor.user_id,
+        target_type="role",
+        target_id=role.id,
+        audit_metadata={"name": role.name},
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate_all()
+    return {"success": True}
+
+
+# ---------------------------------------------------------------------------
+# Permissions
+# ---------------------------------------------------------------------------
+
+
+@router.get("/permissions", response_model=List[PermissionOut])
+async def list_permissions(
+    actor: User = Depends(require_permission("roles:list")),
+    session: AsyncSession = Depends(get_db_session),
+) -> List[PermissionOut]:
+    perms = await PermissionRepo(session).list_all()
+    return [
+        PermissionOut(
+            id=p.id, name=p.name, resource=p.resource, action=p.action,
+            description=p.description,
+        )
+        for p in perms
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Audit log
+# ---------------------------------------------------------------------------
+
+
+@router.get("/audit", response_model=List[AuditOut])
+async def list_audit(
+    limit: int = 100,
+    offset: int = 0,
+    actor: User = Depends(require_permission("audit:read")),
+    session: AsyncSession = Depends(get_db_session),
+) -> List[AuditOut]:
+    rows = await AuditRepo(session).list_recent(limit=limit, offset=offset)
+    return [_audit_to_out(r) for r in rows]

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -5,7 +5,12 @@ from pydantic import BaseModel
 from fastapi.responses import JSONResponse, StreamingResponse
 from utils.logging_config import get_logger
 
-from dependencies import get_chat_service, get_session_manager, get_current_user
+from dependencies import (
+    get_chat_service,
+    get_session_manager,
+    get_current_user,
+    require_permission,
+)
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -25,7 +30,7 @@ async def chat_endpoint(
     body: ChatBody,
     chat_service=Depends(get_chat_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("chat:use")),
 ):
     """Handle chat requests"""
     if not body.prompt:
@@ -75,7 +80,7 @@ async def langflow_endpoint(
     body: ChatBody,
     chat_service=Depends(get_chat_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("chat:use")),
 ):
     """Handle Langflow chat requests"""
     if not body.prompt:
@@ -136,7 +141,7 @@ async def langflow_endpoint(
 
 async def chat_history_endpoint(
     chat_service=Depends(get_chat_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("conversations:read:own")),
 ):
     """Get chat history for a user"""
     try:
@@ -151,7 +156,7 @@ async def chat_history_endpoint(
 
 async def langflow_history_endpoint(
     chat_service=Depends(get_chat_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("conversations:read:own")),
 ):
     """Get langflow chat history for a user"""
     try:
@@ -167,7 +172,7 @@ async def langflow_history_endpoint(
 async def delete_session_endpoint(
     session_id: str,
     chat_service=Depends(get_chat_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("conversations:delete:own")),
 ):
     """Delete a chat session"""
     try:

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -1,6 +1,6 @@
 from typing import Optional, Any, Dict
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from pydantic import BaseModel
 from fastapi.responses import JSONResponse, StreamingResponse
 from utils.logging_config import get_logger
@@ -14,6 +14,23 @@ from dependencies import (
 from session_manager import User
 
 logger = get_logger(__name__)
+
+
+async def _assert_owns(session_id: Optional[str], user_id: str) -> None:
+    """Raise 403 if `session_id` is set but not owned by `user_id`.
+
+    No-op when `session_id` is None (new conversation, nothing to check).
+    Raise 404 if a session is referenced that doesn't exist — don't leak
+    existence to non-owners.
+    """
+    if not session_id:
+        return
+    from services.session_ownership_service import session_ownership_service
+    owner = await session_ownership_service.get_session_owner(session_id)
+    if owner is None:
+        raise HTTPException(status_code=404, detail={"error": "session_not_found"})
+    if owner != user_id:
+        raise HTTPException(status_code=403, detail={"error": "session_forbidden"})
 
 
 class ChatBody(BaseModel):
@@ -35,6 +52,8 @@ async def chat_endpoint(
     """Handle chat requests"""
     if not body.prompt:
         return JSONResponse({"error": "Prompt is required"}, status_code=400)
+
+    await _assert_owns(body.previous_response_id, user.user_id)
 
     jwt_token = user.jwt_token
 
@@ -85,6 +104,8 @@ async def langflow_endpoint(
     """Handle Langflow chat requests"""
     if not body.prompt:
         return JSONResponse({"error": "Prompt is required"}, status_code=400)
+
+    await _assert_owns(body.previous_response_id, user.user_id)
 
     jwt_token = user.jwt_token
 
@@ -175,6 +196,7 @@ async def delete_session_endpoint(
     user: User = Depends(require_permission("conversations:delete:own")),
 ):
     """Delete a chat session"""
+    await _assert_owns(session_id, user.user_id)
     try:
         result = await chat_service.delete_session(user.user_id, session_id)
 

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -16,6 +16,10 @@ from session_manager import User
 logger = get_logger(__name__)
 
 
+def _openrag_user_id(user: User) -> str:
+    return getattr(user, "db_user_id", None) or user.user_id
+
+
 async def _assert_owns(session_id: Optional[str], user_id: str) -> None:
     """Raise 403 if `session_id` is set but not owned by `user_id`.
 
@@ -53,7 +57,8 @@ async def chat_endpoint(
     if not body.prompt:
         return JSONResponse({"error": "Prompt is required"}, status_code=400)
 
-    await _assert_owns(body.previous_response_id, user.user_id)
+    storage_user_id = _openrag_user_id(user)
+    await _assert_owns(body.previous_response_id, storage_user_id)
 
     jwt_token = user.jwt_token
 
@@ -74,6 +79,7 @@ async def chat_endpoint(
                 previous_response_id=body.previous_response_id,
                 stream=True,
                 filter_id=body.filter_id,
+                storage_user_id=storage_user_id,
             ),
             media_type="text/event-stream",
             headers={
@@ -91,6 +97,7 @@ async def chat_endpoint(
             previous_response_id=body.previous_response_id,
             stream=False,
             filter_id=body.filter_id,
+            storage_user_id=storage_user_id,
         )
         return JSONResponse(result)
 
@@ -105,7 +112,8 @@ async def langflow_endpoint(
     if not body.prompt:
         return JSONResponse({"error": "Prompt is required"}, status_code=400)
 
-    await _assert_owns(body.previous_response_id, user.user_id)
+    storage_user_id = _openrag_user_id(user)
+    await _assert_owns(body.previous_response_id, storage_user_id)
 
     jwt_token = user.jwt_token
 
@@ -130,6 +138,7 @@ async def langflow_endpoint(
                     owner=user.user_id,
                     owner_name=user.name,
                     owner_email=user.email,
+                    storage_user_id=storage_user_id,
                 ),
                 media_type="text/event-stream",
                 headers={
@@ -150,6 +159,7 @@ async def langflow_endpoint(
                 owner=user.user_id,
                 owner_name=user.name,
                 owner_email=user.email,
+                storage_user_id=storage_user_id,
             )
             return JSONResponse(result)
 
@@ -166,7 +176,7 @@ async def chat_history_endpoint(
 ):
     """Get chat history for a user"""
     try:
-        history = await chat_service.get_chat_history(user.user_id)
+        history = await chat_service.get_chat_history(_openrag_user_id(user))
         return JSONResponse(history)
     except Exception as e:
         logger.exception("[CHAT] Failed to get chat history")
@@ -181,7 +191,7 @@ async def langflow_history_endpoint(
 ):
     """Get langflow chat history for a user"""
     try:
-        history = await chat_service.get_langflow_history(user.user_id)
+        history = await chat_service.get_langflow_history(_openrag_user_id(user))
         return JSONResponse(history)
     except Exception as e:
         logger.exception("[CHAT] Failed to get langflow history")
@@ -196,9 +206,10 @@ async def delete_session_endpoint(
     user: User = Depends(require_permission("conversations:delete:own")),
 ):
     """Delete a chat session"""
-    await _assert_owns(session_id, user.user_id)
+    storage_user_id = _openrag_user_id(user)
+    await _assert_owns(session_id, storage_user_id)
     try:
-        result = await chat_service.delete_session(user.user_id, session_id)
+        result = await chat_service.delete_session(storage_user_id, session_id)
 
         if result.get("success"):
             return JSONResponse({"message": "Session deleted successfully"})

--- a/src/api/config.py
+++ b/src/api/config.py
@@ -1,0 +1,46 @@
+"""Public workspace-config endpoints.
+
+Today there's just one — ``GET /api/onboarding-status`` — used by the
+frontend on initial render to decide whether to show the onboarding
+wizard or the login flow. No auth required (must work pre-login so the
+wizard can render). Returns exactly two scalar fields, no provider data.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Union
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from dependencies import get_workspace_config_service
+
+# Backend routes are mounted WITHOUT the /api prefix because the Next.js
+# proxy at frontend/app/api/[...path]/route.ts strips it before forwarding.
+# Frontend reaches this via /api/onboarding-status.
+router = APIRouter(tags=["onboarding"])
+
+
+class OnboardingStatusResponse(BaseModel):
+    onboarded: bool
+    # OnboardingState.current_step is an int (step index) in the legacy
+    # config_manager dataclass; future schema may switch it to a string
+    # name. Accept either to stay forward-compatible.
+    current_step: Optional[Union[int, str]] = None
+
+
+@router.get("/onboarding-status", response_model=OnboardingStatusResponse)
+async def onboarding_status(
+    config_service=Depends(get_workspace_config_service),
+) -> OnboardingStatusResponse:
+    """Public endpoint — no auth.
+
+    The frontend hits this on first render to decide between rendering
+    the onboarding wizard and the login screen. Discloses one bit
+    (whether the workspace is set up). Returns no provider keys, no
+    settings details.
+    """
+    return OnboardingStatusResponse(
+        onboarded=await config_service.is_onboarded(),
+        current_step=await config_service.get_onboarding_step(),
+    )

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -7,7 +7,13 @@ from connectors.sharepoint.utils import is_valid_sharepoint_url
 from config.settings import get_index_name
 from utils.logging_config import get_logger
 from utils.telemetry import TelemetryClient, Category, MessageId
-from dependencies import get_connector_service, get_session_manager, get_current_user
+from dependencies import (
+    get_connector_service,
+    get_current_user,
+    get_rbac_service,
+    get_session_manager,
+    require_permission,
+)
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -117,7 +123,7 @@ async def connector_sync(
     body: ConnectorSyncBody,
     connector_service=Depends(get_connector_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("connectors:use")),
 ):
     """Sync files from all active connections of a connector type"""
     max_files = body.max_files
@@ -577,7 +583,7 @@ async def connector_webhook(
 async def connector_disconnect(
     connector_type: str,
     connector_service=Depends(get_connector_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("connectors:delete:own")),
 ):
     """Disconnect a connector by deleting its connection"""
 
@@ -656,7 +662,7 @@ async def connector_disconnect(
 async def sync_all_connectors(
     connector_service=Depends(get_connector_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("connectors:use")),
 ):
     """
     Sync files from all active cloud connector connections.

--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -3,7 +3,7 @@ from pydantic import BaseModel
 from fastapi.responses import JSONResponse
 from utils.logging_config import get_logger
 
-from dependencies import get_session_manager, get_current_user
+from dependencies import get_session_manager, get_current_user, require_permission
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -168,7 +168,7 @@ async def check_filename_exists(
 async def delete_documents_by_filename(
     body: DeleteDocumentBody,
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("knowledge:delete:own")),
     ):
     """Delete all documents with a specific filename"""
     payload, status_code =await delete_documents_by_filename_core(

--- a/src/api/flows.py
+++ b/src/api/flows.py
@@ -5,7 +5,7 @@ from fastapi import Depends
 from fastapi.responses import JSONResponse
 from utils.logging_config import get_logger
 
-from dependencies import get_flows_service, get_current_user
+from dependencies import get_flows_service, get_current_user, require_permission
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -16,7 +16,7 @@ FlowType = Literal["nudges", "retrieval", "ingest"]
 async def reset_flow_endpoint(
     flow_type: str,
     flows_service=Depends(get_flows_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("flows:edit")),
 ):
     """Reset a Langflow flow by type (nudges, retrieval, or ingest)"""
     if flow_type not in ["nudges", "retrieval", "ingest"]:

--- a/src/api/keys.py
+++ b/src/api/keys.py
@@ -9,7 +9,7 @@ from pydantic import BaseModel, Field
 from fastapi.responses import JSONResponse
 from utils.logging_config import get_logger
 
-from dependencies import get_api_key_service, get_current_user
+from dependencies import get_api_key_service, get_current_user, require_permission
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -35,7 +35,7 @@ async def list_keys_endpoint(
 async def create_key_endpoint(
     body: CreateKeyBody,
     api_key_service=Depends(get_api_key_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("apikeys:create:self")),
 ):
     """
     Create a new API key for the authenticated user.
@@ -74,7 +74,7 @@ async def create_key_endpoint(
 async def revoke_key_endpoint(
     key_id: str,
     api_key_service=Depends(get_api_key_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("apikeys:revoke:self")),
 ):
     """
     Revoke an API key.
@@ -100,7 +100,7 @@ async def revoke_key_endpoint(
 async def delete_key_endpoint(
     key_id: str,
     api_key_service=Depends(get_api_key_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("apikeys:revoke:self")),
 ):
     """
     Permanently delete an API key.

--- a/src/api/knowledge_filter.py
+++ b/src/api/knowledge_filter.py
@@ -7,7 +7,13 @@ import uuid
 import json
 from datetime import datetime
 from utils.logging_config import get_logger
-from dependencies import get_knowledge_filter_service, get_monitor_service, get_session_manager, get_current_user
+from dependencies import (
+    get_knowledge_filter_service,
+    get_monitor_service,
+    get_session_manager,
+    get_current_user,
+    require_permission,
+)
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -75,7 +81,7 @@ async def create_knowledge_filter(
     body: CreateFilterBody,
     knowledge_filter_service=Depends(get_knowledge_filter_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("kf:create")),
 ):
     """Create a new knowledge filter"""
     if not body.name:
@@ -170,7 +176,7 @@ async def update_knowledge_filter(
     body: UpdateFilterBody,
     knowledge_filter_service=Depends(get_knowledge_filter_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("kf:edit:own")),
 ):
     """Update an existing knowledge filter by delete + recreate"""
     jwt_token = user.jwt_token
@@ -226,7 +232,7 @@ async def delete_knowledge_filter(
     filter_id: str,
     knowledge_filter_service=Depends(get_knowledge_filter_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("kf:edit:own")),
 ):
     """Delete a knowledge filter"""
     jwt_token = user.jwt_token

--- a/src/api/nudges.py
+++ b/src/api/nudges.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from pydantic import BaseModel
 from fastapi.responses import JSONResponse
 from utils.logging_config import get_logger
@@ -9,6 +9,10 @@ from dependencies import get_chat_service, get_session_manager, get_current_user
 from session_manager import User
 
 logger = get_logger(__name__)
+
+
+def _openrag_user_id(user: User) -> str:
+    return getattr(user, "db_user_id", None) or user.user_id
 
 
 class NudgesBody(BaseModel):
@@ -25,6 +29,7 @@ async def nudges_from_kb_endpoint(
 ):
     """Get nudges for a user"""
     jwt_token = user.jwt_token
+    storage_user_id = _openrag_user_id(user)
 
     try:
         result = await chat_service.langflow_nudges_chat(
@@ -33,8 +38,11 @@ async def nudges_from_kb_endpoint(
             filters=body.filters,
             limit=body.limit,
             score_threshold=body.score_threshold,
+            storage_user_id=storage_user_id,
         )
         return JSONResponse(result)
+    except HTTPException:
+        raise
     except Exception as e:
         return JSONResponse(
             {"error": f"Failed to get nudges: {str(e)}"}, status_code=500
@@ -50,8 +58,11 @@ async def nudges_from_chat_id_endpoint(
 ):
     """Get nudges for a user based on a previous conversation"""
     jwt_token = user.jwt_token
+    storage_user_id = _openrag_user_id(user)
 
     try:
+        from api.chat import _assert_owns
+        await _assert_owns(chat_id, storage_user_id)
         result = await chat_service.langflow_nudges_chat(
             user.user_id,
             jwt_token,
@@ -59,8 +70,11 @@ async def nudges_from_chat_id_endpoint(
             filters=body.filters,
             limit=body.limit,
             score_threshold=body.score_threshold,
+            storage_user_id=storage_user_id,
         )
         return JSONResponse(result)
+    except HTTPException:
+        raise
     except Exception as e:
         return JSONResponse(
             {"error": f"Failed to get nudges: {str(e)}"}, status_code=500

--- a/src/api/search.py
+++ b/src/api/search.py
@@ -6,7 +6,12 @@ from fastapi.responses import JSONResponse
 from utils.logging_config import get_logger
 from utils.opensearch_utils import OpenSearchDiskSpaceError, DISK_SPACE_ERROR_MESSAGE
 
-from dependencies import get_search_service, get_session_manager, get_current_user
+from dependencies import (
+    get_search_service,
+    get_session_manager,
+    get_current_user,
+    require_permission,
+)
 from session_manager import User
 
 logger = get_logger(__name__)
@@ -25,7 +30,7 @@ async def search(
     body: SearchBody,
     search_service=Depends(get_search_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("search:use")),
 ):
     """Search for documents"""
     try:

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -1695,7 +1695,9 @@ async def update_onboarding_state(
         # Convert body to dict excluding None values
         body_dict = body.model_dump(exclude_unset=True)
 
-        # Update onboarding state using config manager
+        # Update onboarding state using config manager (a monkey-patch
+        # installed by WorkspaceConfigService mirrors this to the SQL
+        # workspace_config table fire-and-forget).
         success = config_manager.update_onboarding_state(**body_dict)
 
         if not success:

--- a/src/api/settings.py
+++ b/src/api/settings.py
@@ -37,6 +37,7 @@ from dependencies import (
     get_langflow_file_service,
     get_knowledge_filter_service,
     get_chat_service,
+    require_permission,
 )
 from services.docling_service import DoclingConfig, get_docling_preset_configs
 from session_manager import User
@@ -482,7 +483,7 @@ def _embedding_conflict_response(
 async def update_settings(
     body: SettingsUpdateBody,
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("config:write")),
     models_service=Depends(get_models_service),
 ) -> SettingsUpdateResponse:
     """Update settings in configuration"""
@@ -992,7 +993,7 @@ async def onboarding(
     task_service=Depends(get_task_service),
     langflow_file_service=Depends(get_langflow_file_service),
     knowledge_filter_service=Depends(get_knowledge_filter_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("config:write")),
 ) -> OnboardingResponse:
     """Handle onboarding configuration setup"""
     try:
@@ -1685,7 +1686,7 @@ async def _update_langflow_chunk_settings(config, flows_service):
 
 async def update_onboarding_state(
     body: OnboardingStateBody,
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("config:write")),
 ) -> OnboardingStateResponse:
     """Update onboarding state in configuration"""
     try:
@@ -1775,7 +1776,7 @@ async def rollback_onboarding(
     knowledge_filter_service=Depends(get_knowledge_filter_service),
     flows_service=Depends(get_flows_service),
     chat_service=Depends(get_chat_service),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("config:write")),
 ) -> RollbackResponse:
     """Rollback onboarding configuration when sample data files fail.
 
@@ -1974,7 +1975,7 @@ async def rollback_onboarding(
 async def update_docling_preset(
     body: DoclingPresetBody,
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("config:write")),
 ) -> DoclingPresetResponse:
     """Update docling settings in the ingest flow - deprecated endpoint, use /settings instead"""
     try:
@@ -2047,7 +2048,7 @@ async def refresh_openrag_docs(
     models_service=Depends(get_models_service),
     langflow_file_service=Depends(get_langflow_file_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("config:write")),
 ) -> RefreshOpenRAGDocsResponse:
     """Manually refresh OpenRAG docs ingestion on demand."""
     try:

--- a/src/api/upload.py
+++ b/src/api/upload.py
@@ -15,6 +15,7 @@ from dependencies import (
     get_chat_service,
     get_session_manager,
     get_current_user,
+    require_permission,
 )
 from session_manager import User
 from utils.logging_config import get_logger
@@ -34,7 +35,7 @@ async def upload(
     file: UploadFile = File(...),
     document_service=Depends(get_document_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("knowledge:upload")),
 ):
     """Upload a single file"""
     try:
@@ -70,7 +71,7 @@ async def upload_path(
     body: UploadPathBody,
     task_service=Depends(get_task_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("knowledge:upload")),
 ):
     """Upload all files from a directory path"""
     if not body.path or not os.path.isdir(body.path):
@@ -115,7 +116,7 @@ async def upload_context(
     document_service=Depends(get_document_service),
     chat_service=Depends(get_chat_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("knowledge:upload")),
 ):
     """Upload a file and add its content as context to the current conversation"""
     filename = file.filename or "uploaded_document"
@@ -172,7 +173,7 @@ async def upload_bucket(
     models_service=Depends(get_models_service),
     docling_service=Depends(get_docling_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(get_current_user),
+    user: User = Depends(require_permission("knowledge:upload")),
 ):
     """Process all files from an S3 bucket URL"""
     if not os.getenv("AWS_ACCESS_KEY_ID") or not os.getenv("AWS_SECRET_ACCESS_KEY"):

--- a/src/api/upload.py
+++ b/src/api/upload.py
@@ -15,6 +15,7 @@ from dependencies import (
     get_chat_service,
     get_session_manager,
     get_current_user,
+    require_all_permissions,
     require_permission,
 )
 from session_manager import User
@@ -116,11 +117,18 @@ async def upload_context(
     document_service=Depends(get_document_service),
     chat_service=Depends(get_chat_service),
     session_manager=Depends(get_session_manager),
-    user: User = Depends(require_permission("knowledge:upload")),
+    user: User = Depends(require_all_permissions(("knowledge:upload", "chat:use"))),
 ):
     """Upload a file and add its content as context to the current conversation"""
     filename = file.filename or "uploaded_document"
     user_id = user.user_id if user else None
+    storage_user_id = (
+        (getattr(user, "db_user_id", None) or user.user_id) if user else None
+    )
+
+    if previous_response_id and storage_user_id:
+        from api.chat import _assert_owns
+        await _assert_owns(previous_response_id, storage_user_id)
 
     jwt_token = user.jwt_token
 
@@ -142,6 +150,7 @@ async def upload_context(
         owner=owner_user_id,
         owner_name=owner_name,
         owner_email=owner_email,
+        storage_user_id=storage_user_id,
     )
 
     response_data = {

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -9,10 +9,25 @@ from typing import List
 from fastapi import APIRouter, Depends
 from pydantic import BaseModel
 
-from db.repositories import RoleRepo, UserRepo
+from db.repositories import PermissionRepo, RoleRepo, UserRepo
 from dependencies import get_current_user, get_db_session, get_rbac_service
+from services.rbac_service import is_rbac_enforced
 from session_manager import User
 from sqlalchemy.ext.asyncio import AsyncSession
+
+
+async def _effective_permissions(rbac, db_id: str, session: AsyncSession) -> set[str]:
+    """Return the permissions the UI should treat the user as having.
+
+    When ``OPENRAG_RBAC_ENFORCE=false``, the backend lets every
+    authenticated user through every gate, so the frontend should also
+    show every action — otherwise users see disabled buttons that
+    actually work. We return the full permission catalog from the DB.
+    """
+    if is_rbac_enforced():
+        return await rbac.get_user_permissions(db_id)
+    perms = await PermissionRepo(session).list_all()
+    return {p.name for p in perms}
 
 # Backend routes are mounted WITHOUT the /api prefix because the Next.js
 # proxy at frontend/app/api/[...path]/route.ts strips it before forwarding.
@@ -46,7 +61,7 @@ async def get_me(
     db_id = db_user.id if db_user else user.user_id
 
     roles = await role_repo.list_user_roles(db_id)
-    perms = await rbac.get_user_permissions(db_id)
+    perms = await _effective_permissions(rbac, db_id, session)
 
     return MeResponse(
         user_id=user.user_id,
@@ -75,5 +90,5 @@ async def get_my_permissions(
         db_user = await user_repo.get_by_id(user.user_id)
     db_id = db_user.id if db_user else user.user_id
 
-    perms = await rbac.get_user_permissions(db_id)
+    perms = await _effective_permissions(rbac, db_id, session)
     return PermissionsResponse(permissions=sorted(perms))

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -1,0 +1,79 @@
+"""Per-user identity endpoints.
+
+GET /api/users/me              -> profile of the current user
+GET /api/users/me/permissions  -> list of permission strings
+"""
+
+from typing import List
+
+from fastapi import APIRouter, Depends
+from pydantic import BaseModel
+
+from db.repositories import RoleRepo, UserRepo
+from dependencies import get_current_user, get_db_session, get_rbac_service
+from session_manager import User
+from sqlalchemy.ext.asyncio import AsyncSession
+
+# Backend routes are mounted WITHOUT the /api prefix because the Next.js
+# proxy at frontend/app/api/[...path]/route.ts strips it before forwarding.
+# Frontend reaches these via /api/users/me, /api/users/me/permissions.
+router = APIRouter(prefix="/users", tags=["users"])
+
+
+class MeResponse(BaseModel):
+    user_id: str
+    email: str
+    name: str
+    picture: str | None = None
+    provider: str
+    roles: List[str]
+    permissions: List[str]
+
+
+@router.get("/me", response_model=MeResponse)
+async def get_me(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> MeResponse:
+    role_repo = RoleRepo(session)
+    user_repo = UserRepo(session)
+
+    # Resolve internal DB id from oauth identity (legacy rows used user_id directly).
+    db_user = await user_repo.get_by_oauth(user.provider or "unknown", user.user_id)
+    if db_user is None:
+        db_user = await user_repo.get_by_id(user.user_id)
+    db_id = db_user.id if db_user else user.user_id
+
+    roles = await role_repo.list_user_roles(db_id)
+    perms = await rbac.get_user_permissions(db_id)
+
+    return MeResponse(
+        user_id=user.user_id,
+        email=user.email or "",
+        name=user.name or "",
+        picture=user.picture,
+        provider=user.provider or "unknown",
+        roles=[r.name for r in roles],
+        permissions=sorted(perms),
+    )
+
+
+class PermissionsResponse(BaseModel):
+    permissions: List[str]
+
+
+@router.get("/me/permissions", response_model=PermissionsResponse)
+async def get_my_permissions(
+    user: User = Depends(get_current_user),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> PermissionsResponse:
+    user_repo = UserRepo(session)
+    db_user = await user_repo.get_by_oauth(user.provider or "unknown", user.user_id)
+    if db_user is None:
+        db_user = await user_repo.get_by_id(user.user_id)
+    db_id = db_user.id if db_user else user.user_id
+
+    perms = await rbac.get_user_permissions(db_id)
+    return PermissionsResponse(permissions=sorted(perms))

--- a/src/api/users.py
+++ b/src/api/users.py
@@ -43,6 +43,10 @@ class MeResponse(BaseModel):
     provider: str
     roles: List[str]
     permissions: List[str]
+    # OPENRAG_RBAC_ENFORCE — surfaced so the UI can hide RBAC-only
+    # sections (Users & Roles, Audit log, role pills) when the
+    # operator has the kill switch off.
+    rbac_enforced: bool
 
 
 @router.get("/me", response_model=MeResponse)
@@ -71,6 +75,7 @@ async def get_me(
         provider=user.provider or "unknown",
         roles=[r.name for r in roles],
         permissions=sorted(perms),
+        rbac_enforced=is_rbac_enforced(),
     )
 
 

--- a/src/api/v1/chat.py
+++ b/src/api/v1/chat.py
@@ -7,7 +7,7 @@ Uses API key authentication. Routes through Langflow (chat_service.langflow_chat
 import json
 from typing import Optional, Any, Dict
 
-from fastapi import Depends
+from fastapi import Depends, HTTPException
 from pydantic import BaseModel
 from fastapi.responses import JSONResponse, StreamingResponse
 from utils.logging_config import get_logger
@@ -16,6 +16,10 @@ from dependencies import get_chat_service, get_session_manager, get_api_key_user
 from session_manager import User
 
 logger = get_logger(__name__)
+
+
+def _openrag_user_id(user: User) -> str:
+    return getattr(user, "db_user_id", None) or user.user_id
 
 
 class ChatV1Body(BaseModel):
@@ -112,7 +116,11 @@ async def chat_create_endpoint(
         return JSONResponse({"error": "Message is required"}, status_code=400)
 
     user_id = user.user_id
+    storage_user_id = _openrag_user_id(user)
     jwt_token = user.jwt_token
+    if body.chat_id:
+        from api.chat import _assert_owns
+        await _assert_owns(body.chat_id, storage_user_id)
 
     if body.filters:
         set_search_filters(body.filters)
@@ -131,6 +139,7 @@ async def chat_create_endpoint(
             owner=user.user_id,
             owner_name=user.name,
             owner_email=user.email,
+            storage_user_id=storage_user_id,
         )
         chat_id_container = {}
         return StreamingResponse(
@@ -149,6 +158,7 @@ async def chat_create_endpoint(
             owner=user.user_id,
             owner_name=user.name,
             owner_email=user.email,
+            storage_user_id=storage_user_id,
         )
         return JSONResponse({
             "response": result.get("response", ""),
@@ -163,7 +173,7 @@ async def chat_list_endpoint(
 ):
     """List all conversations for the authenticated user. GET /v1/chat"""
     try:
-        history = await chat_service.get_langflow_history(user.user_id)
+        history = await chat_service.get_langflow_history(_openrag_user_id(user))
         conversations = [
             {
                 "chat_id": conv.get("response_id"),
@@ -187,7 +197,7 @@ async def chat_get_endpoint(
 ):
     """Get a specific conversation with full message history. GET /v1/chat/{chat_id}"""
     try:
-        history = await chat_service.get_langflow_history(user.user_id)
+        history = await chat_service.get_langflow_history(_openrag_user_id(user))
 
         conversation = None
         for conv in history.get("conversations", []):
@@ -231,7 +241,10 @@ async def chat_delete_endpoint(
 ):
     """Delete a conversation. DELETE /v1/chat/{chat_id}"""
     try:
-        result = await chat_service.delete_session(user.user_id, chat_id)
+        from api.chat import _assert_owns
+        storage_user_id = _openrag_user_id(user)
+        await _assert_owns(chat_id, storage_user_id)
+        result = await chat_service.delete_session(storage_user_id, chat_id)
         if result.get("not_found"):
             return JSONResponse({"error": "Conversation not found"}, status_code=404)
         if result.get("success"):
@@ -241,6 +254,8 @@ async def chat_delete_endpoint(
                 {"error": result.get("error", "Failed to delete conversation")},
                 status_code=500,
             )
+    except HTTPException:
+        raise
     except Exception as e:
         logger.error("Failed to delete conversation", error=str(e), user_id=user.user_id, chat_id=chat_id)
         return JSONResponse({"error": f"Failed to delete conversation: {str(e)}"}, status_code=500)

--- a/src/config/storage_mode.py
+++ b/src/config/storage_mode.py
@@ -1,0 +1,58 @@
+"""Single source of truth for OpenRAG's storage-mode flag.
+
+Three modes — one env var, no per-domain proliferation:
+
+    OPENRAG_STORAGE_MODE = hybrid | db | files
+
+| Mode    | DB writes | File writes | File reads (fallback) | When to use                          |
+|---------|-----------|-------------|-----------------------|--------------------------------------|
+| hybrid  | yes       | yes         | yes                   | default — Phase B dual-write         |
+| db      | yes       | NO          | no                    | clean target — DB is sole authority  |
+| files   | NO        | yes         | yes                   | rollback / legacy installs           |
+
+Backwards compat: the legacy ``OPENRAG_DISABLE_DB_WORKSPACE_CONFIG=true``
+kill switch is still honored — if set, mode is forced to ``files``.
+
+Today only ``workspace_config`` consults this flag. As ``connections.json``,
+``conversations.json``, and ``session_ownership.json`` migrate to the DB
+in follow-up PRs, each new service will read the same env var.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Literal
+
+StorageMode = Literal["hybrid", "db", "files"]
+
+_VALID = {"hybrid", "db", "files"}
+_DEFAULT: StorageMode = "hybrid"
+
+
+def get_storage_mode() -> StorageMode:
+    """Resolve the active storage mode. Returns one of: hybrid, db, files."""
+    # Legacy kill switch wins if explicitly set — operators may have it
+    # baked into their deployment manifests.
+    if os.getenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", "").lower() in (
+        "true", "1", "yes",
+    ):
+        return "files"
+
+    raw = (os.getenv("OPENRAG_STORAGE_MODE") or _DEFAULT).strip().lower()
+    if raw not in _VALID:
+        return _DEFAULT
+    return raw  # type: ignore[return-value]
+
+
+def db_writes_enabled() -> bool:
+    return get_storage_mode() in ("hybrid", "db")
+
+
+def file_writes_enabled() -> bool:
+    return get_storage_mode() in ("hybrid", "files")
+
+
+def file_reads_allowed() -> bool:
+    """In `db` mode we deliberately ignore yaml/JSON files even if present.
+    Hybrid + files modes both consult them."""
+    return get_storage_mode() in ("hybrid", "files")

--- a/src/config/storage_mode.py
+++ b/src/config/storage_mode.py
@@ -2,20 +2,23 @@
 
 Three modes — one env var, no per-domain proliferation:
 
-    OPENRAG_STORAGE_MODE = hybrid | db | files
+    OPENRAG_STORAGE_MODE = db | hybrid | files
 
 | Mode    | DB writes | File writes | File reads (fallback) | When to use                          |
 |---------|-----------|-------------|-----------------------|--------------------------------------|
-| hybrid  | yes       | yes         | yes                   | default — Phase B dual-write         |
-| db      | yes       | NO          | no                    | clean target — DB is sole authority  |
+| db      | yes       | NO          | no                    | default — DB is sole authority       |
+| hybrid  | yes       | yes         | yes                   | Phase B dual-write (legacy fallback) |
 | files   | NO        | yes         | yes                   | rollback / legacy installs           |
 
 Backwards compat: the legacy ``OPENRAG_DISABLE_DB_WORKSPACE_CONFIG=true``
 kill switch is still honored — if set, mode is forced to ``files``.
 
-Today only ``workspace_config`` consults this flag. As ``connections.json``,
-``conversations.json``, and ``session_ownership.json`` migrate to the DB
-in follow-up PRs, each new service will read the same env var.
+``workspace_config``, ``session_ownership`` and ``conversations`` all
+consult this flag. The default is now ``db`` so fresh installs never
+write JSON state to disk. Existing installs with JSON files are
+upgraded once at boot via the runtime migrations
+(``config_yaml_to_db_v1``, ``chat_history_json_to_db_v1``); after that
+the JSON files are ignored.
 """
 
 from __future__ import annotations
@@ -26,7 +29,7 @@ from typing import Literal
 StorageMode = Literal["hybrid", "db", "files"]
 
 _VALID = {"hybrid", "db", "files"}
-_DEFAULT: StorageMode = "hybrid"
+_DEFAULT: StorageMode = "db"
 
 
 def get_storage_mode() -> StorageMode:

--- a/src/db/__init__.py
+++ b/src/db/__init__.py
@@ -1,0 +1,21 @@
+"""SQL database layer for OpenRAG.
+
+Owns users, roles, permissions, audit, preferences, api_keys.
+Defaults to SQLite under data/openrag.db; switch via DATABASE_URL.
+"""
+
+from db.engine import (
+    SessionLocal,
+    get_engine,
+    get_database_url,
+    init_engine,
+    dispose_engine,
+)
+
+__all__ = [
+    "SessionLocal",
+    "get_engine",
+    "get_database_url",
+    "init_engine",
+    "dispose_engine",
+]

--- a/src/db/base.py
+++ b/src/db/base.py
@@ -1,0 +1,19 @@
+"""SQLModel metadata + naming convention.
+
+Naming convention is required for Alembic to autogenerate stable
+constraint names across SQLite and Postgres.
+"""
+
+from sqlalchemy import MetaData
+from sqlmodel import SQLModel
+
+NAMING_CONVENTION = {
+    "ix": "ix_%(column_0_label)s",
+    "uq": "uq_%(table_name)s_%(column_0_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+metadata = MetaData(naming_convention=NAMING_CONVENTION)
+SQLModel.metadata.naming_convention = NAMING_CONVENTION  # type: ignore[attr-defined]

--- a/src/db/engine.py
+++ b/src/db/engine.py
@@ -1,0 +1,82 @@
+"""Async SQLAlchemy engine + session factory.
+
+DATABASE_URL is the single switch between SQLite (default) and Postgres.
+"""
+
+import os
+from typing import AsyncIterator, Optional
+
+from sqlalchemy.ext.asyncio import (
+    AsyncEngine,
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from config.paths import get_data_file
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+_engine: Optional[AsyncEngine] = None
+SessionLocal: Optional[async_sessionmaker[AsyncSession]] = None
+
+
+def get_database_url() -> str:
+    url = os.getenv("DATABASE_URL")
+    if url:
+        return url
+    sqlite_path = os.path.abspath(get_data_file("openrag.db"))
+    return f"sqlite+aiosqlite:///{sqlite_path}"
+
+
+def init_engine() -> AsyncEngine:
+    """Initialize the async engine + session factory. Idempotent."""
+    global _engine, SessionLocal
+    if _engine is not None:
+        return _engine
+
+    url = get_database_url()
+    is_sqlite = url.startswith("sqlite")
+
+    connect_args = {"check_same_thread": False} if is_sqlite else {}
+    _engine = create_async_engine(
+        url,
+        echo=os.getenv("OPENRAG_DB_ECHO", "false").lower() in ("true", "1", "yes"),
+        future=True,
+        connect_args=connect_args,
+        pool_pre_ping=not is_sqlite,
+    )
+
+    SessionLocal = async_sessionmaker(
+        _engine,
+        class_=AsyncSession,
+        expire_on_commit=False,
+    )
+
+    dialect = "sqlite" if is_sqlite else "postgres" if "postgres" in url else "other"
+    logger.info("DB engine initialized", dialect=dialect)
+    return _engine
+
+
+def get_engine() -> AsyncEngine:
+    if _engine is None:
+        return init_engine()
+    return _engine
+
+
+async def dispose_engine() -> None:
+    global _engine, SessionLocal
+    if _engine is not None:
+        await _engine.dispose()
+        _engine = None
+        SessionLocal = None
+
+
+async def get_session() -> AsyncIterator[AsyncSession]:
+    """FastAPI dependency body — yields an AsyncSession."""
+    if SessionLocal is None:
+        init_engine()
+    assert SessionLocal is not None
+    async with SessionLocal() as session:
+        yield session

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -34,6 +34,7 @@ logger = get_logger(__name__)
 JSON_TO_DB_V1 = "json_to_db_v1"
 CLEANUP_TEST_FIXTURES_V1 = "cleanup_test_fixtures_v1"
 CONFIG_YAML_TO_DB_V1 = "config_yaml_to_db_v1"
+CHAT_HISTORY_JSON_TO_DB_V1 = "chat_history_json_to_db_v1"
 
 # Stable user_ids used by RBAC unit-test fixtures. If they ended up in a
 # real DB it's because pytest leaked into `data/openrag.db` — sweep them
@@ -216,6 +217,94 @@ async def migrate_config_yaml_to_db(session: AsyncSession) -> int:
     return written
 
 
+async def migrate_chat_history_json_to_db(session: AsyncSession) -> dict[str, int]:
+    """Copy ``data/session_ownership.json`` and ``data/conversations.json``
+    into the DB. Idempotent — only inserts rows that aren't already present.
+
+    Returns a small stats dict for the migration_status notes column.
+    """
+    from db.repositories import ConversationRepo, SessionOwnershipRepo
+
+    stats = {"sessions_inserted": 0, "conversations_inserted": 0}
+
+    # --- session_ownership.json ---------------------------------------
+    so_payload = await _read_json(get_data_file("session_ownership.json"))
+    if isinstance(so_payload, dict):
+        repo = SessionOwnershipRepo(session)
+        for sid, data in so_payload.items():
+            if not isinstance(data, dict):
+                continue
+            uid = data.get("user_id")
+            if not uid:
+                continue
+            try:
+                created = (
+                    datetime.fromisoformat(data["created_at"])
+                    if data.get("created_at")
+                    else None
+                )
+            except Exception:  # noqa: BLE001
+                created = None
+            try:
+                last = (
+                    datetime.fromisoformat(data["last_accessed"])
+                    if data.get("last_accessed")
+                    else None
+                )
+            except Exception:  # noqa: BLE001
+                last = None
+            await repo.upsert_raw(
+                response_id=str(sid),
+                user_id=str(uid),
+                created_at=created,
+                last_accessed=last,
+            )
+            stats["sessions_inserted"] += 1
+
+    # --- conversations.json -------------------------------------------
+    conv_payload = await _read_json(get_data_file("conversations.json"))
+    if isinstance(conv_payload, dict):
+        crepo = ConversationRepo(session)
+        for uid, user_convs in conv_payload.items():
+            if not isinstance(user_convs, dict):
+                continue
+            for resp_id, meta in user_convs.items():
+                if not isinstance(meta, dict):
+                    continue
+                if await crepo.get(str(resp_id)) is not None:
+                    continue
+                try:
+                    created = (
+                        datetime.fromisoformat(meta["created_at"])
+                        if meta.get("created_at")
+                        else None
+                    )
+                except Exception:  # noqa: BLE001
+                    created = None
+                try:
+                    last = (
+                        datetime.fromisoformat(meta["last_activity"])
+                        if meta.get("last_activity")
+                        else None
+                    )
+                except Exception:  # noqa: BLE001
+                    last = None
+                await crepo.upsert(
+                    response_id=str(resp_id),
+                    user_id=str(uid),
+                    title=meta.get("title"),
+                    endpoint=meta.get("endpoint"),
+                    previous_response_id=meta.get("previous_response_id"),
+                    filter_id=meta.get("filter_id"),
+                    total_messages=int(meta.get("total_messages") or 0),
+                    created_at=created,
+                    last_activity=last,
+                )
+                stats["conversations_inserted"] += 1
+
+    return stats
+
+
 async def run(session: AsyncSession) -> None:
     """Top-level entry. Caller is responsible for committing."""
     if not await _already_done(session, JSON_TO_DB_V1):
@@ -250,6 +339,22 @@ async def run(session: AsyncSession) -> None:
             session, CONFIG_YAML_TO_DB_V1, notes=f"sections_written={written}"
         )
         logger.info("config_yaml_to_db_v1 completed", sections_written=written)
+
+    if not await _already_done(session, CHAT_HISTORY_JSON_TO_DB_V1):
+        try:
+            stats = await migrate_chat_history_json_to_db(session)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(
+                "chat_history_json_to_db_v1 failed; will retry on next boot",
+                error=str(exc),
+            )
+            return
+        notes = (
+            f"sessions={stats['sessions_inserted']},"
+            f"conversations={stats['conversations_inserted']}"
+        )
+        await _mark_done(session, CHAT_HISTORY_JSON_TO_DB_V1, notes=notes)
+        logger.info("chat_history_json_to_db_v1 completed", **stats)
 
 
 # ---------------------------------------------------------------------------

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -130,13 +130,17 @@ async def migrate_legacy_users(session: AsyncSession) -> int:
             email_lookup_hash=email_lookup_hash(synth_email),
             display_name=legacy_id,
         )
+        # SAVEPOINT per row so a duplicate (e.g. another runner already
+        # inserted this legacy id) only rolls back THIS row, not the
+        # whole outer transaction with previously inserted legacy users.
         try:
-            session.add(row)
-            await session.flush()
+            async with session.begin_nested():
+                session.add(row)
+                await session.flush()
             inserted += 1
         except IntegrityError:
-            await session.rollback()
-            # Some other run beat us to it.
+            # Some other run beat us to it; savepoint rolled back
+            # automatically — outer transaction and prior inserts intact.
             continue
     return inserted
 

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -33,6 +33,7 @@ logger = get_logger(__name__)
 
 JSON_TO_DB_V1 = "json_to_db_v1"
 CLEANUP_TEST_FIXTURES_V1 = "cleanup_test_fixtures_v1"
+CONFIG_YAML_TO_DB_V1 = "config_yaml_to_db_v1"
 
 # Stable user_ids used by RBAC unit-test fixtures. If they ended up in a
 # real DB it's because pytest leaked into `data/openrag.db` — sweep them
@@ -169,6 +170,52 @@ async def cleanup_test_fixture_rows(session: AsyncSession) -> int:
     return deleted_total
 
 
+async def migrate_config_yaml_to_db(session: AsyncSession) -> int:
+    """Copy what ``config.yaml`` holds today into the ``workspace_config``
+    table. Idempotent.
+
+    Returns the number of section rows written. Zero is fine — means the
+    workspace has no config.yaml yet (fresh install) and the table will
+    fill up the first time an admin completes onboarding.
+    """
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+    from db.repositories import WorkspaceConfigRepo
+    from utils.encryption import encrypt_secret
+
+    # Read the current yaml-backed config exactly the way the legacy
+    # ConfigManager does (decrypts api_keys, applies env overrides, etc.).
+    try:
+        from config.config_manager import config_manager
+        config = config_manager.load_config()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("config_yaml_to_db_v1: load_config() failed; skipping", error=str(exc))
+        return 0
+
+    config_dict = config.to_dict()
+    providers = dict(config_dict.get("providers", {}))
+    for prov_name, prov_data in providers.items():
+        if isinstance(prov_data, dict) and prov_data.get("api_key"):
+            # Re-encrypt with the JSON envelope so the DB row matches
+            # what config.yaml stores on disk.
+            prov_data["api_key"] = encrypt_secret(prov_data["api_key"])
+        providers[prov_name] = prov_data
+
+    sections = {
+        "providers": providers,
+        "knowledge": config_dict.get("knowledge", {}),
+        "agent": config_dict.get("agent", {}),
+        "onboarding": config_dict.get("onboarding", {}),
+        "meta": {"edited": bool(config_dict.get("edited", False))},
+    }
+
+    repo = WorkspaceConfigRepo(session)
+    written = 0
+    for section, value in sections.items():
+        await repo.upsert(section, value)
+        written += 1
+    return written
+
+
 async def run(session: AsyncSession) -> None:
     """Top-level entry. Caller is responsible for committing."""
     if not await _already_done(session, JSON_TO_DB_V1):
@@ -192,6 +239,17 @@ async def run(session: AsyncSession) -> None:
         )
         if removed:
             logger.info("Test-fixture cleanup removed leaked rows", count=removed)
+
+    if not await _already_done(session, CONFIG_YAML_TO_DB_V1):
+        try:
+            written = await migrate_config_yaml_to_db(session)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("config_yaml_to_db_v1 failed; will retry on next boot", error=str(exc))
+            return
+        await _mark_done(
+            session, CONFIG_YAML_TO_DB_V1, notes=f"sections_written={written}"
+        )
+        logger.info("config_yaml_to_db_v1 completed", sections_written=written)
 
 
 # ---------------------------------------------------------------------------

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -42,6 +42,10 @@ CONFIG_YAML_TO_DB_V1 = "config_yaml_to_db_v1"
 CHAT_HISTORY_JSON_TO_DB_V1 = "chat_history_json_to_db_v1"
 
 
+class RuntimeMigrationError(RuntimeError):
+    """Raised when a required startup data migration fails."""
+
+
 async def _already_done(session: AsyncSession, name: str) -> bool:
     row = await session.get(MigrationStatus, name)
     return row is not None
@@ -227,13 +231,14 @@ async def migrate_chat_history_json_to_db(session: AsyncSession) -> dict[str, in
                 )
             except Exception:  # noqa: BLE001
                 last = None
-            await repo.upsert_raw(
+            inserted = await repo.upsert_raw(
                 response_id=str(sid),
                 user_id=str(uid),
                 created_at=created,
                 last_accessed=last,
             )
-            stats["sessions_inserted"] += 1
+            if inserted:
+                stats["sessions_inserted"] += 1
 
     # --- conversations.json -------------------------------------------
     conv_payload = await _read_json(get_data_file("conversations.json"))
@@ -286,8 +291,8 @@ async def run(session: AsyncSession) -> None:
         try:
             inserted = await migrate_legacy_users(session)
         except Exception as exc:  # noqa: BLE001
-            logger.error("JSON->DB migration failed; will retry on next boot", error=str(exc))
-            return
+            logger.error("JSON->DB migration failed; aborting startup", error=str(exc))
+            raise RuntimeMigrationError(f"{JSON_TO_DB_V1} failed") from exc
         await _mark_done(session, JSON_TO_DB_V1, notes=f"legacy_users_inserted={inserted}")
         logger.info("JSON->DB migration completed", inserted=inserted)
 
@@ -295,8 +300,8 @@ async def run(session: AsyncSession) -> None:
         try:
             written = await migrate_config_yaml_to_db(session)
         except Exception as exc:  # noqa: BLE001
-            logger.error("config_yaml_to_db_v1 failed; will retry on next boot", error=str(exc))
-            return
+            logger.error("config_yaml_to_db_v1 failed; aborting startup", error=str(exc))
+            raise RuntimeMigrationError(f"{CONFIG_YAML_TO_DB_V1} failed") from exc
         await _mark_done(
             session, CONFIG_YAML_TO_DB_V1, notes=f"sections_written={written}"
         )
@@ -307,10 +312,10 @@ async def run(session: AsyncSession) -> None:
             stats = await migrate_chat_history_json_to_db(session)
         except Exception as exc:  # noqa: BLE001
             logger.error(
-                "chat_history_json_to_db_v1 failed; will retry on next boot",
+                "chat_history_json_to_db_v1 failed; aborting startup",
                 error=str(exc),
             )
-            return
+            raise RuntimeMigrationError(f"{CHAT_HISTORY_JSON_TO_DB_V1} failed") from exc
         notes = (
             f"sessions={stats['sessions_inserted']},"
             f"conversations={stats['conversations_inserted']}"

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -32,14 +32,14 @@ from utils.logging_config import get_logger
 logger = get_logger(__name__)
 
 JSON_TO_DB_V1 = "json_to_db_v1"
-CLEANUP_TEST_FIXTURES_V1 = "cleanup_test_fixtures_v1"
+# Reserved (do not reuse): "cleanup_test_fixtures_v1" was a one-shot
+# migration that DELETEd users with id IN ('admin-sub','dev-sub',...)
+# — removed because those plain strings could plausibly collide with
+# real OAuth subjects in IBM AMS deployments. Test pollution is now
+# prevented at source by tests/unit/conftest.py forcing in-memory
+# SQLite, so there's no longer dirty data to sweep.
 CONFIG_YAML_TO_DB_V1 = "config_yaml_to_db_v1"
 CHAT_HISTORY_JSON_TO_DB_V1 = "chat_history_json_to_db_v1"
-
-# Stable user_ids used by RBAC unit-test fixtures. If they ended up in a
-# real DB it's because pytest leaked into `data/openrag.db` — sweep them
-# out exactly once.
-LEGACY_TEST_USERS = ("admin-sub", "dev-sub", "user-sub", "viewer-sub")
 
 
 async def _already_done(session: AsyncSession, name: str) -> bool:
@@ -139,36 +139,6 @@ async def migrate_legacy_users(session: AsyncSession) -> int:
             # Some other run beat us to it.
             continue
     return inserted
-
-
-async def cleanup_test_fixture_rows(session: AsyncSession) -> int:
-    """Delete RBAC-test-fixture user rows that leaked into a real DB.
-
-    Only purges rows whose `id` matches one of the stable test fixture
-    user_ids AND whose email ends with the synthetic test domain. Caller
-    commits.
-    """
-    from sqlalchemy import text
-
-    sql_safe_ids = ",".join(f"'{u}'" for u in LEGACY_TEST_USERS)
-    if not sql_safe_ids:
-        return 0
-    deleted_total = 0
-    for table in ("user_roles", "audit_log"):
-        col = "actor_user_id" if table == "audit_log" else "user_id"
-        result = await session.execute(
-            text(f"DELETE FROM {table} WHERE {col} IN ({sql_safe_ids})")
-        )
-        deleted_total += result.rowcount or 0
-    # Match by id alone — the LEGACY_TEST_USERS values are stable strings
-    # uniquely owned by RBAC unit-test fixtures. No real OAuth subject would
-    # ever equal "admin-sub" / "dev-sub" / "user-sub" / "viewer-sub".
-    # (We can't filter by email here because the column is encrypted JSON.)
-    result = await session.execute(
-        text(f"DELETE FROM users WHERE id IN ({sql_safe_ids})")
-    )
-    deleted_total += result.rowcount or 0
-    return deleted_total
 
 
 async def migrate_config_yaml_to_db(session: AsyncSession) -> int:
@@ -316,18 +286,6 @@ async def run(session: AsyncSession) -> None:
             return
         await _mark_done(session, JSON_TO_DB_V1, notes=f"legacy_users_inserted={inserted}")
         logger.info("JSON->DB migration completed", inserted=inserted)
-
-    if not await _already_done(session, CLEANUP_TEST_FIXTURES_V1):
-        try:
-            removed = await cleanup_test_fixture_rows(session)
-        except Exception as exc:  # noqa: BLE001
-            logger.error("Test-fixture cleanup failed", error=str(exc))
-            return
-        await _mark_done(
-            session, CLEANUP_TEST_FIXTURES_V1, notes=f"rows_removed={removed}"
-        )
-        if removed:
-            logger.info("Test-fixture cleanup removed leaked rows", count=removed)
 
     if not await _already_done(session, CONFIG_YAML_TO_DB_V1):
         try:

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -1,0 +1,231 @@
+"""One-shot runtime migrations from JSON state to the SQL DB.
+
+These run on application startup AFTER Alembic upgrade. Idempotency is
+recorded in the `migration_status` table so the migration only ever
+inserts once per install.
+
+Phase 1 only migrates *user identity* — connections.json, conversations.json,
+and config.yaml are left in place. The legacy users get a placeholder row
+with `oauth_provider='legacy'`. The next time they sign in via Google /
+IBM, `user_service.ensure_user_row` matches on `email_lookup_hash` and
+upgrades the row in place, preserving the original user_id so all
+existing JSON references stay valid.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime
+from typing import Iterable
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from config.paths import get_data_file
+from db.models import MigrationStatus, User as UserRow
+from db.repositories._helpers import email_lookup_hash
+from utils.encryption import read_encrypted_file
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+JSON_TO_DB_V1 = "json_to_db_v1"
+CLEANUP_TEST_FIXTURES_V1 = "cleanup_test_fixtures_v1"
+
+# Stable user_ids used by RBAC unit-test fixtures. If they ended up in a
+# real DB it's because pytest leaked into `data/openrag.db` — sweep them
+# out exactly once.
+LEGACY_TEST_USERS = ("admin-sub", "dev-sub", "user-sub", "viewer-sub")
+
+
+async def _already_done(session: AsyncSession, name: str) -> bool:
+    row = await session.get(MigrationStatus, name)
+    return row is not None
+
+
+async def _mark_done(session: AsyncSession, name: str, notes: str = "") -> None:
+    session.add(
+        MigrationStatus(name=name, completed_at=datetime.utcnow(), notes=notes)
+    )
+    await session.flush()
+
+
+async def _read_json(path: str):
+    if not os.path.exists(path):
+        return None
+    raw, _ = await read_encrypted_file(path)
+    if not raw:
+        return None
+    try:
+        return json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Skipping malformed JSON during migration", path=path)
+        return None
+
+
+def _user_ids_from_connections(payload) -> Iterable[str]:
+    if not payload:
+        return []
+    items = payload.get("connections", []) if isinstance(payload, dict) else payload
+    out = []
+    for c in items or []:
+        if isinstance(c, dict) and c.get("user_id"):
+            out.append(str(c["user_id"]))
+    return out
+
+
+def _user_ids_from_conversations(payload) -> Iterable[str]:
+    if not isinstance(payload, dict):
+        return []
+    return [k for k in payload.keys() if isinstance(k, str)]
+
+
+def _user_ids_from_session_ownership(payload) -> Iterable[str]:
+    if not isinstance(payload, dict):
+        return []
+    out = []
+    for v in payload.values():
+        if isinstance(v, dict):
+            uid = v.get("user_id")
+            if uid:
+                out.append(str(uid))
+        elif isinstance(v, str):
+            out.append(v)
+    return out
+
+
+async def migrate_legacy_users(session: AsyncSession) -> int:
+    """Insert legacy/* users discovered in JSON files. Returns insert count."""
+    seen: set[str] = set()
+    sources = [
+        ("connections.json", _user_ids_from_connections),
+        ("conversations.json", _user_ids_from_conversations),
+        ("session_ownership.json", _user_ids_from_session_ownership),
+    ]
+    for filename, extract in sources:
+        payload = await _read_json(get_data_file(filename))
+        if payload is None:
+            continue
+        for uid in extract(payload):
+            if uid:
+                seen.add(uid)
+
+    if not seen:
+        return 0
+
+    inserted = 0
+    for legacy_id in seen:
+        # Email is unknown for legacy rows; use a synthetic placeholder so we
+        # still have *some* lookup hash. Real merge happens on next sign-in.
+        synth_email = f"{legacy_id}@unknown.local"
+        row = UserRow(
+            id=legacy_id,
+            oauth_provider="legacy",
+            oauth_subject=legacy_id,
+            email=synth_email,
+            email_lookup_hash=email_lookup_hash(synth_email),
+            display_name=legacy_id,
+        )
+        try:
+            session.add(row)
+            await session.flush()
+            inserted += 1
+        except IntegrityError:
+            await session.rollback()
+            # Some other run beat us to it.
+            continue
+    return inserted
+
+
+async def cleanup_test_fixture_rows(session: AsyncSession) -> int:
+    """Delete RBAC-test-fixture user rows that leaked into a real DB.
+
+    Only purges rows whose `id` matches one of the stable test fixture
+    user_ids AND whose email ends with the synthetic test domain. Caller
+    commits.
+    """
+    from sqlalchemy import text
+
+    sql_safe_ids = ",".join(f"'{u}'" for u in LEGACY_TEST_USERS)
+    if not sql_safe_ids:
+        return 0
+    deleted_total = 0
+    for table in ("user_roles", "audit_log"):
+        col = "actor_user_id" if table == "audit_log" else "user_id"
+        result = await session.execute(
+            text(f"DELETE FROM {table} WHERE {col} IN ({sql_safe_ids})")
+        )
+        deleted_total += result.rowcount or 0
+    # Match by id alone — the LEGACY_TEST_USERS values are stable strings
+    # uniquely owned by RBAC unit-test fixtures. No real OAuth subject would
+    # ever equal "admin-sub" / "dev-sub" / "user-sub" / "viewer-sub".
+    # (We can't filter by email here because the column is encrypted JSON.)
+    result = await session.execute(
+        text(f"DELETE FROM users WHERE id IN ({sql_safe_ids})")
+    )
+    deleted_total += result.rowcount or 0
+    return deleted_total
+
+
+async def run(session: AsyncSession) -> None:
+    """Top-level entry. Caller is responsible for committing."""
+    if not await _already_done(session, JSON_TO_DB_V1):
+        inserted = 0
+        try:
+            inserted = await migrate_legacy_users(session)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("JSON->DB migration failed; will retry on next boot", error=str(exc))
+            return
+        await _mark_done(session, JSON_TO_DB_V1, notes=f"legacy_users_inserted={inserted}")
+        logger.info("JSON->DB migration completed", inserted=inserted)
+
+    if not await _already_done(session, CLEANUP_TEST_FIXTURES_V1):
+        try:
+            removed = await cleanup_test_fixture_rows(session)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("Test-fixture cleanup failed", error=str(exc))
+            return
+        await _mark_done(
+            session, CLEANUP_TEST_FIXTURES_V1, notes=f"rows_removed={removed}"
+        )
+        if removed:
+            logger.info("Test-fixture cleanup removed leaked rows", count=removed)
+
+
+# ---------------------------------------------------------------------------
+# Alembic upgrade — programmatic invocation
+# ---------------------------------------------------------------------------
+
+def run_alembic_upgrade(target: str = "head") -> None:
+    """Run `alembic upgrade <target>` programmatically.
+
+    Internally Alembic's env.py spins up its own asyncio.run loop, so this
+    function MUST NOT be invoked from inside an already-running event
+    loop. Async callers should use `run_alembic_upgrade_async` instead.
+    """
+    from alembic import command
+    from alembic.config import Config
+    from pathlib import Path
+
+    root = Path(__file__).resolve().parent.parent.parent
+    cfg_path = root / "alembic.ini"
+    if not cfg_path.exists():
+        logger.warning("alembic.ini not found; skipping schema upgrade", path=str(cfg_path))
+        return
+
+    cfg = Config(str(cfg_path))
+    cfg.set_main_option("script_location", str(root / "alembic"))
+    command.upgrade(cfg, target)
+
+
+async def run_alembic_upgrade_async(target: str = "head") -> None:
+    """Async-safe wrapper. Runs the sync alembic command in a worker thread.
+
+    Necessary because `alembic/env.py` uses `asyncio.run(...)` internally,
+    which fails when invoked from a running loop.
+    """
+    import asyncio
+
+    await asyncio.to_thread(run_alembic_upgrade, target)

--- a/src/db/models/__init__.py
+++ b/src/db/models/__init__.py
@@ -1,0 +1,27 @@
+"""SQLModel ORM models for the RBAC layer.
+
+Importing this package registers every model on SQLModel.metadata so
+Alembic autogenerate can see them.
+"""
+
+from db.models.api_key import ApiKey
+from db.models.audit_log import AuditLog
+from db.models.migration_status import MigrationStatus
+from db.models.permission import Permission
+from db.models.role import Role
+from db.models.role_permission import RolePermission
+from db.models.user import User
+from db.models.user_preferences import UserPreferences
+from db.models.user_role import UserRole
+
+__all__ = [
+    "ApiKey",
+    "AuditLog",
+    "MigrationStatus",
+    "Permission",
+    "Role",
+    "RolePermission",
+    "User",
+    "UserPreferences",
+    "UserRole",
+]

--- a/src/db/models/__init__.py
+++ b/src/db/models/__init__.py
@@ -13,6 +13,7 @@ from db.models.role_permission import RolePermission
 from db.models.user import User
 from db.models.user_preferences import UserPreferences
 from db.models.user_role import UserRole
+from db.models.workspace_config import WorkspaceConfig
 
 __all__ = [
     "ApiKey",
@@ -24,4 +25,5 @@ __all__ = [
     "User",
     "UserPreferences",
     "UserRole",
+    "WorkspaceConfig",
 ]

--- a/src/db/models/__init__.py
+++ b/src/db/models/__init__.py
@@ -6,10 +6,12 @@ Alembic autogenerate can see them.
 
 from db.models.api_key import ApiKey
 from db.models.audit_log import AuditLog
+from db.models.conversation import Conversation
 from db.models.migration_status import MigrationStatus
 from db.models.permission import Permission
 from db.models.role import Role
 from db.models.role_permission import RolePermission
+from db.models.session_ownership import SessionOwnership
 from db.models.user import User
 from db.models.user_preferences import UserPreferences
 from db.models.user_role import UserRole
@@ -18,10 +20,12 @@ from db.models.workspace_config import WorkspaceConfig
 __all__ = [
     "ApiKey",
     "AuditLog",
+    "Conversation",
     "MigrationStatus",
     "Permission",
     "Role",
     "RolePermission",
+    "SessionOwnership",
     "User",
     "UserPreferences",
     "UserRole",

--- a/src/db/models/api_key.py
+++ b/src/db/models/api_key.py
@@ -1,0 +1,28 @@
+"""API key ORM (Phase 2 will move keys here from the OpenSearch index).
+
+Placed in Phase 1 only as a forward-compatible schema; the existing
+OpenSearch-backed APIKeyService is unchanged.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import JSON, Column
+from sqlmodel import Field, SQLModel
+
+
+class ApiKey(SQLModel, table=True):
+    __tablename__ = "api_keys"
+
+    id: str = Field(primary_key=True, max_length=64)
+    user_id: str = Field(foreign_key="users.id", max_length=64, index=True)
+    name: str = Field(max_length=128)
+    key_hash: str = Field(max_length=128, unique=True, index=True)
+    key_prefix: str = Field(max_length=32)
+    scope_role_ids: Optional[list] = Field(
+        default=None, sa_column=Column("scope_role_ids", JSON, nullable=True)
+    )
+    last_used_at: Optional[datetime] = Field(default=None)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    revoked_at: Optional[datetime] = Field(default=None)
+    revoked: bool = Field(default=False)

--- a/src/db/models/audit_log.py
+++ b/src/db/models/audit_log.py
@@ -1,0 +1,24 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import JSON, Column
+from sqlmodel import Field, SQLModel
+
+
+class AuditLog(SQLModel, table=True):
+    __tablename__ = "audit_log"
+
+    id: str = Field(primary_key=True, max_length=64)
+    ts: datetime = Field(default_factory=datetime.utcnow, index=True)
+    actor_user_id: Optional[str] = Field(
+        default=None, foreign_key="users.id", max_length=64, index=True
+    )
+    actor_api_key_id: Optional[str] = Field(default=None, max_length=64)
+    event: str = Field(max_length=128, index=True)
+    target_type: Optional[str] = Field(default=None, max_length=64)
+    target_id: Optional[str] = Field(default=None, max_length=128)
+    audit_metadata: Optional[dict] = Field(
+        default=None, sa_column=Column("metadata", JSON, nullable=True)
+    )
+    ip: Optional[str] = Field(default=None, max_length=64)
+    user_agent: Optional[str] = Field(default=None, max_length=512)

--- a/src/db/models/conversation.py
+++ b/src/db/models/conversation.py
@@ -1,0 +1,33 @@
+"""Conversation metadata index — replaces ``data/conversations.json``.
+
+Per-user chat history index. Stores the lightweight metadata about each
+chat session (title, endpoint, timestamps, message count). Full message
+bodies live in Langflow, not here.
+
+The ``user_id`` column has no FK constraint for the same migration-safety
+reason as ``session_ownership.user_id`` — legacy JSON may reference
+ids not in the users table yet.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Index
+from sqlmodel import Field, SQLModel
+
+
+class Conversation(SQLModel, table=True):
+    __tablename__ = "conversations"
+    __table_args__ = (
+        Index("ix_conversations_user_recent", "user_id", "last_activity"),
+    )
+
+    response_id: str = Field(primary_key=True, max_length=64)
+    user_id: str = Field(max_length=64, index=True)
+    title: Optional[str] = Field(default=None, max_length=512)
+    endpoint: Optional[str] = Field(default=None, max_length=64)
+    previous_response_id: Optional[str] = Field(default=None, max_length=64)
+    filter_id: Optional[str] = Field(default=None, max_length=128)
+    total_messages: int = Field(default=0)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    last_activity: datetime = Field(default_factory=datetime.utcnow)

--- a/src/db/models/migration_status.py
+++ b/src/db/models/migration_status.py
@@ -1,0 +1,13 @@
+"""Tracks one-shot runtime migrations (e.g. JSON->DB)."""
+
+from datetime import datetime
+
+from sqlmodel import Field, SQLModel
+
+
+class MigrationStatus(SQLModel, table=True):
+    __tablename__ = "migration_status"
+
+    name: str = Field(primary_key=True, max_length=128)
+    completed_at: datetime = Field(default_factory=datetime.utcnow)
+    notes: str = Field(default="", max_length=2048)

--- a/src/db/models/permission.py
+++ b/src/db/models/permission.py
@@ -1,0 +1,13 @@
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Permission(SQLModel, table=True):
+    __tablename__ = "permissions"
+
+    id: str = Field(primary_key=True, max_length=64)
+    name: str = Field(max_length=128, unique=True, index=True)
+    resource: str = Field(max_length=64, index=True)
+    action: str = Field(max_length=64)
+    description: Optional[str] = Field(default=None, max_length=512)

--- a/src/db/models/role.py
+++ b/src/db/models/role.py
@@ -1,0 +1,15 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class Role(SQLModel, table=True):
+    __tablename__ = "roles"
+
+    id: str = Field(primary_key=True, max_length=64)
+    name: str = Field(max_length=64, unique=True, index=True)
+    description: Optional[str] = Field(default=None, max_length=512)
+    is_system: bool = Field(default=False)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/src/db/models/role_permission.py
+++ b/src/db/models/role_permission.py
@@ -1,0 +1,16 @@
+from sqlmodel import Field, SQLModel
+
+
+class RolePermission(SQLModel, table=True):
+    __tablename__ = "role_permissions"
+
+    role_id: str = Field(
+        foreign_key="roles.id",
+        primary_key=True,
+        max_length=64,
+    )
+    permission_id: str = Field(
+        foreign_key="permissions.id",
+        primary_key=True,
+        max_length=64,
+    )

--- a/src/db/models/session_ownership.py
+++ b/src/db/models/session_ownership.py
@@ -1,0 +1,24 @@
+"""Session ownership — replaces ``data/session_ownership.json``.
+
+Maps a chat session_id (== response_id) to the owning user. Used for
+access-control checks: only the owning user can read/release a session.
+
+The user_id column is intentionally NOT a foreign key — legacy JSON
+state may reference user_ids that haven't been backfilled into the
+``users`` table yet, and we don't want migration to fail on FK
+violations.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class SessionOwnership(SQLModel, table=True):
+    __tablename__ = "session_ownership"
+
+    response_id: str = Field(primary_key=True, max_length=64)
+    user_id: str = Field(max_length=64, index=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    last_accessed: Optional[datetime] = Field(default=None)

--- a/src/db/models/user.py
+++ b/src/db/models/user.py
@@ -1,0 +1,45 @@
+"""User ORM model.
+
+PII columns (email, display_name) use EncryptedString. email_lookup_hash
+is a deterministic SHA-256 of the lowercase email so we keep a unique
+constraint and exact-match lookup despite the encrypted blob.
+"""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column, UniqueConstraint
+from sqlmodel import Field, SQLModel
+
+from db.types import EncryptedString
+
+
+class User(SQLModel, table=True):
+    __tablename__ = "users"
+    __table_args__ = (
+        UniqueConstraint("oauth_provider", "oauth_subject", name="uq_users_oauth"),
+    )
+
+    id: str = Field(primary_key=True, max_length=64)
+    oauth_provider: str = Field(max_length=32, index=True)
+    oauth_subject: str = Field(max_length=255, index=True)
+
+    email: Optional[str] = Field(
+        default=None,
+        sa_column=Column("email", EncryptedString(tenant_id="user_pii"), nullable=True),
+    )
+    email_lookup_hash: Optional[str] = Field(
+        default=None, max_length=64, unique=True, index=True
+    )
+    display_name: Optional[str] = Field(
+        default=None,
+        sa_column=Column(
+            "display_name", EncryptedString(tenant_id="user_pii"), nullable=True
+        ),
+    )
+    picture_url: Optional[str] = Field(default=None, max_length=2048)
+
+    is_active: bool = Field(default=True)
+    created_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    last_login: Optional[datetime] = Field(default=None)

--- a/src/db/models/user_preferences.py
+++ b/src/db/models/user_preferences.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import Column
+from sqlmodel import Field, SQLModel
+
+from db.types import EncryptedString
+
+
+class UserPreferences(SQLModel, table=True):
+    __tablename__ = "user_preferences"
+
+    user_id: str = Field(
+        foreign_key="users.id",
+        primary_key=True,
+        max_length=64,
+    )
+
+    agent_system_prompt_override: Optional[str] = Field(
+        default=None,
+        sa_column=Column(
+            "agent_system_prompt_override",
+            EncryptedString(tenant_id="user_pref"),
+            nullable=True,
+        ),
+    )
+    default_kf_id: Optional[str] = Field(default=None, max_length=128)
+    theme: Optional[str] = Field(default=None, max_length=32)
+    language: Optional[str] = Field(default=None, max_length=16)
+
+    # JSON blob: {"openai":{"api_key":"..."}, "anthropic":{...}}
+    provider_overrides: Optional[str] = Field(
+        default=None,
+        sa_column=Column(
+            "provider_overrides",
+            EncryptedString(tenant_id="user_pref"),
+            nullable=True,
+        ),
+    )
+
+    # Future-proof bag for additional opt-in preferences.
+    preferences_json: Optional[str] = Field(
+        default=None,
+        sa_column=Column(
+            "preferences_json",
+            EncryptedString(tenant_id="user_pref"),
+            nullable=True,
+        ),
+    )
+
+    updated_at: datetime = Field(default_factory=datetime.utcnow)

--- a/src/db/models/user_preferences.py
+++ b/src/db/models/user_preferences.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from sqlalchemy import Column
@@ -48,4 +48,4 @@ class UserPreferences(SQLModel, table=True):
         ),
     )
 
-    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_at: datetime = Field(default_factory=lambda: datetime.now(UTC))

--- a/src/db/models/user_role.py
+++ b/src/db/models/user_role.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlmodel import Field, SQLModel
+
+
+class UserRole(SQLModel, table=True):
+    __tablename__ = "user_roles"
+
+    user_id: str = Field(
+        foreign_key="users.id",
+        primary_key=True,
+        max_length=64,
+    )
+    role_id: str = Field(
+        foreign_key="roles.id",
+        primary_key=True,
+        max_length=64,
+    )
+    granted_by: Optional[str] = Field(
+        default=None, foreign_key="users.id", max_length=64
+    )
+    granted_at: datetime = Field(default_factory=datetime.utcnow)

--- a/src/db/models/workspace_config.py
+++ b/src/db/models/workspace_config.py
@@ -1,0 +1,32 @@
+"""Workspace-level config storage.
+
+One row per logical section ('providers' | 'knowledge' | 'agent' |
+'onboarding' | 'meta'). The `value` JSON column holds the section's
+payload — the same shape the existing ``OpenRAGConfig.to_dict()``
+produces for that section, so the migration is a 1:1 copy of what
+lives in ``config/config.yaml`` today.
+
+Provider api_key fields stay encrypted via ``encrypt_secret`` inside
+the JSON envelope; no DB-level encryption is added here because the
+other fields (embedding model, prompt, etc.) are not secrets.
+"""
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import JSON, Column
+from sqlmodel import Field, SQLModel
+
+
+class WorkspaceConfig(SQLModel, table=True):
+    __tablename__ = "workspace_config"
+
+    section: str = Field(primary_key=True, max_length=64)
+    value: Optional[dict[str, Any]] = Field(
+        default_factory=dict,
+        sa_column=Column("value", JSON, nullable=False),
+    )
+    updated_at: datetime = Field(default_factory=datetime.utcnow)
+    updated_by: Optional[str] = Field(
+        default=None, foreign_key="users.id", max_length=64
+    )

--- a/src/db/repositories/__init__.py
+++ b/src/db/repositories/__init__.py
@@ -1,0 +1,17 @@
+"""Async data-access wrappers for the RBAC layer."""
+
+from db.repositories.api_key_repo import ApiKeyRepo
+from db.repositories.audit_repo import AuditRepo
+from db.repositories.permission_repo import PermissionRepo
+from db.repositories.preferences_repo import PreferencesRepo
+from db.repositories.role_repo import RoleRepo
+from db.repositories.user_repo import UserRepo
+
+__all__ = [
+    "ApiKeyRepo",
+    "AuditRepo",
+    "PermissionRepo",
+    "PreferencesRepo",
+    "RoleRepo",
+    "UserRepo",
+]

--- a/src/db/repositories/__init__.py
+++ b/src/db/repositories/__init__.py
@@ -2,9 +2,11 @@
 
 from db.repositories.api_key_repo import ApiKeyRepo
 from db.repositories.audit_repo import AuditRepo
+from db.repositories.conversation_repo import ConversationRepo
 from db.repositories.permission_repo import PermissionRepo
 from db.repositories.preferences_repo import PreferencesRepo
 from db.repositories.role_repo import RoleRepo
+from db.repositories.session_ownership_repo import SessionOwnershipRepo
 from db.repositories.user_repo import UserRepo
 from db.repositories.workspace_config_repo import (
     SECTIONS as WORKSPACE_CONFIG_SECTIONS,
@@ -14,9 +16,11 @@ from db.repositories.workspace_config_repo import (
 __all__ = [
     "ApiKeyRepo",
     "AuditRepo",
+    "ConversationRepo",
     "PermissionRepo",
     "PreferencesRepo",
     "RoleRepo",
+    "SessionOwnershipRepo",
     "UserRepo",
     "WorkspaceConfigRepo",
     "WORKSPACE_CONFIG_SECTIONS",

--- a/src/db/repositories/__init__.py
+++ b/src/db/repositories/__init__.py
@@ -6,6 +6,10 @@ from db.repositories.permission_repo import PermissionRepo
 from db.repositories.preferences_repo import PreferencesRepo
 from db.repositories.role_repo import RoleRepo
 from db.repositories.user_repo import UserRepo
+from db.repositories.workspace_config_repo import (
+    SECTIONS as WORKSPACE_CONFIG_SECTIONS,
+    WorkspaceConfigRepo,
+)
 
 __all__ = [
     "ApiKeyRepo",
@@ -14,4 +18,6 @@ __all__ = [
     "PreferencesRepo",
     "RoleRepo",
     "UserRepo",
+    "WorkspaceConfigRepo",
+    "WORKSPACE_CONFIG_SECTIONS",
 ]

--- a/src/db/repositories/_helpers.py
+++ b/src/db/repositories/_helpers.py
@@ -1,0 +1,9 @@
+import hashlib
+
+
+def email_lookup_hash(email: str) -> str:
+    """SHA-256 of lowercased email — used as the unique deterministic lookup key
+    even though the email column itself is non-deterministically encrypted."""
+    if not email:
+        return ""
+    return hashlib.sha256(email.lower().strip().encode("utf-8")).hexdigest()

--- a/src/db/repositories/api_key_repo.py
+++ b/src/db/repositories/api_key_repo.py
@@ -1,0 +1,43 @@
+"""ApiKey repo — placeholder for Phase 2.
+
+Phase 1 ships the schema only. Existing OpenSearch-backed APIKeyService
+remains the source of truth until Phase 2 migrates keys here.
+"""
+
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import ApiKey
+
+
+class ApiKeyRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_hash(self, key_hash: str) -> Optional[ApiKey]:
+        result = await self.session.execute(
+            select(ApiKey).where(ApiKey.key_hash == key_hash, ApiKey.revoked.is_(False))
+        )
+        return result.scalar_one_or_none()
+
+    async def list_for_user(self, user_id: str) -> list[ApiKey]:
+        result = await self.session.execute(
+            select(ApiKey).where(ApiKey.user_id == user_id)
+        )
+        return list(result.scalars().all())
+
+    async def add(self, api_key: ApiKey) -> ApiKey:
+        self.session.add(api_key)
+        await self.session.flush()
+        return api_key
+
+    async def revoke(self, key_id: str) -> None:
+        from datetime import datetime
+        row = await self.session.get(ApiKey, key_id)
+        if row:
+            row.revoked = True
+            row.revoked_at = datetime.utcnow()
+            self.session.add(row)
+            await self.session.flush()

--- a/src/db/repositories/audit_repo.py
+++ b/src/db/repositories/audit_repo.py
@@ -1,0 +1,44 @@
+import uuid
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import AuditLog
+
+
+class AuditRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def write(
+        self,
+        event: str,
+        actor_user_id: Optional[str] = None,
+        actor_api_key_id: Optional[str] = None,
+        target_type: Optional[str] = None,
+        target_id: Optional[str] = None,
+        audit_metadata: Optional[dict] = None,
+        ip: Optional[str] = None,
+        user_agent: Optional[str] = None,
+    ) -> AuditLog:
+        row = AuditLog(
+            id=str(uuid.uuid4()),
+            event=event,
+            actor_user_id=actor_user_id,
+            actor_api_key_id=actor_api_key_id,
+            target_type=target_type,
+            target_id=target_id,
+            audit_metadata=audit_metadata,
+            ip=ip,
+            user_agent=user_agent,
+        )
+        self.session.add(row)
+        await self.session.flush()
+        return row
+
+    async def list_recent(self, limit: int = 100, offset: int = 0) -> list[AuditLog]:
+        result = await self.session.execute(
+            select(AuditLog).order_by(AuditLog.ts.desc()).offset(offset).limit(limit)
+        )
+        return list(result.scalars().all())

--- a/src/db/repositories/conversation_repo.py
+++ b/src/db/repositories/conversation_repo.py
@@ -1,0 +1,105 @@
+"""Async CRUD over the ``conversations`` table — chat-history metadata."""
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Conversation
+
+
+class ConversationRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get(self, response_id: str) -> Optional[Conversation]:
+        return await self.session.get(Conversation, response_id)
+
+    async def list_for_user(
+        self, user_id: str, limit: int = 200
+    ) -> list[Conversation]:
+        result = await self.session.execute(
+            select(Conversation)
+            .where(Conversation.user_id == user_id)
+            .order_by(Conversation.last_activity.desc())
+            .limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def upsert(
+        self,
+        *,
+        response_id: str,
+        user_id: str,
+        title: Optional[str] = None,
+        endpoint: Optional[str] = None,
+        previous_response_id: Optional[str] = None,
+        filter_id: Optional[str] = None,
+        total_messages: int = 0,
+        created_at: Optional[datetime] = None,
+        last_activity: Optional[datetime] = None,
+    ) -> Conversation:
+        now = datetime.utcnow()
+        existing = await self.get(response_id)
+        if existing is None:
+            row = Conversation(
+                response_id=response_id,
+                user_id=user_id,
+                title=title,
+                endpoint=endpoint,
+                previous_response_id=previous_response_id,
+                filter_id=filter_id,
+                total_messages=total_messages,
+                created_at=created_at or now,
+                last_activity=last_activity or now,
+            )
+            self.session.add(row)
+            await self.session.flush()
+            return row
+        # Update non-null fields
+        if title is not None:
+            existing.title = title
+        if endpoint is not None:
+            existing.endpoint = endpoint
+        if previous_response_id is not None:
+            existing.previous_response_id = previous_response_id
+        if filter_id is not None:
+            existing.filter_id = filter_id
+        if total_messages:
+            existing.total_messages = total_messages
+        existing.last_activity = last_activity or now
+        self.session.add(existing)
+        await self.session.flush()
+        return existing
+
+    async def delete(self, response_id: str, user_id: str) -> bool:
+        """Delete only if the row is owned by user_id."""
+        row = await self.get(response_id)
+        if row is None or row.user_id != user_id:
+            return False
+        await self.session.delete(row)
+        await self.session.flush()
+        return True
+
+    async def delete_all_for_user(self, user_id: str) -> int:
+        rows = await self.list_for_user(user_id, limit=10_000)
+        for r in rows:
+            await self.session.delete(r)
+        await self.session.flush()
+        return len(rows)
+
+    async def to_metadata_dict(self, c: Conversation) -> dict[str, Any]:
+        """JSON-shaped dict matching the legacy conversations.json
+        per-conversation payload. Used by the service to keep API
+        compatibility with existing call sites."""
+        return {
+            "response_id": c.response_id,
+            "title": c.title,
+            "endpoint": c.endpoint,
+            "previous_response_id": c.previous_response_id,
+            "filter_id": c.filter_id,
+            "total_messages": c.total_messages or 0,
+            "created_at": c.created_at.isoformat() if c.created_at else None,
+            "last_activity": c.last_activity.isoformat() if c.last_activity else None,
+        }

--- a/src/db/repositories/permission_repo.py
+++ b/src/db/repositories/permission_repo.py
@@ -1,0 +1,23 @@
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Permission
+
+
+class PermissionRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def list_all(self) -> list[Permission]:
+        result = await self.session.execute(
+            select(Permission).order_by(Permission.resource, Permission.action)
+        )
+        return list(result.scalars().all())
+
+    async def get_by_name(self, name: str) -> Optional[Permission]:
+        result = await self.session.execute(
+            select(Permission).where(Permission.name == name)
+        )
+        return result.scalar_one_or_none()

--- a/src/db/repositories/preferences_repo.py
+++ b/src/db/repositories/preferences_repo.py
@@ -1,0 +1,44 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import UserPreferences
+
+
+class PreferencesRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get(self, user_id: str) -> Optional[UserPreferences]:
+        return await self.session.get(UserPreferences, user_id)
+
+    async def upsert(
+        self,
+        user_id: str,
+        agent_system_prompt_override: Optional[str] = None,
+        default_kf_id: Optional[str] = None,
+        theme: Optional[str] = None,
+        language: Optional[str] = None,
+        provider_overrides: Optional[str] = None,
+        preferences_json: Optional[str] = None,
+    ) -> UserPreferences:
+        prefs = await self.get(user_id)
+        if prefs is None:
+            prefs = UserPreferences(user_id=user_id)
+        if agent_system_prompt_override is not None:
+            prefs.agent_system_prompt_override = agent_system_prompt_override
+        if default_kf_id is not None:
+            prefs.default_kf_id = default_kf_id
+        if theme is not None:
+            prefs.theme = theme
+        if language is not None:
+            prefs.language = language
+        if provider_overrides is not None:
+            prefs.provider_overrides = provider_overrides
+        if preferences_json is not None:
+            prefs.preferences_json = preferences_json
+        prefs.updated_at = datetime.utcnow()
+        self.session.add(prefs)
+        await self.session.flush()
+        return prefs

--- a/src/db/repositories/preferences_repo.py
+++ b/src/db/repositories/preferences_repo.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -38,7 +38,7 @@ class PreferencesRepo:
             prefs.provider_overrides = provider_overrides
         if preferences_json is not None:
             prefs.preferences_json = preferences_json
-        prefs.updated_at = datetime.utcnow()
+        prefs.updated_at = datetime.now(UTC)
         self.session.add(prefs)
         await self.session.flush()
         return prefs

--- a/src/db/repositories/role_repo.py
+++ b/src/db/repositories/role_repo.py
@@ -1,0 +1,92 @@
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Permission, Role, RolePermission, UserRole
+
+
+class RoleRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_name(self, name: str) -> Optional[Role]:
+        result = await self.session.execute(select(Role).where(Role.name == name))
+        return result.scalar_one_or_none()
+
+    async def get_by_id(self, role_id: str) -> Optional[Role]:
+        return await self.session.get(Role, role_id)
+
+    async def list_all(self) -> list[Role]:
+        result = await self.session.execute(select(Role).order_by(Role.name))
+        return list(result.scalars().all())
+
+    async def count_admins(self) -> int:
+        result = await self.session.execute(
+            select(UserRole)
+            .join(Role, Role.id == UserRole.role_id)
+            .where(Role.name == "admin")
+        )
+        return len(list(result.scalars().all()))
+
+    async def list_user_roles(self, user_id: str) -> list[Role]:
+        result = await self.session.execute(
+            select(Role)
+            .join(UserRole, UserRole.role_id == Role.id)
+            .where(UserRole.user_id == user_id)
+        )
+        return list(result.scalars().all())
+
+    async def list_permissions_for_role(self, role_id: str) -> list[Permission]:
+        result = await self.session.execute(
+            select(Permission)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .where(RolePermission.role_id == role_id)
+        )
+        return list(result.scalars().all())
+
+    async def list_permissions_for_user(self, user_id: str) -> set[str]:
+        result = await self.session.execute(
+            select(Permission.name)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .join(UserRole, UserRole.role_id == RolePermission.role_id)
+            .where(UserRole.user_id == user_id)
+        )
+        return set(result.scalars().all())
+
+    async def list_permissions_for_role_ids(self, role_ids: list[str]) -> set[str]:
+        if not role_ids:
+            return set()
+        result = await self.session.execute(
+            select(Permission.name)
+            .join(RolePermission, RolePermission.permission_id == Permission.id)
+            .where(RolePermission.role_id.in_(role_ids))
+        )
+        return set(result.scalars().all())
+
+    async def assign_role(
+        self, user_id: str, role_id: str, granted_by: Optional[str] = None
+    ) -> UserRole:
+        existing = await self.session.execute(
+            select(UserRole).where(
+                UserRole.user_id == user_id, UserRole.role_id == role_id
+            )
+        )
+        row = existing.scalar_one_or_none()
+        if row:
+            return row
+        ur = UserRole(user_id=user_id, role_id=role_id, granted_by=granted_by)
+        self.session.add(ur)
+        await self.session.flush()
+        return ur
+
+    async def revoke_role(self, user_id: str, role_id: str) -> None:
+        result = await self.session.execute(
+            select(UserRole).where(
+                UserRole.user_id == user_id, UserRole.role_id == role_id
+            )
+        )
+        row = result.scalar_one_or_none()
+        if row:
+            await self.session.delete(row)
+            await self.session.flush()

--- a/src/db/repositories/role_repo.py
+++ b/src/db/repositories/role_repo.py
@@ -1,6 +1,6 @@
 from typing import Optional
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db.models import Permission, Role, RolePermission, UserRole
@@ -23,11 +23,27 @@ class RoleRepo:
 
     async def count_admins(self) -> int:
         result = await self.session.execute(
-            select(UserRole)
+            select(func.count())
+            .select_from(UserRole)
             .join(Role, Role.id == UserRole.role_id)
             .where(Role.name == "admin")
         )
-        return len(list(result.scalars().all()))
+        return int(result.scalar_one() or 0)
+
+    async def list_admin_user_ids(self) -> list[str]:
+        """All user_ids that currently hold the admin role.
+
+        Returned in lexicographic order so callers can use it as a
+        deterministic tie-breaker (e.g. bootstrap-race rollback in
+        ``user_service._assign_bootstrap_or_default``).
+        """
+        result = await self.session.execute(
+            select(UserRole.user_id)
+            .join(Role, Role.id == UserRole.role_id)
+            .where(Role.name == "admin")
+            .order_by(UserRole.user_id)
+        )
+        return list(result.scalars().all())
 
     async def list_user_roles(self, user_id: str) -> list[Role]:
         result = await self.session.execute(

--- a/src/db/repositories/session_ownership_repo.py
+++ b/src/db/repositories/session_ownership_repo.py
@@ -1,6 +1,6 @@
 """Async CRUD over the ``session_ownership`` table."""
 
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from sqlalchemy import select
@@ -25,7 +25,7 @@ class SessionOwnershipRepo:
         the existing owner before calling this for an existing row.
         """
         existing = await self.get(response_id)
-        now = datetime.utcnow()
+        now = datetime.now(UTC)
         if existing is None:
             row = SessionOwnership(
                 response_id=response_id,
@@ -77,7 +77,7 @@ class SessionOwnershipRepo:
         row = SessionOwnership(
             response_id=response_id,
             user_id=user_id,
-            created_at=created_at or datetime.utcnow(),
+            created_at=created_at or datetime.now(UTC),
             last_accessed=last_accessed,
         )
         self.session.add(row)

--- a/src/db/repositories/session_ownership_repo.py
+++ b/src/db/repositories/session_ownership_repo.py
@@ -68,12 +68,12 @@ class SessionOwnershipRepo:
         user_id: str,
         created_at: Optional[datetime] = None,
         last_accessed: Optional[datetime] = None,
-    ) -> None:
+    ) -> bool:
         """Used by the runtime migration to copy JSON rows verbatim
-        without overwriting timestamps."""
+        without overwriting timestamps. Returns True when a row was inserted."""
         existing = await self.get(response_id)
         if existing is not None:
-            return
+            return False
         row = SessionOwnership(
             response_id=response_id,
             user_id=user_id,
@@ -82,3 +82,4 @@ class SessionOwnershipRepo:
         )
         self.session.add(row)
         await self.session.flush()
+        return True

--- a/src/db/repositories/session_ownership_repo.py
+++ b/src/db/repositories/session_ownership_repo.py
@@ -1,0 +1,84 @@
+"""Async CRUD over the ``session_ownership`` table."""
+
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import SessionOwnership
+
+
+class SessionOwnershipRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get(self, response_id: str) -> Optional[SessionOwnership]:
+        return await self.session.get(SessionOwnership, response_id)
+
+    async def claim(
+        self, response_id: str, user_id: str
+    ) -> SessionOwnership:
+        """Idempotent claim. If the row exists, only update last_accessed
+        — never silently re-assign ownership (that would be a security
+        bug). The caller is responsible for ensuring the user_id matches
+        the existing owner before calling this for an existing row.
+        """
+        existing = await self.get(response_id)
+        now = datetime.utcnow()
+        if existing is None:
+            row = SessionOwnership(
+                response_id=response_id,
+                user_id=user_id,
+                created_at=now,
+                last_accessed=now,
+            )
+            self.session.add(row)
+            await self.session.flush()
+            return row
+        existing.last_accessed = now
+        self.session.add(existing)
+        await self.session.flush()
+        return existing
+
+    async def list_for_user(self, user_id: str) -> list[str]:
+        result = await self.session.execute(
+            select(SessionOwnership.response_id).where(
+                SessionOwnership.user_id == user_id
+            )
+        )
+        return list(result.scalars().all())
+
+    async def is_owned_by(self, response_id: str, user_id: str) -> bool:
+        row = await self.get(response_id)
+        return row is not None and row.user_id == user_id
+
+    async def release(self, response_id: str, user_id: str) -> bool:
+        """Returns True if the row existed AND was owned by user_id."""
+        row = await self.get(response_id)
+        if row is None or row.user_id != user_id:
+            return False
+        await self.session.delete(row)
+        await self.session.flush()
+        return True
+
+    async def upsert_raw(
+        self,
+        response_id: str,
+        user_id: str,
+        created_at: Optional[datetime] = None,
+        last_accessed: Optional[datetime] = None,
+    ) -> None:
+        """Used by the runtime migration to copy JSON rows verbatim
+        without overwriting timestamps."""
+        existing = await self.get(response_id)
+        if existing is not None:
+            return
+        row = SessionOwnership(
+            response_id=response_id,
+            user_id=user_id,
+            created_at=created_at or datetime.utcnow(),
+            last_accessed=last_accessed,
+        )
+        self.session.add(row)
+        await self.session.flush()

--- a/src/db/repositories/user_repo.py
+++ b/src/db/repositories/user_repo.py
@@ -1,0 +1,74 @@
+from datetime import datetime
+from typing import Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import User
+from db.repositories._helpers import email_lookup_hash
+
+
+class UserRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_by_id(self, user_id: str) -> Optional[User]:
+        return await self.session.get(User, user_id)
+
+    async def get_by_oauth(self, provider: str, subject: str) -> Optional[User]:
+        result = await self.session.execute(
+            select(User).where(
+                User.oauth_provider == provider, User.oauth_subject == subject
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_email(self, email: str) -> Optional[User]:
+        h = email_lookup_hash(email)
+        if not h:
+            return None
+        result = await self.session.execute(
+            select(User).where(User.email_lookup_hash == h)
+        )
+        return result.scalar_one_or_none()
+
+    async def list_all(self, limit: int = 100, offset: int = 0) -> list[User]:
+        result = await self.session.execute(
+            select(User).order_by(User.created_at.desc()).offset(offset).limit(limit)
+        )
+        return list(result.scalars().all())
+
+    async def add(self, user: User) -> User:
+        if user.email and not user.email_lookup_hash:
+            user.email_lookup_hash = email_lookup_hash(user.email)
+        self.session.add(user)
+        await self.session.flush()
+        return user
+
+    async def update_last_login(self, user_id: str) -> None:
+        user = await self.get_by_id(user_id)
+        if user:
+            user.last_login = datetime.utcnow()
+            user.updated_at = datetime.utcnow()
+            self.session.add(user)
+            await self.session.flush()
+
+    async def merge_legacy(
+        self, legacy: User, real_provider: str, real_subject: str,
+        email: Optional[str], display_name: Optional[str],
+        picture_url: Optional[str],
+    ) -> User:
+        legacy.oauth_provider = real_provider
+        legacy.oauth_subject = real_subject
+        if email:
+            legacy.email = email
+            legacy.email_lookup_hash = email_lookup_hash(email)
+        if display_name:
+            legacy.display_name = display_name
+        if picture_url:
+            legacy.picture_url = picture_url
+        legacy.last_login = datetime.utcnow()
+        legacy.updated_at = datetime.utcnow()
+        self.session.add(legacy)
+        await self.session.flush()
+        return legacy

--- a/src/db/repositories/user_repo.py
+++ b/src/db/repositories/user_repo.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Optional
 
 from sqlalchemy import select
@@ -48,8 +48,8 @@ class UserRepo:
     async def update_last_login(self, user_id: str) -> None:
         user = await self.get_by_id(user_id)
         if user:
-            user.last_login = datetime.utcnow()
-            user.updated_at = datetime.utcnow()
+            user.last_login = datetime.now(UTC)
+            user.updated_at = datetime.now(UTC)
             self.session.add(user)
             await self.session.flush()
 
@@ -67,8 +67,8 @@ class UserRepo:
             legacy.display_name = display_name
         if picture_url:
             legacy.picture_url = picture_url
-        legacy.last_login = datetime.utcnow()
-        legacy.updated_at = datetime.utcnow()
+        legacy.last_login = datetime.now(UTC)
+        legacy.updated_at = datetime.now(UTC)
         self.session.add(legacy)
         await self.session.flush()
         return legacy

--- a/src/db/repositories/workspace_config_repo.py
+++ b/src/db/repositories/workspace_config_repo.py
@@ -1,0 +1,60 @@
+"""Async CRUD over the ``workspace_config`` table.
+
+Each row is one logical section ('providers' | 'knowledge' | 'agent' |
+'onboarding' | 'meta'). The repo speaks plain dicts — serialization
+to/from ``OpenRAGConfig`` is the service's job.
+"""
+
+from datetime import datetime
+from typing import Any, Optional
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import WorkspaceConfig
+
+# Section names recognized by the migration / service.
+SECTIONS = ("providers", "knowledge", "agent", "onboarding", "meta")
+
+
+class WorkspaceConfigRepo:
+    def __init__(self, session: AsyncSession):
+        self.session = session
+
+    async def get_section(self, section: str) -> Optional[dict[str, Any]]:
+        row = await self.session.get(WorkspaceConfig, section)
+        return None if row is None else (row.value or {})
+
+    async def list_all(self) -> dict[str, dict[str, Any]]:
+        result = await self.session.execute(select(WorkspaceConfig))
+        return {row.section: (row.value or {}) for row in result.scalars().all()}
+
+    async def upsert(
+        self,
+        section: str,
+        value: dict[str, Any],
+        actor_user_id: Optional[str] = None,
+    ) -> WorkspaceConfig:
+        existing = await self.session.get(WorkspaceConfig, section)
+        if existing is None:
+            row = WorkspaceConfig(
+                section=section,
+                value=value,
+                updated_at=datetime.utcnow(),
+                updated_by=actor_user_id,
+            )
+            self.session.add(row)
+            await self.session.flush()
+            return row
+        existing.value = value
+        existing.updated_at = datetime.utcnow()
+        if actor_user_id is not None:
+            existing.updated_by = actor_user_id
+        self.session.add(existing)
+        await self.session.flush()
+        return existing
+
+    async def has_any(self) -> bool:
+        """Quick check for the migration: do we have any rows?"""
+        result = await self.session.execute(select(WorkspaceConfig).limit(1))
+        return result.scalar_one_or_none() is not None

--- a/src/db/seed.py
+++ b/src/db/seed.py
@@ -1,0 +1,227 @@
+"""Idempotent seed for built-in roles and permissions.
+
+The full permission catalog and the role-permission default mapping live here
+so adding a permission or a role is a one-file change followed by an Alembic
+data migration. See plan §1.2 / §1.3 / §10.
+
+Built-in role IDs are stable, deterministic strings so cross-environment
+references (e.g. tests, docs) do not depend on UUIDs.
+"""
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import Permission, Role, RolePermission
+
+# ---------------------------------------------------------------------------
+# Permission catalog
+# (resource, action, description)
+# ---------------------------------------------------------------------------
+
+PERMISSIONS: list[tuple[str, str, str]] = [
+    # Infra
+    ("config", "read", "Read workspace configuration"),
+    ("config", "write", "Write workspace configuration"),
+    ("providers", "read", "Read provider configuration"),
+    ("providers", "write", "Write workspace provider configuration"),
+    ("providers", "override:self", "Override providers in own user preferences"),
+    ("opensearch", "admin", "Administer OpenSearch security"),
+
+    # Users / RBAC
+    ("users", "list", "List users"),
+    ("users", "read", "Read user profile"),
+    ("users", "invite", "Invite or update user records"),
+    ("users", "delete", "Delete users"),
+    ("roles", "list", "List roles"),
+    ("roles", "assign", "Assign or revoke roles"),
+    ("roles", "create", "Create custom roles"),
+    ("roles", "edit", "Edit custom roles"),
+    ("roles", "delete", "Delete custom roles"),
+    ("audit", "read", "Read audit log"),
+
+    # Connectors
+    ("connectors", "list:own", "List own connectors"),
+    ("connectors", "list:all", "List all connectors in the workspace"),
+    ("connectors", "create", "Create connectors"),
+    ("connectors", "delete:own", "Delete own connectors"),
+    ("connectors", "delete:any", "Delete any connector"),
+    ("connectors", "use", "Use connector OAuth and browse"),
+
+    # Knowledge
+    ("knowledge", "upload", "Upload documents"),
+    ("knowledge", "delete:own", "Delete own documents"),
+    ("knowledge", "delete:any", "Delete any document"),
+    ("knowledge", "read:own", "Read own documents"),
+    ("knowledge", "read:all", "Read all documents"),
+    ("kf", "create", "Create knowledge filters"),
+    ("kf", "edit:own", "Edit own knowledge filters"),
+    ("kf", "edit:any", "Edit any knowledge filter"),
+    ("kf", "share", "Share knowledge filters"),
+
+    # Chat / search
+    ("chat", "use", "Use chat"),
+    ("search", "use", "Use search"),
+    ("conversations", "read:own", "Read own conversations"),
+    ("conversations", "read:all", "Read all conversations"),
+    ("conversations", "delete:own", "Delete own conversations"),
+    ("conversations", "delete:any", "Delete any conversation"),
+
+    # Flows / agent
+    ("flows", "read", "Read flows"),
+    ("flows", "edit", "Edit flows"),
+    ("agent", "prompt:override", "Override agent system prompt for self"),
+    ("agent", "prompt:global", "Edit global agent system prompt"),
+
+    # API keys
+    ("apikeys", "create:self", "Create own API keys"),
+    ("apikeys", "revoke:self", "Revoke own API keys"),
+    ("apikeys", "revoke:any", "Revoke any API key"),
+    ("apikeys", "list:any", "List API keys for any user"),
+]
+
+
+def permission_name(resource: str, action: str) -> str:
+    return f"{resource}:{action}"
+
+
+# ---------------------------------------------------------------------------
+# Built-in roles + role/permission mapping
+# ---------------------------------------------------------------------------
+
+BUILTIN_ROLES: list[tuple[str, str, str]] = [
+    # (id, name, description)
+    ("role-admin", "admin", "Full control over infra, users, and all data."),
+    ("role-developer", "developer", "Manages own connectors, flows, and ingestion. No infra writes."),
+    ("role-user", "user", "Default end-user. Chat, search, and own connectors."),
+    ("role-viewer", "viewer", "Read-only chat and search."),
+]
+
+
+def _admin_perms() -> set[str]:
+    return {permission_name(r, a) for r, a, _ in PERMISSIONS}
+
+
+def _developer_perms() -> set[str]:
+    return {
+        "providers:override:self",
+        "connectors:list:own", "connectors:create", "connectors:delete:own", "connectors:use",
+        "knowledge:upload", "knowledge:delete:own", "knowledge:read:own",
+        "kf:create", "kf:edit:own",
+        "chat:use", "search:use",
+        "conversations:read:own", "conversations:delete:own",
+        "flows:read", "flows:edit",
+        "agent:prompt:override",
+        "apikeys:create:self", "apikeys:revoke:self",
+    }
+
+
+def _user_perms() -> set[str]:
+    return {
+        "providers:override:self",
+        "connectors:list:own", "connectors:create", "connectors:delete:own", "connectors:use",
+        "knowledge:upload", "knowledge:delete:own", "knowledge:read:own",
+        "kf:create", "kf:edit:own",
+        "chat:use", "search:use",
+        "conversations:read:own", "conversations:delete:own",
+        "flows:read",
+        "agent:prompt:override",
+        "apikeys:create:self", "apikeys:revoke:self",
+    }
+
+
+def _viewer_perms() -> set[str]:
+    return {
+        "chat:use", "search:use",
+        "conversations:read:own", "conversations:delete:own",
+        "flows:read",
+    }
+
+
+ROLE_PERMISSION_MAP: dict[str, set[str]] = {
+    "admin": _admin_perms(),
+    "developer": _developer_perms(),
+    "user": _user_perms(),
+    "viewer": _viewer_perms(),
+}
+
+
+# ---------------------------------------------------------------------------
+# Idempotent seeder
+# ---------------------------------------------------------------------------
+
+async def seed_roles_and_permissions(session: AsyncSession) -> None:
+    """Insert any missing roles/permissions/role_permissions. Safe to call repeatedly.
+
+    Used by the second Alembic data migration AND from tests against an
+    in-memory SQLite. Does not commit — caller commits.
+    """
+
+    # Permissions
+    existing_perms = {
+        p.name: p
+        for p in (await session.execute(select(Permission))).scalars().all()
+    }
+    perm_id_by_name: dict[str, str] = {p.name: p.id for p in existing_perms.values()}
+
+    for resource, action, description in PERMISSIONS:
+        name = permission_name(resource, action)
+        if name in existing_perms:
+            continue
+        pid = str(uuid.uuid4())
+        session.add(
+            Permission(
+                id=pid,
+                name=name,
+                resource=resource,
+                action=action,
+                description=description,
+            )
+        )
+        perm_id_by_name[name] = pid
+    await session.flush()
+
+    # Roles
+    existing_roles = {
+        r.name: r
+        for r in (await session.execute(select(Role))).scalars().all()
+    }
+    for role_id, role_name, description in BUILTIN_ROLES:
+        if role_name in existing_roles:
+            continue
+        session.add(
+            Role(
+                id=role_id,
+                name=role_name,
+                description=description,
+                is_system=True,
+            )
+        )
+    await session.flush()
+
+    # Re-fetch so we have IDs for the just-inserted rows.
+    role_id_by_name = {
+        r.name: r.id
+        for r in (await session.execute(select(Role))).scalars().all()
+    }
+
+    # Role permissions (additive only — never remove perms set by an admin via UI)
+    existing_rp = set(
+        (rp.role_id, rp.permission_id)
+        for rp in (await session.execute(select(RolePermission))).scalars().all()
+    )
+
+    for role_name, perm_names in ROLE_PERMISSION_MAP.items():
+        rid = role_id_by_name.get(role_name)
+        if rid is None:
+            continue
+        for pname in perm_names:
+            pid = perm_id_by_name.get(pname)
+            if pid is None:
+                continue
+            if (rid, pid) in existing_rp:
+                continue
+            session.add(RolePermission(role_id=rid, permission_id=pid))
+
+    await session.flush()

--- a/src/db/types.py
+++ b/src/db/types.py
@@ -1,0 +1,61 @@
+"""Custom SQLAlchemy types.
+
+EncryptedString reuses utils.encryption (AES-256-GCM + PBKDF2) so we never
+introduce a parallel crypto path. Stored on disk as a JSON envelope; if no
+master secret is configured it falls through to plaintext (matching the
+behavior already documented in encryption.py).
+"""
+
+import json
+from typing import Optional
+
+from sqlalchemy.types import String, TypeDecorator
+
+from utils.encryption import (
+    ENCRYPTION_ALGORITHM,
+    decrypt_secret,
+    encrypt_secret,
+    get_master_secret,
+)
+
+
+class EncryptedString(TypeDecorator):
+    """A TEXT column whose value is transparently encrypted at rest."""
+
+    impl = String
+    cache_ok = True
+
+    def __init__(self, tenant_id: str = "user_pii", *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._tenant_id = tenant_id
+
+    def process_bind_param(self, value: Optional[str], dialect) -> Optional[str]:
+        if value is None:
+            return None
+        if not isinstance(value, str):
+            value = str(value)
+        if not value:
+            return value
+        if get_master_secret() is None:
+            return value
+        envelope = encrypt_secret(value, tenant_id=self._tenant_id)
+        if isinstance(envelope, dict):
+            return json.dumps(envelope, separators=(",", ":"))
+        return envelope
+
+    def process_result_value(self, value: Optional[str], dialect) -> Optional[str]:
+        if value is None:
+            return None
+        if not value:
+            return value
+        try:
+            payload = json.loads(value)
+        except (ValueError, TypeError):
+            return value
+        if (
+            isinstance(payload, dict)
+            and payload.get("algorithm") == ENCRYPTION_ALGORITHM
+            and "ciphertext" in payload
+        ):
+            return decrypt_secret(payload, expected_tenant_id=self._tenant_id)
+        return value

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -15,6 +15,7 @@ Usage:
         ...
 """
 
+import asyncio
 import dataclasses
 from typing import AsyncIterator, Optional
 
@@ -36,6 +37,14 @@ logger = get_logger(__name__)
 # Phase-1 new rows had id == uuid4(); permission lookups need the SQL id,
 # not the OAuth subject.
 _ENSURED_USER_IDS: TTLCache[str, str] = TTLCache(maxsize=4096, ttl=300)
+
+# Per-user-id asyncio.Lock used to serialize concurrent first-time
+# `_ensure_db_user` calls for the SAME user_id. Without this, two
+# requests racing through the cache miss → INSERT path both observe an
+# empty users table, both attempt INSERT, and the second fails with
+# `UNIQUE constraint failed: users.email_lookup_hash`. The lock is
+# scoped per-user_id so unrelated logins never block each other.
+_ENSURE_LOCKS: dict[str, asyncio.Lock] = {}
 
 
 # ─────────────────────────────────────────────
@@ -140,23 +149,35 @@ async def _ensure_db_user(user: User) -> Optional[str]:
     cached_db_id = _ENSURED_USER_IDS.get(user.user_id)
     if cached_db_id is not None:
         return cached_db_id
-    try:
-        from db.engine import SessionLocal, init_engine
-        from services.user_service import ensure_user_row
 
-        if SessionLocal is None:
-            init_engine()
-        from db.engine import SessionLocal as _SessionLocal
-        if _SessionLocal is None:
+    # Serialize concurrent first-time ensures for the SAME user_id so a
+    # second caller observes the first's committed row instead of
+    # racing through the cache miss → INSERT path. Per-user lock so
+    # unrelated users never block each other.
+    lock = _ENSURE_LOCKS.setdefault(user.user_id, asyncio.Lock())
+    async with lock:
+        # Re-check the cache inside the lock; the previous holder may
+        # have just populated it.
+        cached_db_id = _ENSURED_USER_IDS.get(user.user_id)
+        if cached_db_id is not None:
+            return cached_db_id
+        try:
+            from db.engine import SessionLocal, init_engine
+            from services.user_service import ensure_user_row
+
+            if SessionLocal is None:
+                init_engine()
+            from db.engine import SessionLocal as _SessionLocal
+            if _SessionLocal is None:
+                return None
+            async with _SessionLocal() as session:
+                db_row = await ensure_user_row(session, user)
+                await session.commit()
+            _ENSURED_USER_IDS[user.user_id] = db_row.id
+            return db_row.id
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ensure_user_row failed", user_id=user.user_id, error=str(exc))
             return None
-        async with _SessionLocal() as session:
-            db_row = await ensure_user_row(session, user)
-            await session.commit()
-        _ENSURED_USER_IDS[user.user_id] = db_row.id
-        return db_row.id
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("ensure_user_row failed", user_id=user.user_id, error=str(exc))
-        return None
 
 
 async def _resolve_db_user_id(user: User) -> str:

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -105,6 +105,10 @@ def get_rbac_service(services: dict = Depends(get_services)):
     return services["rbac_service"]
 
 
+def get_workspace_config_service(services: dict = Depends(get_services)):
+    return services["workspace_config_service"]
+
+
 # ─────────────────────────────────────────────
 # Database session
 # ─────────────────────────────────────────────

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -16,14 +16,26 @@ Usage:
 """
 
 import dataclasses
-from typing import Optional
+from typing import AsyncIterator, Optional
 
+from cachetools import TTLCache
 from fastapi import Depends, HTTPException, Request
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from session_manager import User
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+# Maps OAuth user_id (== JWT subject) -> SQL users.id. Doubles as the
+# "we've already ensured a DB row for this user" cache so we don't pay
+# the round-trip on every authenticated request. Cleared on user/role
+# mutations via the rbac service invalidation hook.
+#
+# Necessary because legacy-migrated rows have id == user_id while older
+# Phase-1 new rows had id == uuid4(); permission lookups need the SQL id,
+# not the OAuth subject.
+_ENSURED_USER_IDS: TTLCache[str, str] = TTLCache(maxsize=4096, ttl=300)
 
 
 # ─────────────────────────────────────────────
@@ -89,6 +101,112 @@ def get_flows_service(services: dict = Depends(get_services)):
 
 def get_docling_service(services: dict = Depends(get_services)):
     return services["docling_service"]
+def get_rbac_service(services: dict = Depends(get_services)):
+    return services["rbac_service"]
+
+
+# ─────────────────────────────────────────────
+# Database session
+# ─────────────────────────────────────────────
+
+
+async def get_db_session() -> AsyncIterator[AsyncSession]:
+    """Yield an async DB session for the duration of a request."""
+    from db.engine import SessionLocal, init_engine
+
+    if SessionLocal is None:
+        init_engine()
+    from db.engine import SessionLocal as _SessionLocal
+    assert _SessionLocal is not None
+    async with _SessionLocal() as session:
+        yield session
+
+
+async def _ensure_db_user(user: User) -> Optional[str]:
+    """Best-effort DB upsert for the authenticated user. Returns the SQL
+    `users.id` for this user (so callers can cache the OAuth-sub → DB-id
+    mapping). Returns None on failure.
+
+    No-ops for anonymous users in no-auth mode beyond the very first call
+    (which does set up the synthetic anonymous row + role). Failures are
+    logged but never block the request.
+    """
+    if not user or not user.user_id:
+        return None
+    cached_db_id = _ENSURED_USER_IDS.get(user.user_id)
+    if cached_db_id is not None:
+        return cached_db_id
+    try:
+        from db.engine import SessionLocal, init_engine
+        from services.user_service import ensure_user_row
+
+        if SessionLocal is None:
+            init_engine()
+        from db.engine import SessionLocal as _SessionLocal
+        if _SessionLocal is None:
+            return None
+        async with _SessionLocal() as session:
+            db_row = await ensure_user_row(session, user)
+            await session.commit()
+        _ENSURED_USER_IDS[user.user_id] = db_row.id
+        return db_row.id
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ensure_user_row failed", user_id=user.user_id, error=str(exc))
+        return None
+
+
+async def _resolve_db_user_id(user: User) -> str:
+    """Translate an authenticated `User` (which carries the JWT/OAuth
+    subject) to the SQL `users.id` used by the RBAC tables. Falls back to
+    `user.user_id` if no DB row can be resolved (no-auth mode, transient
+    DB error, etc.) so caller behavior degrades gracefully.
+    """
+    if not user or not user.user_id:
+        return ""
+    cached = _ENSURED_USER_IDS.get(user.user_id)
+    if cached is not None:
+        return cached
+    resolved = await _ensure_db_user(user)
+    return resolved or user.user_id
+
+
+def invalidate_user_ensured_cache(user_id: Optional[str] = None) -> None:
+    """Called after admin mutations so role changes are picked up promptly."""
+    if user_id is None:
+        _ENSURED_USER_IDS.clear()
+    else:
+        _ENSURED_USER_IDS.pop(user_id, None)
+
+
+# ─────────────────────────────────────────────
+# Permission enforcement
+# ─────────────────────────────────────────────
+
+
+def require_permission(perm: str):
+    """FastAPI dependency factory enforcing a permission on the current user.
+
+    Raises HTTP 403 with `{required: <perm>}` when the user lacks it.
+    Honors API key role snapshots via `request.state.api_key_role_ids`.
+    """
+
+    async def _dep(
+        request: Request,
+        user: User = Depends(get_current_user),
+        rbac=Depends(get_rbac_service),
+    ) -> User:
+        role_override = getattr(request.state, "api_key_role_ids", None)
+        db_user_id = await _resolve_db_user_id(user)
+        perms = await rbac.get_user_permissions(db_user_id, role_override=role_override)
+        if perm not in perms:
+            await rbac.audit_denied(db_user_id, perm)
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "permission_denied", "required": perm},
+            )
+        return user
+
+    return _dep
 
 
 # ─────────────────────────────────────────────
@@ -266,6 +384,7 @@ async def get_current_user(
         user = await _get_ibm_user(request, required=True)
         if user and user.user_id and user.user_id not in session_manager.users:
             session_manager.users[user.user_id] = user
+        await _ensure_db_user(user)
         return user
 
     if is_no_auth_mode():
@@ -273,6 +392,7 @@ async def get_current_user(
         request.state.user = user
         effective_token = session_manager.get_effective_jwt_token(None, None)
         user_with_token = dataclasses.replace(user, jwt_token=effective_token)
+        await _ensure_db_user(user_with_token)
         return user_with_token
 
     auth_token = request.cookies.get("auth_token")
@@ -288,6 +408,7 @@ async def get_current_user(
     user_with_token = dataclasses.replace(user, jwt_token=effective_token)
 
     request.state.user = user_with_token
+    await _ensure_db_user(user_with_token)
     return user_with_token
 
 
@@ -310,6 +431,8 @@ async def get_optional_user(
         user = await _get_ibm_user(request, required=False)
         if user and user.user_id and user.user_id not in session_manager.users:
             session_manager.users[user.user_id] = user
+        if user:
+            await _ensure_db_user(user)
         return user
 
     if is_no_auth_mode():
@@ -317,6 +440,7 @@ async def get_optional_user(
         request.state.user = user
         effective_token = session_manager.get_effective_jwt_token(None, None)
         user_with_token = dataclasses.replace(user, jwt_token=effective_token)
+        await _ensure_db_user(user_with_token)
         return user_with_token
 
     auth_token = request.cookies.get("auth_token")
@@ -336,6 +460,8 @@ async def get_optional_user(
     )
 
     request.state.user = user_with_token
+    if user_with_token:
+        await _ensure_db_user(user_with_token)
     return user_with_token
 
 
@@ -419,5 +545,12 @@ async def get_api_key_user_async(
 
     request.state.user = user_with_token
     request.state.api_key_id = user_info["key_id"]
+    # Phase 2 will populate api_key_role_ids from the SQL api_keys table.
+    # In Phase 1 we leave it unset so require_permission falls back to the
+    # user's live role membership (no privilege escalation possible).
+    request.state.api_key_role_ids = getattr(
+        request.state, "api_key_role_ids", None
+    )
+    await _ensure_db_user(user_with_token)
 
     return user_with_token

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -192,13 +192,25 @@ def require_permission(perm: str):
 
     Raises HTTP 403 with `{required: <perm>}` when the user lacks it.
     Honors API key role snapshots via `request.state.api_key_role_ids`.
+
+    When ``OPENRAG_RBAC_ENFORCE=false`` the check is skipped and the
+    authenticated user is returned unconditionally. The startup event
+    in ``src/main.py`` refuses to boot when this flag is combined with
+    a ``saas`` or ``on_prem`` run mode, so the bypass cannot silently
+    land in production.
     """
+    from services.rbac_service import is_rbac_enforced
 
     async def _dep(
         request: Request,
         user: User = Depends(get_current_user),
         rbac=Depends(get_rbac_service),
     ) -> User:
+        if not is_rbac_enforced():
+            # RBAC kill-switch: still resolve the DB id so downstream
+            # ownership checks that compare against it keep working.
+            await _resolve_db_user_id(user)
+            return user
         role_override = getattr(request.state, "api_key_role_ids", None)
         db_user_id = await _resolve_db_user_id(user)
         perms = await rbac.get_user_permissions(db_user_id, role_override=role_override)

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -17,7 +17,7 @@ Usage:
 
 import asyncio
 import dataclasses
-from typing import AsyncIterator, Optional
+from typing import AsyncIterator, Optional, Sequence
 
 from cachetools import TTLCache
 from fastapi import Depends, HTTPException, Request
@@ -216,6 +216,24 @@ async def _resolve_db_user_id(user: User) -> str:
     return resolved or user.user_id
 
 
+async def _attach_db_user_id(request: Request, user: Optional[User]) -> Optional[User]:
+    """Attach the internal SQL users.id to the request user.
+
+    `User.user_id` remains the external auth subject used in JWT/OpenSearch
+    flows. `User.db_user_id` is the OpenRAG owner id used by SQL-backed
+    RBAC and ownership tables.
+    """
+    if user is None:
+        request.state.db_user_id = None
+        request.state.user = None
+        return None
+    db_user_id = await _resolve_db_user_id(user)
+    user_with_db_id = dataclasses.replace(user, db_user_id=db_user_id)
+    request.state.db_user_id = db_user_id
+    request.state.user = user_with_db_id
+    return user_with_db_id
+
+
 def invalidate_user_ensured_cache(
     oauth_provider: Optional[str] = None,
     oauth_subject: Optional[str] = None,
@@ -263,16 +281,51 @@ def require_permission(perm: str):
         if not is_rbac_enforced():
             # RBAC kill-switch: still resolve the DB id so downstream
             # ownership checks that compare against it keep working.
-            await _resolve_db_user_id(user)
-            return user
+            return await _attach_db_user_id(request, user)
         role_override = getattr(request.state, "api_key_role_ids", None)
         db_user_id = await _resolve_db_user_id(user)
+        user = dataclasses.replace(user, db_user_id=db_user_id)
+        request.state.db_user_id = db_user_id
+        request.state.user = user
         perms = await rbac.get_user_permissions(db_user_id, role_override=role_override)
         if perm not in perms:
             await rbac.audit_denied(db_user_id, perm)
             raise HTTPException(
                 status_code=403,
                 detail={"error": "permission_denied", "required": perm},
+            )
+        return user
+
+    return _dep
+
+
+def require_all_permissions(required_perms: Sequence[str]):
+    """FastAPI dependency factory enforcing all listed permissions."""
+    required = tuple(required_perms)
+    if not required:
+        raise ValueError("require_all_permissions requires at least one permission")
+
+    from services.rbac_service import is_rbac_enforced
+
+    async def _dep(
+        request: Request,
+        user: User = Depends(get_current_user),
+        rbac=Depends(get_rbac_service),
+    ) -> User:
+        if not is_rbac_enforced():
+            return await _attach_db_user_id(request, user)
+        role_override = getattr(request.state, "api_key_role_ids", None)
+        db_user_id = await _resolve_db_user_id(user)
+        user = dataclasses.replace(user, db_user_id=db_user_id)
+        request.state.db_user_id = db_user_id
+        request.state.user = user
+        perms = await rbac.get_user_permissions(db_user_id, role_override=role_override)
+        missing = [perm for perm in required if perm not in perms]
+        if missing:
+            await rbac.audit_denied(db_user_id, ",".join(missing))
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "permission_denied", "required": list(required)},
             )
         return user
 
@@ -454,16 +507,13 @@ async def get_current_user(
         user = await _get_ibm_user(request, required=True)
         if user and user.user_id and user.user_id not in session_manager.users:
             session_manager.users[user.user_id] = user
-        await _ensure_db_user(user)
-        return user
+        return await _attach_db_user_id(request, user)
 
     if is_no_auth_mode():
         user = AnonymousUser()
-        request.state.user = user
         effective_token = session_manager.get_effective_jwt_token(None, None)
         user_with_token = dataclasses.replace(user, jwt_token=effective_token)
-        await _ensure_db_user(user_with_token)
-        return user_with_token
+        return await _attach_db_user_id(request, user_with_token)
 
     auth_token = request.cookies.get("auth_token")
     if not auth_token:
@@ -477,9 +527,7 @@ async def get_current_user(
     effective_token = session_manager.get_effective_jwt_token(user.user_id, auth_token)
     user_with_token = dataclasses.replace(user, jwt_token=effective_token)
 
-    request.state.user = user_with_token
-    await _ensure_db_user(user_with_token)
-    return user_with_token
+    return await _attach_db_user_id(request, user_with_token)
 
 
 async def get_optional_user(
@@ -502,16 +550,15 @@ async def get_optional_user(
         if user and user.user_id and user.user_id not in session_manager.users:
             session_manager.users[user.user_id] = user
         if user:
-            await _ensure_db_user(user)
-        return user
+            return await _attach_db_user_id(request, user)
+        request.state.db_user_id = None
+        return None
 
     if is_no_auth_mode():
         user = AnonymousUser()
-        request.state.user = user
         effective_token = session_manager.get_effective_jwt_token(None, None)
         user_with_token = dataclasses.replace(user, jwt_token=effective_token)
-        await _ensure_db_user(user_with_token)
-        return user_with_token
+        return await _attach_db_user_id(request, user_with_token)
 
     auth_token = request.cookies.get("auth_token")
     if not auth_token:
@@ -529,10 +576,11 @@ async def get_optional_user(
         dataclasses.replace(user, jwt_token=effective_token) if user else None
     )
 
-    request.state.user = user_with_token
     if user_with_token:
-        await _ensure_db_user(user_with_token)
-    return user_with_token
+        return await _attach_db_user_id(request, user_with_token)
+    request.state.user = None
+    request.state.db_user_id = None
+    return None
 
 
 async def get_api_key_user_async(
@@ -567,8 +615,7 @@ async def get_api_key_user_async(
                 opensearch_username=ibm_username,
                 opensearch_credentials=ibm_api_key,
             )
-            request.state.user = user
-            return user
+            return await _attach_db_user_id(request, user)
 
     # API key path
     api_key = request.headers.get("X-API-Key")
@@ -613,7 +660,6 @@ async def get_api_key_user_async(
     effective_token = session_manager.get_effective_jwt_token(user.user_id, None)
     user_with_token = dataclasses.replace(user, jwt_token=effective_token)
 
-    request.state.user = user_with_token
     request.state.api_key_id = user_info["key_id"]
     # Phase 2 will populate api_key_role_ids from the SQL api_keys table.
     # In Phase 1 we leave it unset so require_permission falls back to the
@@ -621,6 +667,5 @@ async def get_api_key_user_async(
     request.state.api_key_role_ids = getattr(
         request.state, "api_key_role_ids", None
     )
-    await _ensure_db_user(user_with_token)
 
-    return user_with_token
+    return await _attach_db_user_id(request, user_with_token)

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -28,7 +28,7 @@ from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-# Maps OAuth user_id (== JWT subject) -> SQL users.id. Doubles as the
+# Maps composite "{provider}:{subject}" -> SQL users.id. Doubles as the
 # "we've already ensured a DB row for this user" cache so we don't pay
 # the round-trip on every authenticated request. Cleared on user/role
 # mutations via the rbac service invalidation hook.
@@ -36,15 +36,35 @@ logger = get_logger(__name__)
 # Necessary because legacy-migrated rows have id == user_id while older
 # Phase-1 new rows had id == uuid4(); permission lookups need the SQL id,
 # not the OAuth subject.
+#
+# The key is composite (provider, subject), NOT just user_id, because the
+# OAuth subject string alone is not unique across providers — e.g. the
+# synthetic `AnonymousUser` (provider="none", user_id="anonymous") must
+# not collide with a hypothetical real user whose IdP issued the same
+# subject string. Identity in this codebase is the (provider, subject)
+# pair (see `ensure_user_row` and the `(oauth_provider, oauth_subject)`
+# UNIQUE constraint on the users table).
 _ENSURED_USER_IDS: TTLCache[str, str] = TTLCache(maxsize=4096, ttl=300)
 
-# Per-user-id asyncio.Lock used to serialize concurrent first-time
-# `_ensure_db_user` calls for the SAME user_id. Without this, two
-# requests racing through the cache miss → INSERT path both observe an
-# empty users table, both attempt INSERT, and the second fails with
-# `UNIQUE constraint failed: users.email_lookup_hash`. The lock is
-# scoped per-user_id so unrelated logins never block each other.
+# Per-(provider, subject) asyncio.Lock used to serialize concurrent
+# first-time `_ensure_db_user` calls for the SAME identity. Without
+# this, two requests racing through the cache miss → INSERT path both
+# observe an empty users table, both attempt INSERT, and the second
+# fails with `UNIQUE constraint failed: users.email_lookup_hash`. The
+# lock is scoped per-identity so unrelated logins never block each
+# other (and so two providers issuing the same subject string don't
+# share a lock).
 _ENSURE_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _user_cache_key(user: User) -> str:
+    """Composite cache/lock key for a `User`.
+
+    Mirrors the (oauth_provider, oauth_subject) UNIQUE constraint in
+    the users table. The fallback to "unknown" matches `ensure_user_row`'s
+    behavior when `user.provider` is empty.
+    """
+    return f"{user.provider or 'unknown'}:{user.user_id}"
 
 
 # ─────────────────────────────────────────────
@@ -146,19 +166,20 @@ async def _ensure_db_user(user: User) -> Optional[str]:
     """
     if not user or not user.user_id:
         return None
-    cached_db_id = _ENSURED_USER_IDS.get(user.user_id)
+    cache_key = _user_cache_key(user)
+    cached_db_id = _ENSURED_USER_IDS.get(cache_key)
     if cached_db_id is not None:
         return cached_db_id
 
-    # Serialize concurrent first-time ensures for the SAME user_id so a
+    # Serialize concurrent first-time ensures for the SAME identity so a
     # second caller observes the first's committed row instead of
-    # racing through the cache miss → INSERT path. Per-user lock so
-    # unrelated users never block each other.
-    lock = _ENSURE_LOCKS.setdefault(user.user_id, asyncio.Lock())
+    # racing through the cache miss → INSERT path. Per-(provider,
+    # subject) lock so unrelated users never block each other.
+    lock = _ENSURE_LOCKS.setdefault(cache_key, asyncio.Lock())
     async with lock:
         # Re-check the cache inside the lock; the previous holder may
         # have just populated it.
-        cached_db_id = _ENSURED_USER_IDS.get(user.user_id)
+        cached_db_id = _ENSURED_USER_IDS.get(cache_key)
         if cached_db_id is not None:
             return cached_db_id
         try:
@@ -173,7 +194,7 @@ async def _ensure_db_user(user: User) -> Optional[str]:
             async with _SessionLocal() as session:
                 db_row = await ensure_user_row(session, user)
                 await session.commit()
-            _ENSURED_USER_IDS[user.user_id] = db_row.id
+            _ENSURED_USER_IDS[cache_key] = db_row.id
             return db_row.id
         except Exception as exc:  # noqa: BLE001
             logger.warning("ensure_user_row failed", user_id=user.user_id, error=str(exc))
@@ -188,19 +209,31 @@ async def _resolve_db_user_id(user: User) -> str:
     """
     if not user or not user.user_id:
         return ""
-    cached = _ENSURED_USER_IDS.get(user.user_id)
+    cached = _ENSURED_USER_IDS.get(_user_cache_key(user))
     if cached is not None:
         return cached
     resolved = await _ensure_db_user(user)
     return resolved or user.user_id
 
 
-def invalidate_user_ensured_cache(user_id: Optional[str] = None) -> None:
-    """Called after admin mutations so role changes are picked up promptly."""
-    if user_id is None:
+def invalidate_user_ensured_cache(
+    oauth_provider: Optional[str] = None,
+    oauth_subject: Optional[str] = None,
+) -> None:
+    """Pop the ensure-cache + lock for a single identity, or clear all
+    if neither argument is provided.
+
+    Called after admin mutations so role changes are picked up promptly.
+    Identity is the (oauth_provider, oauth_subject) composite — the same
+    shape used as the cache key.
+    """
+    if oauth_provider is None or oauth_subject is None:
         _ENSURED_USER_IDS.clear()
-    else:
-        _ENSURED_USER_IDS.pop(user_id, None)
+        _ENSURE_LOCKS.clear()
+        return
+    key = f"{oauth_provider or 'unknown'}:{oauth_subject}"
+    _ENSURED_USER_IDS.pop(key, None)
+    _ENSURE_LOCKS.pop(key, None)
 
 
 # ─────────────────────────────────────────────

--- a/src/main.py
+++ b/src/main.py
@@ -2301,6 +2301,7 @@ async def create_app():
                     await _session.commit()
         except Exception as e:
             logger.error("Runtime DB migration failed", error=str(e))
+            raise
 
         await TelemetryClient.send_event(
             Category.APPLICATION_STARTUP, MessageId.ORB_APP_STARTED

--- a/src/main.py
+++ b/src/main.py
@@ -2235,6 +2235,34 @@ async def create_app():
     # Add startup event handler
     @app.on_event("startup")
     async def startup_event():
+        # Hard-fail if the operator has configured multiple workers. The
+        # RBAC permission cache and the OAuth-subject→DB-id cache are
+        # both per-process; a second worker silently sees stale
+        # permissions for up to OPENRAG_PERM_CACHE_TTL seconds after
+        # role mutations. Until the cache moves to a shared backend
+        # (Redis), this constraint is real and must be enforced.
+        _workers = int(os.getenv("UVICORN_WORKERS", "1") or "1")
+        if _workers > 1:
+            logger.error(
+                "Multi-worker deployment unsupported until cache is "
+                "shared across processes. Set UVICORN_WORKERS=1.",
+                requested_workers=_workers,
+            )
+            raise RuntimeError("UVICORN_WORKERS>1 is not supported")
+        cache_backend = os.getenv("CACHE_BACKEND", "memory").lower()
+        if cache_backend not in ("memory",):
+            logger.error(
+                "Unsupported CACHE_BACKEND. Only 'memory' is wired.",
+                requested=cache_backend,
+            )
+            raise RuntimeError(f"unsupported CACHE_BACKEND={cache_backend!r}")
+        logger.info(
+            "Permission cache configured",
+            backend=cache_backend,
+            workers=_workers,
+            perm_cache_ttl_s=int(os.getenv("OPENRAG_PERM_CACHE_TTL", "60") or "60"),
+        )
+
         # Open the SQL engine on uvicorn's live loop (NOT the one used by
         # asyncio.run(create_app()) which closed already). All RBAC code
         # uses RBACService's lazy factory that reads db.engine.SessionLocal
@@ -2319,6 +2347,17 @@ async def create_app():
             Category.APPLICATION_SHUTDOWN, MessageId.ORB_APP_SHUTDOWN
         )
         logger.info("Application shutdown initiated")
+
+        # Drain any pending workspace_config DB-mirror tasks before we
+        # tear down the engine. Without this, a save_config triggered
+        # right before shutdown can be cancelled mid-write, leaving
+        # yaml and DB out of sync.
+        try:
+            wcs = services.get("workspace_config_service") if isinstance(services, dict) else None
+            if wcs is not None:
+                await wcs.await_pending_mirrors()
+        except Exception as e:  # noqa: BLE001
+            logger.error("Error awaiting pending DB mirrors", error=str(e))
 
         # Gracefully shutdown OpenSearch connection first
         try:

--- a/src/main.py
+++ b/src/main.py
@@ -2263,6 +2263,22 @@ async def create_app():
             perm_cache_ttl_s=int(os.getenv("OPENRAG_PERM_CACHE_TTL", "60") or "60"),
         )
 
+        # RBAC kill-switch visibility. OPENRAG_RBAC_ENFORCE=false makes
+        # every authenticated user effectively admin — log loudly so
+        # operators see it on every boot. Available in all run modes;
+        # the operator owns the trade-off.
+        from services.rbac_service import is_rbac_enforced
+        from utils.run_mode_utils import get_run_mode
+        if is_rbac_enforced():
+            logger.info("RBAC enforcement is ON", run_mode=get_run_mode())
+        else:
+            logger.warning(
+                "RBAC enforcement is DISABLED — every authenticated "
+                "user has full access via the OPENRAG_RBAC_ENFORCE=false "
+                "kill switch.",
+                run_mode=get_run_mode(),
+            )
+
         # Open the SQL engine on uvicorn's live loop (NOT the one used by
         # asyncio.run(create_app()) which closed already). All RBAC code
         # uses RBACService's lazy factory that reads db.engine.SessionLocal

--- a/src/main.py
+++ b/src/main.py
@@ -1474,6 +1474,7 @@ async def initialize_services():
     # the time the lifespan opens the engine.
     from db import engine as _db_engine_mod
     from services.rbac_service import RBACService
+    from services.workspace_config_service import WorkspaceConfigService
 
     def _lazy_session_factory():
         sl = _db_engine_mod.SessionLocal
@@ -1484,6 +1485,14 @@ async def initialize_services():
         return sl()
 
     rbac_service = RBACService(_lazy_session_factory)
+
+    # WorkspaceConfigService — DB-first reads of what config.yaml holds,
+    # with the legacy ConfigManager kept as the yaml fallback during
+    # Phase B (dual-write).
+    workspace_config_service = WorkspaceConfigService(
+        config_manager=config_manager,
+        session_factory=_lazy_session_factory,
+    )
 
     return {
         "document_service": document_service,
@@ -1502,6 +1511,7 @@ async def initialize_services():
         "langflow_mcp_service": langflow_mcp_service,
         "docling_service": clients.docling_service,
         "rbac_service": rbac_service,
+        "workspace_config_service": workspace_config_service,
     }
 
 
@@ -2067,8 +2077,11 @@ async def create_app():
     # ===== Users / RBAC Endpoints (JWT auth) =====
     from api import users as users_api
     from api.admin import rbac as admin_rbac
+    from api import config as config_api
     app.include_router(users_api.router)
     app.include_router(admin_rbac.router)
+    # Public — must work pre-auth so the onboarding wizard can render.
+    app.include_router(config_api.router)
 
     # ===== API Key Management Endpoints (JWT auth for UI) =====
     app.add_api_route(

--- a/src/main.py
+++ b/src/main.py
@@ -1,3 +1,4 @@
+import bootstrap  # noqa: F401  — must be first; loads .env + structured logging
 from contextlib import asynccontextmanager
 from utils.version_utils import OPENRAG_VERSION
 import asyncio
@@ -1461,6 +1462,29 @@ async def initialize_services():
     # API Key service for public API authentication
     api_key_service = APIKeyService(session_manager)
 
+    # ===== RBAC service =====
+    # We do NOT open the SQL engine here. `create_app()` runs inside an
+    # `asyncio.run(...)` whose loop is closed BEFORE uvicorn starts its
+    # own loop — any AsyncEngine bound to this loop would be dead by
+    # then. Instead, RBACService takes a *lazy* session-factory getter
+    # that resolves `db.engine.SessionLocal` at call time — that
+    # attribute is filled in by the lifespan startup event running on
+    # uvicorn's loop. Alembic upgrade is run synchronously from __main__
+    # before `asyncio.run(create_app())` so the schema is in place by
+    # the time the lifespan opens the engine.
+    from db import engine as _db_engine_mod
+    from services.rbac_service import RBACService
+
+    def _lazy_session_factory():
+        sl = _db_engine_mod.SessionLocal
+        if sl is None:
+            raise RuntimeError(
+                "DB engine not yet initialized. RBACService called before lifespan startup."
+            )
+        return sl()
+
+    rbac_service = RBACService(_lazy_session_factory)
+
     return {
         "document_service": document_service,
         "search_service": search_service,
@@ -1477,6 +1501,7 @@ async def initialize_services():
         "api_key_service": api_key_service,
         "langflow_mcp_service": langflow_mcp_service,
         "docling_service": clients.docling_service,
+        "rbac_service": rbac_service,
     }
 
 
@@ -1570,6 +1595,13 @@ async def lifespan(app: FastAPI):
 
     # 6. Global clients cleanup
     await clients.cleanup()
+
+    # 6b. SQL engine cleanup
+    try:
+        from db.engine import dispose_engine
+        await dispose_engine()
+    except Exception as e:
+        logger.error("Error disposing DB engine", error=str(e))
 
     # 7. Telemetry client cleanup
     from utils.telemetry.client import cleanup_telemetry_client
@@ -2032,6 +2064,12 @@ async def create_app():
         "/docling/health", docling.health, methods=["GET"], tags=["internal"]
     )
 
+    # ===== Users / RBAC Endpoints (JWT auth) =====
+    from api import users as users_api
+    from api.admin import rbac as admin_rbac
+    app.include_router(users_api.router)
+    app.include_router(admin_rbac.router)
+
     # ===== API Key Management Endpoints (JWT auth for UI) =====
     app.add_api_route(
         "/keys", api_keys.list_keys_endpoint, methods=["GET"], tags=["internal"]
@@ -2175,6 +2213,29 @@ async def create_app():
     # Add startup event handler
     @app.on_event("startup")
     async def startup_event():
+        # Open the SQL engine on uvicorn's live loop (NOT the one used by
+        # asyncio.run(create_app()) which closed already). All RBAC code
+        # uses RBACService's lazy factory that reads db.engine.SessionLocal
+        # at call time, so it will pick up the binding we set here.
+        try:
+            from db.engine import init_engine
+            init_engine()
+        except Exception as e:
+            logger.error("DB engine init failed at startup", error=str(e))
+            raise
+
+        # One-shot JSON->DB migration + test-fixture cleanup. Runs once
+        # per install, idempotent via migration_status rows.
+        try:
+            from db.engine import SessionLocal as _SL
+            from db.migrations_runtime import run as run_runtime_migration
+            if _SL is not None:
+                async with _SL() as _session:
+                    await run_runtime_migration(_session)
+                    await _session.commit()
+        except Exception as e:
+            logger.error("Runtime DB migration failed", error=str(e))
+
         await TelemetryClient.send_event(
             Category.APPLICATION_STARTUP, MessageId.ORB_APP_STARTED
         )
@@ -2318,6 +2379,22 @@ if __name__ == "__main__":
     # TUI check already handled at top of file
     # Register cleanup function
     atexit.register(cleanup)
+
+    # Run Alembic upgrade SYNCHRONOUSLY before the app builds. This
+    # avoids two pitfalls:
+    #   1. Alembic's env.py uses asyncio.run() which collides with a
+    #      live event loop.
+    #   2. Anything done inside `asyncio.run(create_app())` binds to a
+    #      loop that is closed before uvicorn starts — including DB
+    #      engines. Putting the schema migration here keeps the runtime
+    #      `init_engine()` deferred to the lifespan startup, on the
+    #      live uvicorn loop.
+    try:
+        from db.migrations_runtime import run_alembic_upgrade
+        run_alembic_upgrade("head")
+    except Exception as _e:
+        logger.error("Alembic upgrade failed at startup", error=str(_e))
+        raise
 
     # Create app asynchronously
     app = asyncio.run(create_app())

--- a/src/main.py
+++ b/src/main.py
@@ -1494,6 +1494,15 @@ async def initialize_services():
         session_factory=_lazy_session_factory,
     )
 
+    # Plumb the session factory into the two chat-history services
+    # (session_ownership + conversation_persistence). They lazy-resolve
+    # `db.engine.SessionLocal` as a fallback, but setting it here makes
+    # the wiring explicit and avoids the import path on the hot loop.
+    from services.session_ownership_service import session_ownership_service
+    from services.conversation_persistence_service import conversation_persistence
+    session_ownership_service._session_factory = _lazy_session_factory
+    conversation_persistence._session_factory = _lazy_session_factory
+
     return {
         "document_service": document_service,
         "search_service": search_service,

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -19,10 +19,12 @@ class ChatService:
         previous_response_id: str = None,
         stream: bool = False,
         filter_id: str = None,
+        storage_user_id: str = None,
     ):
         """Handle chat requests using the patched OpenAI client"""
         if not prompt:
             raise ValueError("Prompt is required")
+        conversation_user_id = storage_user_id or user_id
 
         # Set authentication context for this request so tools can access it
         if user_id and jwt_token:
@@ -32,7 +34,7 @@ class ChatService:
             return async_chat_stream(
                 clients.patched_llm_client,
                 prompt,
-                user_id,
+                conversation_user_id,
                 previous_response_id=previous_response_id,
                 filter_id=filter_id,
             )
@@ -40,7 +42,7 @@ class ChatService:
             response_text, response_id = await async_chat(
                 clients.patched_llm_client,
                 prompt,
-                user_id,
+                conversation_user_id,
                 previous_response_id=previous_response_id,
                 filter_id=filter_id,
             )
@@ -60,10 +62,12 @@ class ChatService:
         owner: str = None,
         owner_name: str = None,
         owner_email: str = None,
+        storage_user_id: str = None,
     ):
         """Handle Langflow chat requests"""
         if not prompt:
             raise ValueError("Prompt is required")
+        conversation_user_id = storage_user_id or user_id
 
         if not LANGFLOW_URL or not LANGFLOW_CHAT_FLOW_ID:
             raise ValueError(
@@ -158,7 +162,7 @@ class ChatService:
                 langflow_client,
                 LANGFLOW_CHAT_FLOW_ID,
                 prompt,
-                user_id,
+                conversation_user_id,
                 extra_headers=extra_headers,
                 previous_response_id=previous_response_id,
                 filter_id=filter_id,
@@ -170,7 +174,7 @@ class ChatService:
                 langflow_client,
                 LANGFLOW_CHAT_FLOW_ID,
                 prompt,
-                user_id,
+                conversation_user_id,
                 extra_headers=extra_headers,
                 previous_response_id=previous_response_id,
                 filter_id=filter_id,
@@ -190,8 +194,10 @@ class ChatService:
         filters: dict = None,
         limit: int = None,
         score_threshold: float = None,
+        storage_user_id: str = None,
     ):
         """Handle Langflow nudges chat requests with knowledge filters"""
+        conversation_user_id = storage_user_id or user_id
 
         if not LANGFLOW_URL or not NUDGES_FLOW_ID:
             raise ValueError(
@@ -283,7 +289,7 @@ class ChatService:
             from agent import get_conversation_thread
 
             conversation_history = get_conversation_thread(
-                user_id, previous_response_id
+                conversation_user_id, previous_response_id
             )
             if conversation_history:
                 conversation_history = "\n".join(
@@ -302,7 +308,7 @@ class ChatService:
             langflow_client,
             NUDGES_FLOW_ID,
             prompt,
-            user_id,
+            conversation_user_id,
             extra_headers=extra_headers,
             store_conversation=False,
         )
@@ -322,9 +328,11 @@ class ChatService:
         owner: str = None,
         owner_name: str = None,
         owner_email: str = None,
+        storage_user_id: str = None,
     ):
         """Send document content as user message to get proper response_id"""
         document_prompt = f"I'm uploading a document called '{filename}'. Here is its content:\n\n{document_content}\n\nPlease confirm you've received this document and are ready to answer questions about it."
+        conversation_user_id = storage_user_id or user_id
 
         if endpoint == "langflow":
             # Prepare extra headers for JWT authentication and embedding model
@@ -368,7 +376,7 @@ class ChatService:
             response_text, response_id = await async_chat(
                 clients.patched_llm_client,
                 document_prompt,
-                user_id,
+                conversation_user_id,
                 previous_response_id=previous_response_id,
             )
 

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -382,7 +382,7 @@ class ChatService:
             return {"error": "User ID is required", "conversations": []}
 
         # Get metadata from persistent storage
-        conversations_dict = get_user_conversations(user_id)
+        conversations_dict = await get_user_conversations(user_id)
 
         # Get in-memory conversations (with function calls)
         in_memory_conversations = active_conversations.get(user_id, {})
@@ -498,7 +498,7 @@ class ChatService:
 
         try:
             # 1. Get local conversation metadata (no actual messages stored here)
-            conversations_dict = get_user_conversations(user_id)
+            conversations_dict = await get_user_conversations(user_id)
             local_metadata = {}
 
             for response_id, conversation_metadata in conversations_dict.items():
@@ -667,8 +667,8 @@ class ChatService:
     async def delete_all_user_sessions(self, user_id: str):
         """Delete all sessions for a user from both local storage and Langflow"""
         from agent import get_user_conversations
-        
-        conversations = get_user_conversations(user_id)
+
+        conversations = await get_user_conversations(user_id)
         session_ids = list(conversations.keys())
         
         results = []

--- a/src/services/conversation_persistence_service.py
+++ b/src/services/conversation_persistence_service.py
@@ -3,11 +3,11 @@ bodies live in Langflow).
 
 Mode-aware (``OPENRAG_STORAGE_MODE`` from ``src/config/storage_mode.py``):
 
-| Mode    | Reads                | Writes              |
-|---------|----------------------|---------------------|
-| hybrid  | DB → JSON fallback   | DB + JSON dual      |
-| db      | DB only              | DB only — no JSON   |
-| files   | JSON only            | JSON only           |
+| Mode         | Reads                | Writes              |
+|--------------|----------------------|---------------------|
+| db (default) | DB only              | DB only — no JSON   |
+| hybrid       | DB → JSON fallback   | DB + JSON dual      |
+| files        | JSON only            | JSON only           |
 
 All public methods are async. Call sites in ``src/agent.py`` were
 flipped from sync to ``await`` as part of this migration.

--- a/src/services/conversation_persistence_service.py
+++ b/src/services/conversation_persistence_service.py
@@ -1,140 +1,329 @@
-"""
-Conversation Persistence Service
-Simple service to persist chat conversations to disk so they survive server restarts
+"""Conversation persistence — chat-history metadata only (full message
+bodies live in Langflow).
+
+Mode-aware (``OPENRAG_STORAGE_MODE`` from ``src/config/storage_mode.py``):
+
+| Mode    | Reads                | Writes              |
+|---------|----------------------|---------------------|
+| hybrid  | DB → JSON fallback   | DB + JSON dual      |
+| db      | DB only              | DB only — no JSON   |
+| files   | JSON only            | JSON only           |
+
+All public methods are async. Call sites in ``src/agent.py`` were
+flipped from sync to ``await`` as part of this migration.
 """
 
+from __future__ import annotations
+
+import asyncio
 import json
 import os
-import asyncio
-from typing import Dict, Any
-from datetime import datetime
 import threading
+from datetime import datetime
+from typing import Any, Callable, Dict, Optional
+
+from config.paths import get_data_file
+from config.storage_mode import (
+    db_writes_enabled,
+    file_writes_enabled,
+    get_storage_mode,
+)
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-class ConversationPersistenceService:
-    """Simple service to persist conversations to disk"""
 
-    def __init__(self, storage_file: str = None):
-        from config.paths import get_data_file
+class ConversationPersistenceService:
+    """Per-user chat-history index. Stores metadata only."""
+
+    def __init__(
+        self,
+        storage_file: Optional[str] = None,
+        session_factory: Optional[Callable] = None,
+    ):
         self.storage_file = storage_file or get_data_file("conversations.json")
-        # Ensure data directory exists
         os.makedirs(os.path.dirname(self.storage_file), exist_ok=True)
         self.lock = threading.Lock()
-        self._conversations = self._load_conversations()
-    
+        self._session_factory = session_factory
+        self._conversations: Dict[str, Dict[str, Any]] = self._load_conversations()
+
+    # ------------------------------------------------------------------
+    # JSON helpers
+    # ------------------------------------------------------------------
+
     def _load_conversations(self) -> Dict[str, Dict[str, Any]]:
-        """Load conversations from disk"""
         if os.path.exists(self.storage_file):
             try:
-                with open(self.storage_file, 'r', encoding='utf-8') as f:
-                    data = json.load(f)
-                    logger.debug(f"Loaded {self._count_total_conversations(data)} conversations from {self.storage_file}")
-                    return data
-            except Exception as e:
-                logger.error(f"Error loading conversations from {self.storage_file}: {e}")
+                with open(self.storage_file, "r", encoding="utf-8") as f:
+                    return json.load(f)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(f"Error loading conversations: {exc}")
                 return {}
         return {}
-    
-    def _save_conversations_sync(self):
-        """Synchronous save conversations to disk (runs in executor)"""
+
+    def _save_conversations_sync(self) -> None:
         try:
             with self.lock:
-                with open(self.storage_file, 'w', encoding='utf-8') as f:
-                    json.dump(self._conversations, f, indent=2, ensure_ascii=False, default=str)
-                logger.debug(f"Saved {self._count_total_conversations(self._conversations)} conversations to {self.storage_file}")
-        except Exception as e:
-            logger.error(f"Error saving conversations to {self.storage_file}: {e}")
-    
-    async def _save_conversations(self):
-        """Async save conversations to disk (non-blocking)"""
-        # Run the synchronous file I/O in a thread pool to avoid blocking the event loop
+                with open(self.storage_file, "w", encoding="utf-8") as f:
+                    json.dump(
+                        self._conversations,
+                        f,
+                        indent=2,
+                        ensure_ascii=False,
+                        default=str,
+                    )
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"Error saving conversations: {exc}")
+
+    async def _save_conversations(self) -> None:
         loop = asyncio.get_event_loop()
         await loop.run_in_executor(None, self._save_conversations_sync)
-    
-    def _count_total_conversations(self, data: Dict[str, Any]) -> int:
-        """Count total conversations across all users"""
-        total = 0
-        for user_conversations in data.values():
-            if isinstance(user_conversations, dict):
-                total += len(user_conversations)
-        return total
-    
-    def get_user_conversations(self, user_id: str) -> Dict[str, Any]:
-        """Get all conversations for a user"""
-        if user_id not in self._conversations:
-            self._conversations[user_id] = {}
-        return self._conversations[user_id]
-    
+
     def _serialize_datetime(self, obj: Any) -> Any:
-        """Recursively convert datetime objects to ISO strings for JSON serialization"""
         if isinstance(obj, datetime):
             return obj.isoformat()
-        elif isinstance(obj, dict):
-            return {key: self._serialize_datetime(value) for key, value in obj.items()}
-        elif isinstance(obj, list):
-            return [self._serialize_datetime(item) for item in obj]
-        else:
-            return obj
-    
-    async def store_conversation_thread(self, user_id: str, response_id: str, conversation_state: Dict[str, Any]):
-        """Store a conversation thread and persist to disk (async, non-blocking)"""
-        if user_id not in self._conversations:
-            self._conversations[user_id] = {}
-        
-        # Recursively convert datetime objects to strings for JSON serialization
-        serialized_conversation = self._serialize_datetime(conversation_state)
-        
-        self._conversations[user_id][response_id] = serialized_conversation
-        
-        # Save to disk asynchronously (non-blocking)
-        await self._save_conversations()
-    
-    def get_conversation_thread(self, user_id: str, response_id: str) -> Dict[str, Any]:
-        """Get a specific conversation thread"""
-        user_conversations = self.get_user_conversations(user_id)
-        return user_conversations.get(response_id, {})
-    
-    async def delete_conversation_thread(self, user_id: str, response_id: str) -> bool:
-        """Delete a specific conversation thread (async, non-blocking)"""
-        if user_id in self._conversations and response_id in self._conversations[user_id]:
-            del self._conversations[user_id][response_id]
+        if isinstance(obj, dict):
+            return {k: self._serialize_datetime(v) for k, v in obj.items()}
+        if isinstance(obj, list):
+            return [self._serialize_datetime(x) for x in obj]
+        return obj
+
+    def _count_total(self, data: Dict[str, Any]) -> int:
+        total = 0
+        for user_conv in data.values():
+            if isinstance(user_conv, dict):
+                total += len(user_conv)
+        return total
+
+    # ------------------------------------------------------------------
+    # Public async API
+    # ------------------------------------------------------------------
+
+    async def get_user_conversations(self, user_id: str) -> Dict[str, Any]:
+        mode = get_storage_mode()
+        if mode == "files":
+            if user_id not in self._conversations:
+                self._conversations[user_id] = {}
+            return self._conversations[user_id]
+
+        # db / hybrid — DB read first
+        db_payload = await self._db_get_for_user(user_id)
+        if mode == "db":
+            return db_payload
+
+        # hybrid — merge JSON entries that aren't yet in DB
+        merged = dict(db_payload)
+        for resp_id, payload in self._conversations.get(user_id, {}).items():
+            merged.setdefault(resp_id, payload)
+        return merged
+
+    async def store_conversation_thread(
+        self,
+        user_id: str,
+        response_id: str,
+        conversation_state: Dict[str, Any],
+    ) -> None:
+        serialized = self._serialize_datetime(conversation_state)
+
+        if file_writes_enabled():
+            if user_id not in self._conversations:
+                self._conversations[user_id] = {}
+            self._conversations[user_id][response_id] = serialized
             await self._save_conversations()
-            logger.debug(f"Deleted conversation {response_id} for user {user_id}")
-            return True
-        return False
-    
-    async def clear_user_conversations(self, user_id: str):
-        """Clear all conversations for a user (async, non-blocking)"""
-        if user_id in self._conversations:
+
+        if db_writes_enabled():
+            await self._db_upsert(user_id, response_id, serialized)
+
+    async def get_conversation_thread(
+        self, user_id: str, response_id: str
+    ) -> Dict[str, Any]:
+        mode = get_storage_mode()
+        if mode != "files":
+            payload = await self._db_get_one(response_id, user_id)
+            if payload is not None:
+                return payload
+            if mode == "db":
+                return {}
+        # files or hybrid-with-no-db-row → JSON
+        return self._conversations.get(user_id, {}).get(response_id, {})
+
+    async def delete_conversation_thread(
+        self, user_id: str, response_id: str
+    ) -> bool:
+        deleted = False
+
+        if file_writes_enabled():
+            if (
+                user_id in self._conversations
+                and response_id in self._conversations[user_id]
+            ):
+                del self._conversations[user_id][response_id]
+                await self._save_conversations()
+                deleted = True
+
+        if db_writes_enabled():
+            db_deleted = await self._db_delete(response_id, user_id)
+            deleted = deleted or db_deleted
+
+        return deleted
+
+    async def clear_user_conversations(self, user_id: str) -> None:
+        if file_writes_enabled() and user_id in self._conversations:
             del self._conversations[user_id]
             await self._save_conversations()
-            logger.debug(f"Cleared all conversations for user {user_id}")
-    
-    def get_storage_stats(self) -> Dict[str, Any]:
-        """Get statistics about stored conversations"""
-        total_users = len(self._conversations)
-        total_conversations = self._count_total_conversations(self._conversations)
-        
-        user_stats = {}
-        for user_id, conversations in self._conversations.items():
-            user_stats[user_id] = {
-                'conversation_count': len(conversations),
-                'latest_activity': max(
-                    (conv.get('last_activity', '') for conv in conversations.values()),
-                    default=''
-                )
+
+        if db_writes_enabled():
+            await self._db_delete_all(user_id)
+
+    async def get_storage_stats(self) -> Dict[str, Any]:
+        # Snapshot — uses whichever storage the mode prioritizes.
+        mode = get_storage_mode()
+        if mode == "files":
+            return {
+                "total_users": len(self._conversations),
+                "total_conversations": self._count_total(self._conversations),
+                "storage_file": self.storage_file,
+                "file_exists": os.path.exists(self.storage_file),
             }
-        
+        # db / hybrid summary from DB
+        try:
+            from db.models import Conversation
+            from sqlalchemy import select, func
+
+            sess_factory = self._resolve_session_factory()
+            if sess_factory is None:
+                return {"total_users": 0, "total_conversations": 0}
+            async with sess_factory() as session:
+                total = (
+                    await session.execute(select(func.count(Conversation.response_id)))
+                ).scalar_one()
+                users = (
+                    await session.execute(
+                        select(func.count(func.distinct(Conversation.user_id)))
+                    )
+                ).scalar_one()
+            return {
+                "total_users": int(users or 0),
+                "total_conversations": int(total or 0),
+                "storage_file": self.storage_file,
+                "file_exists": os.path.exists(self.storage_file),
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("conversation stats DB read failed", error=str(exc))
+            return {"total_users": 0, "total_conversations": 0}
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_session_factory(self):
+        if self._session_factory is not None:
+            return self._session_factory
+        try:
+            from db.engine import SessionLocal
+            return SessionLocal
+        except Exception:  # noqa: BLE001
+            return None
+
+    @staticmethod
+    def _payload_from_row(row) -> Dict[str, Any]:
         return {
-            'total_users': total_users,
-            'total_conversations': total_conversations,
-            'storage_file': self.storage_file,
-            'file_exists': os.path.exists(self.storage_file),
-            'user_stats': user_stats
+            "response_id": row.response_id,
+            "title": row.title,
+            "endpoint": row.endpoint,
+            "previous_response_id": row.previous_response_id,
+            "filter_id": row.filter_id,
+            "total_messages": row.total_messages or 0,
+            "created_at": row.created_at.isoformat() if row.created_at else None,
+            "last_activity": row.last_activity.isoformat() if row.last_activity else None,
         }
 
+    async def _db_upsert(
+        self, user_id: str, response_id: str, payload: Dict[str, Any]
+    ) -> None:
+        from db.repositories import ConversationRepo
 
-# Global instance
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return
+        try:
+            async with sess_factory() as session:
+                repo = ConversationRepo(session)
+                await repo.upsert(
+                    response_id=response_id,
+                    user_id=user_id,
+                    title=payload.get("title"),
+                    endpoint=payload.get("endpoint"),
+                    previous_response_id=payload.get("previous_response_id"),
+                    filter_id=payload.get("filter_id"),
+                    total_messages=int(payload.get("total_messages") or 0),
+                )
+                await session.commit()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("DB store_conversation failed", error=str(exc))
+
+    async def _db_get_for_user(self, user_id: str) -> Dict[str, Dict[str, Any]]:
+        from db.repositories import ConversationRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return {}
+        try:
+            async with sess_factory() as session:
+                rows = await ConversationRepo(session).list_for_user(user_id)
+            return {r.response_id: self._payload_from_row(r) for r in rows}
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("DB get_for_user failed", error=str(exc))
+            return {}
+
+    async def _db_get_one(
+        self, response_id: str, user_id: str
+    ) -> Optional[Dict[str, Any]]:
+        from db.repositories import ConversationRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return None
+        try:
+            async with sess_factory() as session:
+                row = await ConversationRepo(session).get(response_id)
+            if row is None or row.user_id != user_id:
+                return None
+            return self._payload_from_row(row)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("DB get_one failed", error=str(exc))
+            return None
+
+    async def _db_delete(self, response_id: str, user_id: str) -> bool:
+        from db.repositories import ConversationRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return False
+        try:
+            async with sess_factory() as session:
+                ok = await ConversationRepo(session).delete(response_id, user_id)
+                await session.commit()
+                return ok
+        except Exception as exc:  # noqa: BLE001
+            logger.error("DB delete failed", error=str(exc))
+            return False
+
+    async def _db_delete_all(self, user_id: str) -> int:
+        from db.repositories import ConversationRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return 0
+        try:
+            async with sess_factory() as session:
+                n = await ConversationRepo(session).delete_all_for_user(user_id)
+                await session.commit()
+                return n
+        except Exception as exc:  # noqa: BLE001
+            logger.error("DB delete_all failed", error=str(exc))
+            return 0
+
+
+# Global instance — session_factory plumbed in main.py at startup.
 conversation_persistence = ConversationPersistenceService()

--- a/src/services/rbac_service.py
+++ b/src/services/rbac_service.py
@@ -1,0 +1,116 @@
+"""RBAC chokepoint.
+
+Every permission decision in OpenRAG goes through `RBACService.has_permission`
+or `RBACService.get_user_permissions`. Keeping a single class here is what
+makes a future swap to Casbin / OpenFGA / SpiceDB a one-class refactor
+rather than a sweep across every route handler.
+
+Permissions are cached per-process for `OPENRAG_PERM_CACHE_TTL` seconds
+(default 60). Cache invalidates explicitly on role/permission mutations.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+from cachetools import TTLCache
+from fastapi import HTTPException
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.repositories import AuditRepo, RoleRepo
+from session_manager import User
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _cache_ttl() -> int:
+    try:
+        return int(os.getenv("OPENRAG_PERM_CACHE_TTL", "60"))
+    except ValueError:
+        return 60
+
+
+class RBACService:
+    def __init__(self, session_factory) -> None:
+        self._session_factory = session_factory
+        self._cache: TTLCache[str, frozenset[str]] = TTLCache(
+            maxsize=1024, ttl=_cache_ttl()
+        )
+
+    # ---------------- public API ---------------------------------------
+
+    async def get_user_permissions(
+        self,
+        user_id: str,
+        role_override: Optional[list[str]] = None,
+    ) -> set[str]:
+        """Resolve the permission set for a user.
+
+        If `role_override` is provided (e.g. via API key snapshot), it
+        replaces the user's live role membership and bypasses the cache.
+        """
+        if role_override is not None:
+            async with self._session_factory() as session:
+                role_repo = RoleRepo(session)
+                return await role_repo.list_permissions_for_role_ids(role_override)
+
+        cached = self._cache.get(user_id)
+        if cached is not None:
+            return set(cached)
+
+        async with self._session_factory() as session:
+            role_repo = RoleRepo(session)
+            perms = await role_repo.list_permissions_for_user(user_id)
+
+        self._cache[user_id] = frozenset(perms)
+        return perms
+
+    async def has_permission(
+        self,
+        user_id: str,
+        perm: str,
+        role_override: Optional[list[str]] = None,
+    ) -> bool:
+        return perm in await self.get_user_permissions(user_id, role_override)
+
+    async def assert_owner_or_perm(
+        self,
+        user: User,
+        owner_id: Optional[str],
+        owned_perm: str,
+        any_perm: str,
+        role_override: Optional[list[str]] = None,
+    ) -> None:
+        """Self-or-elevated check used by /delete:own etc. Raises 403 on miss."""
+        perms = await self.get_user_permissions(user.user_id, role_override)
+        if any_perm in perms:
+            return
+        if owner_id == user.user_id and owned_perm in perms:
+            return
+        await self.audit_denied(user.user_id, f"({owned_perm}|{any_perm})")
+        raise HTTPException(
+            status_code=403,
+            detail={"error": "permission_denied", "required": [owned_perm, any_perm]},
+        )
+
+    async def audit_denied(self, user_id: Optional[str], required: str) -> None:
+        try:
+            async with self._session_factory() as session:
+                audit = AuditRepo(session)
+                await audit.write(
+                    event="permission.denied",
+                    actor_user_id=user_id,
+                    audit_metadata={"required": required},
+                )
+                await session.commit()
+        except Exception as exc:  # noqa: BLE001
+            # Audit failure must never break the request flow.
+            logger.warning("audit_denied write failed", error=str(exc))
+
+    def invalidate(self, user_id: str) -> None:
+        self._cache.pop(user_id, None)
+
+    def invalidate_all(self) -> None:
+        self._cache.clear()

--- a/src/services/rbac_service.py
+++ b/src/services/rbac_service.py
@@ -32,6 +32,23 @@ def _cache_ttl() -> int:
         return 60
 
 
+def is_rbac_enforced() -> bool:
+    """Whether ``require_permission`` should actually check permissions.
+
+    Default: ``false`` — RBAC is **opt-in**. Out of the box OpenRAG
+    behaves exactly like the pre-RBAC release: any authenticated user
+    has full access; API-key role overrides are also bypassed. This is
+    intentional so single-user OSS installs and migration paths don't
+    need any RBAC ceremony.
+
+    Set ``OPENRAG_RBAC_ENFORCE=true`` to turn the permissions system
+    on for multi-user deployments. Available in all ``OPENRAG_RUN_MODE``
+    values; operators own the trade-off.
+    """
+    raw = os.getenv("OPENRAG_RBAC_ENFORCE", "false").strip().lower()
+    return raw in ("true", "1", "yes", "on")
+
+
 class RBACService:
     def __init__(self, session_factory) -> None:
         self._session_factory = session_factory
@@ -83,7 +100,14 @@ class RBACService:
         any_perm: str,
         role_override: Optional[list[str]] = None,
     ) -> None:
-        """Self-or-elevated check used by /delete:own etc. Raises 403 on miss."""
+        """Self-or-elevated check used by /delete:own etc. Raises 403 on miss.
+
+        When ``OPENRAG_RBAC_ENFORCE=false`` this returns immediately —
+        every authenticated user passes every gate, matching the
+        bypass in ``dependencies.require_permission``.
+        """
+        if not is_rbac_enforced():
+            return
         perms = await self.get_user_permissions(user.user_id, role_override)
         if any_perm in perms:
             return

--- a/src/services/rbac_service.py
+++ b/src/services/rbac_service.py
@@ -108,12 +108,13 @@ class RBACService:
         """
         if not is_rbac_enforced():
             return
-        perms = await self.get_user_permissions(user.user_id, role_override)
+        actor_user_id = getattr(user, "db_user_id", None) or user.user_id
+        perms = await self.get_user_permissions(actor_user_id, role_override)
         if any_perm in perms:
             return
-        if owner_id == user.user_id and owned_perm in perms:
+        if owner_id == actor_user_id and owned_perm in perms:
             return
-        await self.audit_denied(user.user_id, f"({owned_perm}|{any_perm})")
+        await self.audit_denied(actor_user_id, f"({owned_perm}|{any_perm})")
         raise HTTPException(
             status_code=403,
             detail={"error": "permission_denied", "required": [owned_perm, any_perm]},

--- a/src/services/session_ownership_service.py
+++ b/src/services/session_ownership_service.py
@@ -1,112 +1,261 @@
-"""
-Session Ownership Service
-Simple service that tracks which user owns which session
+"""Session Ownership Service.
+
+Tracks which user owns which chat session. Mode-aware:
+
+| OPENRAG_STORAGE_MODE | Reads                          | Writes                |
+|----------------------|--------------------------------|-----------------------|
+| hybrid (default)     | DB → JSON fallback             | DB + JSON dual-write  |
+| db                   | DB only — JSON ignored         | DB only — no JSON     |
+| files (legacy)       | JSON only                      | JSON only             |
+
+All public methods are async. Call sites in ``src/agent.py`` were
+flipped from sync to ``await`` as part of this migration.
 """
 
+from __future__ import annotations
+
+import asyncio
 import json
 import os
-from typing import Dict, List, Optional
 from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional
+
+from config.paths import get_data_file
+from config.storage_mode import (
+    db_writes_enabled,
+    file_writes_enabled,
+    get_storage_mode,
+)
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-class SessionOwnershipService:
-    """Simple service to track which user owns which session"""
 
-    def __init__(self):
-        from config.paths import get_data_file
+class SessionOwnershipService:
+    """Tracks which user owns which session."""
+
+    def __init__(self, session_factory: Optional[Callable] = None):
         self.ownership_file = get_data_file("session_ownership.json")
-        # Ensure data directory exists
         os.makedirs(os.path.dirname(self.ownership_file), exist_ok=True)
-        self.ownership_data = self._load_ownership_data()
-    
-    def _load_ownership_data(self) -> Dict[str, Dict[str, any]]:
-        """Load session ownership data from JSON file"""
+        self._session_factory = session_factory
+        # JSON cache — eagerly loaded so `files` and `hybrid` modes
+        # behave like the legacy implementation.
+        self.ownership_data: Dict[str, Dict[str, Any]] = (
+            self._load_ownership_data()
+        )
+
+    # ------------------------------------------------------------------
+    # JSON helpers (legacy + hybrid fallback)
+    # ------------------------------------------------------------------
+
+    def _load_ownership_data(self) -> Dict[str, Dict[str, Any]]:
         if os.path.exists(self.ownership_file):
             try:
-                with open(self.ownership_file, 'r') as f:
+                with open(self.ownership_file, "r") as f:
                     return json.load(f)
-            except Exception as e:
-                logger.error(f"Error loading session ownership data: {e}")
+            except Exception as exc:  # noqa: BLE001
+                logger.error(f"Error loading session ownership data: {exc}")
                 return {}
         return {}
-    
-    def _save_ownership_data(self):
-        """Save session ownership data to JSON file"""
-        try:
-            with open(self.ownership_file, 'w') as f:
-                json.dump(self.ownership_data, f, indent=2)
-            logger.debug(f"Saved session ownership data to {self.ownership_file}")
-        except Exception as e:
-            logger.error(f"Error saving session ownership data: {e}")
-    
-    def claim_session(self, user_id: str, session_id: str):
-        """Claim a session for a user"""
-        if session_id not in self.ownership_data:
-            self.ownership_data[session_id] = {
-                "user_id": user_id,
-                "created_at": datetime.now().isoformat(),
-                "last_accessed": datetime.now().isoformat()
-            }
-            self._save_ownership_data()
-            logger.debug(f"Claimed session {session_id} for user {user_id}")
-        else:
-            # Update last accessed time
-            self.ownership_data[session_id]["last_accessed"] = datetime.now().isoformat()
-            self._save_ownership_data()
-    
-    def get_session_owner(self, session_id: str) -> Optional[str]:
-        """Get the user ID that owns a session"""
-        session_data = self.ownership_data.get(session_id)
-        return session_data.get("user_id") if session_data else None
-    
-    def get_user_sessions(self, user_id: str) -> List[str]:
-        """Get all sessions owned by a user"""
-        return [
-            session_id 
-            for session_id, session_data in self.ownership_data.items()
-            if session_data.get("user_id") == user_id
-        ]
-    
-    def is_session_owned_by_user(self, session_id: str, user_id: str) -> bool:
-        """Check if a session is owned by a specific user"""
-        return self.get_session_owner(session_id) == user_id
-    
-    def filter_sessions_for_user(self, session_ids: List[str], user_id: str) -> List[str]:
-        """Filter a list of sessions to only include those owned by the user"""
-        user_sessions = self.get_user_sessions(user_id)
-        return [session for session in session_ids if session in user_sessions]
 
-    def release_session(self, user_id: str, session_id: str) -> bool:
-        """Release a session from a user (delete ownership record)"""
-        if session_id in self.ownership_data:
-            # Verify the user owns this session before deleting
+    def _save_ownership_data(self) -> None:
+        try:
+            with open(self.ownership_file, "w") as f:
+                json.dump(self.ownership_data, f, indent=2)
+        except Exception as exc:  # noqa: BLE001
+            logger.error(f"Error saving session ownership data: {exc}")
+
+    # ------------------------------------------------------------------
+    # Public async API
+    # ------------------------------------------------------------------
+
+    async def claim_session(self, user_id: str, session_id: str) -> None:
+        if file_writes_enabled():
+            now = datetime.utcnow().isoformat()
+            if session_id not in self.ownership_data:
+                self.ownership_data[session_id] = {
+                    "user_id": user_id,
+                    "created_at": now,
+                    "last_accessed": now,
+                }
+            else:
+                self.ownership_data[session_id]["last_accessed"] = now
+            self._save_ownership_data()
+
+        if db_writes_enabled():
+            await self._db_claim(user_id, session_id)
+
+    async def get_session_owner(self, session_id: str) -> Optional[str]:
+        mode = get_storage_mode()
+        if mode != "files":
+            owner = await self._db_get_owner(session_id)
+            if owner is not None:
+                return owner
+            if mode == "db":
+                return None
+        # files or hybrid-with-no-db-row → fall back to JSON
+        data = self.ownership_data.get(session_id)
+        return data.get("user_id") if data else None
+
+    async def get_user_sessions(self, user_id: str) -> List[str]:
+        mode = get_storage_mode()
+        if mode != "files":
+            db_sessions = await self._db_list_for_user(user_id)
+            if mode == "db":
+                return db_sessions
+            # hybrid: union with JSON-only entries
+            json_sessions = [
+                sid
+                for sid, data in self.ownership_data.items()
+                if data.get("user_id") == user_id
+            ]
+            return list(dict.fromkeys(db_sessions + json_sessions))
+        # files mode
+        return [
+            sid
+            for sid, data in self.ownership_data.items()
+            if data.get("user_id") == user_id
+        ]
+
+    async def is_session_owned_by_user(
+        self, session_id: str, user_id: str
+    ) -> bool:
+        return (await self.get_session_owner(session_id)) == user_id
+
+    async def filter_sessions_for_user(
+        self, session_ids: List[str], user_id: str
+    ) -> List[str]:
+        owned = set(await self.get_user_sessions(user_id))
+        return [sid for sid in session_ids if sid in owned]
+
+    async def release_session(self, user_id: str, session_id: str) -> bool:
+        released = False
+
+        if file_writes_enabled() and session_id in self.ownership_data:
             if self.ownership_data[session_id].get("user_id") == user_id:
                 del self.ownership_data[session_id]
                 self._save_ownership_data()
-                logger.debug(f"Released session {session_id} from user {user_id}")
-                return True
+                released = True
             else:
-                logger.warning(f"User {user_id} tried to release session {session_id} they don't own")
-                return False
-        return False
-    
-    def get_ownership_stats(self) -> Dict[str, any]:
-        """Get statistics about session ownership"""
-        users = set()
-        for session_data in self.ownership_data.values():
-            users.add(session_data.get("user_id"))
-        
-        return {
-            "total_tracked_sessions": len(self.ownership_data),
-            "unique_users": len(users),
-            "sessions_per_user": {
-                user: len(self.get_user_sessions(user))
-                for user in users if user
+                logger.warning(
+                    f"User {user_id} tried to release session "
+                    f"{session_id} they don't own (json)"
+                )
+
+        if db_writes_enabled():
+            db_released = await self._db_release(session_id, user_id)
+            released = released or db_released
+
+        return released
+
+    async def get_ownership_stats(self) -> Dict[str, Any]:
+        mode = get_storage_mode()
+        if mode == "files":
+            users = {
+                d.get("user_id")
+                for d in self.ownership_data.values()
+                if d.get("user_id")
             }
-        }
+            return {
+                "total_tracked_sessions": len(self.ownership_data),
+                "unique_users": len(users),
+                "sessions_per_user": {
+                    u: len([s for s, d in self.ownership_data.items() if d.get("user_id") == u])
+                    for u in users
+                },
+            }
+        # db / hybrid — best-effort summary from DB only
+        try:
+            from db.models import SessionOwnership
+            from sqlalchemy import select
+
+            sess_factory = self._resolve_session_factory()
+            if sess_factory is None:
+                return {"total_tracked_sessions": 0, "unique_users": 0}
+            async with sess_factory() as session:
+                result = await session.execute(select(SessionOwnership))
+                rows = result.scalars().all()
+            users: Dict[str, int] = {}
+            for r in rows:
+                users[r.user_id] = users.get(r.user_id, 0) + 1
+            return {
+                "total_tracked_sessions": len(rows),
+                "unique_users": len(users),
+                "sessions_per_user": users,
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("ownership stats DB read failed", error=str(exc))
+            return {"total_tracked_sessions": 0, "unique_users": 0}
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    def _resolve_session_factory(self):
+        if self._session_factory is not None:
+            return self._session_factory
+        # Lazy: try the module-level SessionLocal
+        try:
+            from db.engine import SessionLocal
+            return SessionLocal
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def _db_claim(self, user_id: str, session_id: str) -> None:
+        from db.repositories import SessionOwnershipRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return
+        try:
+            async with sess_factory() as session:
+                await SessionOwnershipRepo(session).claim(session_id, user_id)
+                await session.commit()
+        except Exception as exc:  # noqa: BLE001
+            logger.error("DB claim_session failed", error=str(exc))
+
+    async def _db_get_owner(self, session_id: str) -> Optional[str]:
+        from db.repositories import SessionOwnershipRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return None
+        try:
+            async with sess_factory() as session:
+                row = await SessionOwnershipRepo(session).get(session_id)
+                return row.user_id if row else None
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("DB get_session_owner failed", error=str(exc))
+            return None
+
+    async def _db_list_for_user(self, user_id: str) -> List[str]:
+        from db.repositories import SessionOwnershipRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return []
+        try:
+            async with sess_factory() as session:
+                return await SessionOwnershipRepo(session).list_for_user(user_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("DB list_for_user failed", error=str(exc))
+            return []
+
+    async def _db_release(self, session_id: str, user_id: str) -> bool:
+        from db.repositories import SessionOwnershipRepo
+
+        sess_factory = self._resolve_session_factory()
+        if sess_factory is None:
+            return False
+        try:
+            async with sess_factory() as session:
+                ok = await SessionOwnershipRepo(session).release(session_id, user_id)
+                await session.commit()
+                return ok
+        except Exception as exc:  # noqa: BLE001
+            logger.error("DB release_session failed", error=str(exc))
+            return False
 
 
-# Global instance
+# Global instance — session_factory plumbed in main.py at startup.
 session_ownership_service = SessionOwnershipService()

--- a/src/services/session_ownership_service.py
+++ b/src/services/session_ownership_service.py
@@ -4,8 +4,8 @@ Tracks which user owns which chat session. Mode-aware:
 
 | OPENRAG_STORAGE_MODE | Reads                          | Writes                |
 |----------------------|--------------------------------|-----------------------|
-| hybrid (default)     | DB → JSON fallback             | DB + JSON dual-write  |
-| db                   | DB only — JSON ignored         | DB only — no JSON     |
+| db (default)         | DB only — JSON ignored         | DB only — no JSON     |
+| hybrid               | DB → JSON fallback             | DB + JSON dual-write  |
 | files (legacy)       | JSON only                      | JSON only             |
 
 All public methods are async. Call sites in ``src/agent.py`` were

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -106,25 +106,22 @@ async def ensure_user_row(session: AsyncSession, user: User) -> UserRow:
     try:
         await user_repo.add(row)
     except IntegrityError:
-        # Race or pre-existing row. Roll back and look the row up by
-        # any of its three unique constraints — (oauth_provider,
-        # oauth_subject), email_lookup_hash, or id (PK). Whichever
-        # matches is the row we should use.
+        # The collision could be on any of the three unique constraints:
+        # (oauth_provider, oauth_subject), email_lookup_hash, or id (PK).
+        # Only the FIRST means we hit our own identity (same logical
+        # user via concurrent insert by a peer process); the latter two
+        # mean a *different* identity already owns that id or email.
         await session.rollback()
         existing = await user_repo.get_by_oauth(provider, subject)
-        if existing is None and user.email:
-            # email_lookup_hash UNIQUE collision — same user identified
-            # by email; reuse it instead of trying to insert a sibling.
-            existing = await user_repo.get_by_email(user.email)
-        if existing is None:
-            existing = await user_repo.get_by_id(new_id)
         if existing:
             await user_repo.update_last_login(existing.id)
             return existing
-        # Genuine PK collision across providers (different subject string,
-        # same id). Retry with a UUID id; oauth_provider/subject and
-        # email differ from the conflicting row, so the unique constraints
-        # won't fire again.
+        # PK collision across providers (different subject chose the
+        # same id). Retry with a UUID id; (provider, subject) and email
+        # differ from the conflicting row so this insert succeeds.
+        # email_lookup_hash collision is NOT recoverable here — that's
+        # a real conflict (two identities with the same email) and we
+        # let it propagate to the caller.
         new_id = str(uuid.uuid4())
         row = UserRow(
             id=new_id,

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -1,0 +1,187 @@
+"""User lifecycle service.
+
+Single chokepoint for "given an authenticated principal, make sure a row
+exists in the users table and assign a default role." Race-safe via a
+serialized SQL transaction. Idempotent.
+
+ensure_user_row is intentionally synchronous on its critical section so
+parallel sign-ins from the same provider/subject collapse into a single
+INSERT (the unique constraint on (oauth_provider, oauth_subject) does the
+heavy lifting; we catch IntegrityError and re-fetch).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from typing import Optional
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db.models import User as UserRow
+from db.repositories import AuditRepo, RoleRepo, UserRepo
+from session_manager import User
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _default_new_user_role() -> str:
+    return os.getenv("OPENRAG_DEFAULT_ROLE", "user")
+
+
+def _noauth_role() -> str:
+    return os.getenv("OPENRAG_NOAUTH_ROLE", "admin")
+
+
+async def ensure_user_row(session: AsyncSession, user: User) -> UserRow:
+    """Ensure the authenticated `user` exists in the SQL `users` table.
+
+    First-ever user gets the `admin` role. All subsequent users get the
+    role named in `OPENRAG_DEFAULT_ROLE` (default `user`). The synthetic
+    no-auth user is granted `OPENRAG_NOAUTH_ROLE` (default `admin`).
+
+    Returns the persisted UserRow. Caller commits.
+    """
+
+    if not user or not user.user_id:
+        raise ValueError("ensure_user_row requires a user with a user_id")
+
+    user_repo = UserRepo(session)
+    role_repo = RoleRepo(session)
+    audit_repo = AuditRepo(session)
+
+    provider = user.provider or "unknown"
+    subject = user.user_id
+
+    existing = await user_repo.get_by_oauth(provider, subject)
+    if existing:
+        await user_repo.update_last_login(existing.id)
+        return existing
+
+    # Possible legacy row (oauth_provider='legacy', oauth_subject==user_id)
+    legacy = await user_repo.get_by_oauth("legacy", subject)
+    if legacy is None and user.email:
+        # Or a legacy row matched by email_lookup_hash from a prior sign-in
+        by_email = await user_repo.get_by_email(user.email)
+        if by_email and by_email.oauth_provider == "legacy":
+            legacy = by_email
+
+    if legacy is not None:
+        merged = await user_repo.merge_legacy(
+            legacy,
+            real_provider=provider,
+            real_subject=subject,
+            email=user.email,
+            display_name=user.name,
+            picture_url=user.picture,
+        )
+        await audit_repo.write(
+            event="user.merged_legacy",
+            actor_user_id=merged.id,
+            target_type="user",
+            target_id=merged.id,
+            audit_metadata={"provider": provider},
+        )
+        # Legacy rows had no role assignment — give them the default.
+        await _assign_bootstrap_or_default(session, role_repo, audit_repo, merged.id)
+        return merged
+
+    # Brand-new row.
+    # We use the OAuth subject (== user.user_id) as the DB primary key so
+    # the SQL `users.id` lines up with the JWT subject and with the
+    # user_id strings already used by connections.json / conversations.json.
+    # If a different provider ever sign-ins with the same subject string we
+    # fall back to a UUID — extremely rare in practice.
+    new_id = subject if subject else str(uuid.uuid4())
+    row = UserRow(
+        id=new_id,
+        oauth_provider=provider,
+        oauth_subject=subject,
+        email=user.email,
+        display_name=user.name,
+        picture_url=user.picture,
+    )
+    try:
+        await user_repo.add(row)
+    except IntegrityError:
+        await session.rollback()
+        existing = await user_repo.get_by_oauth(provider, subject)
+        if existing:
+            await user_repo.update_last_login(existing.id)
+            return existing
+        # Primary-key collision across providers — retry with UUID.
+        new_id = str(uuid.uuid4())
+        row = UserRow(
+            id=new_id,
+            oauth_provider=provider,
+            oauth_subject=subject,
+            email=user.email,
+            display_name=user.name,
+            picture_url=user.picture,
+        )
+        await user_repo.add(row)
+
+    await _assign_bootstrap_or_default(session, role_repo, audit_repo, row.id)
+    return row
+
+
+async def _assign_bootstrap_or_default(
+    session: AsyncSession,
+    role_repo: RoleRepo,
+    audit_repo: AuditRepo,
+    user_id: str,
+) -> None:
+    admin_count = await role_repo.count_admins()
+    if admin_count == 0:
+        admin_role = await role_repo.get_by_name("admin")
+        if admin_role is None:
+            logger.warning("admin role not seeded; skipping bootstrap assignment")
+            return
+        await role_repo.assign_role(user_id, admin_role.id)
+        await audit_repo.write(
+            event="user.bootstrap_admin",
+            actor_user_id=user_id,
+            target_type="user",
+            target_id=user_id,
+        )
+        return
+
+    # No-auth synthetic user -> configurable role
+    if user_id == "anonymous":
+        target_name = _noauth_role()
+    else:
+        target_name = _default_new_user_role()
+
+    role = await role_repo.get_by_name(target_name)
+    if role is None:
+        logger.warning(
+            "default role not found, skipping role assignment",
+            role_name=target_name,
+            user_id=user_id,
+        )
+        return
+    await role_repo.assign_role(user_id, role.id)
+    await audit_repo.write(
+        event="user.created",
+        actor_user_id=user_id,
+        target_type="user",
+        target_id=user_id,
+        audit_metadata={"role": target_name},
+    )
+
+
+async def get_effective_provider_keys(session: AsyncSession, user_id: str) -> dict:
+    """Phase-4 helper. Returns a dict of provider -> overrides for this user.
+
+    Phase 1 ships a no-op shape so call sites can be wired without behavior
+    change. Phase 4 will fill it in by reading user_preferences.provider_overrides
+    and overlaying onto config_manager's workspace defaults.
+    """
+    return {}
+
+
+async def get_effective_agent_config(session: AsyncSession, user_id: str) -> Optional[dict]:
+    """Phase-4 helper. Returns the per-user agent config overlay (or None)."""
+    return None

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -106,12 +106,25 @@ async def ensure_user_row(session: AsyncSession, user: User) -> UserRow:
     try:
         await user_repo.add(row)
     except IntegrityError:
+        # Race or pre-existing row. Roll back and look the row up by
+        # any of its three unique constraints — (oauth_provider,
+        # oauth_subject), email_lookup_hash, or id (PK). Whichever
+        # matches is the row we should use.
         await session.rollback()
         existing = await user_repo.get_by_oauth(provider, subject)
+        if existing is None and user.email:
+            # email_lookup_hash UNIQUE collision — same user identified
+            # by email; reuse it instead of trying to insert a sibling.
+            existing = await user_repo.get_by_email(user.email)
+        if existing is None:
+            existing = await user_repo.get_by_id(new_id)
         if existing:
             await user_repo.update_last_login(existing.id)
             return existing
-        # Primary-key collision across providers — retry with UUID.
+        # Genuine PK collision across providers (different subject string,
+        # same id). Retry with a UUID id; oauth_provider/subject and
+        # email differ from the conflicting row, so the unique constraints
+        # won't fire again.
         new_id = str(uuid.uuid4())
         row = UserRow(
             id=new_id,

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -140,13 +140,32 @@ async def _assign_bootstrap_or_default(
             logger.warning("admin role not seeded; skipping bootstrap assignment")
             return
         await role_repo.assign_role(user_id, admin_role.id)
-        await audit_repo.write(
-            event="user.bootstrap_admin",
-            actor_user_id=user_id,
-            target_type="user",
-            target_id=user_id,
-        )
-        return
+        await session.flush()
+
+        # Race-detect: a concurrent caller may have *also* observed
+        # admin_count == 0 and granted admin to a different user. Both
+        # writes succeeded (no DB-level mutex). Resolve by lexicographic
+        # tie-break — only the smallest user_id keeps admin; others
+        # demote and fall through to the default-role path. This is
+        # portable across SQLite and Postgres without advisory locks.
+        admins = await role_repo.list_admin_user_ids()
+        if len(admins) > 1 and min(admins) != user_id:
+            await role_repo.revoke_role(user_id, admin_role.id)
+            await session.flush()
+            logger.warning(
+                "bootstrap race detected; demoted to default role",
+                user_id=user_id,
+                winner=min(admins),
+            )
+            # Fall through to the default-role assignment block below.
+        else:
+            await audit_repo.write(
+                event="user.bootstrap_admin",
+                actor_user_id=user_id,
+                target_type="user",
+                target_id=user_id,
+            )
+            return
 
     # No-auth synthetic user -> configurable role
     if user_id == "anonymous":

--- a/src/services/workspace_config_service.py
+++ b/src/services/workspace_config_service.py
@@ -1,29 +1,40 @@
 """DB-backed workspace config — replaces ``config.yaml`` as the source
-of truth, with yaml kept as a fallback during the Phase B transition.
+of truth, with yaml kept as a fallback when storage mode is `hybrid`.
 
-Mirrors the existing ``ConfigManager`` API surface
-(``load_config`` / ``get_config`` / ``reload_config`` / ``save_config_file``
-/ ``update_onboarding_state``) so call sites in the API layer don't need
+Honors the unified ``OPENRAG_STORAGE_MODE`` flag (see
+``src/config/storage_mode.py``):
+
+| Mode    | Reads             | Writes               |
+|---------|-------------------|----------------------|
+| hybrid  | DB → yaml fallback| DB + yaml (default)  |
+| db      | DB only           | DB only — yaml ignored, never written |
+| files   | yaml only         | yaml only            |
+
+Mirrors the existing ``ConfigManager`` API surface (``load_config`` /
+``get_config`` / ``reload_config`` / ``save_config_file`` /
+``update_onboarding_state``) so call sites in ``src/api/`` don't need
 rewrites. Adds two new helpers (``is_onboarded``, ``get_onboarding_step``)
 that the new public ``GET /api/onboarding-status`` endpoint uses.
 
-Phase B (this PR) — read DB first, fall back to yaml; write to BOTH
-DB and yaml on every save. Phase C (next release) drops the yaml path.
-
-Kill switch: set OPENRAG_DISABLE_DB_WORKSPACE_CONFIG=true to bypass the
-DB entirely and operate exactly like the legacy ConfigManager. Intended
-as a fast rollback if anything goes wrong in production.
+In `hybrid` and `db` modes a one-time monkey-patch on ``config_manager``
+intercepts every legacy ``save_config_file`` / ``update_onboarding_state``
+call so the DB stays in sync without each call site needing changes.
+In `files` mode the patch is not installed.
 """
 
 from __future__ import annotations
 
 import asyncio
-import os
 from typing import Any, Optional
 
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from config.config_manager import ConfigManager, OpenRAGConfig
+from config.storage_mode import (
+    db_writes_enabled,
+    file_writes_enabled,
+    get_storage_mode,
+)
 from db.repositories import WorkspaceConfigRepo
 from utils.encryption import encrypt_secret
 from utils.logging_config import get_logger
@@ -31,21 +42,9 @@ from utils.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-_SECTIONS_FROM_CONFIG = ("providers", "knowledge", "agent", "onboarding")
-
-
-def _kill_switch_on() -> bool:
-    return os.getenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", "").lower() in (
-        "true", "1", "yes",
-    )
-
-
 class WorkspaceConfigService:
     """Drop-in replacement for the parts of ConfigManager that touch
-    persistence. Delegates to the legacy ConfigManager for yaml writes
-    and installs a monkey-patch on it so EVERY yaml save/update —
-    including legacy call sites in src/api/settings.py — auto-mirrors
-    to the SQL workspace_config table fire-and-forget."""
+    persistence. Behavior selected by ``OPENRAG_STORAGE_MODE``."""
 
     def __init__(
         self,
@@ -54,80 +53,29 @@ class WorkspaceConfigService:
     ):
         self._cm = config_manager
         self._session_factory = session_factory
-        if not _kill_switch_on():
+        if db_writes_enabled():
             self._install_yaml_write_hooks()
-
-    # ------------------------------------------------------------------
-    # Auto-mirror hook (covers legacy callers that bypass this service)
-    # ------------------------------------------------------------------
-
-    def _install_yaml_write_hooks(self) -> None:
-        """Wrap config_manager.save_config_file + update_onboarding_state
-        so any successful yaml write schedules an async DB mirror.
-
-        Idempotent — guarded by an `_db_mirror_installed` flag on the
-        config_manager instance so re-instantiating the service (e.g.
-        in tests) doesn't double-patch.
-        """
-        cm = self._cm
-        if getattr(cm, "_db_mirror_installed", False):
-            return
-
-        original_save = cm.save_config_file
-        original_update_ob = cm.update_onboarding_state
-
-        def patched_save(config=None, preserve_edited: bool = False) -> bool:
-            ok = original_save(config, preserve_edited=preserve_edited)
-            if ok:
-                self._schedule_mirror()
-            return ok
-
-        def patched_update_ob(**kwargs) -> bool:
-            ok = original_update_ob(**kwargs)
-            if ok:
-                self._schedule_mirror()
-            return ok
-
-        cm.save_config_file = patched_save  # type: ignore[method-assign]
-        cm.update_onboarding_state = patched_update_ob  # type: ignore[method-assign]
-        cm._db_mirror_installed = True  # type: ignore[attr-defined]
-        logger.info("WorkspaceConfigService: yaml-write → DB mirror hooks installed")
-
-    def _schedule_mirror(self) -> None:
-        """Fire-and-forget DB mirror of the current config_manager state.
-
-        Runs as an asyncio Task on whatever loop is currently active
-        (uvicorn's request loop in production). Failures are logged but
-        never propagate back to the synchronous yaml writer.
-
-        If called from a context with no running loop (e.g. a test that
-        invokes save_config_file synchronously), the mirror is skipped —
-        the next async-aware caller (load_config / explicit save_config)
-        will catch up.
-        """
-        try:
-            loop = asyncio.get_running_loop()
-        except RuntimeError:
-            return  # no loop, no mirror — boot-time migration handles backfill
-
-        async def _do_mirror():
-            try:
-                await self._mirror_to_db(self._cm.get_config())
-            except Exception as exc:  # noqa: BLE001
-                logger.warning("DB mirror after yaml save failed", error=str(exc))
-
-        loop.create_task(_do_mirror())
+        logger.info(
+            "WorkspaceConfigService initialized",
+            storage_mode=get_storage_mode(),
+        )
 
     # ------------------------------------------------------------------
     # Read paths
     # ------------------------------------------------------------------
 
     async def load_config(self) -> OpenRAGConfig:
-        """DB-first read. Falls back to yaml when DB is empty or the
-        kill-switch is on. Updates the underlying ConfigManager cache so
-        synchronous call sites (``get_openrag_config()``) see the same
-        view as DB readers."""
-        if _kill_switch_on():
+        """Mode-aware read.
+
+        - ``files``: yaml only.
+        - ``db``: DB only — empty DB returns defaults, yaml is ignored.
+        - ``hybrid``: DB-first, yaml fallback when DB is empty.
+
+        Updates the ConfigManager in-process cache so synchronous
+        ``get_openrag_config()`` callers see the same data.
+        """
+        mode = get_storage_mode()
+        if mode == "files":
             return self._cm.load_config()
 
         try:
@@ -135,21 +83,23 @@ class WorkspaceConfigService:
                 repo = WorkspaceConfigRepo(session)
                 rows = await repo.list_all()
         except Exception as exc:  # noqa: BLE001
+            if mode == "db":
+                logger.error("DB read failed in db mode — returning defaults", error=str(exc))
+                return OpenRAGConfig.from_dict({})
             logger.warning(
-                "workspace_config DB read failed, falling back to yaml",
+                "DB read failed, falling back to yaml (hybrid)",
                 error=str(exc),
             )
             return self._cm.load_config()
 
         if not rows:
-            # No DB rows yet (pre-migration boot or fresh install). Use
-            # yaml as authority; the migration will populate the DB on
-            # first chance.
-            return self._cm.load_config()
+            if mode == "db":
+                # Pre-migration boot in pure-db mode — return defaults.
+                # The boot-time migration (config_yaml_to_db_v1) will
+                # populate the DB on the next request.
+                return OpenRAGConfig.from_dict({})
+            return self._cm.load_config()  # hybrid fallback
 
-        # Build a config_data dict matching what ConfigManager.from_dict
-        # expects, then hand off so all the existing decryption /
-        # default-merging logic stays in one place.
         merged: dict[str, Any] = {
             "providers": rows.get("providers", {}),
             "knowledge": rows.get("knowledge", {}),
@@ -158,9 +108,6 @@ class WorkspaceConfigService:
             "edited": (rows.get("meta") or {}).get("edited", False),
         }
         config = OpenRAGConfig.from_dict(merged)
-
-        # Keep the legacy in-process cache aligned with the DB so
-        # synchronous get_openrag_config() callers see the same data.
         self._cm._config = config
         return config
 
@@ -174,7 +121,8 @@ class WorkspaceConfigService:
         return await self.load_config()
 
     async def is_onboarded(self) -> bool:
-        if _kill_switch_on():
+        mode = get_storage_mode()
+        if mode == "files":
             return self._cm.load_config().edited
 
         try:
@@ -184,16 +132,17 @@ class WorkspaceConfigService:
                 if "edited" in meta:
                     return bool(meta["edited"])
         except Exception as exc:  # noqa: BLE001
-            logger.debug("is_onboarded DB read failed, falling back to yaml", error=str(exc))
+            logger.debug("is_onboarded DB read failed", error=str(exc))
 
-        # Fall back to yaml
+        if mode == "db":
+            return False  # no yaml fallback in pure-db mode
         return self._cm.load_config().edited
 
     async def get_onboarding_step(self) -> Optional[Any]:
         """Returns the legacy step indicator — usually an int index from
-        the OnboardingState dataclass, sometimes None. Callers should
-        treat the value as opaque."""
-        if _kill_switch_on():
+        the OnboardingState dataclass, sometimes None. Treat as opaque."""
+        mode = get_storage_mode()
+        if mode == "files":
             return self._cm.load_config().onboarding.current_step
 
         try:
@@ -205,10 +154,12 @@ class WorkspaceConfigService:
         except Exception as exc:  # noqa: BLE001
             logger.debug("get_onboarding_step DB read failed", error=str(exc))
 
+        if mode == "db":
+            return None
         return self._cm.load_config().onboarding.current_step
 
     # ------------------------------------------------------------------
-    # Write paths (dual-write during Phase B)
+    # Write paths
     # ------------------------------------------------------------------
 
     async def save_config(
@@ -218,27 +169,33 @@ class WorkspaceConfigService:
         preserve_edited: bool = False,
         actor_user_id: Optional[str] = None,
     ) -> bool:
-        """Write to both yaml and DB. Yaml goes via the patched
-        ``config_manager.save_config_file`` (which schedules a
-        fire-and-forget DB mirror). For stronger consistency we then
-        ALSO await the DB mirror synchronously so callers can rely on
-        ``is_onboarded()`` reflecting the new state immediately on
-        return. Idempotent upserts so the duplicate write is safe."""
-        try:
-            ok = self._cm.save_config_file(config, preserve_edited=preserve_edited)
-            if not ok:
-                return False
-        except Exception as exc:  # noqa: BLE001
-            logger.error("save_config: yaml write failed", error=str(exc))
-            return False
+        mode = get_storage_mode()
 
-        if _kill_switch_on():
+        # Yaml write — only when file_writes are enabled.
+        if file_writes_enabled():
+            try:
+                ok = self._cm.save_config_file(config, preserve_edited=preserve_edited)
+                if not ok:
+                    return False
+            except Exception as exc:  # noqa: BLE001
+                logger.error("save_config: yaml write failed", error=str(exc))
+                return False
+        else:
+            # In `db` mode we still need to update the in-process
+            # ConfigManager cache and flip `edited` so callers see the
+            # new state via the legacy synchronous ``get_openrag_config()``.
+            self._apply_in_memory(config, preserve_edited=preserve_edited)
+
+        if not db_writes_enabled():
             return True
 
         try:
             await self._mirror_to_db(self._cm.get_config(), actor_user_id=actor_user_id)
         except Exception as exc:  # noqa: BLE001
-            logger.error("save_config: explicit DB mirror failed", error=str(exc))
+            if mode == "db":
+                logger.error("save_config: DB write failed in db mode", error=str(exc))
+                return False
+            logger.error("save_config: DB mirror failed (yaml ok)", error=str(exc))
         return True
 
     async def update_onboarding_state(
@@ -246,26 +203,129 @@ class WorkspaceConfigService:
         actor_user_id: Optional[str] = None,
         **kwargs: Any,
     ) -> bool:
-        try:
-            ok = self._cm.update_onboarding_state(**kwargs)
-            if not ok:
-                return False
-        except Exception as exc:  # noqa: BLE001
-            logger.error("update_onboarding_state: yaml failed", error=str(exc))
-            return False
+        mode = get_storage_mode()
 
-        if _kill_switch_on():
+        if file_writes_enabled():
+            try:
+                ok = self._cm.update_onboarding_state(**kwargs)
+                if not ok:
+                    return False
+            except Exception as exc:  # noqa: BLE001
+                logger.error("update_onboarding_state: yaml failed", error=str(exc))
+                return False
+        else:
+            # In-memory only update for db mode
+            cfg = self._cm.get_config()
+            for k, v in kwargs.items():
+                if hasattr(cfg.onboarding, k):
+                    setattr(cfg.onboarding, k, v)
+
+        if not db_writes_enabled():
             return True
 
         try:
             await self._mirror_to_db(self._cm.get_config(), actor_user_id=actor_user_id)
         except Exception as exc:  # noqa: BLE001
-            logger.error("update_onboarding_state: explicit DB mirror failed", error=str(exc))
+            if mode == "db":
+                logger.error("update_onboarding_state: DB write failed in db mode", error=str(exc))
+                return False
+            logger.error("update_onboarding_state: DB mirror failed", error=str(exc))
         return True
+
+    # ------------------------------------------------------------------
+    # Auto-mirror hook (covers legacy callers that bypass this service)
+    # ------------------------------------------------------------------
+
+    def _install_yaml_write_hooks(self) -> None:
+        """Wrap ``config_manager.save_config_file`` and
+        ``update_onboarding_state`` so legacy callers in
+        ``src/api/settings.py`` (and elsewhere) auto-mirror to the DB
+        without per-call-site changes.
+
+        In ``db`` mode the patch SKIPS the underlying yaml write but
+        still updates the in-process cache and schedules the DB mirror —
+        so ``config_manager`` stays internally consistent without
+        creating ``config.yaml``.
+        """
+        cm = self._cm
+        if getattr(cm, "_db_mirror_installed", False):
+            return
+
+        original_save = cm.save_config_file
+        original_update_ob = cm.update_onboarding_state
+
+        def patched_save(config=None, preserve_edited: bool = False) -> bool:
+            mode = get_storage_mode()
+            if mode == "db":
+                # Don't write yaml; only update memory + schedule mirror.
+                self._apply_in_memory(config, preserve_edited=preserve_edited)
+                self._schedule_mirror()
+                return True
+            ok = original_save(config, preserve_edited=preserve_edited)
+            if ok and db_writes_enabled():
+                self._schedule_mirror()
+            return ok
+
+        def patched_update_ob(**kwargs) -> bool:
+            mode = get_storage_mode()
+            if mode == "db":
+                cfg = cm.get_config()
+                for k, v in kwargs.items():
+                    if hasattr(cfg.onboarding, k):
+                        setattr(cfg.onboarding, k, v)
+                self._schedule_mirror()
+                return True
+            ok = original_update_ob(**kwargs)
+            if ok and db_writes_enabled():
+                self._schedule_mirror()
+            return ok
+
+        cm.save_config_file = patched_save  # type: ignore[method-assign]
+        cm.update_onboarding_state = patched_update_ob  # type: ignore[method-assign]
+        cm._db_mirror_installed = True  # type: ignore[attr-defined]
+        logger.info(
+            "WorkspaceConfigService: yaml-write hooks installed",
+            mode=get_storage_mode(),
+        )
 
     # ------------------------------------------------------------------
     # Internals
     # ------------------------------------------------------------------
+
+    def _apply_in_memory(
+        self,
+        config: Optional[OpenRAGConfig],
+        preserve_edited: bool,
+    ) -> None:
+        """Mirror the in-process effects of ``ConfigManager.save_config_file``
+        WITHOUT touching disk — used in `db` mode so callers still see
+        the cache change."""
+        if config is None:
+            config = self._cm.get_config()
+        if not preserve_edited:
+            config.edited = True
+        self._cm._config = config
+
+    def _schedule_mirror(self) -> None:
+        """Fire-and-forget DB mirror of the current config_manager state.
+
+        Runs as an asyncio Task on whatever loop is currently active.
+        Failures are logged but don't propagate to the synchronous
+        caller. If there's no running loop (sync test context), the
+        mirror is skipped — the next async-aware caller catches up.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+
+        async def _do_mirror():
+            try:
+                await self._mirror_to_db(self._cm.get_config())
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("DB mirror after yaml save failed", error=str(exc))
+
+        loop.create_task(_do_mirror())
 
     async def _mirror_to_db(
         self,
@@ -273,16 +333,11 @@ class WorkspaceConfigService:
         *,
         actor_user_id: Optional[str] = None,
     ) -> None:
-        """Upsert all sections + meta. Provider api_keys are re-encrypted
-        with the JSON envelope so the DB never sees plaintext."""
         config_dict = config.to_dict()
 
         providers = dict(config_dict.get("providers", {}))
         for prov_name, prov_data in providers.items():
             if isinstance(prov_data, dict) and "api_key" in prov_data and prov_data["api_key"]:
-                # Re-encrypt to keep the on-disk and in-DB envelopes in
-                # the same shape (encrypt_secret is a no-op when the
-                # master key is unset, matching ConfigManager behavior).
                 prov_data["api_key"] = encrypt_secret(prov_data["api_key"])
             providers[prov_name] = prov_data
 

--- a/src/services/workspace_config_service.py
+++ b/src/services/workspace_config_service.py
@@ -1,0 +1,301 @@
+"""DB-backed workspace config — replaces ``config.yaml`` as the source
+of truth, with yaml kept as a fallback during the Phase B transition.
+
+Mirrors the existing ``ConfigManager`` API surface
+(``load_config`` / ``get_config`` / ``reload_config`` / ``save_config_file``
+/ ``update_onboarding_state``) so call sites in the API layer don't need
+rewrites. Adds two new helpers (``is_onboarded``, ``get_onboarding_step``)
+that the new public ``GET /api/onboarding-status`` endpoint uses.
+
+Phase B (this PR) — read DB first, fall back to yaml; write to BOTH
+DB and yaml on every save. Phase C (next release) drops the yaml path.
+
+Kill switch: set OPENRAG_DISABLE_DB_WORKSPACE_CONFIG=true to bypass the
+DB entirely and operate exactly like the legacy ConfigManager. Intended
+as a fast rollback if anything goes wrong in production.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Optional
+
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from config.config_manager import ConfigManager, OpenRAGConfig
+from db.repositories import WorkspaceConfigRepo
+from utils.encryption import encrypt_secret
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+_SECTIONS_FROM_CONFIG = ("providers", "knowledge", "agent", "onboarding")
+
+
+def _kill_switch_on() -> bool:
+    return os.getenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", "").lower() in (
+        "true", "1", "yes",
+    )
+
+
+class WorkspaceConfigService:
+    """Drop-in replacement for the parts of ConfigManager that touch
+    persistence. Delegates to the legacy ConfigManager for yaml writes
+    and installs a monkey-patch on it so EVERY yaml save/update —
+    including legacy call sites in src/api/settings.py — auto-mirrors
+    to the SQL workspace_config table fire-and-forget."""
+
+    def __init__(
+        self,
+        config_manager: ConfigManager,
+        session_factory: async_sessionmaker,
+    ):
+        self._cm = config_manager
+        self._session_factory = session_factory
+        if not _kill_switch_on():
+            self._install_yaml_write_hooks()
+
+    # ------------------------------------------------------------------
+    # Auto-mirror hook (covers legacy callers that bypass this service)
+    # ------------------------------------------------------------------
+
+    def _install_yaml_write_hooks(self) -> None:
+        """Wrap config_manager.save_config_file + update_onboarding_state
+        so any successful yaml write schedules an async DB mirror.
+
+        Idempotent — guarded by an `_db_mirror_installed` flag on the
+        config_manager instance so re-instantiating the service (e.g.
+        in tests) doesn't double-patch.
+        """
+        cm = self._cm
+        if getattr(cm, "_db_mirror_installed", False):
+            return
+
+        original_save = cm.save_config_file
+        original_update_ob = cm.update_onboarding_state
+
+        def patched_save(config=None, preserve_edited: bool = False) -> bool:
+            ok = original_save(config, preserve_edited=preserve_edited)
+            if ok:
+                self._schedule_mirror()
+            return ok
+
+        def patched_update_ob(**kwargs) -> bool:
+            ok = original_update_ob(**kwargs)
+            if ok:
+                self._schedule_mirror()
+            return ok
+
+        cm.save_config_file = patched_save  # type: ignore[method-assign]
+        cm.update_onboarding_state = patched_update_ob  # type: ignore[method-assign]
+        cm._db_mirror_installed = True  # type: ignore[attr-defined]
+        logger.info("WorkspaceConfigService: yaml-write → DB mirror hooks installed")
+
+    def _schedule_mirror(self) -> None:
+        """Fire-and-forget DB mirror of the current config_manager state.
+
+        Runs as an asyncio Task on whatever loop is currently active
+        (uvicorn's request loop in production). Failures are logged but
+        never propagate back to the synchronous yaml writer.
+
+        If called from a context with no running loop (e.g. a test that
+        invokes save_config_file synchronously), the mirror is skipped —
+        the next async-aware caller (load_config / explicit save_config)
+        will catch up.
+        """
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return  # no loop, no mirror — boot-time migration handles backfill
+
+        async def _do_mirror():
+            try:
+                await self._mirror_to_db(self._cm.get_config())
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("DB mirror after yaml save failed", error=str(exc))
+
+        loop.create_task(_do_mirror())
+
+    # ------------------------------------------------------------------
+    # Read paths
+    # ------------------------------------------------------------------
+
+    async def load_config(self) -> OpenRAGConfig:
+        """DB-first read. Falls back to yaml when DB is empty or the
+        kill-switch is on. Updates the underlying ConfigManager cache so
+        synchronous call sites (``get_openrag_config()``) see the same
+        view as DB readers."""
+        if _kill_switch_on():
+            return self._cm.load_config()
+
+        try:
+            async with self._session_factory() as session:
+                repo = WorkspaceConfigRepo(session)
+                rows = await repo.list_all()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "workspace_config DB read failed, falling back to yaml",
+                error=str(exc),
+            )
+            return self._cm.load_config()
+
+        if not rows:
+            # No DB rows yet (pre-migration boot or fresh install). Use
+            # yaml as authority; the migration will populate the DB on
+            # first chance.
+            return self._cm.load_config()
+
+        # Build a config_data dict matching what ConfigManager.from_dict
+        # expects, then hand off so all the existing decryption /
+        # default-merging logic stays in one place.
+        merged: dict[str, Any] = {
+            "providers": rows.get("providers", {}),
+            "knowledge": rows.get("knowledge", {}),
+            "agent": rows.get("agent", {}),
+            "onboarding": rows.get("onboarding", {}),
+            "edited": (rows.get("meta") or {}).get("edited", False),
+        }
+        config = OpenRAGConfig.from_dict(merged)
+
+        # Keep the legacy in-process cache aligned with the DB so
+        # synchronous get_openrag_config() callers see the same data.
+        self._cm._config = config
+        return config
+
+    async def get_config(self) -> OpenRAGConfig:
+        if self._cm._config is not None:
+            return self._cm._config
+        return await self.load_config()
+
+    async def reload_config(self) -> OpenRAGConfig:
+        self._cm._config = None
+        return await self.load_config()
+
+    async def is_onboarded(self) -> bool:
+        if _kill_switch_on():
+            return self._cm.load_config().edited
+
+        try:
+            async with self._session_factory() as session:
+                repo = WorkspaceConfigRepo(session)
+                meta = await repo.get_section("meta") or {}
+                if "edited" in meta:
+                    return bool(meta["edited"])
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("is_onboarded DB read failed, falling back to yaml", error=str(exc))
+
+        # Fall back to yaml
+        return self._cm.load_config().edited
+
+    async def get_onboarding_step(self) -> Optional[Any]:
+        """Returns the legacy step indicator — usually an int index from
+        the OnboardingState dataclass, sometimes None. Callers should
+        treat the value as opaque."""
+        if _kill_switch_on():
+            return self._cm.load_config().onboarding.current_step
+
+        try:
+            async with self._session_factory() as session:
+                repo = WorkspaceConfigRepo(session)
+                ob = await repo.get_section("onboarding") or {}
+                if "current_step" in ob:
+                    return ob.get("current_step")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("get_onboarding_step DB read failed", error=str(exc))
+
+        return self._cm.load_config().onboarding.current_step
+
+    # ------------------------------------------------------------------
+    # Write paths (dual-write during Phase B)
+    # ------------------------------------------------------------------
+
+    async def save_config(
+        self,
+        config: Optional[OpenRAGConfig] = None,
+        *,
+        preserve_edited: bool = False,
+        actor_user_id: Optional[str] = None,
+    ) -> bool:
+        """Write to both yaml and DB. Yaml goes via the patched
+        ``config_manager.save_config_file`` (which schedules a
+        fire-and-forget DB mirror). For stronger consistency we then
+        ALSO await the DB mirror synchronously so callers can rely on
+        ``is_onboarded()`` reflecting the new state immediately on
+        return. Idempotent upserts so the duplicate write is safe."""
+        try:
+            ok = self._cm.save_config_file(config, preserve_edited=preserve_edited)
+            if not ok:
+                return False
+        except Exception as exc:  # noqa: BLE001
+            logger.error("save_config: yaml write failed", error=str(exc))
+            return False
+
+        if _kill_switch_on():
+            return True
+
+        try:
+            await self._mirror_to_db(self._cm.get_config(), actor_user_id=actor_user_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("save_config: explicit DB mirror failed", error=str(exc))
+        return True
+
+    async def update_onboarding_state(
+        self,
+        actor_user_id: Optional[str] = None,
+        **kwargs: Any,
+    ) -> bool:
+        try:
+            ok = self._cm.update_onboarding_state(**kwargs)
+            if not ok:
+                return False
+        except Exception as exc:  # noqa: BLE001
+            logger.error("update_onboarding_state: yaml failed", error=str(exc))
+            return False
+
+        if _kill_switch_on():
+            return True
+
+        try:
+            await self._mirror_to_db(self._cm.get_config(), actor_user_id=actor_user_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("update_onboarding_state: explicit DB mirror failed", error=str(exc))
+        return True
+
+    # ------------------------------------------------------------------
+    # Internals
+    # ------------------------------------------------------------------
+
+    async def _mirror_to_db(
+        self,
+        config: OpenRAGConfig,
+        *,
+        actor_user_id: Optional[str] = None,
+    ) -> None:
+        """Upsert all sections + meta. Provider api_keys are re-encrypted
+        with the JSON envelope so the DB never sees plaintext."""
+        config_dict = config.to_dict()
+
+        providers = dict(config_dict.get("providers", {}))
+        for prov_name, prov_data in providers.items():
+            if isinstance(prov_data, dict) and "api_key" in prov_data and prov_data["api_key"]:
+                # Re-encrypt to keep the on-disk and in-DB envelopes in
+                # the same shape (encrypt_secret is a no-op when the
+                # master key is unset, matching ConfigManager behavior).
+                prov_data["api_key"] = encrypt_secret(prov_data["api_key"])
+            providers[prov_name] = prov_data
+
+        sections = {
+            "providers": providers,
+            "knowledge": config_dict.get("knowledge", {}),
+            "agent": config_dict.get("agent", {}),
+            "onboarding": config_dict.get("onboarding", {}),
+            "meta": {"edited": bool(config_dict.get("edited", False))},
+        }
+
+        async with self._session_factory() as session:
+            repo = WorkspaceConfigRepo(session)
+            for section, value in sections.items():
+                await repo.upsert(section, value, actor_user_id=actor_user_id)
+            await session.commit()

--- a/src/services/workspace_config_service.py
+++ b/src/services/workspace_config_service.py
@@ -53,12 +53,29 @@ class WorkspaceConfigService:
     ):
         self._cm = config_manager
         self._session_factory = session_factory
+        # Track in-flight DB-mirror tasks so the lifespan shutdown can
+        # await them, and serialize them so rapid double-saves don't
+        # race on the DB.
+        self._mirror_lock = asyncio.Lock()
+        self._pending_mirrors: set[asyncio.Task] = set()
         if db_writes_enabled():
             self._install_yaml_write_hooks()
         logger.info(
             "WorkspaceConfigService initialized",
             storage_mode=get_storage_mode(),
         )
+
+    async def await_pending_mirrors(self) -> None:
+        """Block until every pending mirror task has finished.
+
+        Called from the lifespan shutdown handler so we don't drop
+        in-flight DB writes when uvicorn cancels remaining tasks.
+        """
+        if not self._pending_mirrors:
+            return
+        pending = list(self._pending_mirrors)
+        logger.info("awaiting pending DB mirror tasks", count=len(pending))
+        await asyncio.gather(*pending, return_exceptions=True)
 
     # ------------------------------------------------------------------
     # Read paths
@@ -251,8 +268,18 @@ class WorkspaceConfigService:
         if getattr(cm, "_db_mirror_installed", False):
             return
 
-        original_save = cm.save_config_file
-        original_update_ob = cm.update_onboarding_state
+        # Pin the *truly original* unpatched methods on the cm BEFORE
+        # any patching happens. Test cleanup may delete
+        # `_db_mirror_installed` to force re-install — without this
+        # capture-once attribute, the second install would close over
+        # the FIRST install's patched method, building an
+        # ever-deepening closure chain.
+        if not hasattr(cm, "_db_mirror_original_save"):
+            cm._db_mirror_original_save = cm.save_config_file  # type: ignore[attr-defined]
+            cm._db_mirror_original_update_ob = cm.update_onboarding_state  # type: ignore[attr-defined]
+
+        original_save = cm._db_mirror_original_save
+        original_update_ob = cm._db_mirror_original_update_ob
 
         def patched_save(config=None, preserve_edited: bool = False) -> bool:
             mode = get_storage_mode()
@@ -309,23 +336,38 @@ class WorkspaceConfigService:
     def _schedule_mirror(self) -> None:
         """Fire-and-forget DB mirror of the current config_manager state.
 
-        Runs as an asyncio Task on whatever loop is currently active.
-        Failures are logged but don't propagate to the synchronous
-        caller. If there's no running loop (sync test context), the
-        mirror is skipped — the next async-aware caller catches up.
+        Runs as a tracked asyncio Task on the active loop. Three
+        guarantees:
+          1. The config snapshot is captured at SCHEDULE time, not at
+             task-run time — so rapid `save(A)` then `save(B)` mirrors
+             *both* states in order, not B twice.
+          2. An asyncio.Lock serializes mirror writes, preventing two
+             concurrent ``UPSERT`` against the same row.
+          3. The task is tracked in ``self._pending_mirrors`` so the
+             shutdown handler can await it before disposing the engine.
+
+        If there's no running loop (sync test context) the mirror is
+        skipped; the next async-aware caller catches up.
         """
         try:
             loop = asyncio.get_running_loop()
         except RuntimeError:
             return
 
+        # Snapshot NOW. Reading at task-run time would race with
+        # subsequent saves to the in-memory config.
+        config_snapshot = self._cm.get_config()
+
         async def _do_mirror():
             try:
-                await self._mirror_to_db(self._cm.get_config())
+                async with self._mirror_lock:
+                    await self._mirror_to_db(config_snapshot)
             except Exception as exc:  # noqa: BLE001
                 logger.warning("DB mirror after yaml save failed", error=str(exc))
 
-        loop.create_task(_do_mirror())
+        task = loop.create_task(_do_mirror())
+        self._pending_mirrors.add(task)
+        task.add_done_callback(self._pending_mirrors.discard)
 
     async def _mirror_to_db(
         self,

--- a/src/services/workspace_config_service.py
+++ b/src/services/workspace_config_service.py
@@ -4,11 +4,11 @@ of truth, with yaml kept as a fallback when storage mode is `hybrid`.
 Honors the unified ``OPENRAG_STORAGE_MODE`` flag (see
 ``src/config/storage_mode.py``):
 
-| Mode    | Reads             | Writes               |
-|---------|-------------------|----------------------|
-| hybrid  | DB → yaml fallback| DB + yaml (default)  |
-| db      | DB only           | DB only — yaml ignored, never written |
-| files   | yaml only         | yaml only            |
+| Mode             | Reads             | Writes               |
+|------------------|-------------------|----------------------|
+| db (default)     | DB only           | DB only — yaml ignored, never written |
+| hybrid           | DB → yaml fallback| DB + yaml dual-write |
+| files            | yaml only         | yaml only            |
 
 Mirrors the existing ``ConfigManager`` API surface (``load_config`` /
 ``get_config`` / ``reload_config`` / ``save_config_file`` /

--- a/src/session_manager.py
+++ b/src/session_manager.py
@@ -26,6 +26,7 @@ class User:
     jwt_token: Optional[str] = None
     opensearch_username: Optional[str] = None
     opensearch_credentials: Optional[str] = None  # Raw base64 credentials (without "Basic " prefix)
+    db_user_id: Optional[str] = None  # Internal OpenRAG users.id
 
     def __post_init__(self):
         if self.created_at is None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,12 @@ load_dotenv()
 os.environ['GOOGLE_OAUTH_CLIENT_ID'] = ''
 os.environ['GOOGLE_OAUTH_CLIENT_SECRET'] = ''
 
+# RBAC is OFF by default in production. For tests we keep it ON so the
+# RBAC assertions in admin-endpoint and require_permission tests aren't
+# silently bypassed. Specific tests that exercise the kill switch
+# override this via monkeypatch.
+os.environ.setdefault("OPENRAG_RBAC_ENFORCE", "true")
+
 # Pin the RBAC/SQL DB to an isolated temp file BEFORE any code that
 # imports `db.engine` runs. The DB engine module reads DATABASE_URL at
 # init time, so this must happen at module load. Without it the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,16 @@ load_dotenv()
 os.environ['GOOGLE_OAUTH_CLIENT_ID'] = ''
 os.environ['GOOGLE_OAUTH_CLIENT_SECRET'] = ''
 
+# Pin the RBAC/SQL DB to an isolated temp file BEFORE any code that
+# imports `db.engine` runs. The DB engine module reads DATABASE_URL at
+# init time, so this must happen at module load. Without it the
+# integration tests share `data/openrag.db` with a developer's local
+# install (or a stale CI volume), which is both flaky and unsafe.
+if not os.environ.get("SDK_TESTS_ONLY") == "true":
+    _test_db_dir = tempfile.mkdtemp(prefix="openrag-itest-db-")
+    _test_db_path = Path(_test_db_dir) / "openrag.db"
+    os.environ["DATABASE_URL"] = f"sqlite+aiosqlite:///{_test_db_path}"
+
 from config.settings import clients
 from session_manager import SessionManager
 from main import generate_jwt_keys
@@ -38,6 +48,21 @@ async def onboard_system():
     config_file = Path("config/config.yaml")
     if config_file.exists():
         config_file.unlink()
+
+    # Apply Alembic migrations to the test DB BEFORE the FastAPI app is
+    # built. The app's @on_event("startup") (which calls init_engine and
+    # would normally run schema creation) only fires when uvicorn boots
+    # — but integration tests await create_app() directly. Without this
+    # explicit migration, the very first RBAC query inside any
+    # require_permission-gated endpoint dies with
+    # "no such table: permissions".
+    from db.migrations_runtime import run_alembic_upgrade_async
+    await run_alembic_upgrade_async("head")
+
+    # Bind the SQLAlchemy engine to the migrated DB. init_engine is
+    # idempotent and synchronous; safe to call from the test event loop.
+    from db.engine import init_engine
+    init_engine()
 
     # Clean up OpenSearch indices to ensure fresh state for tests
     try:

--- a/tests/integration/core/test_runtime_migration.py
+++ b/tests/integration/core/test_runtime_migration.py
@@ -1,0 +1,320 @@
+"""API-only upgrade-path test for legacy file state -> SQL runtime migration."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+import yaml
+from sqlalchemy import func, select
+
+
+@pytest_asyncio.fixture
+async def legacy_migration_workspace(tmp_path: Path, monkeypatch):
+    """Isolate config/data/DB paths and reset module singletons for one app boot."""
+    data_dir = tmp_path / "data"
+    config_dir = tmp_path / "config"
+    keys_dir = tmp_path / "keys"
+    data_dir.mkdir()
+    config_dir.mkdir()
+    keys_dir.mkdir()
+
+    db_path = tmp_path / "openrag.db"
+    monkeypatch.setenv("DATABASE_URL", f"sqlite+aiosqlite:///{db_path}")
+    monkeypatch.setenv("OPENRAG_DATA_PATH", str(data_dir))
+    monkeypatch.setenv("OPENRAG_CONFIG_PATH", str(config_dir))
+    monkeypatch.setenv("OPENRAG_KEYS_PATH", str(keys_dir))
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+    monkeypatch.setenv("OPENRAG_NOAUTH_ROLE", "admin")
+    monkeypatch.setenv("DISABLE_STARTUP_INGEST", "true")
+    monkeypatch.setenv("FETCH_OPENRAG_DOCS_AT_STARTUP", "false")
+
+    from config.config_manager import config_manager
+    from db.engine import dispose_engine
+    from dependencies import invalidate_user_ensured_cache
+    from services.conversation_persistence_service import conversation_persistence
+    from services.session_ownership_service import session_ownership_service
+
+    old_config_file = config_manager.config_file
+    old_config_cache = config_manager._config
+    old_conversation_file = conversation_persistence.storage_file
+    old_conversations = conversation_persistence._conversations
+    old_ownership_file = session_ownership_service.ownership_file
+    old_ownership_data = session_ownership_service.ownership_data
+    old_conversation_session_factory = conversation_persistence._session_factory
+    old_ownership_session_factory = session_ownership_service._session_factory
+
+    await dispose_engine()
+    invalidate_user_ensured_cache()
+    config_manager.config_file = config_dir / "config.yaml"
+    config_manager._config = None
+    conversation_persistence.storage_file = str(data_dir / "conversations.json")
+    conversation_persistence._conversations = {}
+    conversation_persistence._session_factory = None
+    session_ownership_service.ownership_file = str(data_dir / "session_ownership.json")
+    session_ownership_service.ownership_data = {}
+    session_ownership_service._session_factory = None
+
+    _write_legacy_files(config_dir=config_dir, data_dir=data_dir)
+
+    try:
+        yield {
+            "config_dir": config_dir,
+            "data_dir": data_dir,
+            "db_path": db_path,
+        }
+    finally:
+        await dispose_engine()
+        invalidate_user_ensured_cache()
+        config_manager.config_file = old_config_file
+        config_manager._config = old_config_cache
+        conversation_persistence.storage_file = old_conversation_file
+        conversation_persistence._conversations = old_conversations
+        conversation_persistence._session_factory = old_conversation_session_factory
+        session_ownership_service.ownership_file = old_ownership_file
+        session_ownership_service.ownership_data = old_ownership_data
+        session_ownership_service._session_factory = old_ownership_session_factory
+
+
+def _write_legacy_files(*, config_dir: Path, data_dir: Path) -> None:
+    (config_dir / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "providers": {
+                    "openai": {
+                        "configured": True,
+                        "api_key": "legacy-openai-key",
+                    },
+                    "anthropic": {},
+                    "watsonx": {},
+                    "ollama": {},
+                },
+                "knowledge": {
+                    "embedding_model": "text-embedding-3-small",
+                    "embedding_provider": "openai",
+                    "chunk_size": 777,
+                    "index_name": "documents",
+                },
+                "agent": {
+                    "llm_model": "gpt-4o-mini",
+                    "llm_provider": "openai",
+                    "system_prompt": "legacy prompt",
+                },
+                "onboarding": {
+                    "current_step": 4,
+                    "openrag_docs_filter_id": "legacy-filter",
+                },
+                "edited": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (data_dir / "session_ownership.json").write_text(
+        json.dumps(
+            {
+                "legacy-session": {
+                    "user_id": "anonymous",
+                    "created_at": "2026-04-01T10:00:00",
+                    "last_accessed": "2026-04-02T11:00:00",
+                },
+                "other-session": {
+                    "user_id": "legacy-owner",
+                    "created_at": "2026-04-03T09:00:00",
+                    "last_accessed": "2026-04-03T09:30:00",
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (data_dir / "conversations.json").write_text(
+        json.dumps(
+            {
+                "anonymous": {
+                    "legacy-session": {
+                        "title": "Migrated chat",
+                        "endpoint": "chat",
+                        "previous_response_id": None,
+                        "filter_id": "legacy-filter",
+                        "total_messages": 3,
+                        "created_at": "2026-04-01T10:00:00",
+                        "last_activity": "2026-04-02T11:00:00",
+                    }
+                },
+                "legacy-owner": {
+                    "other-session": {
+                        "title": "Other migrated chat",
+                        "endpoint": "langflow",
+                        "total_messages": 1,
+                        "created_at": "2026-04-03T09:00:00",
+                        "last_activity": "2026-04-03T09:30:00",
+                    }
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    (data_dir / "connections.json").write_text(
+        json.dumps(
+            {
+                "connections": [
+                    {
+                        "connection_id": "legacy-connection",
+                        "user_id": "legacy-owner",
+                        "config": {},
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+async def _build_and_start_app():
+    """Run the same Alembic-before-app, runtime-migration-on-startup sequence."""
+    from config.config_manager import config_manager
+    from db.migrations_runtime import run_alembic_upgrade_async
+    from main import create_app
+
+    config_manager._config = None
+    await run_alembic_upgrade_async("head")
+    app = await create_app()
+    await app.router.startup()
+    return app
+
+
+async def _shutdown_app(app) -> None:
+    from db.engine import dispose_engine
+
+    tasks = list(getattr(app.state, "background_tasks", set()))
+    for task in tasks:
+        task.cancel()
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
+    await app.router.shutdown()
+    await dispose_engine()
+
+
+async def _db_snapshot() -> dict[str, int]:
+    from db.engine import SessionLocal
+    from db.models import Conversation, MigrationStatus, SessionOwnership, User
+
+    assert SessionLocal is not None
+    async with SessionLocal() as session:
+        users = await session.scalar(select(func.count()).select_from(User))
+        conversations = await session.scalar(
+            select(func.count()).select_from(Conversation)
+        )
+        ownership = await session.scalar(
+            select(func.count()).select_from(SessionOwnership)
+        )
+        statuses = await session.scalar(select(func.count()).select_from(MigrationStatus))
+    return {
+        "users": int(users or 0),
+        "conversations": int(conversations or 0),
+        "ownership": int(ownership or 0),
+        "statuses": int(statuses or 0),
+    }
+
+
+async def _assert_migrated_db_state() -> None:
+    from db.engine import SessionLocal
+    from db.migrations_runtime import (
+        CHAT_HISTORY_JSON_TO_DB_V1,
+        CONFIG_YAML_TO_DB_V1,
+        JSON_TO_DB_V1,
+    )
+    from db.models import (
+        Conversation,
+        MigrationStatus,
+        SessionOwnership,
+        User,
+        WorkspaceConfig,
+    )
+
+    assert SessionLocal is not None
+    async with SessionLocal() as session:
+        statuses = {
+            row.name: row.notes
+            for row in (await session.execute(select(MigrationStatus))).scalars().all()
+        }
+        assert JSON_TO_DB_V1 in statuses
+        assert CONFIG_YAML_TO_DB_V1 in statuses
+        assert CHAT_HISTORY_JSON_TO_DB_V1 in statuses
+
+        meta = await session.get(WorkspaceConfig, "meta")
+        onboarding = await session.get(WorkspaceConfig, "onboarding")
+        knowledge = await session.get(WorkspaceConfig, "knowledge")
+        assert meta is not None
+        assert meta.value == {"edited": True}
+        assert onboarding is not None
+        assert onboarding.value["current_step"] == 4
+        assert knowledge is not None
+        assert knowledge.value["chunk_size"] == 777
+
+        legacy_session = await session.get(SessionOwnership, "legacy-session")
+        assert legacy_session is not None
+        assert legacy_session.user_id == "anonymous"
+
+        conversation = await session.get(Conversation, "legacy-session")
+        assert conversation is not None
+        assert conversation.user_id == "anonymous"
+        assert conversation.title == "Migrated chat"
+        assert conversation.total_messages == 3
+
+        subjects = {
+            row.oauth_subject
+            for row in (await session.execute(select(User))).scalars().all()
+            if row.oauth_provider == "legacy"
+        }
+        assert {"anonymous", "legacy-owner"}.issubset(subjects)
+
+
+@pytest.mark.asyncio
+@pytest.mark.usefixtures("legacy_migration_workspace")
+async def test_legacy_file_state_migrates_on_backend_startup_and_is_idempotent():
+    app = await _build_and_start_app()
+    try:
+        await _assert_migrated_db_state()
+        first_snapshot = await _db_snapshot()
+
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            onboarding = await client.get("/onboarding-status")
+            assert onboarding.status_code == 200, onboarding.text
+            assert onboarding.json() == {"onboarded": True, "current_step": 4}
+
+            history = await client.get("/chat/history")
+            assert history.status_code == 200, history.text
+            conversations = {
+                item["response_id"]: item
+                for item in history.json().get("conversations", [])
+            }
+            assert conversations["legacy-session"]["title"] == "Migrated chat"
+            assert conversations["legacy-session"]["total_messages"] == 3
+    finally:
+        await _shutdown_app(app)
+
+    # A second backend boot against the same DB must not duplicate migrated rows.
+    app = await _build_and_start_app()
+    try:
+        assert await _db_snapshot() == first_snapshot
+        transport = httpx.ASGITransport(app=app)
+        async with httpx.AsyncClient(
+            transport=transport, base_url="http://testserver"
+        ) as client:
+            onboarding = await client.get("/onboarding-status")
+            assert onboarding.status_code == 200, onboarding.text
+            assert onboarding.json()["onboarded"] is True
+    finally:
+        await _shutdown_app(app)

--- a/tests/unit/api/admin/test_rbac_endpoints.py
+++ b/tests/unit/api/admin/test_rbac_endpoints.py
@@ -10,7 +10,7 @@ from fastapi import FastAPI, Request
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/api/test_chat_ownership_enforcement.py
+++ b/tests/unit/api/test_chat_ownership_enforcement.py
@@ -107,6 +107,40 @@ async def test_chat_endpoint_calls_assert_owns_with_previous_response_id(monkeyp
 
 
 @pytest.mark.asyncio
+async def test_chat_endpoint_uses_db_user_id_for_ownership_and_storage(monkeypatch):
+    from api import chat as chat_module
+    from api.chat import ChatBody
+
+    calls = []
+
+    async def _fake_assert(sid, uid):
+        calls.append(("assert", sid, uid))
+
+    fake_chat_service = AsyncMock()
+    fake_chat_service.chat = AsyncMock(return_value={"response": "ok"})
+
+    monkeypatch.setattr(chat_module, "_assert_owns", _fake_assert)
+
+    class FakeUser:
+        user_id = "oauth-alice"
+        db_user_id = "db-alice"
+        jwt_token = None
+        name = "A"
+        email = "a@x"
+
+    body = ChatBody(prompt="hi", previous_response_id="sess-1")
+    await chat_module.chat_endpoint(
+        body=body,
+        chat_service=fake_chat_service,
+        session_manager=None,
+        user=FakeUser(),
+    )
+    assert calls[0] == ("assert", "sess-1", "db-alice")
+    assert fake_chat_service.chat.await_args.kwargs["storage_user_id"] == "db-alice"
+    assert fake_chat_service.chat.await_args.args[1] == "oauth-alice"
+
+
+@pytest.mark.asyncio
 async def test_langflow_endpoint_calls_assert_owns(monkeypatch):
     from api import chat as chat_module
     from api.chat import ChatBody
@@ -162,3 +196,57 @@ async def test_delete_session_endpoint_calls_assert_owns(monkeypatch):
         user=FakeUser(),
     )
     assert calls[0] == ("assert", "sess-1", "alice")
+
+
+@pytest.mark.asyncio
+async def test_upload_context_uses_db_user_id_for_existing_session(monkeypatch):
+    from api import upload as upload_module
+
+    calls = []
+
+    async def _fake_assert(sid, uid):
+        calls.append(("assert", sid, uid))
+
+    monkeypatch.setattr("api.chat._assert_owns", _fake_assert)
+
+    class FakeFile:
+        filename = "notes.txt"
+
+    class FakeUser:
+        user_id = "oauth-alice"
+        db_user_id = "db-alice"
+        jwt_token = "token"
+        name = "A"
+        email = "a@x"
+
+    fake_document_service = AsyncMock()
+    fake_document_service.process_upload_context = AsyncMock(
+        return_value={
+            "content": "hello",
+            "filename": "notes.txt",
+            "pages": 1,
+            "content_length": 5,
+        }
+    )
+    fake_chat_service = AsyncMock()
+    fake_chat_service.upload_context_chat = AsyncMock(return_value=("ok", "resp-1"))
+
+    await upload_module.upload_context(
+        file=FakeFile(),
+        previous_response_id="sess-1",
+        endpoint="chat",
+        document_service=fake_document_service,
+        chat_service=fake_chat_service,
+        session_manager=None,
+        user=FakeUser(),
+    )
+
+    assert calls[0] == ("assert", "sess-1", "db-alice")
+    assert (
+        fake_chat_service.upload_context_chat.await_args.kwargs["storage_user_id"]
+        == "db-alice"
+    )
+    assert (
+        fake_chat_service.upload_context_chat.await_args.kwargs["user_id"]
+        == "oauth-alice"
+    )

--- a/tests/unit/api/test_chat_ownership_enforcement.py
+++ b/tests/unit/api/test_chat_ownership_enforcement.py
@@ -12,7 +12,7 @@ from unittest.mock import AsyncMock
 import pytest
 from fastapi import HTTPException
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/config/test_storage_mode.py
+++ b/tests/unit/config/test_storage_mode.py
@@ -19,7 +19,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,12 +2,39 @@
 
 Overrides the session-scoped onboard_system fixture from the root conftest
 so that unit tests don't require running infrastructure (Langflow, OpenSearch, etc.).
+
+Also forces every unit test to use an in-memory SQLite for the RBAC layer
+so test fixtures cannot accidentally pollute the dev `data/openrag.db` file.
 """
 
+# CRITICAL: set DATABASE_URL BEFORE any module imports `db.engine`. This
+# guarantees that even if a test imports something that triggers
+# `init_engine()` at import time, the engine binds to an in-memory DB.
+import os as _os
+_os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+
+import pytest
 import pytest_asyncio
 
 
 @pytest_asyncio.fixture(scope="session", autouse=True)
 async def onboard_system():
     """No-op override — unit tests mock their own dependencies."""
+    yield
+
+
+@pytest.fixture(autouse=True)
+def _reset_db_engine_module_state(monkeypatch):
+    """Defensive: per-test, ensure `db.engine`'s module-level singletons
+    don't leak across tests. Most tests build their own AsyncEngine via
+    `create_async_engine(...)` and never touch the module-level engine,
+    but if a code path *does* reach for it, this fixture forces a clean
+    re-init bound to the in-memory URL set above.
+    """
+    try:
+        import db.engine as _engine_mod
+        monkeypatch.setattr(_engine_mod, "_engine", None, raising=False)
+        monkeypatch.setattr(_engine_mod, "SessionLocal", None, raising=False)
+    except ImportError:
+        pass
     yield

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -13,6 +13,12 @@ so test fixtures cannot accidentally pollute the dev `data/openrag.db` file.
 import os as _os
 _os.environ.setdefault("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
+# Defensive default: pin OPENRAG_RBAC_ENFORCE=true for unit tests so a
+# developer who has the kill switch in their local `.env` doesn't
+# silently make every 403-asserting test pass-through. Tests that
+# explicitly want the bypass override this via monkeypatch.
+_os.environ["OPENRAG_RBAC_ENFORCE"] = "true"
+
 import pytest
 import pytest_asyncio
 

--- a/tests/unit/db/migrations/test_chat_history_migration.py
+++ b/tests/unit/db/migrations/test_chat_history_migration.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/db/migrations/test_chat_history_migration.py
+++ b/tests/unit/db/migrations/test_chat_history_migration.py
@@ -118,8 +118,8 @@ async def test_migration_is_idempotent(staged_files, session_factory):
     assert first["sessions_inserted"] == 2
     assert first["conversations_inserted"] == 2
     # Second pass: rows already there, no new inserts
-    assert second["sessions_inserted"] == 2  # upsert_raw is no-op when present
-    assert second["conversations_inserted"] == 0  # repo.get short-circuits
+    assert second["sessions_inserted"] == 0
+    assert second["conversations_inserted"] == 0
 
 
 @pytest.mark.asyncio

--- a/tests/unit/db/migrations/test_config_yaml_to_db_migration.py
+++ b/tests/unit/db/migrations/test_config_yaml_to_db_migration.py
@@ -10,7 +10,7 @@ import yaml
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/db/migrations/test_json_to_db_migration.py
+++ b/tests/unit/db/migrations/test_json_to_db_migration.py
@@ -12,7 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/db/migrations/test_json_to_db_migration.py
+++ b/tests/unit/db/migrations/test_json_to_db_migration.py
@@ -18,7 +18,7 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 import db.models  # noqa: E402,F401
-from db.migrations_runtime import run as run_migration  # noqa: E402
+from db.migrations_runtime import RuntimeMigrationError, run as run_migration  # noqa: E402
 from db.models import MigrationStatus, User as UserRow  # noqa: E402
 
 
@@ -127,3 +127,19 @@ async def test_partial_collision_keeps_other_legacy_inserts(session_in_temp_data
     assert legacy == {"user-aaa", "user-bbb", "user-ccc", "user-ddd"}
     # user-aaa was a duplicate, so insert count is 3.
     assert inserted == 3
+
+
+@pytest.mark.asyncio
+async def test_run_aborts_when_required_step_fails(session_in_temp_data, monkeypatch):
+    s = session_in_temp_data
+
+    async def _boom(session):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr("db.migrations_runtime.migrate_legacy_users", _boom)
+
+    with pytest.raises(RuntimeMigrationError):
+        await run_migration(s)
+
+    status = await s.get(MigrationStatus, "json_to_db_v1")
+    assert status is None

--- a/tests/unit/db/test_rbac_seed_idempotency.py
+++ b/tests/unit/db/test_rbac_seed_idempotency.py
@@ -10,7 +10,7 @@ from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy import select
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/dependencies/test_rbac_kill_switch.py
+++ b/tests/unit/dependencies/test_rbac_kill_switch.py
@@ -22,7 +22,7 @@ from fastapi import FastAPI, Request
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/dependencies/test_require_permission.py
+++ b/tests/unit/dependencies/test_require_permission.py
@@ -18,7 +18,7 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/dependencies/test_require_permission.py
+++ b/tests/unit/dependencies/test_require_permission.py
@@ -24,11 +24,15 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 import db.models  # noqa: E402,F401
+from db.models import User as UserRow  # noqa: E402
 from db.repositories import RoleRepo  # noqa: E402
 from db.seed import seed_roles_and_permissions  # noqa: E402
 from dependencies import (  # noqa: E402
+    _ENSURED_USER_IDS,
+    _user_cache_key,
     get_current_user,
     get_rbac_service,
+    require_all_permissions,
     require_permission,
 )
 from services.rbac_service import RBACService  # noqa: E402
@@ -81,6 +85,17 @@ async def app(monkeypatch):
         await role_repo.revoke_role(viewer_db.id, user_role.id)
         await role_repo.assign_role(viewer_db.id, viewer_role.id)
 
+        aliased_db = UserRow(
+            id="db-aliased-user",
+            oauth_provider="google",
+            oauth_subject="oauth-aliased-sub",
+            email="alias@x.com",
+            display_name="Alias",
+        )
+        s.add(aliased_db)
+        await s.flush()
+        await role_repo.assign_role(aliased_db.id, user_role.id)
+
         await s.commit()
 
         # Map persona name -> User dataclass with id matching the DB row id so
@@ -99,6 +114,13 @@ async def app(monkeypatch):
         PERSONAS["viewer"] = User(
             user_id=viewer_db.id, email="v@x.com", name="V", provider="google"
         )
+        PERSONAS["aliased"] = User(
+            user_id="oauth-aliased-sub",
+            email="alias@x.com",
+            name="Alias",
+            provider="google",
+        )
+        _ENSURED_USER_IDS[_user_cache_key(PERSONAS["aliased"])] = aliased_db.id
 
     rbac = RBACService(SessionLocal)
 
@@ -131,7 +153,18 @@ async def app(monkeypatch):
     async def flows_edit(user=Depends(require_permission("flows:edit"))):
         return JSONResponse({"user_id": user.user_id})
 
+    @app.post("/test/upload-context")
+    async def upload_context_gate(
+        user=Depends(require_all_permissions(("knowledge:upload", "chat:use")))
+    ):
+        return JSONResponse({"user_id": user.user_id})
+
+    @app.post("/test/whoami")
+    async def whoami(user=Depends(require_permission("chat:use"))):
+        return JSONResponse({"user_id": user.user_id, "db_user_id": user.db_user_id})
+
     yield app
+    _ENSURED_USER_IDS.pop(_user_cache_key(PERSONAS["aliased"]), None)
     await engine.dispose()
 
 
@@ -163,6 +196,9 @@ async def app(monkeypatch):
         ("viewer", "/test/kf-create", 403),
         ("viewer", "/test/users-list", 403),
         ("viewer", "/test/flows-edit", 403),
+        # upload-context is both ingestion and chat behavior
+        ("user", "/test/upload-context", 200),
+        ("viewer", "/test/upload-context", 403),
     ],
 )
 async def test_permission_enforcement(app, persona, perm_path, expected):
@@ -182,3 +218,24 @@ async def test_403_response_includes_required_perm(app):
         r = await c.post("/test/config-write", headers={"X-Test-Persona": "user"})
     assert r.status_code == 403
     assert r.json()["detail"]["required"] == "config:write"
+
+
+@pytest.mark.asyncio
+async def test_all_permissions_response_lists_required_permissions(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post("/test/upload-context", headers={"X-Test-Persona": "viewer"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["required"] == ["knowledge:upload", "chat:use"]
+
+
+@pytest.mark.asyncio
+async def test_permission_check_uses_resolved_db_user_id(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post("/test/whoami", headers={"X-Test-Persona": "aliased"})
+    assert r.status_code == 200
+    assert r.json() == {
+        "user_id": "oauth-aliased-sub",
+        "db_user_id": "db-aliased-user",
+    }

--- a/tests/unit/services/test_bootstrap_race.py
+++ b/tests/unit/services/test_bootstrap_race.py
@@ -16,7 +16,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/services/test_conversation_persistence_service_modes.py
+++ b/tests/unit/services/test_conversation_persistence_service_modes.py
@@ -9,7 +9,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/services/test_rbac_service.py
+++ b/tests/unit/services/test_rbac_service.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/services/test_session_ownership_service_modes.py
+++ b/tests/unit/services/test_session_ownership_service_modes.py
@@ -10,7 +10,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/services/test_user_service_bootstrap.py
+++ b/tests/unit/services/test_user_service_bootstrap.py
@@ -8,7 +8,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/services/test_workspace_config_service.py
+++ b/tests/unit/services/test_workspace_config_service.py
@@ -11,7 +11,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/services/test_workspace_mirror_lifecycle.py
+++ b/tests/unit/services/test_workspace_mirror_lifecycle.py
@@ -16,7 +16,7 @@ import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
-ROOT = Path(__file__).resolve().parent.parent.parent
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))

--- a/tests/unit/test_bootstrap_race.py
+++ b/tests/unit/test_bootstrap_race.py
@@ -167,3 +167,92 @@ async def test_concurrent_signins_same_user_no_integrity_error(
         from db.repositories import UserRepo
         rows = await UserRepo(session).list_all()
     assert len(rows) == 1, f"expected 1 anonymous user row, got {len(rows)}"
+
+
+@pytest.mark.asyncio
+async def test_cache_keys_are_per_provider_subject_pair(
+    session_factory, monkeypatch
+):
+    """Two users with the SAME oauth_subject string but DIFFERENT
+    providers must NOT share a cache slot. Pre-fix the cache was keyed
+    on user.user_id alone, so e.g. AnonymousUser (provider="none",
+    user_id="anonymous") would collide with any future identity that
+    issued the same subject string.
+    """
+    import db.engine as _engine_mod
+    monkeypatch.setattr(_engine_mod, "SessionLocal", session_factory, raising=False)
+
+    from dependencies import _ensure_db_user, _ENSURED_USER_IDS, _ENSURE_LOCKS
+    _ENSURED_USER_IDS.clear()
+    _ENSURE_LOCKS.clear()
+
+    # Same subject string, different providers, different emails.
+    user_a = User(
+        user_id="shared-subject",
+        email="a@x.com",
+        name="A",
+        provider="google",
+    )
+    user_b = User(
+        user_id="shared-subject",
+        email="b@x.com",
+        name="B",
+        provider="ibm",
+    )
+
+    id_a = await _ensure_db_user(user_a)
+    id_b = await _ensure_db_user(user_b)
+
+    # Distinct cache slots…
+    assert "google:shared-subject" in _ENSURED_USER_IDS
+    assert "ibm:shared-subject" in _ENSURED_USER_IDS
+    # …and distinct DB ids (the (oauth_provider, oauth_subject) UNIQUE
+    # constraint isn't violated because the two pairs differ on provider).
+    assert id_a is not None and id_b is not None
+    assert id_a != id_b, "distinct identities must map to distinct DB ids"
+
+    # And distinct locks were created — same-provider concurrent calls
+    # serialize, but cross-provider calls don't block each other.
+    assert "google:shared-subject" in _ENSURE_LOCKS
+    assert "ibm:shared-subject" in _ENSURE_LOCKS
+    assert _ENSURE_LOCKS["google:shared-subject"] is not _ENSURE_LOCKS["ibm:shared-subject"]
+
+
+@pytest.mark.asyncio
+async def test_invalidate_pops_only_target_identity(
+    session_factory, monkeypatch
+):
+    """invalidate_user_ensured_cache(provider, subject) must pop only
+    the matching identity's cache + lock entries — not the whole cache."""
+    import db.engine as _engine_mod
+    monkeypatch.setattr(_engine_mod, "SessionLocal", session_factory, raising=False)
+
+    from dependencies import (
+        _ensure_db_user,
+        _ENSURED_USER_IDS,
+        _ENSURE_LOCKS,
+        invalidate_user_ensured_cache,
+    )
+    _ENSURED_USER_IDS.clear()
+    _ENSURE_LOCKS.clear()
+
+    await _ensure_db_user(
+        User(user_id="alice-sub", email="a@x", name="A", provider="google")
+    )
+    await _ensure_db_user(
+        User(user_id="bob-sub", email="b@x", name="B", provider="ibm")
+    )
+    assert {"google:alice-sub", "ibm:bob-sub"} <= set(_ENSURED_USER_IDS.keys())
+
+    invalidate_user_ensured_cache("google", "alice-sub")
+
+    assert "google:alice-sub" not in _ENSURED_USER_IDS
+    assert "google:alice-sub" not in _ENSURE_LOCKS
+    # bob's entries untouched
+    assert "ibm:bob-sub" in _ENSURED_USER_IDS
+    assert "ibm:bob-sub" in _ENSURE_LOCKS
+
+    # Calling with no args clears everything.
+    invalidate_user_ensured_cache()
+    assert len(_ENSURED_USER_IDS) == 0
+    assert len(_ENSURE_LOCKS) == 0

--- a/tests/unit/test_bootstrap_race.py
+++ b/tests/unit/test_bootstrap_race.py
@@ -121,3 +121,49 @@ async def test_no_race_single_signin_unchanged(session_factory):
     async with session_factory() as session:
         admins = await RoleRepo(session).list_admin_user_ids()
     assert admins == ["solo"]
+
+
+@pytest.mark.asyncio
+async def test_concurrent_signins_same_user_no_integrity_error(
+    session_factory, monkeypatch
+):
+    """Five concurrent `_ensure_db_user` calls for the SAME anonymous
+    user must not raise IntegrityError on email_lookup_hash. The
+    previous bug: both callers observed an empty users table, both
+    tried to INSERT, the second failed with
+    `UNIQUE constraint failed: users.email_lookup_hash`.
+
+    The fix is a per-user-id `asyncio.Lock` in `_ensure_db_user` that
+    serializes concurrent first-time ensures for the same user_id, so
+    the second caller sees the first's committed row in the cache
+    instead of racing through the cache miss → INSERT path.
+    """
+    # _ensure_db_user reads `db.engine.SessionLocal`, so wire it to
+    # our test session_factory.
+    import db.engine as _engine_mod
+    monkeypatch.setattr(_engine_mod, "SessionLocal", session_factory, raising=False)
+
+    from dependencies import _ensure_db_user, _ENSURED_USER_IDS, _ENSURE_LOCKS
+    _ENSURED_USER_IDS.clear()
+    _ENSURE_LOCKS.clear()
+
+    anon = User(
+        user_id="anonymous",
+        email="anonymous@localhost",
+        name="Anonymous",
+        provider="none",
+    )
+
+    ids = await asyncio.gather(*[_ensure_db_user(anon) for _ in range(5)])
+
+    # All concurrent callers receive the same DB id…
+    assert all(uid == ids[0] for uid in ids), (
+        f"expected all callers to observe the same id, got {ids}"
+    )
+    assert ids[0] is not None, "expected a non-None id (no IntegrityError)"
+
+    # …and exactly one user row exists.
+    async with session_factory() as session:
+        from db.repositories import UserRepo
+        rows = await UserRepo(session).list_all()
+    assert len(rows) == 1, f"expected 1 anonymous user row, got {len(rows)}"

--- a/tests/unit/test_bootstrap_race.py
+++ b/tests/unit/test_bootstrap_race.py
@@ -1,0 +1,123 @@
+"""First-admin bootstrap must yield exactly one admin even under
+concurrent first-sign-ins.
+
+Two `ensure_user_row` calls fired with `asyncio.gather` against an empty
+DB: both observe `count_admins == 0`, both attempt to grant admin. The
+post-grant rollback (lexicographic tie-break) must demote the loser
+before either request returns.
+"""
+
+import asyncio
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from services.user_service import ensure_user_row  # noqa: E402
+from session_manager import User  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with factory() as s:
+        await seed_roles_and_permissions(s)
+        await s.commit()
+    yield factory
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_race_yields_single_admin(session_factory):
+    """Two concurrent first-sign-ins → exactly one admin.
+
+    Each call uses its own session (mirrors what FastAPI does per
+    request). The post-grant rollback must observe the second admin
+    and demote whichever caller is not min(user_id).
+    """
+    async def signin(user_id: str) -> None:
+        async with session_factory() as session:
+            await ensure_user_row(
+                session,
+                User(
+                    user_id=user_id,
+                    email=f"{user_id}@x.com",
+                    name=user_id,
+                    provider="google",
+                ),
+            )
+            await session.commit()
+
+    # SQLite serializes writes, so true parallelism is limited; but the
+    # service does several reads/writes per call, so even on SQLite the
+    # interleaving exercises the rollback branch.
+    await asyncio.gather(signin("alice"), signin("bob"))
+
+    async with session_factory() as session:
+        admins = await RoleRepo(session).list_admin_user_ids()
+
+    assert len(admins) == 1, f"expected 1 admin, got {admins}"
+    # Lexicographic min wins
+    assert admins[0] == "alice"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_loser_falls_through_to_default_role(session_factory):
+    """The demoted bootstrap loser must still end up with the default
+    role, not zero roles."""
+    async def signin(user_id: str) -> None:
+        async with session_factory() as session:
+            await ensure_user_row(
+                session,
+                User(
+                    user_id=user_id,
+                    email=f"{user_id}@x.com",
+                    name=user_id,
+                    provider="google",
+                ),
+            )
+            await session.commit()
+
+    await asyncio.gather(signin("alice"), signin("zach"))
+
+    async with session_factory() as session:
+        repo = RoleRepo(session)
+        admins = await repo.list_admin_user_ids()
+        zach_roles = await repo.list_user_roles("zach")
+
+    assert admins == ["alice"]
+    role_names = {r.name for r in zach_roles}
+    # Default role is "user" (set by OPENRAG_DEFAULT_ROLE, default "user")
+    assert "user" in role_names, f"loser should have default role, got {role_names}"
+    assert "admin" not in role_names
+
+
+@pytest.mark.asyncio
+async def test_no_race_single_signin_unchanged(session_factory):
+    """Sanity check — when there's no race, the first user becomes admin."""
+    async with session_factory() as session:
+        await ensure_user_row(
+            session,
+            User(user_id="solo", email="s@x", name="S", provider="google"),
+        )
+        await session.commit()
+    async with session_factory() as session:
+        admins = await RoleRepo(session).list_admin_user_ids()
+    assert admins == ["solo"]

--- a/tests/unit/test_chat_history_migration.py
+++ b/tests/unit/test_chat_history_migration.py
@@ -1,0 +1,149 @@
+"""Runtime migration: session_ownership.json + conversations.json → DB."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import ConversationRepo, SessionOwnershipRepo  # noqa: E402
+from db import migrations_runtime  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def staged_files(tmp_path, monkeypatch):
+    """Drop sample JSON files where the migration expects them."""
+    so_path = tmp_path / "session_ownership.json"
+    conv_path = tmp_path / "conversations.json"
+
+    so_path.write_text(json.dumps({
+        "sess-1": {
+            "user_id": "alice",
+            "created_at": "2026-04-01T10:00:00",
+            "last_accessed": "2026-04-02T11:00:00",
+        },
+        "sess-2": {
+            "user_id": "bob",
+            "created_at": "2026-04-03T09:00:00",
+            "last_accessed": "2026-04-03T09:00:00",
+        },
+    }))
+
+    conv_path.write_text(json.dumps({
+        "alice": {
+            "r-1": {
+                "title": "Project sync",
+                "endpoint": "chat",
+                "previous_response_id": None,
+                "filter_id": None,
+                "total_messages": 4,
+                "created_at": "2026-04-01T10:00:00",
+                "last_activity": "2026-04-02T11:00:00",
+            },
+        },
+        "bob": {
+            "r-2": {
+                "title": "Bug triage",
+                "endpoint": "langflow",
+                "total_messages": 1,
+                "created_at": "2026-04-03T09:00:00",
+                "last_activity": "2026-04-03T09:00:00",
+            },
+        },
+    }))
+
+    def _resolver(name):
+        return str(tmp_path / name)
+
+    monkeypatch.setattr(migrations_runtime, "get_data_file", _resolver)
+    yield tmp_path
+
+
+@pytest.mark.asyncio
+async def test_migration_copies_both_files(staged_files, session_factory):
+    async with session_factory() as session:
+        stats = await migrations_runtime.migrate_chat_history_json_to_db(session)
+        await session.commit()
+
+    assert stats["sessions_inserted"] == 2
+    assert stats["conversations_inserted"] == 2
+
+    async with session_factory() as session:
+        so_repo = SessionOwnershipRepo(session)
+        assert (await so_repo.get("sess-1")).user_id == "alice"
+        assert (await so_repo.get("sess-2")).user_id == "bob"
+
+        conv_repo = ConversationRepo(session)
+        r1 = await conv_repo.get("r-1")
+        assert r1.title == "Project sync"
+        assert r1.user_id == "alice"
+        assert r1.total_messages == 4
+        r2 = await conv_repo.get("r-2")
+        assert r2.endpoint == "langflow"
+
+
+@pytest.mark.asyncio
+async def test_migration_is_idempotent(staged_files, session_factory):
+    """Re-running yields zero new rows (no upsert overwrite, no errors)."""
+    async with session_factory() as session:
+        first = await migrations_runtime.migrate_chat_history_json_to_db(session)
+        await session.commit()
+
+    async with session_factory() as session:
+        second = await migrations_runtime.migrate_chat_history_json_to_db(session)
+        await session.commit()
+
+    assert first["sessions_inserted"] == 2
+    assert first["conversations_inserted"] == 2
+    # Second pass: rows already there, no new inserts
+    assert second["sessions_inserted"] == 2  # upsert_raw is no-op when present
+    assert second["conversations_inserted"] == 0  # repo.get short-circuits
+
+
+@pytest.mark.asyncio
+async def test_migration_no_files_is_noop(tmp_path, monkeypatch, session_factory):
+    """Migration on a fresh install (no JSON files) succeeds silently."""
+    monkeypatch.setattr(
+        migrations_runtime,
+        "get_data_file",
+        lambda name: str(tmp_path / name),
+    )
+    async with session_factory() as session:
+        stats = await migrations_runtime.migrate_chat_history_json_to_db(session)
+        await session.commit()
+    assert stats == {"sessions_inserted": 0, "conversations_inserted": 0}
+
+
+@pytest.mark.asyncio
+async def test_run_marks_migration_done(staged_files, session_factory):
+    """Top-level run() records the step in migration_status."""
+    async with session_factory() as session:
+        await migrations_runtime.run(session)
+        await session.commit()
+
+    async with session_factory() as session:
+        assert await migrations_runtime._already_done(
+            session, migrations_runtime.CHAT_HISTORY_JSON_TO_DB_V1
+        )

--- a/tests/unit/test_chat_ownership_enforcement.py
+++ b/tests/unit/test_chat_ownership_enforcement.py
@@ -1,0 +1,164 @@
+"""Cross-user ownership enforcement on chat endpoints.
+
+Issue: a user could resume another user's conversation by submitting
+the other user's `response_id` as `previous_response_id`. This regression
+test pins the fix in `src/api/chat.py::_assert_owns`.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.mark.asyncio
+async def test_assert_owns_passes_when_session_owned(monkeypatch):
+    from api import chat as chat_module
+    fake_svc = AsyncMock()
+    fake_svc.get_session_owner = AsyncMock(return_value="alice")
+    monkeypatch.setattr(
+        "services.session_ownership_service.session_ownership_service",
+        fake_svc,
+    )
+    # Same user — no exception
+    await chat_module._assert_owns("sess-1", "alice")
+
+
+@pytest.mark.asyncio
+async def test_assert_owns_returns_403_for_other_user(monkeypatch):
+    from api import chat as chat_module
+    fake_svc = AsyncMock()
+    fake_svc.get_session_owner = AsyncMock(return_value="alice")
+    monkeypatch.setattr(
+        "services.session_ownership_service.session_ownership_service",
+        fake_svc,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await chat_module._assert_owns("sess-1", "mallory")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.detail == {"error": "session_forbidden"}
+
+
+@pytest.mark.asyncio
+async def test_assert_owns_returns_404_for_unknown_session(monkeypatch):
+    """Don't leak existence — unknown session is 404 not 403."""
+    from api import chat as chat_module
+    fake_svc = AsyncMock()
+    fake_svc.get_session_owner = AsyncMock(return_value=None)
+    monkeypatch.setattr(
+        "services.session_ownership_service.session_ownership_service",
+        fake_svc,
+    )
+    with pytest.raises(HTTPException) as exc_info:
+        await chat_module._assert_owns("ghost-sess", "alice")
+    assert exc_info.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_assert_owns_noop_when_session_id_none():
+    """New conversation — no previous_response_id to check."""
+    from api import chat as chat_module
+    # No monkeypatch needed — should short-circuit before hitting the service
+    await chat_module._assert_owns(None, "alice")
+    await chat_module._assert_owns("", "alice")
+
+
+@pytest.mark.asyncio
+async def test_chat_endpoint_calls_assert_owns_with_previous_response_id(monkeypatch):
+    """Spot-check the wiring: the endpoint must invoke _assert_owns BEFORE
+    forwarding to chat_service. Use a sentinel to detect the order."""
+    from api import chat as chat_module
+    from api.chat import ChatBody
+
+    calls = []
+
+    async def _fake_assert(sid, uid):
+        calls.append(("assert", sid, uid))
+
+    fake_chat_service = AsyncMock()
+    fake_chat_service.chat = AsyncMock(
+        side_effect=lambda *a, **k: calls.append(("chat",)) or "ok"
+    )
+
+    monkeypatch.setattr(chat_module, "_assert_owns", _fake_assert)
+
+    class FakeUser:
+        user_id = "alice"
+        jwt_token = None
+        name = "A"
+        email = "a@x"
+
+    body = ChatBody(prompt="hi", previous_response_id="sess-1")
+    await chat_module.chat_endpoint(
+        body=body,
+        chat_service=fake_chat_service,
+        session_manager=None,
+        user=FakeUser(),
+    )
+    # _assert_owns must run, and must run BEFORE the chat call
+    assert calls[0] == ("assert", "sess-1", "alice")
+
+
+@pytest.mark.asyncio
+async def test_langflow_endpoint_calls_assert_owns(monkeypatch):
+    from api import chat as chat_module
+    from api.chat import ChatBody
+
+    calls = []
+
+    async def _fake_assert(sid, uid):
+        calls.append(("assert", sid, uid))
+
+    fake_chat_service = AsyncMock()
+    fake_chat_service.langflow_chat = AsyncMock(
+        side_effect=lambda *a, **k: calls.append(("lc",)) or "ok"
+    )
+
+    monkeypatch.setattr(chat_module, "_assert_owns", _fake_assert)
+
+    class FakeUser:
+        user_id = "alice"
+        jwt_token = None
+        name = "A"
+        email = "a@x"
+
+    body = ChatBody(prompt="hi", previous_response_id="sess-1")
+    await chat_module.langflow_endpoint(
+        body=body,
+        chat_service=fake_chat_service,
+        session_manager=None,
+        user=FakeUser(),
+    )
+    assert calls[0] == ("assert", "sess-1", "alice")
+
+
+@pytest.mark.asyncio
+async def test_delete_session_endpoint_calls_assert_owns(monkeypatch):
+    from api import chat as chat_module
+
+    calls = []
+
+    async def _fake_assert(sid, uid):
+        calls.append(("assert", sid, uid))
+
+    fake_chat_service = AsyncMock()
+    fake_chat_service.delete_session = AsyncMock(return_value={"success": True})
+
+    monkeypatch.setattr(chat_module, "_assert_owns", _fake_assert)
+
+    class FakeUser:
+        user_id = "alice"
+
+    await chat_module.delete_session_endpoint(
+        session_id="sess-1",
+        chat_service=fake_chat_service,
+        user=FakeUser(),
+    )
+    assert calls[0] == ("assert", "sess-1", "alice")

--- a/tests/unit/test_config_yaml_to_db_migration.py
+++ b/tests/unit/test_config_yaml_to_db_migration.py
@@ -1,0 +1,115 @@
+"""migrations_runtime.run — config_yaml_to_db_v1 step."""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+import yaml
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.migrations_runtime import (  # noqa: E402
+    CONFIG_YAML_TO_DB_V1,
+    migrate_config_yaml_to_db,
+)
+from db.models import MigrationStatus  # noqa: E402
+from db.repositories import WorkspaceConfigRepo  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.fixture
+def tmp_yaml(monkeypatch):
+    """Point ConfigManager at an isolated temp directory for the test."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_dir = Path(tmp) / "config"
+        cfg_dir.mkdir()
+        monkeypatch.setenv("OPENRAG_CONFIG_PATH", str(cfg_dir))
+        # ConfigManager is a singleton at module level — reset its
+        # internal state so it picks up the new path on next load.
+        from config.config_manager import config_manager
+        config_manager.config_file = cfg_dir / "config.yaml"
+        config_manager._config = None
+        yield cfg_dir / "config.yaml"
+
+
+@pytest.mark.asyncio
+async def test_migration_writes_all_sections_from_existing_yaml(
+    tmp_yaml, session
+):
+    """Existing install with config.yaml → all sections copied to DB."""
+    yaml_payload = {
+        "providers": {
+            "openai": {"configured": True},
+            "anthropic": {},
+            "watsonx": {},
+            "ollama": {},
+        },
+        "knowledge": {"embedding_model": "text-embedding-3-small", "chunk_size": 1024},
+        "agent": {"llm_model": "gpt-4o", "system_prompt": "be helpful"},
+        "onboarding": {"current_step": "complete"},
+        "edited": True,
+    }
+    tmp_yaml.write_text(yaml.safe_dump(yaml_payload))
+
+    written = await migrate_config_yaml_to_db(session)
+    await session.commit()
+    assert written == 5  # providers, knowledge, agent, onboarding, meta
+
+    repo = WorkspaceConfigRepo(session)
+    assert (await repo.get_section("agent"))["llm_model"] == "gpt-4o"
+    assert (await repo.get_section("knowledge"))["embedding_model"] == "text-embedding-3-small"
+    assert (await repo.get_section("onboarding"))["current_step"] == "complete"
+    assert (await repo.get_section("meta")) == {"edited": True}
+
+
+@pytest.mark.asyncio
+async def test_migration_fresh_install_writes_empty_sections(tmp_yaml, session):
+    """No yaml file present — migration still runs, writes empty/default
+    sections, edited=False."""
+    # Don't create yaml file; ConfigManager.load_config returns defaults
+    written = await migrate_config_yaml_to_db(session)
+    await session.commit()
+    assert written == 5
+
+    repo = WorkspaceConfigRepo(session)
+    meta = await repo.get_section("meta")
+    assert meta == {"edited": False}
+
+
+@pytest.mark.asyncio
+async def test_migration_via_run_marks_status(tmp_yaml, session):
+    """Calling migrations_runtime.run multiple times is idempotent."""
+    from db.migrations_runtime import run
+
+    await run(session)
+    await session.commit()
+    status = await session.get(MigrationStatus, CONFIG_YAML_TO_DB_V1)
+    assert status is not None
+
+    # Second run — no-op
+    await run(session)
+    await session.commit()
+    # Still exists, single status row
+    status2 = await session.get(MigrationStatus, CONFIG_YAML_TO_DB_V1)
+    assert status2 is not None

--- a/tests/unit/test_conversation_persistence_service_modes.py
+++ b/tests/unit/test_conversation_persistence_service_modes.py
@@ -1,0 +1,176 @@
+"""ConversationPersistenceService — hybrid / db / files mode coverage."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import ConversationRepo  # noqa: E402
+from services.conversation_persistence_service import (  # noqa: E402
+    ConversationPersistenceService,
+)
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def storage_path(tmp_path):
+    return tmp_path / "conversations.json"
+
+
+def _svc(storage_path, session_factory) -> ConversationPersistenceService:
+    return ConversationPersistenceService(
+        storage_file=str(storage_path),
+        session_factory=session_factory,
+    )
+
+
+def _payload(title="Hello", endpoint="chat") -> dict:
+    return {
+        "response_id": "r-1",
+        "title": title,
+        "endpoint": endpoint,
+        "previous_response_id": None,
+        "filter_id": None,
+        "total_messages": 3,
+    }
+
+
+@pytest.mark.asyncio
+async def test_db_mode_writes_to_db_only(monkeypatch, storage_path, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = _svc(storage_path, session_factory)
+
+    await svc.store_conversation_thread("alice", "r-1", _payload())
+
+    # JSON never created
+    assert not storage_path.exists()
+
+    # DB row present
+    async with session_factory() as session:
+        row = await ConversationRepo(session).get("r-1")
+        assert row is not None
+        assert row.user_id == "alice"
+        assert row.title == "Hello"
+        assert row.total_messages == 3
+
+
+@pytest.mark.asyncio
+async def test_files_mode_writes_to_json_only(monkeypatch, storage_path, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "files")
+    svc = _svc(storage_path, session_factory)
+
+    await svc.store_conversation_thread("alice", "r-1", _payload())
+
+    assert storage_path.exists()
+    body = json.loads(storage_path.read_text())
+    assert body["alice"]["r-1"]["title"] == "Hello"
+
+    async with session_factory() as session:
+        row = await ConversationRepo(session).get("r-1")
+        assert row is None
+
+
+@pytest.mark.asyncio
+async def test_hybrid_mode_dual_writes(monkeypatch, storage_path, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "hybrid")
+    svc = _svc(storage_path, session_factory)
+
+    await svc.store_conversation_thread("alice", "r-1", _payload())
+
+    assert storage_path.exists()
+    async with session_factory() as session:
+        assert await ConversationRepo(session).get("r-1") is not None
+
+
+@pytest.mark.asyncio
+async def test_db_mode_ignores_pre_existing_json(
+    monkeypatch, storage_path, session_factory
+):
+    storage_path.write_text(json.dumps({
+        "alice": {
+            "ghost-r": {"title": "leak", "total_messages": 1}
+        }
+    }))
+
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = _svc(storage_path, session_factory)
+
+    convs = await svc.get_user_conversations("alice")
+    assert convs == {}  # JSON ignored
+
+
+@pytest.mark.asyncio
+async def test_hybrid_merges_db_and_json_on_read(
+    monkeypatch, storage_path, session_factory
+):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "hybrid")
+
+    # Seed JSON with one entry
+    storage_path.write_text(json.dumps({
+        "alice": {"r-json": {"title": "from-json", "total_messages": 0}}
+    }))
+
+    svc = _svc(storage_path, session_factory)
+    # Add a DB-only entry
+    await svc._db_upsert("alice", "r-db", _payload(title="from-db"))
+
+    convs = await svc.get_user_conversations("alice")
+    assert "r-db" in convs and convs["r-db"]["title"] == "from-db"
+    assert "r-json" in convs and convs["r-json"]["title"] == "from-json"
+
+
+@pytest.mark.asyncio
+async def test_delete_only_owner_can_delete(monkeypatch, storage_path, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = _svc(storage_path, session_factory)
+
+    await svc.store_conversation_thread("alice", "r-1", _payload())
+    # Mallory cannot delete
+    assert await svc.delete_conversation_thread("mallory", "r-1") is False
+    # Alice can
+    assert await svc.delete_conversation_thread("alice", "r-1") is True
+    async with session_factory() as session:
+        assert await ConversationRepo(session).get("r-1") is None
+
+
+@pytest.mark.asyncio
+async def test_clear_user_removes_all_their_threads(
+    monkeypatch, storage_path, session_factory
+):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = _svc(storage_path, session_factory)
+
+    p1 = _payload()
+    p2 = dict(_payload(), response_id="r-2")
+    await svc.store_conversation_thread("alice", "r-1", p1)
+    await svc.store_conversation_thread("alice", "r-2", p2)
+    await svc.store_conversation_thread("bob", "r-3", p1)
+
+    await svc.clear_user_conversations("alice")
+
+    convs = await svc.get_user_conversations("alice")
+    assert convs == {}
+    bob_convs = await svc.get_user_conversations("bob")
+    assert "r-3" in bob_convs

--- a/tests/unit/test_json_to_db_migration.py
+++ b/tests/unit/test_json_to_db_migration.py
@@ -1,0 +1,85 @@
+"""migrations_runtime.run — legacy users discovered from JSON files."""
+
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.migrations_runtime import run as run_migration  # noqa: E402
+from db.models import MigrationStatus, User as UserRow  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session_in_temp_data():
+    with tempfile.TemporaryDirectory() as data_dir:
+        os.environ["OPENRAG_DATA_PATH"] = data_dir
+        Path(data_dir, "connections.json").write_text(
+            json.dumps(
+                {
+                    "connections": [
+                        {"connection_id": "x1", "user_id": "user-aaa", "config": {}},
+                        {"connection_id": "x2", "user_id": "user-bbb", "config": {}},
+                        {"connection_id": "x3", "user_id": "user-aaa", "config": {}},
+                    ]
+                }
+            )
+        )
+        Path(data_dir, "conversations.json").write_text(
+            json.dumps({"user-bbb": {}, "user-ccc": {}})
+        )
+        Path(data_dir, "session_ownership.json").write_text(
+            json.dumps({"sess1": {"user_id": "user-ddd"}})
+        )
+
+        engine = create_async_engine(
+            "sqlite+aiosqlite:///:memory:",
+            connect_args={"check_same_thread": False},
+        )
+        async with engine.begin() as conn:
+            await conn.run_sync(SQLModel.metadata.create_all)
+        SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+        async with SessionLocal() as s:
+            yield s
+        await engine.dispose()
+        del os.environ["OPENRAG_DATA_PATH"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_users_are_inserted(session_in_temp_data):
+    s = session_in_temp_data
+    await run_migration(s)
+    await s.commit()
+
+    rows = (await s.execute(select(UserRow))).scalars().all()
+    legacy_ids = {r.oauth_subject for r in rows if r.oauth_provider == "legacy"}
+    assert legacy_ids == {"user-aaa", "user-bbb", "user-ccc", "user-ddd"}
+
+    status = await s.get(MigrationStatus, "json_to_db_v1")
+    assert status is not None
+
+
+@pytest.mark.asyncio
+async def test_idempotent_second_run(session_in_temp_data):
+    s = session_in_temp_data
+    await run_migration(s)
+    await s.commit()
+    count_before = len((await s.execute(select(UserRow))).scalars().all())
+
+    await run_migration(s)
+    await s.commit()
+    count_after = len((await s.execute(select(UserRow))).scalars().all())
+
+    assert count_before == count_after

--- a/tests/unit/test_json_to_db_migration.py
+++ b/tests/unit/test_json_to_db_migration.py
@@ -83,3 +83,47 @@ async def test_idempotent_second_run(session_in_temp_data):
     count_after = len((await s.execute(select(UserRow))).scalars().all())
 
     assert count_before == count_after
+
+
+@pytest.mark.asyncio
+async def test_partial_collision_keeps_other_legacy_inserts(session_in_temp_data):
+    """If one legacy user_id already exists in the DB (e.g. from a prior
+    run on a different file), the per-row IntegrityError must roll back
+    only THAT savepoint, not the whole outer transaction. Previously
+    `session.rollback()` in the except dropped every other newly-flushed
+    row in the same migration pass.
+    """
+    s = session_in_temp_data
+    from db.migrations_runtime import migrate_legacy_users
+    from db.repositories._helpers import email_lookup_hash
+
+    # Seed: pre-existing legacy row for user-aaa (one of the four ids
+    # that the JSON fixtures will try to insert).
+    pre_existing = UserRow(
+        id="user-aaa",
+        oauth_provider="legacy",
+        oauth_subject="user-aaa",
+        email="user-aaa@unknown.local",
+        email_lookup_hash=email_lookup_hash("user-aaa@unknown.local"),
+        display_name="user-aaa",
+    )
+    s.add(pre_existing)
+    await s.commit()
+    # Expunge so the session's identity map is empty for the migration —
+    # mirrors production, where the migration runs on a session that
+    # didn't load this row.
+    s.expunge_all()
+
+    inserted = await migrate_legacy_users(s)
+    await s.commit()
+
+    legacy = {
+        r.oauth_subject
+        for r in (await s.execute(select(UserRow))).scalars().all()
+        if r.oauth_provider == "legacy"
+    }
+    # All four legacy ids should be present: user-aaa (pre-existing) +
+    # user-bbb / user-ccc / user-ddd (newly migrated).
+    assert legacy == {"user-aaa", "user-bbb", "user-ccc", "user-ddd"}
+    # user-aaa was a duplicate, so insert count is 3.
+    assert inserted == 3

--- a/tests/unit/test_phase2_permission_enforcement.py
+++ b/tests/unit/test_phase2_permission_enforcement.py
@@ -1,0 +1,184 @@
+"""Phase 2: end-to-end gate test for require_permission.
+
+Builds a tiny FastAPI app whose routes use the real `require_permission`
+dependency against an in-memory SQLite seeded with the real catalog. The
+in-process auth dependency is overridden via FastAPI's dependency_overrides
+so we can switch between admin / developer / user / viewer personas per
+request without touching cookies or JWTs.
+"""
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import Depends, FastAPI, Request
+from fastapi.responses import JSONResponse
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from dependencies import (  # noqa: E402
+    get_current_user,
+    get_rbac_service,
+    require_permission,
+)
+from services.rbac_service import RBACService  # noqa: E402
+from services.user_service import ensure_user_row  # noqa: E402
+from session_manager import User  # noqa: E402
+
+
+# Map role-name -> User dataclass we hand to overrides
+PERSONAS: dict[str, User] = {}
+
+
+@pytest_asyncio.fixture
+async def app(monkeypatch):
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    PERSONAS.clear()
+    async with SessionLocal() as s:
+        await seed_roles_and_permissions(s)
+        # First user becomes admin (bootstrap rule)
+        admin_db = await ensure_user_row(
+            s, User(user_id="admin-sub", email="a@x.com", name="A", provider="google")
+        )
+        # Subsequent users get OPENRAG_DEFAULT_ROLE = "user"
+        user_db = await ensure_user_row(
+            s, User(user_id="user-sub", email="u@x.com", name="U", provider="google")
+        )
+
+        # Promote a fresh user to "developer" by replacing its default role.
+        dev_db = await ensure_user_row(
+            s, User(user_id="dev-sub", email="d@x.com", name="D", provider="google")
+        )
+        role_repo = RoleRepo(s)
+        user_role = await role_repo.get_by_name("user")
+        dev_role = await role_repo.get_by_name("developer")
+        viewer_role = await role_repo.get_by_name("viewer")
+        await role_repo.revoke_role(dev_db.id, user_role.id)
+        await role_repo.assign_role(dev_db.id, dev_role.id)
+
+        # And a viewer
+        viewer_db = await ensure_user_row(
+            s, User(user_id="viewer-sub", email="v@x.com", name="V", provider="google")
+        )
+        await role_repo.revoke_role(viewer_db.id, user_role.id)
+        await role_repo.assign_role(viewer_db.id, viewer_role.id)
+
+        await s.commit()
+
+        # Map persona name -> User dataclass with id matching the DB row id so
+        # require_permission's lookups via rbac.get_user_permissions(user.user_id)
+        # resolve correctly. Note: User.user_id is the *DB id* here so the key
+        # lookups (which use db_user.id) line up.
+        PERSONAS["admin"] = User(
+            user_id=admin_db.id, email="a@x.com", name="A", provider="google"
+        )
+        PERSONAS["user"] = User(
+            user_id=user_db.id, email="u@x.com", name="U", provider="google"
+        )
+        PERSONAS["developer"] = User(
+            user_id=dev_db.id, email="d@x.com", name="D", provider="google"
+        )
+        PERSONAS["viewer"] = User(
+            user_id=viewer_db.id, email="v@x.com", name="V", provider="google"
+        )
+
+    rbac = RBACService(SessionLocal)
+
+    app = FastAPI()
+
+    async def _stub_user(request: Request) -> User:
+        persona = request.headers.get("X-Test-Persona", "user")
+        return PERSONAS[persona]
+
+    app.dependency_overrides[get_current_user] = _stub_user
+    app.dependency_overrides[get_rbac_service] = lambda: rbac
+
+    @app.post("/test/config-write")
+    async def write_config(user=Depends(require_permission("config:write"))):
+        return JSONResponse({"user_id": user.user_id})
+
+    @app.post("/test/chat-use")
+    async def use_chat(user=Depends(require_permission("chat:use"))):
+        return JSONResponse({"user_id": user.user_id})
+
+    @app.post("/test/kf-create")
+    async def kf_create(user=Depends(require_permission("kf:create"))):
+        return JSONResponse({"user_id": user.user_id})
+
+    @app.post("/test/users-list")
+    async def users_list(user=Depends(require_permission("users:list"))):
+        return JSONResponse({"user_id": user.user_id})
+
+    @app.post("/test/flows-edit")
+    async def flows_edit(user=Depends(require_permission("flows:edit"))):
+        return JSONResponse({"user_id": user.user_id})
+
+    yield app
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "persona, perm_path, expected",
+    [
+        # admin → everything passes
+        ("admin", "/test/config-write", 200),
+        ("admin", "/test/chat-use", 200),
+        ("admin", "/test/kf-create", 200),
+        ("admin", "/test/users-list", 200),
+        ("admin", "/test/flows-edit", 200),
+        # developer → no infra writes, no users:list
+        ("developer", "/test/config-write", 403),
+        ("developer", "/test/chat-use", 200),
+        ("developer", "/test/kf-create", 200),
+        ("developer", "/test/users-list", 403),
+        ("developer", "/test/flows-edit", 200),
+        # default user → chat + kf:create yes; flows:edit no
+        ("user", "/test/config-write", 403),
+        ("user", "/test/chat-use", 200),
+        ("user", "/test/kf-create", 200),
+        ("user", "/test/users-list", 403),
+        ("user", "/test/flows-edit", 403),
+        # viewer → chat yes; everything else no
+        ("viewer", "/test/config-write", 403),
+        ("viewer", "/test/chat-use", 200),
+        ("viewer", "/test/kf-create", 403),
+        ("viewer", "/test/users-list", 403),
+        ("viewer", "/test/flows-edit", 403),
+    ],
+)
+async def test_permission_enforcement(app, persona, perm_path, expected):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(perm_path, headers={"X-Test-Persona": persona})
+    assert r.status_code == expected, f"{persona} {perm_path} -> {r.status_code} {r.text}"
+    if expected == 403:
+        body = r.json()
+        assert body["detail"]["error"] == "permission_denied"
+
+
+@pytest.mark.asyncio
+async def test_403_response_includes_required_perm(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post("/test/config-write", headers={"X-Test-Persona": "user"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["required"] == "config:write"

--- a/tests/unit/test_phase3_admin_endpoints.py
+++ b/tests/unit/test_phase3_admin_endpoints.py
@@ -1,0 +1,278 @@
+"""Phase 3: admin RBAC endpoints — happy paths + access control."""
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from dependencies import (  # noqa: E402
+    get_current_user,
+    get_db_session,
+    get_rbac_service,
+)
+from services.rbac_service import RBACService  # noqa: E402
+from services.user_service import ensure_user_row  # noqa: E402
+from session_manager import User  # noqa: E402
+
+PERSONAS: dict[str, User] = {}
+
+
+@pytest_asyncio.fixture
+async def app(monkeypatch):
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    PERSONAS.clear()
+    async with SessionLocal() as s:
+        await seed_roles_and_permissions(s)
+        admin_db = await ensure_user_row(
+            s, User(user_id="admin-sub", email="a@x.com", name="A", provider="google")
+        )
+        user_db = await ensure_user_row(
+            s, User(user_id="user-sub", email="u@x.com", name="U", provider="google")
+        )
+        await s.commit()
+
+        PERSONAS["admin"] = User(
+            user_id=admin_db.id, email="a@x.com", name="A", provider="google"
+        )
+        PERSONAS["user"] = User(
+            user_id=user_db.id, email="u@x.com", name="U", provider="google"
+        )
+
+    rbac = RBACService(SessionLocal)
+
+    fastapi_app = FastAPI()
+
+    async def _stub_user(request: Request) -> User:
+        persona = request.headers.get("X-Test-Persona", "admin")
+        return PERSONAS[persona]
+
+    async def _db_session():
+        async with SessionLocal() as s:
+            yield s
+
+    fastapi_app.dependency_overrides[get_current_user] = _stub_user
+    fastapi_app.dependency_overrides[get_rbac_service] = lambda: rbac
+    fastapi_app.dependency_overrides[get_db_session] = _db_session
+
+    from api.admin import rbac as admin_rbac
+    fastapi_app.include_router(admin_rbac.router)
+
+    yield fastapi_app, SessionLocal, rbac
+    await engine.dispose()
+
+
+def _admin_headers():
+    return {"X-Test-Persona": "admin"}
+
+
+def _user_headers():
+    return {"X-Test-Persona": "user"}
+
+
+@pytest.mark.asyncio
+async def test_admin_can_list_users(app):
+    fastapi_app, _, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/admin/users", headers=_admin_headers())
+    assert r.status_code == 200
+    assert len(r.json()) == 2
+
+
+@pytest.mark.asyncio
+async def test_non_admin_cannot_list_users(app):
+    fastapi_app, _, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/admin/users", headers=_user_headers())
+    assert r.status_code == 403
+    assert r.json()["detail"]["required"] == "users:list"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_promote_user(app):
+    fastapi_app, SessionLocal, rbac = app
+    user_id = PERSONAS["user"].user_id
+
+    async with SessionLocal() as s:
+        dev_role = await RoleRepo(s).get_by_name("developer")
+    role_id = dev_role.id
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            f"/admin/users/{user_id}/roles",
+            json={"role_id": role_id},
+            headers=_admin_headers(),
+        )
+    assert r.status_code == 200
+    body = r.json()
+    assert "developer" in body["roles"]
+
+
+@pytest.mark.asyncio
+async def test_cannot_remove_last_admin(app):
+    fastapi_app, SessionLocal, _ = app
+    admin_id = PERSONAS["admin"].user_id
+
+    async with SessionLocal() as s:
+        admin_role = await RoleRepo(s).get_by_name("admin")
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.delete(
+            f"/admin/users/{admin_id}/roles/{admin_role.id}",
+            headers=_admin_headers(),
+        )
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "cannot_remove_last_admin"
+
+
+@pytest.mark.asyncio
+async def test_admin_can_create_and_delete_custom_role(app):
+    fastapi_app, _, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        # Create
+        r = await c.post(
+            "/admin/roles",
+            json={
+                "name": "reviewer",
+                "description": "Doc reviewer",
+                "permissions": ["chat:use", "search:use", "kf:edit:own"],
+            },
+            headers=_admin_headers(),
+        )
+        assert r.status_code == 200
+        role = r.json()
+        assert role["name"] == "reviewer"
+        assert role["is_system"] is False
+        assert set(role["permissions"]) == {"chat:use", "search:use", "kf:edit:own"}
+
+        # List
+        r = await c.get("/admin/roles", headers=_admin_headers())
+        names = {row["name"] for row in r.json()}
+        assert "reviewer" in names
+
+        # Delete
+        r = await c.delete(f"/admin/roles/{role['id']}", headers=_admin_headers())
+        assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cannot_delete_system_role(app):
+    fastapi_app, SessionLocal, _ = app
+    async with SessionLocal() as s:
+        admin_role = await RoleRepo(s).get_by_name("admin")
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.delete(
+            f"/admin/roles/{admin_role.id}", headers=_admin_headers()
+        )
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "cannot_delete_system_role"
+
+
+@pytest.mark.asyncio
+async def test_role_edit_replaces_permissions_and_invalidates_cache(app):
+    fastapi_app, SessionLocal, rbac = app
+    async with SessionLocal() as s:
+        user_role = await RoleRepo(s).get_by_name("user")
+    user_id = PERSONAS["user"].user_id
+
+    # Warm cache
+    perms_before = await rbac.get_user_permissions(user_id)
+    assert "chat:use" in perms_before
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.patch(
+            f"/admin/roles/{user_role.id}",
+            json={"permissions": ["search:use"]},
+            headers=_admin_headers(),
+        )
+    assert r.status_code == 200
+
+    perms_after = await rbac.get_user_permissions(user_id)
+    assert "chat:use" not in perms_after
+    assert "search:use" in perms_after
+
+
+@pytest.mark.asyncio
+async def test_audit_log_records_role_assignment(app):
+    fastapi_app, SessionLocal, _ = app
+    user_id = PERSONAS["user"].user_id
+    async with SessionLocal() as s:
+        dev_role = await RoleRepo(s).get_by_name("developer")
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        await c.post(
+            f"/admin/users/{user_id}/roles",
+            json={"role_id": dev_role.id},
+            headers=_admin_headers(),
+        )
+
+        r = await c.get("/admin/audit?limit=50", headers=_admin_headers())
+    assert r.status_code == 200
+    events = [row["event"] for row in r.json()]
+    assert "user.role.assigned" in events
+
+
+@pytest.mark.asyncio
+async def test_permissions_endpoint(app):
+    fastapi_app, _, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/admin/permissions", headers=_admin_headers())
+    assert r.status_code == 200
+    names = {p["name"] for p in r.json()}
+    # Sample known catalog members
+    assert {"config:write", "users:list", "chat:use", "kf:create"}.issubset(names)
+
+
+@pytest.mark.asyncio
+async def test_cannot_delete_self(app):
+    fastapi_app, _, _ = app
+    admin_id = PERSONAS["admin"].user_id
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.delete(f"/admin/users/{admin_id}", headers=_admin_headers())
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "cannot_delete_self"
+
+
+@pytest.mark.asyncio
+async def test_unknown_permission_rejected_on_create_role(app):
+    fastapi_app, _, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/admin/roles",
+            json={"name": "weird", "permissions": ["does:not:exist"]},
+            headers=_admin_headers(),
+        )
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "unknown_permission"

--- a/tests/unit/test_phase3_admin_endpoints.py
+++ b/tests/unit/test_phase3_admin_endpoints.py
@@ -265,6 +265,90 @@ async def test_cannot_delete_self(app):
 
 
 @pytest.mark.asyncio
+async def test_cannot_delete_last_admin(app):
+    """Single-admin DB. A non-admin actor with `users:delete` permission
+    tries to DELETE the sole admin → cannot_delete_last_admin (400).
+
+    The cannot_delete_self guard runs first, so we use a non-admin actor
+    with a custom role granting `users:delete`. This isolates the
+    last-admin guard from the self-delete guard.
+    """
+    fastapi_app, SessionLocal, _ = app
+    admin_id = PERSONAS["admin"].user_id
+    user_id = PERSONAS["user"].user_id
+
+    # Grant the `user` persona a custom role that includes users:delete
+    # without being an admin. This requires us to create the role and
+    # assign it via the admin endpoints.
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/admin/roles",
+            json={"name": "user_deleter", "permissions": ["users:delete"]},
+            headers=_admin_headers(),
+        )
+        assert r.status_code == 200
+        deleter_role_id = r.json()["id"]
+        r = await c.post(
+            f"/admin/users/{user_id}/roles",
+            json={"role_id": deleter_role_id},
+            headers=_admin_headers(),
+        )
+        assert r.status_code == 200
+        # `user` (non-admin, has users:delete) tries to delete the sole admin.
+        r = await c.delete(
+            f"/admin/users/{admin_id}",
+            headers={"X-Test-Persona": "user"},
+        )
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "cannot_delete_last_admin"
+
+
+@pytest.mark.asyncio
+async def test_can_delete_non_last_admin(app):
+    """Two-admin DB → deleting one admin leaves the other; should succeed."""
+    fastapi_app, SessionLocal, _ = app
+    user_id = PERSONAS["user"].user_id
+    async with SessionLocal() as s:
+        admin_role = await RoleRepo(s).get_by_name("admin")
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        # Promote user to admin → now 2 admins.
+        r = await c.post(
+            f"/admin/users/{user_id}/roles",
+            json={"role_id": admin_role.id},
+            headers=_admin_headers(),
+        )
+        assert r.status_code == 200
+        # Admin (still admin) deletes the second admin → succeeds.
+        r = await c.delete(
+            f"/admin/users/{user_id}",
+            headers=_admin_headers(),
+        )
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_cannot_deactivate_last_admin(app):
+    """PATCH /users/{admin_id} {is_active: False} on the only admin → 400."""
+    fastapi_app, SessionLocal, _ = app
+    admin_id = PERSONAS["admin"].user_id
+    async with SessionLocal() as s:
+        admin_role = await RoleRepo(s).get_by_name("admin")
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.patch(
+            f"/admin/users/{admin_id}",
+            json={"is_active": False},
+            headers=_admin_headers(),
+        )
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "cannot_deactivate_last_admin"
+
+
+@pytest.mark.asyncio
 async def test_unknown_permission_rejected_on_create_role(app):
     fastapi_app, _, _ = app
     transport = httpx.ASGITransport(app=fastapi_app)

--- a/tests/unit/test_rbac_kill_switch.py
+++ b/tests/unit/test_rbac_kill_switch.py
@@ -203,6 +203,8 @@ async def test_me_returns_full_permission_catalog_when_disabled(app, monkeypatch
     # Should include the entire seeded catalog
     expected_subset = {"users:list", "users:delete", "config:write", "chat:use"}
     assert expected_subset.issubset(set(body["permissions"]))
+    # And the flag is surfaced so the UI can hide RBAC-only sections
+    assert body["rbac_enforced"] is False
 
 
 @pytest.mark.asyncio
@@ -221,3 +223,4 @@ async def test_me_returns_only_user_perms_when_enforced(app, monkeypatch):
 
     # Should NOT include admin-only perms when enforced
     assert "users:delete" not in body["permissions"]
+    assert body["rbac_enforced"] is True

--- a/tests/unit/test_rbac_kill_switch.py
+++ b/tests/unit/test_rbac_kill_switch.py
@@ -1,0 +1,223 @@
+"""OPENRAG_RBAC_ENFORCE kill switch.
+
+When the flag is off, every authenticated user passes every gate:
+- ``require_permission`` returns the user without checking
+- ``RBACService.assert_owner_or_perm`` returns immediately
+- API-key role overrides are also bypassed
+- ``/users/me`` reports the full permission catalog so the UI shows
+  every action
+
+This is the "pre-RBAC behavior" mode the operator can toggle on for
+single-user OSS installs or emergency debugging.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from dependencies import (  # noqa: E402
+    get_current_user,
+    get_db_session,
+    get_rbac_service,
+)
+from services.rbac_service import RBACService, is_rbac_enforced  # noqa: E402
+from services.user_service import ensure_user_row  # noqa: E402
+from session_manager import User  # noqa: E402
+
+
+# ----------------------------------------------------------------------
+# is_rbac_enforced() resolver
+# ----------------------------------------------------------------------
+
+
+def test_default_does_not_enforce(monkeypatch):
+    """RBAC is opt-in: with no env var set, enforcement is off."""
+    monkeypatch.delenv("OPENRAG_RBAC_ENFORCE", raising=False)
+    assert is_rbac_enforced() is False
+
+
+@pytest.mark.parametrize("v", ["true", "TRUE", "1", "yes", "on", "True"])
+def test_on_values(monkeypatch, v):
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", v)
+    assert is_rbac_enforced() is True
+
+
+@pytest.mark.parametrize("v", ["false", "0", "no", "off", "", "garbage"])
+def test_off_values(monkeypatch, v):
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", v)
+    assert is_rbac_enforced() is False
+
+
+# ----------------------------------------------------------------------
+# Bypass — require_permission + assert_owner_or_perm
+# ----------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def app(monkeypatch):
+    """Spin up a tiny FastAPI app with one gated endpoint, two personas
+    (admin + non-admin), and the kill switch monkeypatch-controlled."""
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    personas: dict[str, User] = {}
+    async with SessionLocal() as s:
+        await seed_roles_and_permissions(s)
+        admin_db = await ensure_user_row(
+            s, User(user_id="admin-sub", email="a@x", name="A", provider="google")
+        )
+        user_db = await ensure_user_row(
+            s, User(user_id="user-sub", email="u@x", name="U", provider="google")
+        )
+        await s.commit()
+        personas["admin"] = User(
+            user_id=admin_db.id, email="a@x", name="A", provider="google"
+        )
+        personas["user"] = User(
+            user_id=user_db.id, email="u@x", name="U", provider="google"
+        )
+
+    rbac = RBACService(SessionLocal)
+    fastapi_app = FastAPI()
+
+    async def _stub_user(request: Request) -> User:
+        persona = request.headers.get("X-Test-Persona", "user")
+        return personas[persona]
+
+    async def _db_session():
+        async with SessionLocal() as s:
+            yield s
+
+    fastapi_app.dependency_overrides[get_current_user] = _stub_user
+    fastapi_app.dependency_overrides[get_rbac_service] = lambda: rbac
+    fastapi_app.dependency_overrides[get_db_session] = _db_session
+
+    # Mount the admin router so we can hit a real require_permission gate.
+    from api.admin import rbac as admin_rbac
+    fastapi_app.include_router(admin_rbac.router)
+
+    yield fastapi_app, SessionLocal, rbac, personas
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_bypasses_require_permission(app, monkeypatch):
+    """`user` persona has no admin role but DELETE /admin/users requires
+    `users:delete`. Default = 403. With kill switch = 200/4xx-from-handler."""
+    fastapi_app, _, _, personas = app
+    target_id = personas["admin"].user_id  # arbitrary other id
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        # Enforced: blocked
+        monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+        r = await c.get("/admin/users", headers={"X-Test-Persona": "user"})
+        assert r.status_code == 403
+        assert r.json()["detail"]["required"] == "users:list"
+
+        # Kill switch off (default): passes
+        monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
+        r = await c.get("/admin/users", headers={"X-Test-Persona": "user"})
+        assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_bypasses_assert_owner_or_perm(monkeypatch):
+    """The shared helper used by `:own` endpoints must also bypass."""
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
+
+    # Mock session_factory — it should never be hit
+    factory = MagicMock(side_effect=AssertionError("DB should not be queried"))
+    rbac = RBACService(factory)
+
+    # Non-owner, no permissions → would normally 403; kill switch returns silently
+    user = User(user_id="alice", email="a@x", name="A", provider="google")
+    await rbac.assert_owner_or_perm(
+        user=user,
+        owner_id="bob",
+        owned_perm="kf:delete:own",
+        any_perm="kf:delete",
+    )
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_bypasses_api_key_role_override(app, monkeypatch):
+    """API-key role_override is also bypassed — the flag is unconditional."""
+    fastapi_app, _, _, _ = app
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
+
+    # Inject a request middleware that pretends an API key with a
+    # "viewer-only" role override is in play. With the kill switch the
+    # role_override is never consulted, so the request still succeeds.
+    @fastapi_app.middleware("http")
+    async def _inject_key_scope(request, call_next):
+        request.state.api_key_role_ids = ["nonexistent-role-id"]
+        return await call_next(request)
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/admin/users", headers={"X-Test-Persona": "user"})
+    assert r.status_code == 200
+
+
+# ----------------------------------------------------------------------
+# /users/me — full catalog when the kill switch is on
+# ----------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_me_returns_full_permission_catalog_when_disabled(app, monkeypatch):
+    fastapi_app, SessionLocal, _, _ = app
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
+
+    from api import users as users_api
+    fastapi_app.include_router(users_api.router)
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/users/me", headers={"X-Test-Persona": "user"})
+    assert r.status_code == 200
+    body = r.json()
+
+    # Should include the entire seeded catalog
+    expected_subset = {"users:list", "users:delete", "config:write", "chat:use"}
+    assert expected_subset.issubset(set(body["permissions"]))
+
+
+@pytest.mark.asyncio
+async def test_me_returns_only_user_perms_when_enforced(app, monkeypatch):
+    fastapi_app, _, _, _ = app
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+
+    from api import users as users_api
+    fastapi_app.include_router(users_api.router)
+
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/users/me", headers={"X-Test-Persona": "user"})
+    assert r.status_code == 200
+    body = r.json()
+
+    # Should NOT include admin-only perms when enforced
+    assert "users:delete" not in body["permissions"]

--- a/tests/unit/test_rbac_seed_idempotency.py
+++ b/tests/unit/test_rbac_seed_idempotency.py
@@ -1,0 +1,87 @@
+"""Verify db.seed.seed_roles_and_permissions is idempotent."""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy import select
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401  (registers tables)
+from db.models import Permission, Role, RolePermission  # noqa: E402
+from db.seed import (  # noqa: E402
+    BUILTIN_ROLES,
+    PERMISSIONS,
+    ROLE_PERMISSION_MAP,
+    seed_roles_and_permissions,
+)
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as s:
+        yield s
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_seed_creates_expected_rows(session):
+    await seed_roles_and_permissions(session)
+    await session.commit()
+
+    perms = (await session.execute(select(Permission))).scalars().all()
+    roles = (await session.execute(select(Role))).scalars().all()
+
+    assert len(perms) == len(PERMISSIONS)
+    assert {r.name for r in roles} == {n for _, n, _ in BUILTIN_ROLES}
+
+    # admin gets every permission
+    admin_role = next(r for r in roles if r.name == "admin")
+    admin_perm_ids = {
+        rp.permission_id
+        for rp in (await session.execute(select(RolePermission).where(RolePermission.role_id == admin_role.id))).scalars().all()
+    }
+    assert len(admin_perm_ids) == len(PERMISSIONS)
+
+
+@pytest.mark.asyncio
+async def test_seed_is_idempotent(session):
+    await seed_roles_and_permissions(session)
+    await session.commit()
+
+    perm_count_before = len((await session.execute(select(Permission))).scalars().all())
+    role_count_before = len((await session.execute(select(Role))).scalars().all())
+    rp_count_before = len((await session.execute(select(RolePermission))).scalars().all())
+
+    # Re-run should not duplicate anything.
+    await seed_roles_and_permissions(session)
+    await session.commit()
+
+    assert len((await session.execute(select(Permission))).scalars().all()) == perm_count_before
+    assert len((await session.execute(select(Role))).scalars().all()) == role_count_before
+    assert len((await session.execute(select(RolePermission))).scalars().all()) == rp_count_before
+
+
+@pytest.mark.asyncio
+async def test_role_permission_map_references_known_perms(session):
+    await seed_roles_and_permissions(session)
+    await session.commit()
+    perm_names = {p.name for p in (await session.execute(select(Permission))).scalars().all()}
+    for role_name, expected in ROLE_PERMISSION_MAP.items():
+        missing = expected - perm_names
+        assert not missing, f"role {role_name} references unknown perms: {missing}"

--- a/tests/unit/test_rbac_service.py
+++ b/tests/unit/test_rbac_service.py
@@ -1,0 +1,109 @@
+"""RBACService — caching, invalidation, and role-override behavior."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from services.rbac_service import RBACService  # noqa: E402
+from services.user_service import ensure_user_row  # noqa: E402
+from session_manager import User  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def setup():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with SessionLocal() as s:
+        await seed_roles_and_permissions(s)
+        admin_user = await ensure_user_row(
+            s, User(user_id="admin-sub", email="admin@x.com", name="A", provider="google")
+        )
+        end_user = await ensure_user_row(
+            s, User(user_id="user-sub", email="u@x.com", name="U", provider="google")
+        )
+        await s.commit()
+
+    yield SessionLocal, admin_user.id, end_user.id
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_admin_has_all_perms(setup):
+    SessionLocal, admin_id, _ = setup
+    rbac = RBACService(SessionLocal)
+    perms = await rbac.get_user_permissions(admin_id)
+    # admin gets everything in the catalog
+    assert "config:write" in perms
+    assert "users:list" in perms
+    assert "agent:prompt:global" in perms
+
+
+@pytest.mark.asyncio
+async def test_default_user_lacks_admin_perms(setup):
+    SessionLocal, _, user_id = setup
+    rbac = RBACService(SessionLocal)
+    perms = await rbac.get_user_permissions(user_id)
+    assert "chat:use" in perms
+    assert "config:write" not in perms
+    assert "users:list" not in perms
+
+
+@pytest.mark.asyncio
+async def test_cache_invalidation_picks_up_new_role(setup):
+    SessionLocal, _, user_id = setup
+    rbac = RBACService(SessionLocal)
+
+    perms_before = await rbac.get_user_permissions(user_id)
+    assert "users:list" not in perms_before
+
+    # Promote to admin out-of-band
+    async with SessionLocal() as s:
+        role_repo = RoleRepo(s)
+        admin_role = await role_repo.get_by_name("admin")
+        await role_repo.assign_role(user_id, admin_role.id)
+        await s.commit()
+
+    # Stale cache: still no admin perms
+    perms_stale = await rbac.get_user_permissions(user_id)
+    assert "users:list" not in perms_stale
+
+    rbac.invalidate(user_id)
+
+    perms_after = await rbac.get_user_permissions(user_id)
+    assert "users:list" in perms_after
+
+
+@pytest.mark.asyncio
+async def test_role_override_bypasses_cache(setup):
+    SessionLocal, admin_id, user_id = setup
+    rbac = RBACService(SessionLocal)
+
+    # Warm cache
+    await rbac.get_user_permissions(admin_id)
+
+    async with SessionLocal() as s:
+        role_repo = RoleRepo(s)
+        viewer_role = await role_repo.get_by_name("viewer")
+
+    perms = await rbac.get_user_permissions(admin_id, role_override=[viewer_role.id])
+    assert "config:write" not in perms
+    assert "chat:use" in perms

--- a/tests/unit/test_session_ownership_service_modes.py
+++ b/tests/unit/test_session_ownership_service_modes.py
@@ -1,0 +1,148 @@
+"""SessionOwnershipService — hybrid / db / files mode coverage."""
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import SessionOwnershipRepo  # noqa: E402
+from services.session_ownership_service import (  # noqa: E402
+    SessionOwnershipService,
+)
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def tmp_data_dir(tmp_path, monkeypatch):
+    """Redirect the service's JSON file into a tmp dir."""
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    json_path = data_dir / "session_ownership.json"
+    # The service resolves the path via get_data_file at construction —
+    # patch it to return our tmp path.
+    monkeypatch.setattr(
+        "services.session_ownership_service.get_data_file",
+        lambda name: str(data_dir / name),
+    )
+    yield json_path
+
+
+def _svc(session_factory) -> SessionOwnershipService:
+    return SessionOwnershipService(session_factory=session_factory)
+
+
+@pytest.mark.asyncio
+async def test_db_mode_writes_to_db_only(monkeypatch, tmp_data_dir, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = _svc(session_factory)
+
+    await svc.claim_session("user-a", "sess-1")
+
+    # JSON never created
+    assert not tmp_data_dir.exists()
+
+    # DB has the row
+    async with session_factory() as session:
+        row = await SessionOwnershipRepo(session).get("sess-1")
+        assert row is not None
+        assert row.user_id == "user-a"
+
+
+@pytest.mark.asyncio
+async def test_files_mode_writes_to_json_only(monkeypatch, tmp_data_dir, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "files")
+    svc = _svc(session_factory)
+
+    await svc.claim_session("user-a", "sess-1")
+
+    # JSON file created
+    assert tmp_data_dir.exists()
+    payload = json.loads(tmp_data_dir.read_text())
+    assert payload["sess-1"]["user_id"] == "user-a"
+
+    # DB untouched
+    async with session_factory() as session:
+        row = await SessionOwnershipRepo(session).get("sess-1")
+        assert row is None
+
+
+@pytest.mark.asyncio
+async def test_hybrid_mode_writes_both(monkeypatch, tmp_data_dir, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "hybrid")
+    svc = _svc(session_factory)
+
+    await svc.claim_session("user-a", "sess-1")
+
+    assert tmp_data_dir.exists()
+    async with session_factory() as session:
+        row = await SessionOwnershipRepo(session).get("sess-1")
+        assert row is not None
+
+
+@pytest.mark.asyncio
+async def test_db_mode_ignores_pre_existing_json(monkeypatch, tmp_data_dir, session_factory):
+    """Stale JSON on disk must not bleed through in db mode."""
+    tmp_data_dir.parent.mkdir(parents=True, exist_ok=True)
+    tmp_data_dir.write_text(json.dumps({
+        "ghost-sess": {"user_id": "ghost-user", "created_at": "x", "last_accessed": "x"}
+    }))
+
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = _svc(session_factory)
+
+    owner = await svc.get_session_owner("ghost-sess")
+    assert owner is None  # JSON ignored
+
+
+@pytest.mark.asyncio
+async def test_cross_user_ownership_check(monkeypatch, tmp_data_dir, session_factory):
+    """User B must not see User A's sessions in any mode."""
+    for mode in ("db", "files", "hybrid"):
+        monkeypatch.setenv("OPENRAG_STORAGE_MODE", mode)
+        # Fresh service per mode so the in-memory dict and JSON are reset
+        if tmp_data_dir.exists():
+            tmp_data_dir.unlink()
+        svc = _svc(session_factory)
+
+        await svc.claim_session("alice", f"sess-{mode}")
+        assert await svc.is_session_owned_by_user(f"sess-{mode}", "alice") is True
+        assert await svc.is_session_owned_by_user(f"sess-{mode}", "bob") is False
+
+
+@pytest.mark.asyncio
+async def test_release_only_owner_can_release(monkeypatch, tmp_data_dir, session_factory):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = _svc(session_factory)
+
+    await svc.claim_session("alice", "sess-1")
+    # Mallory tries to steal
+    released = await svc.release_session("mallory", "sess-1")
+    assert released is False
+
+    # Alice can release
+    released = await svc.release_session("alice", "sess-1")
+    assert released is True
+    assert await svc.get_session_owner("sess-1") is None

--- a/tests/unit/test_storage_mode.py
+++ b/tests/unit/test_storage_mode.py
@@ -1,0 +1,284 @@
+"""WorkspaceConfigService — coverage for the 3 storage modes
+(`hybrid`, `db`, `files`) selected by ``OPENRAG_STORAGE_MODE``.
+
+The contract:
+
+| Mode    | yaml created on save? | DB written? | yaml read fallback? |
+|---------|-----------------------|-------------|---------------------|
+| hybrid  | yes                   | yes         | yes                 |
+| db      | NO                    | yes         | NO                  |
+| files   | yes                   | NO          | yes                 |
+"""
+
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from config.config_manager import ConfigManager  # noqa: E402
+from config.storage_mode import (  # noqa: E402
+    db_writes_enabled,
+    file_writes_enabled,
+    get_storage_mode,
+)
+from db.repositories import WorkspaceConfigRepo  # noqa: E402
+from services.workspace_config_service import WorkspaceConfigService  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def tmp_config_manager():
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_file = Path(tmp) / "config.yaml"
+        cm = ConfigManager(config_file=str(cfg_file))
+        yield cm
+
+
+# ======================================================================
+# Mode resolver
+# ======================================================================
+
+
+def test_default_mode_is_hybrid(monkeypatch):
+    monkeypatch.delenv("OPENRAG_STORAGE_MODE", raising=False)
+    monkeypatch.delenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", raising=False)
+    assert get_storage_mode() == "hybrid"
+
+
+def test_explicit_mode_db(monkeypatch):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    assert get_storage_mode() == "db"
+    assert db_writes_enabled() is True
+    assert file_writes_enabled() is False
+
+
+def test_explicit_mode_files(monkeypatch):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "files")
+    assert get_storage_mode() == "files"
+    assert db_writes_enabled() is False
+    assert file_writes_enabled() is True
+
+
+def test_legacy_kill_switch_forces_files(monkeypatch):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    monkeypatch.setenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", "true")
+    assert get_storage_mode() == "files"  # legacy switch wins
+
+
+def test_invalid_value_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "weird")
+    monkeypatch.delenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", raising=False)
+    assert get_storage_mode() == "hybrid"
+
+
+# ======================================================================
+# Save behavior per mode
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_db_mode_does_not_create_yaml(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    config = tmp_config_manager.load_config()
+    config.agent.system_prompt = "db-only test"
+
+    ok = await svc.save_config(config)
+    assert ok is True
+
+    # Yaml file MUST NOT be created in db mode
+    assert not tmp_config_manager.config_file.exists()
+
+    # DB has the data
+    async with session_factory() as session:
+        agent = await WorkspaceConfigRepo(session).get_section("agent")
+        assert agent and agent.get("system_prompt") == "db-only test"
+
+
+@pytest.mark.asyncio
+async def test_files_mode_does_not_write_db(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "files")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    config = tmp_config_manager.load_config()
+    config.agent.system_prompt = "files-only test"
+
+    ok = await svc.save_config(config)
+    assert ok is True
+
+    # Yaml created
+    assert tmp_config_manager.config_file.exists()
+
+    # DB untouched
+    async with session_factory() as session:
+        rows = await WorkspaceConfigRepo(session).list_all()
+        assert rows == {}
+
+
+@pytest.mark.asyncio
+async def test_hybrid_mode_writes_both(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "hybrid")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    config = tmp_config_manager.load_config()
+    config.agent.system_prompt = "hybrid test"
+
+    ok = await svc.save_config(config)
+    assert ok is True
+
+    assert tmp_config_manager.config_file.exists()
+    async with session_factory() as session:
+        agent = await WorkspaceConfigRepo(session).get_section("agent")
+        assert agent and agent.get("system_prompt") == "hybrid test"
+
+
+# ======================================================================
+# Read behavior — db mode ignores yaml entirely
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_db_mode_ignores_yaml_fallback(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    """If yaml exists with edited=true but DB is empty, db mode must
+    NOT report onboarded — it ignores yaml entirely."""
+    # Seed yaml so the legacy ConfigManager would say edited=True
+    cfg = tmp_config_manager.load_config()
+    cfg.agent.system_prompt = "from yaml only"
+    cfg.edited = True
+    tmp_config_manager.save_config_file(cfg)
+    assert tmp_config_manager.config_file.exists()
+
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    # DB is empty → db mode must say NOT onboarded
+    assert await svc.is_onboarded() is False
+    # And current_step has nothing to report
+    assert await svc.get_onboarding_step() is None
+
+
+@pytest.mark.asyncio
+async def test_files_mode_reads_only_yaml(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    """If DB has edited=true but yaml is empty, files mode must NOT
+    report onboarded — DB is invisible to it."""
+    async with session_factory() as session:
+        await WorkspaceConfigRepo(session).upsert("meta", {"edited": True})
+        await session.commit()
+
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "files")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    assert await svc.is_onboarded() is False
+
+
+@pytest.mark.asyncio
+async def test_hybrid_falls_back_to_yaml_when_db_empty(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    """In hybrid: empty DB + populated yaml → reads yaml."""
+    cfg = tmp_config_manager.load_config()
+    cfg.edited = True
+    tmp_config_manager.save_config_file(cfg)
+
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "hybrid")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    assert await svc.is_onboarded() is True
+
+
+# ======================================================================
+# Monkey-patch hook respects mode
+# ======================================================================
+
+
+@pytest.mark.asyncio
+async def test_db_mode_legacy_save_skips_yaml_writes(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    """A legacy caller that hits config_manager.save_config_file()
+    directly should NOT create a yaml file in db mode."""
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "db")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    # Legacy-style call
+    cfg = tmp_config_manager.load_config()
+    cfg.agent.llm_model = "claude-3-opus"
+    tmp_config_manager.save_config_file(cfg)
+
+    # Wait briefly for the async DB mirror
+    import asyncio
+    for _ in range(20):
+        async with session_factory() as session:
+            agent = await WorkspaceConfigRepo(session).get_section("agent")
+            if agent and agent.get("llm_model") == "claude-3-opus":
+                break
+        await asyncio.sleep(0.05)
+    else:
+        pytest.fail("DB mirror task didn't run within 1s")
+
+    # Critically: NO yaml file
+    assert not tmp_config_manager.config_file.exists()
+
+    delattr(tmp_config_manager, "_db_mirror_installed")
+
+
+@pytest.mark.asyncio
+async def test_files_mode_does_not_install_hooks(
+    monkeypatch, tmp_config_manager, session_factory
+):
+    """In files mode the monkey-patch must not be installed —
+    legacy ``config_manager.save_config_file`` is left pristine."""
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "files")
+    WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    assert not getattr(tmp_config_manager, "_db_mirror_installed", False)
+
+    # And a direct legacy save creates yaml without scheduling a DB mirror.
+    cfg = tmp_config_manager.load_config()
+    cfg.agent.system_prompt = "files mode unhooked"
+    tmp_config_manager.save_config_file(cfg)
+    assert tmp_config_manager.config_file.exists()
+    async with session_factory() as session:
+        rows = await WorkspaceConfigRepo(session).list_all()
+        assert rows == {}  # nothing mirrored — hook never ran

--- a/tests/unit/test_storage_mode.py
+++ b/tests/unit/test_storage_mode.py
@@ -61,10 +61,10 @@ def tmp_config_manager():
 # ======================================================================
 
 
-def test_default_mode_is_hybrid(monkeypatch):
+def test_default_mode_is_db(monkeypatch):
     monkeypatch.delenv("OPENRAG_STORAGE_MODE", raising=False)
     monkeypatch.delenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", raising=False)
-    assert get_storage_mode() == "hybrid"
+    assert get_storage_mode() == "db"
 
 
 def test_explicit_mode_db(monkeypatch):
@@ -90,7 +90,7 @@ def test_legacy_kill_switch_forces_files(monkeypatch):
 def test_invalid_value_falls_back_to_default(monkeypatch):
     monkeypatch.setenv("OPENRAG_STORAGE_MODE", "weird")
     monkeypatch.delenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", raising=False)
-    assert get_storage_mode() == "hybrid"
+    assert get_storage_mode() == "db"
 
 
 # ======================================================================

--- a/tests/unit/test_user_service_bootstrap.py
+++ b/tests/unit/test_user_service_bootstrap.py
@@ -1,0 +1,124 @@
+"""ensure_user_row: first user becomes admin; subsequent users get default role."""
+
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from services.user_service import ensure_user_row  # noqa: E402
+from session_manager import User  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as s:
+        await seed_roles_and_permissions(s)
+        await s.commit()
+        yield s
+    await engine.dispose()
+
+
+def _user(uid="u1", email="a@example.com", name="A", provider="google"):
+    return User(user_id=uid, email=email, name=name, provider=provider)
+
+
+@pytest.mark.asyncio
+async def test_first_user_becomes_admin(session):
+    row = await ensure_user_row(session, _user(uid="oauth-1"))
+    await session.commit()
+
+    role_repo = RoleRepo(session)
+    roles = await role_repo.list_user_roles(row.id)
+    assert {r.name for r in roles} == {"admin"}
+
+
+@pytest.mark.asyncio
+async def test_second_user_gets_default_role(session, monkeypatch):
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+    first = await ensure_user_row(session, _user(uid="oauth-1", email="a@x.com"))
+    second = await ensure_user_row(session, _user(uid="oauth-2", email="b@x.com"))
+    await session.commit()
+
+    role_repo = RoleRepo(session)
+    first_roles = {r.name for r in await role_repo.list_user_roles(first.id)}
+    second_roles = {r.name for r in await role_repo.list_user_roles(second.id)}
+    assert first_roles == {"admin"}
+    assert second_roles == {"user"}
+
+
+@pytest.mark.asyncio
+async def test_repeated_calls_are_idempotent(session):
+    a = await ensure_user_row(session, _user(uid="oauth-1"))
+    b = await ensure_user_row(session, _user(uid="oauth-1"))
+    await session.commit()
+
+    assert a.id == b.id
+    role_repo = RoleRepo(session)
+    roles = await role_repo.list_user_roles(a.id)
+    assert {r.name for r in roles} == {"admin"}
+
+
+@pytest.mark.asyncio
+async def test_new_user_id_matches_oauth_subject(session):
+    """Regression: the SQL users.id must equal the OAuth subject so
+    require_permission can use the JWT sub directly (no extra lookup)."""
+    row = await ensure_user_row(
+        session, _user(uid="oauth-subject-xyz", email="z@x.com")
+    )
+    await session.commit()
+    assert row.id == "oauth-subject-xyz"
+    assert row.oauth_subject == "oauth-subject-xyz"
+
+
+@pytest.mark.asyncio
+async def test_legacy_user_merges_on_real_signin(session, monkeypatch):
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+    # Pre-seed first admin so the legacy merge does NOT take admin.
+    await ensure_user_row(session, _user(uid="oauth-admin", email="root@x.com"))
+    await session.commit()
+
+    # Pretend a JSON migration inserted a legacy row keyed by a GA user_id.
+    from db.models import User as UserRow
+    from db.repositories._helpers import email_lookup_hash
+    legacy = UserRow(
+        id="legacy-123",
+        oauth_provider="legacy",
+        oauth_subject="legacy-123",
+        email="alice@example.com",
+        email_lookup_hash=email_lookup_hash("alice@example.com"),
+        display_name="alice (legacy)",
+    )
+    session.add(legacy)
+    await session.commit()
+
+    merged = await ensure_user_row(
+        session,
+        User(user_id="legacy-123", email="alice@example.com", name="Alice", provider="google"),
+    )
+    await session.commit()
+
+    assert merged.id == "legacy-123", "user_id must be preserved across merge"
+    assert merged.oauth_provider == "google"
+    assert merged.oauth_subject == "legacy-123"
+
+    role_repo = RoleRepo(session)
+    roles = {r.name for r in await role_repo.list_user_roles(merged.id)}
+    assert roles == {"user"}

--- a/tests/unit/test_workspace_config_service.py
+++ b/tests/unit/test_workspace_config_service.py
@@ -1,0 +1,172 @@
+"""WorkspaceConfigService — yaml/DB dual-write contract."""
+
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from config.config_manager import ConfigManager, OpenRAGConfig  # noqa: E402
+from db.repositories import WorkspaceConfigRepo  # noqa: E402
+from services.workspace_config_service import WorkspaceConfigService  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def tmp_config_manager():
+    """Real ConfigManager pointed at a tmp file so yaml writes don't
+    touch the dev workspace."""
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_file = Path(tmp) / "config.yaml"
+        cm = ConfigManager(config_file=str(cfg_file))
+        yield cm
+
+
+@pytest.mark.asyncio
+async def test_load_config_falls_back_to_yaml_when_db_empty(
+    tmp_config_manager, session_factory
+):
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    config = await svc.load_config()
+    assert isinstance(config, OpenRAGConfig)
+    assert config.edited is False  # fresh install
+
+
+@pytest.mark.asyncio
+async def test_save_config_writes_to_yaml_and_db(
+    tmp_config_manager, session_factory
+):
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    config = tmp_config_manager.load_config()
+    config.agent.system_prompt = "Be helpful."
+
+    ok = await svc.save_config(config)
+    assert ok is True
+
+    # Yaml write happened (file exists, contents include the prompt)
+    assert tmp_config_manager.config_file.exists()
+
+    # DB mirror happened (rows for each section)
+    async with session_factory() as session:
+        repo = WorkspaceConfigRepo(session)
+        agent = await repo.get_section("agent")
+        assert agent is not None
+        assert agent.get("system_prompt") == "Be helpful."
+        meta = await repo.get_section("meta")
+        assert meta == {"edited": True}
+
+
+@pytest.mark.asyncio
+async def test_is_onboarded_reads_from_db_first(
+    tmp_config_manager, session_factory
+):
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+
+    # Seed only the DB (no yaml) — DB read should return True
+    async with session_factory() as session:
+        await WorkspaceConfigRepo(session).upsert("meta", {"edited": True})
+        await session.commit()
+
+    assert await svc.is_onboarded() is True
+
+
+@pytest.mark.asyncio
+async def test_is_onboarded_false_when_neither_set(
+    tmp_config_manager, session_factory
+):
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    assert await svc.is_onboarded() is False
+
+
+@pytest.mark.asyncio
+async def test_get_onboarding_step_returns_db_value(
+    tmp_config_manager, session_factory
+):
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    async with session_factory() as session:
+        await WorkspaceConfigRepo(session).upsert(
+            "onboarding", {"current_step": "agent_setup"}
+        )
+        await session.commit()
+
+    assert await svc.get_onboarding_step() == "agent_setup"
+
+
+@pytest.mark.asyncio
+async def test_yaml_write_hooks_mirror_to_db(
+    tmp_config_manager, session_factory
+):
+    """Legacy callers that hit config_manager.save_config_file directly
+    should auto-mirror to the DB via the installed monkey-patch."""
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    # Direct legacy-style call (no service, no await)
+    config = tmp_config_manager.load_config()
+    config.agent.llm_model = "gpt-4o"
+    tmp_config_manager.save_config_file(config)
+
+    # The hook scheduled an asyncio task — wait for it briefly
+    import asyncio
+    for _ in range(20):
+        async with session_factory() as session:
+            agent = await WorkspaceConfigRepo(session).get_section("agent")
+            if agent and agent.get("llm_model") == "gpt-4o":
+                break
+        await asyncio.sleep(0.05)
+    else:
+        pytest.fail("DB mirror task didn't run within 1s")
+
+    # Cleanup the patch so other tests with the same config_manager
+    # instance don't inherit it
+    delattr(tmp_config_manager, "_db_mirror_installed")
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_disables_db(monkeypatch, tmp_config_manager, session_factory):
+    monkeypatch.setenv("OPENRAG_DISABLE_DB_WORKSPACE_CONFIG", "true")
+    svc = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    config = tmp_config_manager.load_config()
+    config.agent.llm_model = "gpt-5"
+    ok = await svc.save_config(config)
+    assert ok is True
+
+    # DB should be empty — kill switch bypassed it
+    async with session_factory() as session:
+        agent = await WorkspaceConfigRepo(session).get_section("agent")
+        assert agent is None  # never written

--- a/tests/unit/test_workspace_config_service.py
+++ b/tests/unit/test_workspace_config_service.py
@@ -59,8 +59,14 @@ async def test_load_config_falls_back_to_yaml_when_db_empty(
 
 @pytest.mark.asyncio
 async def test_save_config_writes_to_yaml_and_db(
-    tmp_config_manager, session_factory
+    monkeypatch, tmp_config_manager, session_factory
 ):
+    """Hybrid mode dual-writes to both yaml and the DB.
+
+    The default mode is ``db`` (DB-only, no yaml), so this test forces
+    hybrid via an env override to exercise the dual-write contract.
+    """
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "hybrid")
     svc = WorkspaceConfigService(
         config_manager=tmp_config_manager, session_factory=session_factory
     )

--- a/tests/unit/test_workspace_config_service.py
+++ b/tests/unit/test_workspace_config_service.py
@@ -170,3 +170,46 @@ async def test_kill_switch_disables_db(monkeypatch, tmp_config_manager, session_
     async with session_factory() as session:
         agent = await WorkspaceConfigRepo(session).get_section("agent")
         assert agent is None  # never written
+
+
+@pytest.mark.asyncio
+async def test_reinstall_does_not_chain_closures(tmp_config_manager, session_factory):
+    """Regression: re-instantiating WorkspaceConfigService over the same
+    ConfigManager (after `_db_mirror_installed` is deleted by test
+    cleanup) must NOT close over the previous install's patched method.
+
+    Without the capture-once fix, the second install captures the
+    already-patched method as `original_save`, then patches again, so
+    every call to `cm.save_config_file` runs the mirror logic TWICE.
+    """
+    svc1 = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+    captured_original = tmp_config_manager._db_mirror_original_save  # noqa: SLF001
+
+    # Simulate test teardown that deletes the install flag without
+    # restoring the patched method (matches the existing pattern at
+    # tests/unit/test_workspace_config_service.py:155).
+    delattr(tmp_config_manager, "_db_mirror_installed")
+
+    svc2 = WorkspaceConfigService(
+        config_manager=tmp_config_manager, session_factory=session_factory
+    )
+
+    # The pinned original on the cm must be the FIRST install's
+    # original — not the patched method captured by the first install.
+    assert tmp_config_manager._db_mirror_original_save is captured_original  # noqa: SLF001
+
+    # Save once and confirm exactly ONE mirror task is scheduled, not two.
+    config = tmp_config_manager.load_config()
+    config.agent.llm_model = "no-chain"
+    tmp_config_manager.save_config_file(config)
+    # Both services share the cm, so both _pending_mirrors sets see
+    # different views — but only ONE patched method runs, so total
+    # cross-service tasks must be exactly 1.
+    total_pending = len(svc1._pending_mirrors) + len(svc2._pending_mirrors)  # noqa: SLF001
+    assert total_pending == 1
+
+    await svc1.await_pending_mirrors()
+    await svc2.await_pending_mirrors()
+    delattr(tmp_config_manager, "_db_mirror_installed")

--- a/tests/unit/test_workspace_mirror_lifecycle.py
+++ b/tests/unit/test_workspace_mirror_lifecycle.py
@@ -1,0 +1,116 @@
+"""DB-mirror task lifecycle: snapshot at schedule time, serialized
+under a lock, drained on shutdown.
+
+These tests pin the fix for the fire-and-forget hazards in
+``WorkspaceConfigService._schedule_mirror`` — orphaned tasks, lost
+writes on rapid double-save, races on the DB upsert.
+"""
+
+import asyncio
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from config.config_manager import ConfigManager  # noqa: E402
+from db.repositories import WorkspaceConfigRepo  # noqa: E402
+from services.workspace_config_service import WorkspaceConfigService  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest.fixture
+def cm(monkeypatch):
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "hybrid")
+    with tempfile.TemporaryDirectory() as tmp:
+        cfg_file = Path(tmp) / "config.yaml"
+        yield ConfigManager(config_file=str(cfg_file))
+
+
+@pytest.mark.asyncio
+async def test_double_save_mirrors_in_order_with_distinct_snapshots(
+    cm, session_factory
+):
+    """save(A), save(B) — both writes must reach the DB. Without the
+    snapshot fix, the second mirror task would read the post-B config
+    twice and A would be lost.
+    """
+    svc = WorkspaceConfigService(config_manager=cm, session_factory=session_factory)
+
+    cfg = cm.load_config()
+    cfg.agent.llm_model = "model-A"
+    cm.save_config_file(cfg)
+    cfg.agent.llm_model = "model-B"
+    cm.save_config_file(cfg)
+
+    # Both tasks must have been scheduled
+    assert len(svc._pending_mirrors) >= 1
+
+    await svc.await_pending_mirrors()
+
+    async with session_factory() as session:
+        agent = await WorkspaceConfigRepo(session).get_section("agent")
+    assert agent is not None
+    # Final state must be model-B (the lock serializes writes — A then B)
+    assert agent["llm_model"] == "model-B"
+
+    # And no tasks should be lingering
+    assert len(svc._pending_mirrors) == 0
+
+    delattr(cm, "_db_mirror_installed")
+
+
+@pytest.mark.asyncio
+async def test_pending_mirrors_drained_via_await_handle(cm, session_factory):
+    """The shutdown handler calls await_pending_mirrors() which must
+    block until in-flight writes complete."""
+    svc = WorkspaceConfigService(config_manager=cm, session_factory=session_factory)
+
+    cfg = cm.load_config()
+    cfg.agent.system_prompt = "Be helpful."
+    cm.save_config_file(cfg)
+
+    # The mirror task is scheduled but may not have run yet.
+    # await_pending_mirrors must block until it does.
+    await svc.await_pending_mirrors()
+
+    async with session_factory() as session:
+        agent = await WorkspaceConfigRepo(session).get_section("agent")
+    assert agent.get("system_prompt") == "Be helpful."
+    assert len(svc._pending_mirrors) == 0
+
+    delattr(cm, "_db_mirror_installed")
+
+
+@pytest.mark.asyncio
+async def test_no_pending_mirrors_on_files_mode(cm, monkeypatch, session_factory):
+    """In files mode the mirror is never scheduled."""
+    monkeypatch.setenv("OPENRAG_STORAGE_MODE", "files")
+    svc = WorkspaceConfigService(config_manager=cm, session_factory=session_factory)
+    cfg = cm.load_config()
+    cfg.agent.system_prompt = "files mode"
+    cm.save_config_file(cfg)
+    # files mode means hooks aren't installed; no mirror tasks scheduled
+    assert len(svc._pending_mirrors) == 0
+    await svc.await_pending_mirrors()  # noop, no exception

--- a/uv.lock
+++ b/uv.lock
@@ -68,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.4"
+version = "3.13.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -79,59 +79,59 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/45/4a/064321452809dae953c1ed6e017504e72551a26b6f5708a5a80e4bf556ff/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38", size = 7859748, upload-time = "2026-03-28T17:19:40.6Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e3/ac/892f4162df9b115b4758d615f32ec63d00f3084c705ff5526630887b9b42/aiohttp-3.13.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:63dd5e5b1e43b8fb1e91b79b7ceba1feba588b317d1edff385084fcc7a0a4538", size = 745744, upload-time = "2026-03-28T17:16:44.67Z" },
-    { url = "https://files.pythonhosted.org/packages/97/a9/c5b87e4443a2f0ea88cb3000c93a8fdad1ee63bffc9ded8d8c8e0d66efc6/aiohttp-3.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:746ac3cc00b5baea424dacddea3ec2c2702f9590de27d837aa67004db1eebc6e", size = 498178, upload-time = "2026-03-28T17:16:46.766Z" },
-    { url = "https://files.pythonhosted.org/packages/94/42/07e1b543a61250783650df13da8ddcdc0d0a5538b2bd15cef6e042aefc61/aiohttp-3.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bda8f16ea99d6a6705e5946732e48487a448be874e54a4f73d514660ff7c05d3", size = 498331, upload-time = "2026-03-28T17:16:48.9Z" },
-    { url = "https://files.pythonhosted.org/packages/20/d6/492f46bf0328534124772d0cf58570acae5b286ea25006900650f69dae0e/aiohttp-3.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b061e7b5f840391e3f64d0ddf672973e45c4cfff7a0feea425ea24e51530fc2", size = 1744414, upload-time = "2026-03-28T17:16:50.968Z" },
-    { url = "https://files.pythonhosted.org/packages/e2/4d/e02627b2683f68051246215d2d62b2d2f249ff7a285e7a858dc47d6b6a14/aiohttp-3.13.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b252e8d5cd66184b570d0d010de742736e8a4fab22c58299772b0c5a466d4b21", size = 1719226, upload-time = "2026-03-28T17:16:53.173Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/6c/5d0a3394dd2b9f9aeba6e1b6065d0439e4b75d41f1fb09a3ec010b43552b/aiohttp-3.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20af8aad61d1803ff11152a26146d8d81c266aa8c5aa9b4504432abb965c36a0", size = 1782110, upload-time = "2026-03-28T17:16:55.362Z" },
-    { url = "https://files.pythonhosted.org/packages/0d/2d/c20791e3437700a7441a7edfb59731150322424f5aadf635602d1d326101/aiohttp-3.13.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:13a5cc924b59859ad2adb1478e31f410a7ed46e92a2a619d6d1dd1a63c1a855e", size = 1884809, upload-time = "2026-03-28T17:16:57.734Z" },
-    { url = "https://files.pythonhosted.org/packages/c8/94/d99dbfbd1924a87ef643833932eb2a3d9e5eee87656efea7d78058539eff/aiohttp-3.13.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:534913dfb0a644d537aebb4123e7d466d94e3be5549205e6a31f72368980a81a", size = 1764938, upload-time = "2026-03-28T17:17:00.221Z" },
-    { url = "https://files.pythonhosted.org/packages/49/61/3ce326a1538781deb89f6cf5e094e2029cd308ed1e21b2ba2278b08426f6/aiohttp-3.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:320e40192a2dcc1cf4b5576936e9652981ab596bf81eb309535db7e2f5b5672f", size = 1570697, upload-time = "2026-03-28T17:17:02.985Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/77/4ab5a546857bb3028fbaf34d6eea180267bdab022ee8b1168b1fcde4bfdd/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9e587fcfce2bcf06526a43cb705bdee21ac089096f2e271d75de9c339db3100c", size = 1702258, upload-time = "2026-03-28T17:17:05.28Z" },
-    { url = "https://files.pythonhosted.org/packages/79/63/d8f29021e39bc5af8e5d5e9da1b07976fb9846487a784e11e4f4eeda4666/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9eb9c2eea7278206b5c6c1441fdd9dc420c278ead3f3b2cc87f9b693698cc500", size = 1740287, upload-time = "2026-03-28T17:17:07.712Z" },
-    { url = "https://files.pythonhosted.org/packages/55/3a/cbc6b3b124859a11bc8055d3682c26999b393531ef926754a3445b99dfef/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:29be00c51972b04bf9d5c8f2d7f7314f48f96070ca40a873a53056e652e805f7", size = 1753011, upload-time = "2026-03-28T17:17:10.053Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/30/836278675205d58c1368b21520eab9572457cf19afd23759216c04483048/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90c06228a6c3a7c9f776fe4fc0b7ff647fffd3bed93779a6913c804ae00c1073", size = 1566359, upload-time = "2026-03-28T17:17:12.433Z" },
-    { url = "https://files.pythonhosted.org/packages/50/b4/8032cc9b82d17e4277704ba30509eaccb39329dc18d6a35f05e424439e32/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a533ec132f05fd9a1d959e7f34184cd7d5e8511584848dab85faefbaac573069", size = 1785537, upload-time = "2026-03-28T17:17:14.721Z" },
-    { url = "https://files.pythonhosted.org/packages/17/7d/5873e98230bde59f493bf1f7c3e327486a4b5653fa401144704df5d00211/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1c946f10f413836f82ea4cfb90200d2a59578c549f00857e03111cf45ad01ca5", size = 1740752, upload-time = "2026-03-28T17:17:17.387Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/f2/13e46e0df051494d7d3c68b7f72d071f48c384c12716fc294f75d5b1a064/aiohttp-3.13.4-cp313-cp313-win32.whl", hash = "sha256:48708e2706106da6967eff5908c78ca3943f005ed6bcb75da2a7e4da94ef8c70", size = 433187, upload-time = "2026-03-28T17:17:19.523Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/c0/649856ee655a843c8f8664592cfccb73ac80ede6a8c8db33a25d810c12db/aiohttp-3.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:74a2eb058da44fa3a877a49e2095b591d4913308bb424c418b77beb160c55ce3", size = 459778, upload-time = "2026-03-28T17:17:21.964Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/29/6657cc37ae04cacc2dbf53fb730a06b6091cc4cbe745028e047c53e6d840/aiohttp-3.13.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:e0a2c961fc92abeff61d6444f2ce6ad35bb982db9fc8ff8a47455beacf454a57", size = 749363, upload-time = "2026-03-28T17:17:24.044Z" },
-    { url = "https://files.pythonhosted.org/packages/90/7f/30ccdf67ca3d24b610067dc63d64dcb91e5d88e27667811640644aa4a85d/aiohttp-3.13.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:153274535985a0ff2bff1fb6c104ed547cec898a09213d21b0f791a44b14d933", size = 499317, upload-time = "2026-03-28T17:17:26.199Z" },
-    { url = "https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7", size = 500477, upload-time = "2026-03-28T17:17:28.279Z" },
-    { url = "https://files.pythonhosted.org/packages/e5/fe/ee6298e8e586096fb6f5eddd31393d8544f33ae0792c71ecbb4c2bef98ac/aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f989ac8bc5595ff761a5ccd32bdb0768a117f36dd1504b1c2c074ed5d3f4df9c", size = 1737227, upload-time = "2026-03-28T17:17:30.587Z" },
-    { url = "https://files.pythonhosted.org/packages/b0/b9/a7a0463a09e1a3fe35100f74324f23644bfc3383ac5fd5effe0722a5f0b7/aiohttp-3.13.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d36fc1709110ec1e87a229b201dd3ddc32aa01e98e7868083a794609b081c349", size = 1694036, upload-time = "2026-03-28T17:17:33.29Z" },
-    { url = "https://files.pythonhosted.org/packages/57/7c/8972ae3fb7be00a91aee6b644b2a6a909aedb2c425269a3bfd90115e6f8f/aiohttp-3.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42adaeea83cbdf069ab94f5103ce0787c21fb1a0153270da76b59d5578302329", size = 1786814, upload-time = "2026-03-28T17:17:36.035Z" },
-    { url = "https://files.pythonhosted.org/packages/93/01/c81e97e85c774decbaf0d577de7d848934e8166a3a14ad9f8aa5be329d28/aiohttp-3.13.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:92deb95469928cc41fd4b42a95d8012fa6df93f6b1c0a83af0ffbc4a5e218cde", size = 1866676, upload-time = "2026-03-28T17:17:38.441Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed", size = 1740842, upload-time = "2026-03-28T17:17:40.783Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a2/0d4b03d011cca6b6b0acba8433193c1e484efa8d705ea58295590fe24203/aiohttp-3.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f062c45de8a1098cb137a1898819796a2491aec4e637a06b03f149315dff4d8f", size = 1566508, upload-time = "2026-03-28T17:17:43.235Z" },
-    { url = "https://files.pythonhosted.org/packages/98/17/e689fd500da52488ec5f889effd6404dece6a59de301e380f3c64f167beb/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:76093107c531517001114f0ebdb4f46858ce818590363e3e99a4a2280334454a", size = 1700569, upload-time = "2026-03-28T17:17:46.165Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/0d/66402894dbcf470ef7db99449e436105ea862c24f7ea4c95c683e635af35/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:6f6ec32162d293b82f8b63a16edc80769662fbd5ae6fbd4936d3206a2c2cc63b", size = 1707407, upload-time = "2026-03-28T17:17:48.825Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/eb/af0ab1a3650092cbd8e14ef29e4ab0209e1460e1c299996c3f8288b3f1ff/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5903e2db3d202a00ad9f0ec35a122c005e85d90c9836ab4cda628f01edf425e2", size = 1752214, upload-time = "2026-03-28T17:17:51.206Z" },
-    { url = "https://files.pythonhosted.org/packages/5a/bf/72326f8a98e4c666f292f03c385545963cc65e358835d2a7375037a97b57/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2d5bea57be7aca98dbbac8da046d99b5557c5cf4e28538c4c786313078aca09e", size = 1562162, upload-time = "2026-03-28T17:17:53.634Z" },
-    { url = "https://files.pythonhosted.org/packages/67/9f/13b72435f99151dd9a5469c96b3b5f86aa29b7e785ca7f35cf5e538f74c0/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bcf0c9902085976edc0232b75006ef38f89686901249ce14226b6877f88464fb", size = 1768904, upload-time = "2026-03-28T17:17:55.991Z" },
-    { url = "https://files.pythonhosted.org/packages/18/bc/28d4970e7d5452ac7776cdb5431a1164a0d9cf8bd2fffd67b4fb463aa56d/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3295f98bfeed2e867cab588f2a146a9db37a85e3ae9062abf46ba062bd29165", size = 1723378, upload-time = "2026-03-28T17:17:58.348Z" },
-    { url = "https://files.pythonhosted.org/packages/53/74/b32458ca1a7f34d65bdee7aef2036adbe0438123d3d53e2b083c453c24dd/aiohttp-3.13.4-cp314-cp314-win32.whl", hash = "sha256:a598a5c5767e1369d8f5b08695cab1d8160040f796c4416af76fd773d229b3c9", size = 438711, upload-time = "2026-03-28T17:18:00.728Z" },
-    { url = "https://files.pythonhosted.org/packages/40/b2/54b487316c2df3e03a8f3435e9636f8a81a42a69d942164830d193beb56a/aiohttp-3.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:c555db4bc7a264bead5a7d63d92d41a1122fcd39cc62a4db815f45ad46f9c2c8", size = 464977, upload-time = "2026-03-28T17:18:03.367Z" },
-    { url = "https://files.pythonhosted.org/packages/47/fb/e41b63c6ce71b07a59243bb8f3b457ee0c3402a619acb9d2c0d21ef0e647/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45abbbf09a129825d13c18c7d3182fecd46d9da3cfc383756145394013604ac1", size = 781549, upload-time = "2026-03-28T17:18:05.779Z" },
-    { url = "https://files.pythonhosted.org/packages/97/53/532b8d28df1e17e44c4d9a9368b78dcb6bf0b51037522136eced13afa9e8/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:74c80b2bc2c2adb7b3d1941b2b60701ee2af8296fc8aad8b8bc48bc25767266c", size = 514383, upload-time = "2026-03-28T17:18:08.096Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/1f/62e5d400603e8468cd635812d99cb81cfdc08127a3dc474c647615f31339/aiohttp-3.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c97989ae40a9746650fa196894f317dafc12227c808c774929dda0ff873a5954", size = 518304, upload-time = "2026-03-28T17:18:10.642Z" },
-    { url = "https://files.pythonhosted.org/packages/90/57/2326b37b10896447e3c6e0cbef4fe2486d30913639a5cfd1332b5d870f82/aiohttp-3.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dae86be9811493f9990ef44fff1685f5c1a3192e9061a71a109d527944eed551", size = 1893433, upload-time = "2026-03-28T17:18:13.121Z" },
-    { url = "https://files.pythonhosted.org/packages/d2/b4/a24d82112c304afdb650167ef2fe190957d81cbddac7460bedd245f765aa/aiohttp-3.13.4-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1db491abe852ca2fa6cc48a3341985b0174b3741838e1341b82ac82c8bd9e871", size = 1755901, upload-time = "2026-03-28T17:18:16.21Z" },
-    { url = "https://files.pythonhosted.org/packages/9e/2d/0883ef9d878d7846287f036c162a951968f22aabeef3ac97b0bea6f76d5d/aiohttp-3.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e5d701c0aad02a7dce72eef6b93226cf3734330f1a31d69ebbf69f33b86666e", size = 1876093, upload-time = "2026-03-28T17:18:18.703Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/52/9204bb59c014869b71971addad6778f005daa72a96eed652c496789d7468/aiohttp-3.13.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ac32a189081ae0a10ba18993f10f338ec94341f0d5df8fff348043962f3c6f8", size = 1970815, upload-time = "2026-03-28T17:18:21.858Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/b5/e4eb20275a866dde0f570f411b36c6b48f7b53edfe4f4071aa1b0728098a/aiohttp-3.13.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98e968cdaba43e45c73c3f306fca418c8009a957733bac85937c9f9cf3f4de27", size = 1816223, upload-time = "2026-03-28T17:18:24.729Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/23/e98075c5bb146aa61a1239ee1ac7714c85e814838d6cebbe37d3fe19214a/aiohttp-3.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca114790c9144c335d538852612d3e43ea0f075288f4849cf4b05d6cd2238ce7", size = 1649145, upload-time = "2026-03-28T17:18:27.269Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/c1/7bad8be33bb06c2bb224b6468874346026092762cbec388c3bdb65a368ee/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ea2e071661ba9cfe11eabbc81ac5376eaeb3061f6e72ec4cc86d7cdd1ffbdbbb", size = 1816562, upload-time = "2026-03-28T17:18:29.847Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/10/c00323348695e9a5e316825969c88463dcc24c7e9d443244b8a2c9cf2eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:34e89912b6c20e0fd80e07fa401fd218a410aa1ce9f1c2f1dad6db1bd0ce0927", size = 1800333, upload-time = "2026-03-28T17:18:32.269Z" },
-    { url = "https://files.pythonhosted.org/packages/84/43/9b2147a1df3559f49bd723e22905b46a46c068a53adb54abdca32c4de180/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0e217cf9f6a42908c52b46e42c568bd57adc39c9286ced31aaace614b6087965", size = 1820617, upload-time = "2026-03-28T17:18:35.238Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/7f/b3481a81e7a586d02e99387b18c6dafff41285f6efd3daa2124c01f87eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:0c296f1221e21ba979f5ac1964c3b78cfde15c5c5f855ffd2caab337e9cd9182", size = 1643417, upload-time = "2026-03-28T17:18:37.949Z" },
-    { url = "https://files.pythonhosted.org/packages/8f/72/07181226bc99ce1124e0f89280f5221a82d3ae6a6d9d1973ce429d48e52b/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d99a9d168ebaffb74f36d011750e490085ac418f4db926cce3989c8fe6cb6b1b", size = 1849286, upload-time = "2026-03-28T17:18:40.534Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/e6/1b3566e103eca6da5be4ae6713e112a053725c584e96574caf117568ffef/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cb19177205d93b881f3f89e6081593676043a6828f59c78c17a0fd6c1fbed2ba", size = 1782635, upload-time = "2026-03-28T17:18:43.073Z" },
-    { url = "https://files.pythonhosted.org/packages/37/58/1b11c71904b8d079eb0c39fe664180dd1e14bebe5608e235d8bfbadc8929/aiohttp-3.13.4-cp314-cp314t-win32.whl", hash = "sha256:c606aa5656dab6552e52ca368e43869c916338346bfaf6304e15c58fb113ea30", size = 472537, upload-time = "2026-03-28T17:18:46.286Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/8f/87c56a1a1977d7dddea5b31e12189665a140fdb48a71e9038ff90bb564ec/aiohttp-3.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:014dcc10ec8ab8db681f0d68e939d1e9286a5aa2b993cbbdb0db130853e02144", size = 506381, upload-time = "2026-03-28T17:18:48.74Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
+    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
+    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
+    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
+    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
+    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
+    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
+    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
+    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
+    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
+    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
+    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
+    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
+    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
+    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
+    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
+    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
 ]
 
 [[package]]
@@ -144,6 +144,29 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/62/06741b579156360248d1ec624842ad0edf697050bbaf7c3e46394e106ad1/aiosignal-1.4.0.tar.gz", hash = "sha256:f47eecd9468083c2029cc99945502cb7708b082c232f9aca65da147157b251c7", size = 25007, upload-time = "2025-07-03T22:54:43.528Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fb/76/641ae371508676492379f16e2fa48f4e2c11741bd63c48be4b12a6b09cba/aiosignal-1.4.0-py3-none-any.whl", hash = "sha256:053243f8b92b990551949e63930a839ff0cf0b0ebbe0597b0f3fb19e1a0fe82e", size = 7490, upload-time = "2025-07-03T22:54:42.156Z" },
+]
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
+
+[[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
 ]
 
 [[package]]
@@ -174,6 +197,38 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/11/97b5c2af72a5d0b9bc3fa30cd4b9ce22284a9a943a150fdc768763caf035/asyncpg-0.31.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c204fab1b91e08b0f47e90a75d1b3c62174dab21f670ad6c5d0f243a228f015b", size = 661111, upload-time = "2025-11-24T23:26:04.467Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/71/157d611c791a5e2d0423f09f027bd499935f0906e0c2a416ce712ba51ef3/asyncpg-0.31.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:54a64f91839ba59008eccf7aad2e93d6e3de688d796f35803235ea1c4898ae1e", size = 636928, upload-time = "2025-11-24T23:26:05.944Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/fc/9e3486fb2bbe69d4a867c0b76d68542650a7ff1574ca40e84c3111bb0c6e/asyncpg-0.31.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0e0822b1038dc7253b337b0f3f676cadc4ac31b126c5d42691c39691962e403", size = 3424067, upload-time = "2025-11-24T23:26:07.957Z" },
+    { url = "https://files.pythonhosted.org/packages/12/c6/8c9d076f73f07f995013c791e018a1cd5f31823c2a3187fc8581706aa00f/asyncpg-0.31.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bef056aa502ee34204c161c72ca1f3c274917596877f825968368b2c33f585f4", size = 3518156, upload-time = "2025-11-24T23:26:09.591Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3b/60683a0baf50fbc546499cfb53132cb6835b92b529a05f6a81471ab60d0c/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0bfbcc5b7ffcd9b75ab1558f00db2ae07db9c80637ad1b2469c43df79d7a5ae2", size = 3319636, upload-time = "2025-11-24T23:26:11.168Z" },
+    { url = "https://files.pythonhosted.org/packages/50/dc/8487df0f69bd398a61e1792b3cba0e47477f214eff085ba0efa7eac9ce87/asyncpg-0.31.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:22bc525ebbdc24d1261ecbf6f504998244d4e3be1721784b5f64664d61fbe602", size = 3472079, upload-time = "2025-11-24T23:26:13.164Z" },
+    { url = "https://files.pythonhosted.org/packages/13/a1/c5bbeeb8531c05c89135cb8b28575ac2fac618bcb60119ee9696c3faf71c/asyncpg-0.31.0-cp313-cp313-win32.whl", hash = "sha256:f890de5e1e4f7e14023619399a471ce4b71f5418cd67a51853b9910fdfa73696", size = 527606, upload-time = "2025-11-24T23:26:14.78Z" },
+    { url = "https://files.pythonhosted.org/packages/91/66/b25ccb84a246b470eb943b0107c07edcae51804912b824054b3413995a10/asyncpg-0.31.0-cp313-cp313-win_amd64.whl", hash = "sha256:dc5f2fa9916f292e5c5c8b2ac2813763bcd7f58e130055b4ad8a0531314201ab", size = 596569, upload-time = "2025-11-24T23:26:16.189Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/36/e9450d62e84a13aea6580c83a47a437f26c7ca6fa0f0fd40b6670793ea30/asyncpg-0.31.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:f6b56b91bb0ffc328c4e3ed113136cddd9deefdf5f79ab448598b9772831df44", size = 660867, upload-time = "2025-11-24T23:26:17.631Z" },
+    { url = "https://files.pythonhosted.org/packages/82/4b/1d0a2b33b3102d210439338e1beea616a6122267c0df459ff0265cd5807a/asyncpg-0.31.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:334dec28cf20d7f5bb9e45b39546ddf247f8042a690bff9b9573d00086e69cb5", size = 638349, upload-time = "2025-11-24T23:26:19.689Z" },
+    { url = "https://files.pythonhosted.org/packages/41/aa/e7f7ac9a7974f08eff9183e392b2d62516f90412686532d27e196c0f0eeb/asyncpg-0.31.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:98cc158c53f46de7bb677fd20c417e264fc02b36d901cc2a43bd6cb0dc6dbfd2", size = 3410428, upload-time = "2025-11-24T23:26:21.275Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/de/bf1b60de3dede5c2731e6788617a512bc0ebd9693eac297ee74086f101d7/asyncpg-0.31.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9322b563e2661a52e3cdbc93eed3be7748b289f792e0011cb2720d278b366ce2", size = 3471678, upload-time = "2025-11-24T23:26:23.627Z" },
+    { url = "https://files.pythonhosted.org/packages/46/78/fc3ade003e22d8bd53aaf8f75f4be48f0b460fa73738f0391b9c856a9147/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19857a358fc811d82227449b7ca40afb46e75b33eb8897240c3839dd8b744218", size = 3313505, upload-time = "2025-11-24T23:26:25.235Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e9/73eb8a6789e927816f4705291be21f2225687bfa97321e40cd23055e903a/asyncpg-0.31.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ba5f8886e850882ff2c2ace5732300e99193823e8107e2c53ef01c1ebfa1e85d", size = 3434744, upload-time = "2025-11-24T23:26:26.944Z" },
+    { url = "https://files.pythonhosted.org/packages/08/4b/f10b880534413c65c5b5862f79b8e81553a8f364e5238832ad4c0af71b7f/asyncpg-0.31.0-cp314-cp314-win32.whl", hash = "sha256:cea3a0b2a14f95834cee29432e4ddc399b95700eb1d51bbc5bfee8f31fa07b2b", size = 532251, upload-time = "2025-11-24T23:26:28.404Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/2d/7aa40750b7a19efa5d66e67fc06008ca0f27ba1bd082e457ad82f59aba49/asyncpg-0.31.0-cp314-cp314-win_amd64.whl", hash = "sha256:04d19392716af6b029411a0264d92093b6e5e8285ae97a39957b9a9c14ea72be", size = 604901, upload-time = "2025-11-24T23:26:30.34Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/fe/b9dfe349b83b9dee28cc42360d2c86b2cdce4cb551a2c2d27e156bcac84d/asyncpg-0.31.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:bdb957706da132e982cc6856bb2f7b740603472b54c3ebc77fe60ea3e57e1bd2", size = 702280, upload-time = "2025-11-24T23:26:32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/81/e6be6e37e560bd91e6c23ea8a6138a04fd057b08cf63d3c5055c98e81c1d/asyncpg-0.31.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d11b198111a72f47154fa03b85799f9be63701e068b43f84ac25da0bda9cb31", size = 682931, upload-time = "2025-11-24T23:26:33.572Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/45/6009040da85a1648dd5bc75b3b0a062081c483e75a1a29041ae63a0bf0dc/asyncpg-0.31.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18c83b03bc0d1b23e6230f5bf8d4f217dc9bc08644ce0502a9d91dc9e634a9c7", size = 3581608, upload-time = "2025-11-24T23:26:35.638Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/06/2e3d4d7608b0b2b3adbee0d0bd6a2d29ca0fc4d8a78f8277df04e2d1fd7b/asyncpg-0.31.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e009abc333464ff18b8f6fd146addffd9aaf63e79aa3bb40ab7a4c332d0c5e9e", size = 3498738, upload-time = "2025-11-24T23:26:37.275Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/aa/7d75ede780033141c51d83577ea23236ba7d3a23593929b32b49db8ed36e/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:3b1fbcb0e396a5ca435a8826a87e5c2c2cc0c8c68eb6fadf82168056b0e53a8c", size = 3401026, upload-time = "2025-11-24T23:26:39.423Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/7a/15e37d45e7f7c94facc1e9148c0e455e8f33c08f0b8a0b1deb2c5171771b/asyncpg-0.31.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8df714dba348efcc162d2adf02d213e5fab1bd9f557e1305633e851a61814a7a", size = 3429426, upload-time = "2025-11-24T23:26:41.032Z" },
+    { url = "https://files.pythonhosted.org/packages/13/d5/71437c5f6ae5f307828710efbe62163974e71237d5d46ebd2869ea052d10/asyncpg-0.31.0-cp314-cp314t-win32.whl", hash = "sha256:1b41f1afb1033f2b44f3234993b15096ddc9cd71b21a42dbd87fc6a57b43d65d", size = 614495, upload-time = "2025-11-24T23:26:42.659Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/d7/8fb3044eaef08a310acfe23dae9a8e2e07d305edc29a53497e52bc76eca7/asyncpg-0.31.0-cp314-cp314t-win_amd64.whl", hash = "sha256:bd4107bb7cdd0e9e65fae66a62afd3a249663b844fa34d479f6d5b3bef9c04c3", size = 706062, upload-time = "2025-11-24T23:26:44.086Z" },
 ]
 
 [[package]]
@@ -849,15 +904,40 @@ wheels = [
 ]
 
 [[package]]
-name = "griffe"
-version = "1.15.0"
+name = "greenlet"
+version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3c/3f/dbf99fb14bfeb88c28f16729215478c0e265cacd6dc22270c8f31bb6892f/greenlet-3.5.0.tar.gz", hash = "sha256:d419647372241bc68e957bf38d5c1f98852155e4146bd1e4121adea81f4f01e4", size = 196995, upload-time = "2026-04-27T13:37:15.544Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/58/fc576f99037ce19c5aa16628e4c3226b6d1419f72a62c79f5f40576e6eb3/greenlet-3.5.0-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:5a5ed18de6a0f6cc7087f1563f6bd93fc7df1c19165ca01e9bde5a5dc281d106", size = 285066, upload-time = "2026-04-27T12:23:05.033Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/ba/b28ddbe6bfad6a8ac196ef0e8cff37bc65b79735995b9e410923fffeeb70/greenlet-3.5.0-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a717fbc46d8a354fa675f7c1e813485b6ba3885f9bef0cd56e5ba27d758ff5b", size = 604414, upload-time = "2026-04-27T12:52:42.358Z" },
+    { url = "https://files.pythonhosted.org/packages/09/06/4b69f8f0b67603a8be2790e55107a190b376f2627fe0eaf5695d85ffb3cd/greenlet-3.5.0-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ddc090c5c1792b10246a78e8c2163ebbe04cf877f9d785c230a7b27b39ad038e", size = 617349, upload-time = "2026-04-27T12:59:43.32Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/15/a643b4ecd09969e30b8a150d5919960caae0abe4f5af75ab040b1ab85e78/greenlet-3.5.0-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:4964101b8585c144cbda5532b1aa644255126c08a265dae90c16e7a0e63aaa9d", size = 623234, upload-time = "2026-04-27T13:02:40.611Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/17/a3918541fd0ddefe024a69de6d16aa7b46d36ac19562adaa63c7fa180eff/greenlet-3.5.0-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2094acd54b272cb6eae8c03dd87b3fa1820a4cef18d6889c378d503500a1dc13", size = 613927, upload-time = "2026-04-27T12:25:30.28Z" },
+    { url = "https://files.pythonhosted.org/packages/77/18/3b13d5ef1275b0ffaf933b05efa21408ac4ca95823c7411d79682e4fdcff/greenlet-3.5.0-cp313-cp313-manylinux_2_39_riscv64.whl", hash = "sha256:7022615368890680e67b9965d33f5773aade330d5343bbe25560135aaa849eae", size = 425243, upload-time = "2026-04-27T13:05:15.689Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/e1/bd0af6213c7dd33175d8a462d4c1fe1175124ebed4855bc1475a5b5242c2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5e05ba267789ea87b5a155cf0e810b1ab88bf18e9e8740813945ceb8ee4350ba", size = 1570893, upload-time = "2026-04-27T12:53:29.483Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2a/0789702f864f5382cb476b93d7a9c823c10472658102ccd65f415747d2e2/greenlet-3.5.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0ecec963079cd58cbd14723582384f11f166fd58883c15dcbfb342e0bc9b5846", size = 1636060, upload-time = "2026-04-27T12:25:28.845Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/8f/22bf9df92bbff0eb07842b60f7e63bf7675a9742df628437a9f02d09137f/greenlet-3.5.0-cp313-cp313-win_amd64.whl", hash = "sha256:728d9667d8f2f586644b748dbd9bb67e50d6a9381767d1357714ea6825bb3bf5", size = 238740, upload-time = "2026-04-27T12:24:01.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/b7/9c5c3d653bd4ff614277c049ac676422e2c557db47b4fe43e6313fc005dc/greenlet-3.5.0-cp313-cp313-win_arm64.whl", hash = "sha256:47422135b1d308c14b2c6e758beedb1acd33bb91679f5670edf77bf46244722b", size = 235525, upload-time = "2026-04-27T12:23:12.308Z" },
+    { url = "https://files.pythonhosted.org/packages/94/5e/a70f31e3e8d961c4ce589c15b28e4225d63704e431a23932a3808cbcc867/greenlet-3.5.0-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:f35807464c4c58c55f0d31dfa83c541a5615d825c2fe3d2b95360cf7c4e3c0a8", size = 285564, upload-time = "2026-04-27T12:23:08.555Z" },
+    { url = "https://files.pythonhosted.org/packages/af/a6/046c0a28e21833e4086918218cfb3d8bed51c075a1b700f20b9d7861c0f4/greenlet-3.5.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:55fa7ea52771be44af0de27d8b80c02cd18c2c3cddde6c847ecebdf72418b6a1", size = 651166, upload-time = "2026-04-27T12:52:43.644Z" },
+    { url = "https://files.pythonhosted.org/packages/47/f8/4af27f71c5ff32a7fbc516adb46370d9c4ae2bc7bd3dc7d066ac542b4b15/greenlet-3.5.0-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a97e4821aa710603f94de0da25f25096454d78ffdace5dc77f3a006bc01abba3", size = 663792, upload-time = "2026-04-27T12:59:44.93Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/89/2dadb89793c37ee8b4c237857188293e9060dc085f19845c292e00f8e091/greenlet-3.5.0-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:bf2d8a80bec89ab46221ae45c5373d5ba0bd36c19aa8508e85c6cd7e5106cd37", size = 668086, upload-time = "2026-04-27T13:02:42.314Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/59/1bd6d7428d6ed9106efbb8c52310c60fd04f6672490f452aeaa3829aa436/greenlet-3.5.0-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8f52a464e4ed91780bdfbbdd2b97197f3accaa629b98c200f4dffada759f3ae7", size = 660933, upload-time = "2026-04-27T12:25:33.276Z" },
+    { url = "https://files.pythonhosted.org/packages/82/35/75722be7e26a2af4cbd2dc35b0ed382dacf9394b7e75551f76ed1abe87f2/greenlet-3.5.0-cp314-cp314-manylinux_2_39_riscv64.whl", hash = "sha256:1bae92a1dd94c5f9d9493c3a212dd874c202442047cf96446412c862feca83a2", size = 470799, upload-time = "2026-04-27T13:05:17.094Z" },
+    { url = "https://files.pythonhosted.org/packages/83/e4/b903e5a5fae1e8a28cdd32a0cfbfd560b668c25b692f67768822ddc5f40f/greenlet-3.5.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:762612baf1161ccb8437c0161c668a688223cba28e1bf038f4eb47b13e39ccdf", size = 1618401, upload-time = "2026-04-27T12:53:31.062Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/e3/5ec408a329acb854fb607a122e1ee5fb3ff649f9a97952948a90803c0d8e/greenlet-3.5.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:57a43c6079a89713522bc4bcb9f75070ecf5d3dbad7792bfe42239362cbf2a16", size = 1682038, upload-time = "2026-04-27T12:25:31.838Z" },
+    { url = "https://files.pythonhosted.org/packages/91/20/6b165108058767ee643c55c5c4904d591a830ee2b3c7dbd359828fbc829f/greenlet-3.5.0-cp314-cp314-win_amd64.whl", hash = "sha256:3bc59be3945ae9750b9e7d45067d01ae3fe90ea5f9ade99239dabdd6e28a5033", size = 239835, upload-time = "2026-04-27T12:24:54.136Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/62/1c498375cee177b55d980c1db319f26470e5309e54698c8f8fc06c0fd539/greenlet-3.5.0-cp314-cp314-win_arm64.whl", hash = "sha256:a96fcee45e03fe30a62669fd16ab5c9d3c172660d3085605cb1e2d1280d3c988", size = 236862, upload-time = "2026-04-27T12:23:24.957Z" },
+    { url = "https://files.pythonhosted.org/packages/78/a8/4522939255bb5409af4e87132f915446bf3622c2c292d14d3c38d128ae82/greenlet-3.5.0-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:a10a732421ab4fec934783ce3e54763470d0181db6e3468f9103a275c3ed1853", size = 293614, upload-time = "2026-04-27T12:24:12.874Z" },
+    { url = "https://files.pythonhosted.org/packages/15/5e/8744c52e2c027b5a8772a01561934c8835f869733e101f62075c60430340/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7fc391b1566f2907d17aaebe78f8855dc45675159a775fcf9e61f8ee0078e87f", size = 650723, upload-time = "2026-04-27T12:52:45.412Z" },
+    { url = "https://files.pythonhosted.org/packages/00/ef/7b4c39c03cf46ceca512c5d3f914afd85aa30b2cc9a93015b0dd73e4be6c/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:680bd0e7ad5e8daa8a4aa89f68fd6adc834b8a8036dc256533f7e08f4a4b01f7", size = 656529, upload-time = "2026-04-27T12:59:46.295Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5c/0602239503b124b70e39355cbdb39361ecfe65b87a5f2f63752c32f5286f/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:1aa4ce8debcd4ea7fb2e150f3036588c41493d1d52c43538924ae1819003f4ce", size = 657015, upload-time = "2026-04-27T13:02:43.973Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/c7768f352f5c010f92064d0063f987e7dc0cd290a6d92a34109015ce4aa1/greenlet-3.5.0-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddb36c7d6c9c0a65f18c7258634e0c416c6ab59caac8c987b96f80c2ebda0112", size = 654364, upload-time = "2026-04-27T12:25:35.64Z" },
+    { url = "https://files.pythonhosted.org/packages/38/51/8699f865f125dc952384cb432b0f7138aa4d8f2969a7d12d0df5b94d054d/greenlet-3.5.0-cp314-cp314t-manylinux_2_39_riscv64.whl", hash = "sha256:728a73687e39ae9ca34e4694cbf2f049d3fbc7174639468d0f67200a97d8f9e2", size = 488275, upload-time = "2026-04-27T13:05:18.28Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/d0/079ebe12e4b1fc758857ce5be1a5e73f06870f2101e52611d1e71925ce54/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e5ddf316ced87539144621453c3aef229575825fe60c604e62bedc4003f372b2", size = 1614204, upload-time = "2026-04-27T12:53:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/89/6c2fb63df3596552d20e58fb4d96669243388cf680cff222758812c7bfaa/greenlet-3.5.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:4a448128607be0de65342dc9b31be7f948ef4cc0bc8832069350abefd310a8f2", size = 1675480, upload-time = "2026-04-27T12:25:34.168Z" },
+    { url = "https://files.pythonhosted.org/packages/15/32/77ee8a6c1564fc345a491a4e85b3bf360e4cf26eac98c4532d2fdb96e01f/greenlet-3.5.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d60097128cb0a1cab9ea541186ea13cd7b847b8449a7787c2e2350da0cb82d86", size = 245324, upload-time = "2026-04-27T12:24:40.295Z" },
 ]
 
 [[package]]
@@ -1267,7 +1347,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.14"
+version = "1.83.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1283,9 +1363,21 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/9d/da5583536348e942f6c8cadeab1047ff2c389293802f956e3bfa98cc8819/litellm-1.83.3.tar.gz", hash = "sha256:38a452f708f9bb682fdfc3607aa44d68cfe936bf4a18683b0cdc5fb476424a6f", size = 17732031, upload-time = "2026-04-05T00:54:09.187Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/cc/626df09cd4c31a13d5c6df097a228cac155f3739e0fa54dd0abc3479c88e/litellm-1.83.3-py3-none-any.whl", hash = "sha256:eab4d2e1871cac0239799c33eb724d239116bf1bd275e287f92ae76ba8c7a05a", size = 16014342, upload-time = "2026-04-05T00:54:05.53Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
 ]
 
 [[package]]
@@ -1530,7 +1622,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.24.0"
+version = "2.30.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1542,17 +1634,17 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
 ]
 
 [[package]]
 name = "openai-agents"
-version = "0.10.5"
+version = "0.13.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "griffe" },
+    { name = "griffelib" },
     { name = "mcp" },
     { name = "openai" },
     { name = "pydantic" },
@@ -1560,9 +1652,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/10/38/f47644c5de02f1853483d1a16d1fb7d12cc2c219c5548ec26a3e9aee1c29/openai_agents-0.10.5.tar.gz", hash = "sha256:73cef5263eeb98437b874b29c800694617af7d9626be19514b4ed6f434874c1e", size = 2511640, upload-time = "2026-03-05T20:43:59.308Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/e8/a3bc1a91af9c71d2934f8e2f3eee2954540fa95d47b0e3f155d348d91b38/openai_agents-0.13.6.tar.gz", hash = "sha256:de7b3add7933ae704a5ee6e531f650d8aabb3ebaa1631f458ba39684a5ed966e", size = 2704270, upload-time = "2026-04-09T04:10:51.581Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e2/07/ad27018fb42d6f1e70f471a5ca3f6398a2159575b623edf86e1ddde66ce4/openai_agents-0.10.5-py3-none-any.whl", hash = "sha256:6c92491c61ba85b4790d76562b4af2e6e230c8844f9c12fed8a721400a320c86", size = 413046, upload-time = "2026-03-05T20:43:57.874Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/83/a991b2ad389abadabf13f6c4228bd88ac8dc363e4b50fcae8c5ea966bd41/openai_agents-0.13.6-py3-none-any.whl", hash = "sha256:8decb9eb0cc5dbe7749858e97a7d8316f9439526ca4e539e3bd105e0eb41115e", size = 471763, upload-time = "2026-04-09T04:10:49.81Z" },
 ]
 
 [[package]]
@@ -1585,7 +1677,11 @@ dependencies = [
     { name = "agentd" },
     { name = "aiofiles" },
     { name = "aiohttp" },
+    { name = "aiosqlite" },
+    { name = "alembic" },
+    { name = "asyncpg" },
     { name = "boto3" },
+    { name = "cachetools" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "fastmcp" },
@@ -1608,6 +1704,8 @@ dependencies = [
     { name = "pyyaml" },
     { name = "requests" },
     { name = "rich" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
+    { name = "sqlmodel" },
     { name = "structlog" },
     { name = "tenacity" },
     { name = "textual" },
@@ -1630,7 +1728,11 @@ requires-dist = [
     { name = "agentd", specifier = ">=0.8.1" },
     { name = "aiofiles", specifier = ">=24.1.0" },
     { name = "aiohttp", specifier = ">=3.13.4" },
+    { name = "aiosqlite", specifier = ">=0.20.0" },
+    { name = "alembic", specifier = ">=1.13.0" },
+    { name = "asyncpg", specifier = ">=0.30.0" },
     { name = "boto3", specifier = ">=1.35.0" },
+    { name = "cachetools", specifier = ">=5.5.0" },
     { name = "cryptography", specifier = ">=46.0.6" },
     { name = "fastapi", specifier = ">=0.115.0" },
     { name = "fastmcp", specifier = ">=3.2.3" },
@@ -1639,9 +1741,9 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "ibm-cos-sdk", specifier = ">=2.13.0" },
-    { name = "litellm", specifier = "==1.83.14" },
+    { name = "litellm", specifier = "==1.83.3" },
     { name = "msal", specifier = ">=1.29.0" },
-    { name = "openai", specifier = "==2.24.0" },
+    { name = "openai", specifier = ">=2.30.0" },
     { name = "opensearch-py", extras = ["async"], specifier = ">=3.0.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
     { name = "psutil", specifier = ">=7.0.0" },
@@ -1653,6 +1755,8 @@ requires-dist = [
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "requests", specifier = ">=2.33.0" },
     { name = "rich", specifier = ">=13.0.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
+    { name = "sqlmodel", specifier = ">=0.0.22" },
     { name = "structlog", specifier = ">=25.4.0" },
     { name = "tenacity", specifier = ">=9.1.4" },
     { name = "textual", specifier = ">=0.45.0" },
@@ -2479,6 +2583,64 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
+]
+
+[[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/81/81755f50eb2478eaf2049728491d4ea4f416c1eb013338682173259efa09/sqlalchemy-2.0.49-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:df2d441bacf97022e81ad047e1597552eb3f83ca8a8f1a1fdd43cd7fe3898120", size = 2154547, upload-time = "2026-04-03T16:53:08.64Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/bc/3494270da80811d08bcfa247404292428c4fe16294932bce5593f215cad9/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8e20e511dc15265fb433571391ba313e10dd8ea7e509d51686a51313b4ac01a2", size = 3280782, upload-time = "2026-04-03T17:07:43.508Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/f5/038741f5e747a5f6ea3e72487211579d8cbea5eb9827a9cbd61d0108c4bd/sqlalchemy-2.0.49-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:47604cb2159f8bbd5a1ab48a714557156320f20871ee64d550d8bf2683d980d3", size = 3297156, upload-time = "2026-04-03T17:12:27.697Z" },
+    { url = "https://files.pythonhosted.org/packages/88/50/a6af0ff9dc954b43a65ca9b5367334e45d99684c90a3d3413fc19a02d43c/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:22d8798819f86720bc646ab015baff5ea4c971d68121cb36e2ebc2ee43ead2b7", size = 3228832, upload-time = "2026-04-03T17:07:45.38Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/d1/5f6bdad8de0bf546fc74370939621396515e0cdb9067402d6ba1b8afbe9a/sqlalchemy-2.0.49-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:9b1c058c171b739e7c330760044803099c7fff11511e3ab3573e5327116a9c33", size = 3267000, upload-time = "2026-04-03T17:12:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/30/ad62227b4a9819a5e1c6abff77c0f614fa7c9326e5a3bdbee90f7139382b/sqlalchemy-2.0.49-cp313-cp313-win32.whl", hash = "sha256:a143af2ea6672f2af3f44ed8f9cd020e9cc34c56f0e8db12019d5d9ecf41cb3b", size = 2115641, upload-time = "2026-04-03T17:05:43.989Z" },
+    { url = "https://files.pythonhosted.org/packages/17/3a/7215b1b7d6d49dc9a87211be44562077f5f04f9bb5a59552c1c8e2d98173/sqlalchemy-2.0.49-cp313-cp313-win_amd64.whl", hash = "sha256:12b04d1db2663b421fe072d638a138460a51d5a862403295671c4f3987fb9148", size = 2141498, upload-time = "2026-04-03T17:05:45.7Z" },
+    { url = "https://files.pythonhosted.org/packages/28/4b/52a0cb2687a9cd1648252bb257be5a1ba2c2ded20ba695c65756a55a15a4/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:24bd94bb301ec672d8f0623eba9226cc90d775d25a0c92b5f8e4965d7f3a1518", size = 3560807, upload-time = "2026-04-03T16:58:31.666Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d8/fda95459204877eed0458550d6c7c64c98cc50c2d8d618026737de9ed41a/sqlalchemy-2.0.49-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a51d3db74ba489266ef55c7a4534eb0b8db9a326553df481c11e5d7660c8364d", size = 3527481, upload-time = "2026-04-03T17:06:00.155Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0a/2aac8b78ac6487240cf7afef8f203ca783e8796002dc0cf65c4ee99ff8bb/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:55250fe61d6ebfd6934a272ee16ef1244e0f16b7af6cd18ab5b1fc9f08631db0", size = 3468565, upload-time = "2026-04-03T16:58:33.414Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/ce71cfa82c50a373fd2148b3c870be05027155ce791dc9a5dcf439790b8b/sqlalchemy-2.0.49-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:46796877b47034b559a593d7e4b549aba151dae73f9e78212a3478161c12ab08", size = 3477769, upload-time = "2026-04-03T17:06:02.787Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e8/0a9f5c1f7c6f9ca480319bf57c2d7423f08d31445974167a27d14483c948/sqlalchemy-2.0.49-cp313-cp313t-win32.whl", hash = "sha256:9c4969a86e41454f2858256c39bdfb966a20961e9b58bf8749b65abf447e9a8d", size = 2143319, upload-time = "2026-04-03T17:02:04.328Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/51/fb5240729fbec73006e137c4f7a7918ffd583ab08921e6ff81a999d6517a/sqlalchemy-2.0.49-cp313-cp313t-win_amd64.whl", hash = "sha256:b9870d15ef00e4d0559ae10ee5bc71b654d1f20076dbe8bc7ed19b4c0625ceba", size = 2175104, upload-time = "2026-04-03T17:02:05.989Z" },
+    { url = "https://files.pythonhosted.org/packages/55/33/bf28f618c0a9597d14e0b9ee7d1e0622faff738d44fe986ee287cdf1b8d0/sqlalchemy-2.0.49-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:233088b4b99ebcbc5258c755a097aa52fbf90727a03a5a80781c4b9c54347a2e", size = 2156356, upload-time = "2026-04-03T16:53:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a7/5f476227576cb8644650eff68cc35fa837d3802b997465c96b8340ced1e2/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57ca426a48eb2c682dae8204cd89ea8ab7031e2675120a47924fabc7caacbc2a", size = 3276486, upload-time = "2026-04-03T17:07:46.9Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/84/efc7c0bf3a1c5eef81d397f6fddac855becdbb11cb38ff957888603014a7/sqlalchemy-2.0.49-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:685e93e9c8f399b0c96a624799820176312f5ceef958c0f88215af4013d29066", size = 3281479, upload-time = "2026-04-03T17:12:32.226Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/bb406fa4257099c67bd75f3f2261b129c63204b9155de0d450b37f004698/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e0400fa22f79acc334d9a6b185dc00a44a8e6578aa7e12d0ddcd8434152b187", size = 3226269, upload-time = "2026-04-03T17:07:48.678Z" },
+    { url = "https://files.pythonhosted.org/packages/67/84/acb56c00cca9f251f437cb49e718e14f7687505749ea9255d7bd8158a6df/sqlalchemy-2.0.49-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a05977bffe9bffd2229f477fa75eabe3192b1b05f408961d1bebff8d1cd4d401", size = 3248260, upload-time = "2026-04-03T17:12:34.381Z" },
+    { url = "https://files.pythonhosted.org/packages/56/19/6a20ea25606d1efd7bd1862149bb2a22d1451c3f851d23d887969201633f/sqlalchemy-2.0.49-cp314-cp314-win32.whl", hash = "sha256:0f2fa354ba106eafff2c14b0cc51f22801d1e8b2e4149342023bd6f0955de5f5", size = 2118463, upload-time = "2026-04-03T17:05:47.093Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4f/8297e4ed88e80baa1f5aa3c484a0ee29ef3c69c7582f206c916973b75057/sqlalchemy-2.0.49-cp314-cp314-win_amd64.whl", hash = "sha256:77641d299179c37b89cf2343ca9972c88bb6eef0d5fc504a2f86afd15cd5adf5", size = 2144204, upload-time = "2026-04-03T17:05:48.694Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/33/95e7216df810c706e0cd3655a778604bbd319ed4f43333127d465a46862d/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c1dc3368794d522f43914e03312202523cc89692f5389c32bea0233924f8d977", size = 3565474, upload-time = "2026-04-03T16:58:35.128Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/a4/ed7b18d8ccf7f954a83af6bb73866f5bc6f5636f44c7731fbb741f72cc4f/sqlalchemy-2.0.49-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7c821c47ecfe05cc32140dcf8dc6fd5d21971c86dbd56eabfe5ba07a64910c01", size = 3530567, upload-time = "2026-04-03T17:06:04.587Z" },
+    { url = "https://files.pythonhosted.org/packages/73/a3/20faa869c7e21a827c4a2a42b41353a54b0f9f5e96df5087629c306df71e/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:9c04bff9a5335eb95c6ecf1c117576a0aa560def274876fd156cfe5510fccc61", size = 3474282, upload-time = "2026-04-03T16:58:37.131Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/50/276b9a007aa0764304ad467eceb70b04822dc32092492ee5f322d559a4dc/sqlalchemy-2.0.49-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7f605a456948c35260e7b2a39f8952a26f077fd25653c37740ed186b90aaa68a", size = 3480406, upload-time = "2026-04-03T17:06:07.176Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/c3/c80fcdb41905a2df650c2a3e0337198b6848876e63d66fe9188ef9003d24/sqlalchemy-2.0.49-cp314-cp314t-win32.whl", hash = "sha256:6270d717b11c5476b0cbb21eedc8d4dbb7d1a956fd6c15a23e96f197a6193158", size = 2149151, upload-time = "2026-04-03T17:02:07.281Z" },
+    { url = "https://files.pythonhosted.org/packages/05/52/9f1a62feab6ed368aff068524ff414f26a6daebc7361861035ae00b05530/sqlalchemy-2.0.49-cp314-cp314t-win_amd64.whl", hash = "sha256:275424295f4256fd301744b8f335cff367825d270f155d522b30c7bf49903ee7", size = 2184178, upload-time = "2026-04-03T17:02:08.623Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
+name = "sqlmodel"
+version = "0.0.38"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/64/0d/26ec1329960ea9430131fe63f63a95ea4cb8971d49c891ff7e1f3255421c/sqlmodel-0.0.38.tar.gz", hash = "sha256:d583ec237b14103809f74e8630032bc40ab68cd6b754a610f0813c56911a547b", size = 86710, upload-time = "2026-04-02T21:03:55.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/72/c7/10c60af0607ab6fa136264f7f39d205932218516226d38585324ffda705d/sqlmodel-0.0.38-py3-none-any.whl", hash = "sha256:84e3fa990a77395461ded72a6c73173438ce8449d5c1c4d97fbff1b1df692649", size = 27294, upload-time = "2026-04-02T21:03:56.406Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -68,7 +68,7 @@ wheels = [
 
 [[package]]
 name = "aiohttp"
-version = "3.13.5"
+version = "3.13.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohappyeyeballs" },
@@ -79,59 +79,59 @@ dependencies = [
     { name = "propcache" },
     { name = "yarl" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/9a/152096d4808df8e4268befa55fba462f440f14beab85e8ad9bf990516918/aiohttp-3.13.5.tar.gz", hash = "sha256:9d98cc980ecc96be6eb4c1994ce35d28d8b1f5e5208a23b421187d1209dbb7d1", size = 7858271, upload-time = "2026-03-31T22:01:03.343Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/4a/064321452809dae953c1ed6e017504e72551a26b6f5708a5a80e4bf556ff/aiohttp-3.13.4.tar.gz", hash = "sha256:d97a6d09c66087890c2ab5d49069e1e570583f7ac0314ecf98294c1b6aaebd38", size = 7859748, upload-time = "2026-03-28T17:19:40.6Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/e9/d76bf503005709e390122d34e15256b88f7008e246c4bdbe915cd4f1adce/aiohttp-3.13.5-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:a5029cc80718bbd545123cd8fe5d15025eccaaaace5d0eeec6bd556ad6163d61", size = 742930, upload-time = "2026-03-31T21:58:13.155Z" },
-    { url = "https://files.pythonhosted.org/packages/57/00/4b7b70223deaebd9bb85984d01a764b0d7bd6526fcdc73cca83bcbe7243e/aiohttp-3.13.5-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4bb6bf5811620003614076bdc807ef3b5e38244f9d25ca5fe888eaccea2a9832", size = 496927, upload-time = "2026-03-31T21:58:15.073Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/f5/0fb20fb49f8efdcdce6cd8127604ad2c503e754a8f139f5e02b01626523f/aiohttp-3.13.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a84792f8631bf5a94e52d9cc881c0b824ab42717165a5579c760b830d9392ac9", size = 497141, upload-time = "2026-03-31T21:58:17.009Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/86/b7c870053e36a94e8951b803cb5b909bfbc9b90ca941527f5fcafbf6b0fa/aiohttp-3.13.5-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:57653eac22c6a4c13eb22ecf4d673d64a12f266e72785ab1c8b8e5940d0e8090", size = 1732476, upload-time = "2026-03-31T21:58:18.925Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/e5/4e161f84f98d80c03a238671b4136e6530453d65262867d989bbe78244d0/aiohttp-3.13.5-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:e5e5f7debc7a57af53fdf5c5009f9391d9f4c12867049d509bf7bb164a6e295b", size = 1706507, upload-time = "2026-03-31T21:58:21.094Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/56/ea11a9f01518bd5a2a2fcee869d248c4b8a0cfa0bb13401574fa31adf4d4/aiohttp-3.13.5-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c719f65bebcdf6716f10e9eff80d27567f7892d8988c06de12bbbd39307c6e3a", size = 1773465, upload-time = "2026-03-31T21:58:23.159Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/40/333ca27fb74b0383f17c90570c748f7582501507307350a79d9f9f3c6eb1/aiohttp-3.13.5-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:d97f93fdae594d886c5a866636397e2bcab146fd7a132fd6bb9ce182224452f8", size = 1873523, upload-time = "2026-03-31T21:58:25.59Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/d2/e2f77eef1acb7111405433c707dc735e63f67a56e176e72e9e7a2cd3f493/aiohttp-3.13.5-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3df334e39d4c2f899a914f1dba283c1aadc311790733f705182998c6f7cae665", size = 1754113, upload-time = "2026-03-31T21:58:27.624Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/56/3f653d7f53c89669301ec9e42c95233e2a0c0a6dd051269e6e678db4fdb0/aiohttp-3.13.5-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:fe6970addfea9e5e081401bcbadf865d2b6da045472f58af08427e108d618540", size = 1562351, upload-time = "2026-03-31T21:58:29.918Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/a6/9b3e91eb8ae791cce4ee736da02211c85c6f835f1bdfac0594a8a3b7018c/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7becdf835feff2f4f335d7477f121af787e3504b48b449ff737afb35869ba7bb", size = 1693205, upload-time = "2026-03-31T21:58:32.214Z" },
-    { url = "https://files.pythonhosted.org/packages/98/fc/bfb437a99a2fcebd6b6eaec609571954de2ed424f01c352f4b5504371dd3/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:676e5651705ad5d8a70aeb8eb6936c436d8ebbd56e63436cb7dd9bb36d2a9a46", size = 1730618, upload-time = "2026-03-31T21:58:34.728Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/b6/c8534862126191a034f68153194c389addc285a0f1347d85096d349bbc15/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:9b16c653d38eb1a611cc898c41e76859ca27f119d25b53c12875fd0474ae31a8", size = 1745185, upload-time = "2026-03-31T21:58:36.909Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/93/4ca8ee2ef5236e2707e0fd5fecb10ce214aee1ff4ab307af9c558bda3b37/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:999802d5fa0389f58decd24b537c54aa63c01c3219ce17d1214cbda3c2b22d2d", size = 1557311, upload-time = "2026-03-31T21:58:39.38Z" },
-    { url = "https://files.pythonhosted.org/packages/57/ae/76177b15f18c5f5d094f19901d284025db28eccc5ae374d1d254181d33f4/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:ec707059ee75732b1ba130ed5f9580fe10ff75180c812bc267ded039db5128c6", size = 1773147, upload-time = "2026-03-31T21:58:41.476Z" },
-    { url = "https://files.pythonhosted.org/packages/01/a4/62f05a0a98d88af59d93b7fcac564e5f18f513cb7471696ac286db970d6a/aiohttp-3.13.5-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2d6d44a5b48132053c2f6cd5c8cb14bc67e99a63594e336b0f2af81e94d5530c", size = 1730356, upload-time = "2026-03-31T21:58:44.049Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/85/fc8601f59dfa8c9523808281f2da571f8b4699685f9809a228adcc90838d/aiohttp-3.13.5-cp313-cp313-win32.whl", hash = "sha256:329f292ed14d38a6c4c435e465f48bebb47479fd676a0411936cc371643225cc", size = 432637, upload-time = "2026-03-31T21:58:46.167Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/1b/ac685a8882896acf0f6b31d689e3792199cfe7aba37969fa91da63a7fa27/aiohttp-3.13.5-cp313-cp313-win_amd64.whl", hash = "sha256:69f571de7500e0557801c0b51f4780482c0ec5fe2ac851af5a92cfce1af1cb83", size = 458896, upload-time = "2026-03-31T21:58:48.119Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/ce/46572759afc859e867a5bc8ec3487315869013f59281ce61764f76d879de/aiohttp-3.13.5-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:eb4639f32fd4a9904ab8fb45bf3383ba71137f3d9d4ba25b3b3f3109977c5b8c", size = 745721, upload-time = "2026-03-31T21:58:50.229Z" },
-    { url = "https://files.pythonhosted.org/packages/13/fe/8a2efd7626dbe6049b2ef8ace18ffda8a4dfcbe1bcff3ac30c0c7575c20b/aiohttp-3.13.5-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:7e5dc4311bd5ac493886c63cbf76ab579dbe4641268e7c74e48e774c74b6f2be", size = 497663, upload-time = "2026-03-31T21:58:52.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9b/91/cc8cc78a111826c54743d88651e1687008133c37e5ee615fee9b57990fac/aiohttp-3.13.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:756c3c304d394977519824449600adaf2be0ccee76d206ee339c5e76b70ded25", size = 499094, upload-time = "2026-03-31T21:58:54.566Z" },
-    { url = "https://files.pythonhosted.org/packages/0a/33/a8362cb15cf16a3af7e86ed11962d5cd7d59b449202dc576cdc731310bde/aiohttp-3.13.5-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecc26751323224cf8186efcf7fbcbc30f4e1d8c7970659daf25ad995e4032a56", size = 1726701, upload-time = "2026-03-31T21:58:56.864Z" },
-    { url = "https://files.pythonhosted.org/packages/45/0c/c091ac5c3a17114bd76cbf85d674650969ddf93387876cf67f754204bd77/aiohttp-3.13.5-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:10a75acfcf794edf9d8db50e5a7ec5fc818b2a8d3f591ce93bc7b1210df016d2", size = 1683360, upload-time = "2026-03-31T21:58:59.072Z" },
-    { url = "https://files.pythonhosted.org/packages/23/73/bcee1c2b79bc275e964d1446c55c54441a461938e70267c86afaae6fba27/aiohttp-3.13.5-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0f7a18f258d124cd678c5fe072fe4432a4d5232b0657fca7c1847f599233c83a", size = 1773023, upload-time = "2026-03-31T21:59:01.776Z" },
-    { url = "https://files.pythonhosted.org/packages/c7/ef/720e639df03004fee2d869f771799d8c23046dec47d5b81e396c7cda583a/aiohttp-3.13.5-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:df6104c009713d3a89621096f3e3e88cc323fd269dbd7c20afe18535094320be", size = 1853795, upload-time = "2026-03-31T21:59:04.568Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/c9/989f4034fb46841208de7aeeac2c6d8300745ab4f28c42f629ba77c2d916/aiohttp-3.13.5-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:241a94f7de7c0c3b616627aaad530fe2cb620084a8b144d3be7b6ecfe95bae3b", size = 1730405, upload-time = "2026-03-31T21:59:07.221Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/75/ee1fd286ca7dc599d824b5651dad7b3be7ff8d9a7e7b3fe9820d9180f7db/aiohttp-3.13.5-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:c974fb66180e58709b6fc402846f13791240d180b74de81d23913abe48e96d94", size = 1558082, upload-time = "2026-03-31T21:59:09.484Z" },
-    { url = "https://files.pythonhosted.org/packages/c3/20/1e9e6650dfc436340116b7aa89ff8cb2bbdf0abc11dfaceaad8f74273a10/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:6e27ea05d184afac78aabbac667450c75e54e35f62238d44463131bd3f96753d", size = 1692346, upload-time = "2026-03-31T21:59:12.068Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/40/8ebc6658d48ea630ac7903912fe0dd4e262f0e16825aa4c833c56c9f1f56/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a79a6d399cef33a11b6f004c67bb07741d91f2be01b8d712d52c75711b1e07c7", size = 1698891, upload-time = "2026-03-31T21:59:14.552Z" },
-    { url = "https://files.pythonhosted.org/packages/d8/78/ea0ae5ec8ba7a5c10bdd6e318f1ba5e76fcde17db8275188772afc7917a4/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:c632ce9c0b534fbe25b52c974515ed674937c5b99f549a92127c85f771a78772", size = 1742113, upload-time = "2026-03-31T21:59:17.068Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/66/9d308ed71e3f2491be1acb8769d96c6f0c47d92099f3bc9119cada27b357/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:fceedde51fbd67ee2bcc8c0b33d0126cc8b51ef3bbde2f86662bd6d5a6f10ec5", size = 1553088, upload-time = "2026-03-31T21:59:19.541Z" },
-    { url = "https://files.pythonhosted.org/packages/da/a6/6cc25ed8dfc6e00c90f5c6d126a98e2cf28957ad06fa1036bd34b6f24a2c/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:f92995dfec9420bb69ae629abf422e516923ba79ba4403bc750d94fb4a6c68c1", size = 1757976, upload-time = "2026-03-31T21:59:22.311Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/2b/cce5b0ffe0de99c83e5e36d8f828e4161e415660a9f3e58339d07cce3006/aiohttp-3.13.5-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:20ae0ff08b1f2c8788d6fb85afcb798654ae6ba0b747575f8562de738078457b", size = 1712444, upload-time = "2026-03-31T21:59:24.635Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/cf/9e1795b4160c58d29421eafd1a69c6ce351e2f7c8d3c6b7e4ca44aea1a5b/aiohttp-3.13.5-cp314-cp314-win32.whl", hash = "sha256:b20df693de16f42b2472a9c485e1c948ee55524786a0a34345511afdd22246f3", size = 438128, upload-time = "2026-03-31T21:59:27.291Z" },
-    { url = "https://files.pythonhosted.org/packages/22/4d/eaedff67fc805aeba4ba746aec891b4b24cebb1a7d078084b6300f79d063/aiohttp-3.13.5-cp314-cp314-win_amd64.whl", hash = "sha256:f85c6f327bf0b8c29da7d93b1cabb6363fb5e4e160a32fa241ed2dce21b73162", size = 464029, upload-time = "2026-03-31T21:59:29.429Z" },
-    { url = "https://files.pythonhosted.org/packages/79/11/c27d9332ee20d68dd164dc12a6ecdef2e2e35ecc97ed6cf0d2442844624b/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:1efb06900858bb618ff5cee184ae2de5828896c448403d51fb633f09e109be0a", size = 778758, upload-time = "2026-03-31T21:59:31.547Z" },
-    { url = "https://files.pythonhosted.org/packages/04/fb/377aead2e0a3ba5f09b7624f702a964bdf4f08b5b6728a9799830c80041e/aiohttp-3.13.5-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:fee86b7c4bd29bdaf0d53d14739b08a106fdda809ca5fe032a15f52fae5fe254", size = 512883, upload-time = "2026-03-31T21:59:34.098Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/a6/aa109a33671f7a5d3bd78b46da9d852797c5e665bfda7d6b373f56bff2ec/aiohttp-3.13.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:20058e23909b9e65f9da62b396b77dfa95965cbe840f8def6e572538b1d32e36", size = 516668, upload-time = "2026-03-31T21:59:36.497Z" },
-    { url = "https://files.pythonhosted.org/packages/79/b3/ca078f9f2fa9563c36fb8ef89053ea2bb146d6f792c5104574d49d8acb63/aiohttp-3.13.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8cf20a8d6868cb15a73cab329ffc07291ba8c22b1b88176026106ae39aa6df0f", size = 1883461, upload-time = "2026-03-31T21:59:38.723Z" },
-    { url = "https://files.pythonhosted.org/packages/b7/e3/a7ad633ca1ca497b852233a3cce6906a56c3225fb6d9217b5e5e60b7419d/aiohttp-3.13.5-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:330f5da04c987f1d5bdb8ae189137c77139f36bd1cb23779ca1a354a4b027800", size = 1747661, upload-time = "2026-03-31T21:59:41.187Z" },
-    { url = "https://files.pythonhosted.org/packages/33/b9/cd6fe579bed34a906d3d783fe60f2fa297ef55b27bb4538438ee49d4dc41/aiohttp-3.13.5-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:6f1cbf0c7926d315c3c26c2da41fd2b5d2fe01ac0e157b78caefc51a782196cf", size = 1863800, upload-time = "2026-03-31T21:59:43.84Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/3f/2c1e2f5144cefa889c8afd5cf431994c32f3b29da9961698ff4e3811b79a/aiohttp-3.13.5-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:53fc049ed6390d05423ba33103ded7281fe897cf97878f369a527070bd95795b", size = 1958382, upload-time = "2026-03-31T21:59:46.187Z" },
-    { url = "https://files.pythonhosted.org/packages/66/1d/f31ec3f1013723b3babe3609e7f119c2c2fb6ef33da90061a705ef3e1bc8/aiohttp-3.13.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:898703aa2667e3c5ca4c54ca36cd73f58b7a38ef87a5606414799ebce4d3fd3a", size = 1803724, upload-time = "2026-03-31T21:59:48.656Z" },
-    { url = "https://files.pythonhosted.org/packages/0e/b4/57712dfc6f1542f067daa81eb61da282fab3e6f1966fca25db06c4fc62d5/aiohttp-3.13.5-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0494a01ca9584eea1e5fbd6d748e61ecff218c51b576ee1999c23db7066417d8", size = 1640027, upload-time = "2026-03-31T21:59:51.284Z" },
-    { url = "https://files.pythonhosted.org/packages/25/3c/734c878fb43ec083d8e31bf029daae1beafeae582d1b35da234739e82ee7/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:6cf81fe010b8c17b09495cbd15c1d35afbc8fb405c0c9cf4738e5ae3af1d65be", size = 1806644, upload-time = "2026-03-31T21:59:53.753Z" },
-    { url = "https://files.pythonhosted.org/packages/20/a5/f671e5cbec1c21d044ff3078223f949748f3a7f86b14e34a365d74a5d21f/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:c564dd5f09ddc9d8f2c2d0a301cd30a79a2cc1b46dd1a73bef8f0038863d016b", size = 1791630, upload-time = "2026-03-31T21:59:56.239Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/63/fb8d0ad63a0b8a99be97deac8c04dacf0785721c158bdf23d679a87aa99e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:2994be9f6e51046c4f864598fd9abeb4fba6e88f0b2152422c9666dcd4aea9c6", size = 1809403, upload-time = "2026-03-31T21:59:59.103Z" },
-    { url = "https://files.pythonhosted.org/packages/59/0c/bfed7f30662fcf12206481c2aac57dedee43fe1c49275e85b3a1e1742294/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:157826e2fa245d2ef46c83ea8a5faf77ca19355d278d425c29fda0beb3318037", size = 1634924, upload-time = "2026-03-31T22:00:02.116Z" },
-    { url = "https://files.pythonhosted.org/packages/17/d6/fd518d668a09fd5a3319ae5e984d4d80b9a4b3df4e21c52f02251ef5a32e/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:a8aca50daa9493e9e13c0f566201a9006f080e7c50e5e90d0b06f53146a54500", size = 1836119, upload-time = "2026-03-31T22:00:04.756Z" },
-    { url = "https://files.pythonhosted.org/packages/78/b7/15fb7a9d52e112a25b621c67b69c167805cb1f2ab8f1708a5c490d1b52fe/aiohttp-3.13.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3b13560160d07e047a93f23aaa30718606493036253d5430887514715b67c9d9", size = 1772072, upload-time = "2026-03-31T22:00:07.494Z" },
-    { url = "https://files.pythonhosted.org/packages/7e/df/57ba7f0c4a553fc2bd8b6321df236870ec6fd64a2a473a8a13d4f733214e/aiohttp-3.13.5-cp314-cp314t-win32.whl", hash = "sha256:9a0f4474b6ea6818b41f82172d799e4b3d29e22c2c520ce4357856fced9af2f8", size = 471819, upload-time = "2026-03-31T22:00:10.277Z" },
-    { url = "https://files.pythonhosted.org/packages/62/29/2f8418269e46454a26171bfdd6a055d74febf32234e474930f2f60a17145/aiohttp-3.13.5-cp314-cp314t-win_amd64.whl", hash = "sha256:18a2f6c1182c51baa1d28d68fea51513cb2a76612f038853c0ad3c145423d3d9", size = 505441, upload-time = "2026-03-31T22:00:12.791Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/ac/892f4162df9b115b4758d615f32ec63d00f3084c705ff5526630887b9b42/aiohttp-3.13.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:63dd5e5b1e43b8fb1e91b79b7ceba1feba588b317d1edff385084fcc7a0a4538", size = 745744, upload-time = "2026-03-28T17:16:44.67Z" },
+    { url = "https://files.pythonhosted.org/packages/97/a9/c5b87e4443a2f0ea88cb3000c93a8fdad1ee63bffc9ded8d8c8e0d66efc6/aiohttp-3.13.4-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:746ac3cc00b5baea424dacddea3ec2c2702f9590de27d837aa67004db1eebc6e", size = 498178, upload-time = "2026-03-28T17:16:46.766Z" },
+    { url = "https://files.pythonhosted.org/packages/94/42/07e1b543a61250783650df13da8ddcdc0d0a5538b2bd15cef6e042aefc61/aiohttp-3.13.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bda8f16ea99d6a6705e5946732e48487a448be874e54a4f73d514660ff7c05d3", size = 498331, upload-time = "2026-03-28T17:16:48.9Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d6/492f46bf0328534124772d0cf58570acae5b286ea25006900650f69dae0e/aiohttp-3.13.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4b061e7b5f840391e3f64d0ddf672973e45c4cfff7a0feea425ea24e51530fc2", size = 1744414, upload-time = "2026-03-28T17:16:50.968Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4d/e02627b2683f68051246215d2d62b2d2f249ff7a285e7a858dc47d6b6a14/aiohttp-3.13.4-cp313-cp313-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:b252e8d5cd66184b570d0d010de742736e8a4fab22c58299772b0c5a466d4b21", size = 1719226, upload-time = "2026-03-28T17:16:53.173Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/6c/5d0a3394dd2b9f9aeba6e1b6065d0439e4b75d41f1fb09a3ec010b43552b/aiohttp-3.13.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:20af8aad61d1803ff11152a26146d8d81c266aa8c5aa9b4504432abb965c36a0", size = 1782110, upload-time = "2026-03-28T17:16:55.362Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/2d/c20791e3437700a7441a7edfb59731150322424f5aadf635602d1d326101/aiohttp-3.13.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:13a5cc924b59859ad2adb1478e31f410a7ed46e92a2a619d6d1dd1a63c1a855e", size = 1884809, upload-time = "2026-03-28T17:16:57.734Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/94/d99dbfbd1924a87ef643833932eb2a3d9e5eee87656efea7d78058539eff/aiohttp-3.13.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:534913dfb0a644d537aebb4123e7d466d94e3be5549205e6a31f72368980a81a", size = 1764938, upload-time = "2026-03-28T17:17:00.221Z" },
+    { url = "https://files.pythonhosted.org/packages/49/61/3ce326a1538781deb89f6cf5e094e2029cd308ed1e21b2ba2278b08426f6/aiohttp-3.13.4-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:320e40192a2dcc1cf4b5576936e9652981ab596bf81eb309535db7e2f5b5672f", size = 1570697, upload-time = "2026-03-28T17:17:02.985Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/77/4ab5a546857bb3028fbaf34d6eea180267bdab022ee8b1168b1fcde4bfdd/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:9e587fcfce2bcf06526a43cb705bdee21ac089096f2e271d75de9c339db3100c", size = 1702258, upload-time = "2026-03-28T17:17:05.28Z" },
+    { url = "https://files.pythonhosted.org/packages/79/63/d8f29021e39bc5af8e5d5e9da1b07976fb9846487a784e11e4f4eeda4666/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:9eb9c2eea7278206b5c6c1441fdd9dc420c278ead3f3b2cc87f9b693698cc500", size = 1740287, upload-time = "2026-03-28T17:17:07.712Z" },
+    { url = "https://files.pythonhosted.org/packages/55/3a/cbc6b3b124859a11bc8055d3682c26999b393531ef926754a3445b99dfef/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:29be00c51972b04bf9d5c8f2d7f7314f48f96070ca40a873a53056e652e805f7", size = 1753011, upload-time = "2026-03-28T17:17:10.053Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/30/836278675205d58c1368b21520eab9572457cf19afd23759216c04483048/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:90c06228a6c3a7c9f776fe4fc0b7ff647fffd3bed93779a6913c804ae00c1073", size = 1566359, upload-time = "2026-03-28T17:17:12.433Z" },
+    { url = "https://files.pythonhosted.org/packages/50/b4/8032cc9b82d17e4277704ba30509eaccb39329dc18d6a35f05e424439e32/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:a533ec132f05fd9a1d959e7f34184cd7d5e8511584848dab85faefbaac573069", size = 1785537, upload-time = "2026-03-28T17:17:14.721Z" },
+    { url = "https://files.pythonhosted.org/packages/17/7d/5873e98230bde59f493bf1f7c3e327486a4b5653fa401144704df5d00211/aiohttp-3.13.4-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1c946f10f413836f82ea4cfb90200d2a59578c549f00857e03111cf45ad01ca5", size = 1740752, upload-time = "2026-03-28T17:17:17.387Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/f2/13e46e0df051494d7d3c68b7f72d071f48c384c12716fc294f75d5b1a064/aiohttp-3.13.4-cp313-cp313-win32.whl", hash = "sha256:48708e2706106da6967eff5908c78ca3943f005ed6bcb75da2a7e4da94ef8c70", size = 433187, upload-time = "2026-03-28T17:17:19.523Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/c0/649856ee655a843c8f8664592cfccb73ac80ede6a8c8db33a25d810c12db/aiohttp-3.13.4-cp313-cp313-win_amd64.whl", hash = "sha256:74a2eb058da44fa3a877a49e2095b591d4913308bb424c418b77beb160c55ce3", size = 459778, upload-time = "2026-03-28T17:17:21.964Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/29/6657cc37ae04cacc2dbf53fb730a06b6091cc4cbe745028e047c53e6d840/aiohttp-3.13.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:e0a2c961fc92abeff61d6444f2ce6ad35bb982db9fc8ff8a47455beacf454a57", size = 749363, upload-time = "2026-03-28T17:17:24.044Z" },
+    { url = "https://files.pythonhosted.org/packages/90/7f/30ccdf67ca3d24b610067dc63d64dcb91e5d88e27667811640644aa4a85d/aiohttp-3.13.4-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:153274535985a0ff2bff1fb6c104ed547cec898a09213d21b0f791a44b14d933", size = 499317, upload-time = "2026-03-28T17:17:26.199Z" },
+    { url = "https://files.pythonhosted.org/packages/93/13/e372dd4e68ad04ee25dafb050c7f98b0d91ea643f7352757e87231102555/aiohttp-3.13.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:351f3171e2458da3d731ce83f9e6b9619e325c45cbd534c7759750cabf453ad7", size = 500477, upload-time = "2026-03-28T17:17:28.279Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/fe/ee6298e8e586096fb6f5eddd31393d8544f33ae0792c71ecbb4c2bef98ac/aiohttp-3.13.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f989ac8bc5595ff761a5ccd32bdb0768a117f36dd1504b1c2c074ed5d3f4df9c", size = 1737227, upload-time = "2026-03-28T17:17:30.587Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/b9/a7a0463a09e1a3fe35100f74324f23644bfc3383ac5fd5effe0722a5f0b7/aiohttp-3.13.4-cp314-cp314-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:d36fc1709110ec1e87a229b201dd3ddc32aa01e98e7868083a794609b081c349", size = 1694036, upload-time = "2026-03-28T17:17:33.29Z" },
+    { url = "https://files.pythonhosted.org/packages/57/7c/8972ae3fb7be00a91aee6b644b2a6a909aedb2c425269a3bfd90115e6f8f/aiohttp-3.13.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:42adaeea83cbdf069ab94f5103ce0787c21fb1a0153270da76b59d5578302329", size = 1786814, upload-time = "2026-03-28T17:17:36.035Z" },
+    { url = "https://files.pythonhosted.org/packages/93/01/c81e97e85c774decbaf0d577de7d848934e8166a3a14ad9f8aa5be329d28/aiohttp-3.13.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:92deb95469928cc41fd4b42a95d8012fa6df93f6b1c0a83af0ffbc4a5e218cde", size = 1866676, upload-time = "2026-03-28T17:17:38.441Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5f/5b46fe8694a639ddea2cd035bf5729e4677ea882cb251396637e2ef1590d/aiohttp-3.13.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0c0c7c07c4257ef3a1df355f840bc62d133bcdef5c1c5ba75add3c08553e2eed", size = 1740842, upload-time = "2026-03-28T17:17:40.783Z" },
+    { url = "https://files.pythonhosted.org/packages/20/a2/0d4b03d011cca6b6b0acba8433193c1e484efa8d705ea58295590fe24203/aiohttp-3.13.4-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f062c45de8a1098cb137a1898819796a2491aec4e637a06b03f149315dff4d8f", size = 1566508, upload-time = "2026-03-28T17:17:43.235Z" },
+    { url = "https://files.pythonhosted.org/packages/98/17/e689fd500da52488ec5f889effd6404dece6a59de301e380f3c64f167beb/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:76093107c531517001114f0ebdb4f46858ce818590363e3e99a4a2280334454a", size = 1700569, upload-time = "2026-03-28T17:17:46.165Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/0d/66402894dbcf470ef7db99449e436105ea862c24f7ea4c95c683e635af35/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:6f6ec32162d293b82f8b63a16edc80769662fbd5ae6fbd4936d3206a2c2cc63b", size = 1707407, upload-time = "2026-03-28T17:17:48.825Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/eb/af0ab1a3650092cbd8e14ef29e4ab0209e1460e1c299996c3f8288b3f1ff/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:5903e2db3d202a00ad9f0ec35a122c005e85d90c9836ab4cda628f01edf425e2", size = 1752214, upload-time = "2026-03-28T17:17:51.206Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/bf/72326f8a98e4c666f292f03c385545963cc65e358835d2a7375037a97b57/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:2d5bea57be7aca98dbbac8da046d99b5557c5cf4e28538c4c786313078aca09e", size = 1562162, upload-time = "2026-03-28T17:17:53.634Z" },
+    { url = "https://files.pythonhosted.org/packages/67/9f/13b72435f99151dd9a5469c96b3b5f86aa29b7e785ca7f35cf5e538f74c0/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:bcf0c9902085976edc0232b75006ef38f89686901249ce14226b6877f88464fb", size = 1768904, upload-time = "2026-03-28T17:17:55.991Z" },
+    { url = "https://files.pythonhosted.org/packages/18/bc/28d4970e7d5452ac7776cdb5431a1164a0d9cf8bd2fffd67b4fb463aa56d/aiohttp-3.13.4-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:c3295f98bfeed2e867cab588f2a146a9db37a85e3ae9062abf46ba062bd29165", size = 1723378, upload-time = "2026-03-28T17:17:58.348Z" },
+    { url = "https://files.pythonhosted.org/packages/53/74/b32458ca1a7f34d65bdee7aef2036adbe0438123d3d53e2b083c453c24dd/aiohttp-3.13.4-cp314-cp314-win32.whl", hash = "sha256:a598a5c5767e1369d8f5b08695cab1d8160040f796c4416af76fd773d229b3c9", size = 438711, upload-time = "2026-03-28T17:18:00.728Z" },
+    { url = "https://files.pythonhosted.org/packages/40/b2/54b487316c2df3e03a8f3435e9636f8a81a42a69d942164830d193beb56a/aiohttp-3.13.4-cp314-cp314-win_amd64.whl", hash = "sha256:c555db4bc7a264bead5a7d63d92d41a1122fcd39cc62a4db815f45ad46f9c2c8", size = 464977, upload-time = "2026-03-28T17:18:03.367Z" },
+    { url = "https://files.pythonhosted.org/packages/47/fb/e41b63c6ce71b07a59243bb8f3b457ee0c3402a619acb9d2c0d21ef0e647/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:45abbbf09a129825d13c18c7d3182fecd46d9da3cfc383756145394013604ac1", size = 781549, upload-time = "2026-03-28T17:18:05.779Z" },
+    { url = "https://files.pythonhosted.org/packages/97/53/532b8d28df1e17e44c4d9a9368b78dcb6bf0b51037522136eced13afa9e8/aiohttp-3.13.4-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:74c80b2bc2c2adb7b3d1941b2b60701ee2af8296fc8aad8b8bc48bc25767266c", size = 514383, upload-time = "2026-03-28T17:18:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/1f/62e5d400603e8468cd635812d99cb81cfdc08127a3dc474c647615f31339/aiohttp-3.13.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c97989ae40a9746650fa196894f317dafc12227c808c774929dda0ff873a5954", size = 518304, upload-time = "2026-03-28T17:18:10.642Z" },
+    { url = "https://files.pythonhosted.org/packages/90/57/2326b37b10896447e3c6e0cbef4fe2486d30913639a5cfd1332b5d870f82/aiohttp-3.13.4-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dae86be9811493f9990ef44fff1685f5c1a3192e9061a71a109d527944eed551", size = 1893433, upload-time = "2026-03-28T17:18:13.121Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b4/a24d82112c304afdb650167ef2fe190957d81cbddac7460bedd245f765aa/aiohttp-3.13.4-cp314-cp314t-manylinux2014_armv7l.manylinux_2_17_armv7l.manylinux_2_31_armv7l.whl", hash = "sha256:1db491abe852ca2fa6cc48a3341985b0174b3741838e1341b82ac82c8bd9e871", size = 1755901, upload-time = "2026-03-28T17:18:16.21Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0883ef9d878d7846287f036c162a951968f22aabeef3ac97b0bea6f76d5d/aiohttp-3.13.4-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:0e5d701c0aad02a7dce72eef6b93226cf3734330f1a31d69ebbf69f33b86666e", size = 1876093, upload-time = "2026-03-28T17:18:18.703Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/52/9204bb59c014869b71971addad6778f005daa72a96eed652c496789d7468/aiohttp-3.13.4-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8ac32a189081ae0a10ba18993f10f338ec94341f0d5df8fff348043962f3c6f8", size = 1970815, upload-time = "2026-03-28T17:18:21.858Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/b5/e4eb20275a866dde0f570f411b36c6b48f7b53edfe4f4071aa1b0728098a/aiohttp-3.13.4-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:98e968cdaba43e45c73c3f306fca418c8009a957733bac85937c9f9cf3f4de27", size = 1816223, upload-time = "2026-03-28T17:18:24.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/23/e98075c5bb146aa61a1239ee1ac7714c85e814838d6cebbe37d3fe19214a/aiohttp-3.13.4-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:ca114790c9144c335d538852612d3e43ea0f075288f4849cf4b05d6cd2238ce7", size = 1649145, upload-time = "2026-03-28T17:18:27.269Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c1/7bad8be33bb06c2bb224b6468874346026092762cbec388c3bdb65a368ee/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ea2e071661ba9cfe11eabbc81ac5376eaeb3061f6e72ec4cc86d7cdd1ffbdbbb", size = 1816562, upload-time = "2026-03-28T17:18:29.847Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/10/c00323348695e9a5e316825969c88463dcc24c7e9d443244b8a2c9cf2eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:34e89912b6c20e0fd80e07fa401fd218a410aa1ce9f1c2f1dad6db1bd0ce0927", size = 1800333, upload-time = "2026-03-28T17:18:32.269Z" },
+    { url = "https://files.pythonhosted.org/packages/84/43/9b2147a1df3559f49bd723e22905b46a46c068a53adb54abdca32c4de180/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0e217cf9f6a42908c52b46e42c568bd57adc39c9286ced31aaace614b6087965", size = 1820617, upload-time = "2026-03-28T17:18:35.238Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/7f/b3481a81e7a586d02e99387b18c6dafff41285f6efd3daa2124c01f87eae/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:0c296f1221e21ba979f5ac1964c3b78cfde15c5c5f855ffd2caab337e9cd9182", size = 1643417, upload-time = "2026-03-28T17:18:37.949Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/72/07181226bc99ce1124e0f89280f5221a82d3ae6a6d9d1973ce429d48e52b/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:d99a9d168ebaffb74f36d011750e490085ac418f4db926cce3989c8fe6cb6b1b", size = 1849286, upload-time = "2026-03-28T17:18:40.534Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/e6/1b3566e103eca6da5be4ae6713e112a053725c584e96574caf117568ffef/aiohttp-3.13.4-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:cb19177205d93b881f3f89e6081593676043a6828f59c78c17a0fd6c1fbed2ba", size = 1782635, upload-time = "2026-03-28T17:18:43.073Z" },
+    { url = "https://files.pythonhosted.org/packages/37/58/1b11c71904b8d079eb0c39fe664180dd1e14bebe5608e235d8bfbadc8929/aiohttp-3.13.4-cp314-cp314t-win32.whl", hash = "sha256:c606aa5656dab6552e52ca368e43869c916338346bfaf6304e15c58fb113ea30", size = 472537, upload-time = "2026-03-28T17:18:46.286Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/8f/87c56a1a1977d7dddea5b31e12189665a140fdb48a71e9038ff90bb564ec/aiohttp-3.13.4-cp314-cp314t-win_amd64.whl", hash = "sha256:014dcc10ec8ab8db681f0d68e939d1e9286a5aa2b993cbbdb0db130853e02144", size = 506381, upload-time = "2026-03-28T17:18:48.74Z" },
 ]
 
 [[package]]
@@ -941,6 +941,18 @@ wheels = [
 ]
 
 [[package]]
+name = "griffe"
+version = "1.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/0c/3a471b6e31951dce2360477420d0a8d1e00dea6cf33b70f3e8c3ab6e28e1/griffe-1.15.0.tar.gz", hash = "sha256:7726e3afd6f298fbc3696e67958803e7ac843c1cfe59734b6251a40cdbfb5eea", size = 424112, upload-time = "2025-11-10T15:03:15.52Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9c/83/3b1d03d36f224edded98e9affd0467630fc09d766c0e56fb1498cbb04a9b/griffe-1.15.0-py3-none-any.whl", hash = "sha256:6f6762661949411031f5fcda9593f586e6ce8340f0ba88921a0f2ef7a81eb9a3", size = 150705, upload-time = "2025-11-10T15:03:13.549Z" },
+]
+
+[[package]]
 name = "griffelib"
 version = "2.0.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1347,7 +1359,7 @@ wheels = [
 
 [[package]]
 name = "litellm"
-version = "1.83.3"
+version = "1.83.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiohttp" },
@@ -1363,9 +1375,9 @@ dependencies = [
     { name = "tiktoken" },
     { name = "tokenizers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3b/9d/da5583536348e942f6c8cadeab1047ff2c389293802f956e3bfa98cc8819/litellm-1.83.3.tar.gz", hash = "sha256:38a452f708f9bb682fdfc3607aa44d68cfe936bf4a18683b0cdc5fb476424a6f", size = 17732031, upload-time = "2026-04-05T00:54:09.187Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/7c/c095649380adc96c8630273c1768c2ad1e74aa2ee1dd8dd05d218a60569f/litellm-1.83.14.tar.gz", hash = "sha256:24aef9b47cdc424c833e32f3727f411741c690832cd1fe4405e0077144fe09c9", size = 14836599, upload-time = "2026-04-26T03:16:10.176Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/cc/626df09cd4c31a13d5c6df097a228cac155f3739e0fa54dd0abc3479c88e/litellm-1.83.3-py3-none-any.whl", hash = "sha256:eab4d2e1871cac0239799c33eb724d239116bf1bd275e287f92ae76ba8c7a05a", size = 16014342, upload-time = "2026-04-05T00:54:05.53Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5c/1b5691575420135e90578543b2bf219497caa33cfd0af64cb38f30288450/litellm-1.83.14-py3-none-any.whl", hash = "sha256:92b11ba2a32cf80707ddf388d18526696c7999a21b418c5e3b6eda1243d2cfdb", size = 16457054, upload-time = "2026-04-26T03:16:05.72Z" },
 ]
 
 [[package]]
@@ -1622,7 +1634,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "2.30.0"
+version = "2.24.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1634,17 +1646,17 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/15/52580c8fbc16d0675d516e8749806eda679b16de1e4434ea06fb6feaa610/openai-2.30.0.tar.gz", hash = "sha256:92f7661c990bda4b22a941806c83eabe4896c3094465030dd882a71abe80c885", size = 676084, upload-time = "2026-03-25T22:08:59.96Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/55/13/17e87641b89b74552ed408a92b231283786523edddc95f3545809fab673c/openai-2.24.0.tar.gz", hash = "sha256:1e5769f540dbd01cb33bc4716a23e67b9d695161a734aff9c5f925e2bf99a673", size = 658717, upload-time = "2026-02-24T20:02:07.958Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/9e/5bfa2270f902d5b92ab7d41ce0475b8630572e71e349b2a4996d14bdda93/openai-2.30.0-py3-none-any.whl", hash = "sha256:9a5ae616888eb2748ec5e0c5b955a51592e0b201a11f4262db920f2a78c5231d", size = 1146656, upload-time = "2026-03-25T22:08:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/30/844dc675ee6902579b8eef01ed23917cc9319a1c9c0c14ec6e39340c96d0/openai-2.24.0-py3-none-any.whl", hash = "sha256:fed30480d7d6c884303287bde864980a4b137b60553ffbcf9ab4a233b7a73d94", size = 1120122, upload-time = "2026-02-24T20:02:05.669Z" },
 ]
 
 [[package]]
 name = "openai-agents"
-version = "0.13.6"
+version = "0.10.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "griffelib" },
+    { name = "griffe" },
     { name = "mcp" },
     { name = "openai" },
     { name = "pydantic" },
@@ -1652,9 +1664,9 @@ dependencies = [
     { name = "types-requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4f/e8/a3bc1a91af9c71d2934f8e2f3eee2954540fa95d47b0e3f155d348d91b38/openai_agents-0.13.6.tar.gz", hash = "sha256:de7b3add7933ae704a5ee6e531f650d8aabb3ebaa1631f458ba39684a5ed966e", size = 2704270, upload-time = "2026-04-09T04:10:51.581Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/10/38/f47644c5de02f1853483d1a16d1fb7d12cc2c219c5548ec26a3e9aee1c29/openai_agents-0.10.5.tar.gz", hash = "sha256:73cef5263eeb98437b874b29c800694617af7d9626be19514b4ed6f434874c1e", size = 2511640, upload-time = "2026-03-05T20:43:59.308Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1c/83/a991b2ad389abadabf13f6c4228bd88ac8dc363e4b50fcae8c5ea966bd41/openai_agents-0.13.6-py3-none-any.whl", hash = "sha256:8decb9eb0cc5dbe7749858e97a7d8316f9439526ca4e539e3bd105e0eb41115e", size = 471763, upload-time = "2026-04-09T04:10:49.81Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/07/ad27018fb42d6f1e70f471a5ca3f6398a2159575b623edf86e1ddde66ce4/openai_agents-0.10.5-py3-none-any.whl", hash = "sha256:6c92491c61ba85b4790d76562b4af2e6e230c8844f9c12fed8a721400a320c86", size = 413046, upload-time = "2026-03-05T20:43:57.874Z" },
 ]
 
 [[package]]
@@ -1741,9 +1753,9 @@ requires-dist = [
     { name = "google-auth-oauthlib", specifier = ">=1.2.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "ibm-cos-sdk", specifier = ">=2.13.0" },
-    { name = "litellm", specifier = "==1.83.3" },
+    { name = "litellm", specifier = "==1.83.14" },
     { name = "msal", specifier = ">=1.29.0" },
-    { name = "openai", specifier = ">=2.30.0" },
+    { name = "openai", specifier = "==2.24.0" },
     { name = "opensearch-py", extras = ["async"], specifier = ">=3.0.0" },
     { name = "prometheus-fastapi-instrumentator", specifier = ">=7.1.0" },
     { name = "psutil", specifier = ">=7.0.0" },


### PR DESCRIPTION
This PR introduces a versioned, Alembic-based database migration system and migrates the project's persistent state to a SQL-backed model. It adds identity management, role-based access control (RBAC), DB-backed workspace configuration, chat history storage, and wires opt-in RBAC enforcement across the full stack (backend API, service layer, and frontend UI).

---

## What's Changed

### Database Layer (SQLModel + async SQLAlchemy + Alembic)

- Added `alembic.ini`, `alembic/env.py`, and `alembic/script.py.mako` for CLI and programmatic migrations.
- **Migration 0001** — Creates core tables: `users`, `roles`, `permissions`, `role_permissions`, `user_roles`, `user_preferences`, `api_keys`, `audit_log`, `migration_status`.
- **Migration 0002** — Seeds built-in roles (`admin`, `developer`, `user`, `viewer`) and permissions idempotently.
- **Migration 0003** — Adds `workspace_config` table (replaces `config.yaml` as primary store).
- **Migration 0004** — Adds `session_ownership` and `conversations` tables for DB-backed chat history.
- **Migration 0005** — Enforces `ON DELETE CASCADE / SET NULL` rules for user-related foreign keys.
- SQLModel ORM models in `src/db/models/` for all tables.
- Async repositories in `src/db/repositories/` (`UserRepo`, `RoleRepo`, `PermissionRepo`, `AuditRepo`, `ConversationRepo`, `SessionOwnershipRepo`, `ApiKeyRepo`, `PreferencesRepo`, `WorkspaceConfigRepo`).
- `EncryptedString` SQLAlchemy type (AES-256-GCM) for PII fields (email, display_name, preferences).
- Alembic naming convention applied to `SQLModel.metadata` for stable constraint/index names.
- Replaced `datetime.utcnow()` with `datetime.now(UTC)` throughout for Python 3.13+ compatibility.

### Runtime Migrations (`src/db/migrations_runtime.py`)

- One-shot, idempotent JSON → DB migrations run at startup:
  - `migrate_legacy_users` — imports existing OAuth user identities as placeholder rows.
  - `migrate_config_yaml_to_db` — copies `config.yaml` sections into `workspace_config` table.
  - `migrate_chat_history_json_to_db` — imports `session_ownership.json` and `conversations.json` into DB.
- Idempotency guards via `migration_status` table.

### RBAC Service & Enforcement

- `RBACService` (`src/services/rbac_service.py`) — per-process TTL cache, permission resolution, owner-or-permission checks, audit-on-denial.
- `require_permission(perm)` FastAPI dependency — replaces `get_current_user` across all endpoints.
- **RBAC kill-switch**: `OPENRAG_RBAC_ENFORCE=true` (defaults to `false`); when off, all permission checks are bypassed and `/api/users/me` returns the full permission catalog.
- Admin RBAC API (`src/api/admin/rbac.py`) — endpoints to list/manage users, roles, permissions, and audit events; all mutations emit audit log entries and invalidate caches.
- `UserService` (`src/services/user_service.py`) — idempotent, race-safe user bootstrap; first user becomes admin; per-user asyncio locks prevent duplicate INSERT races; `provider:subject` composite cache key prevents cross-provider collisions.

### Storage Mode Abstraction

- `OPENRAG_STORAGE_MODE` (`hybrid` | `db` | `files`, default `hybrid`):
  - `db` — reads and writes go to SQL only.
  - `files` — legacy JSON only.
  - `hybrid` — writes to both; DB takes precedence on reads.
- `ConversationPersistenceService` and `SessionOwnershipService` converted to async with mode-aware routing.
- `WorkspaceConfigService` (`src/services/workspace_config_service.py`) — DB-backed config with YAML fallback in hybrid mode, serialized writes via asyncio lock, background mirror tasks, and `await_pending_mirrors()` for clean shutdown.

### API Surface

- `GET /api/users/me` — returns profile, roles, permissions, `rbac_enforced` flag.
- `GET /api/users/me/permissions` — returns effective permission strings.
- `GET /api/onboarding-status` — pre-auth endpoint for frontend onboarding flow.
- Admin endpoints: `/api/admin/users`, `/api/admin/roles`, `/api/admin/permissions`, `/api/admin/audit`.
- All existing endpoints (`chat`, `upload`, `connectors`, `search`, `flows`, `keys`, `documents`, `settings`, `knowledge_filter`) now use `require_permission` instead of `get_current_user`.

### Frontend

- `usePermissions` hook and `RequirePermission` component for declarative permission gating.
- Auth context extended with `permissions`, `roles`, `rbacEnforced`, `isOnboarded`, `can()`.
- Settings page: Users & Roles section (with role assignment, revoke, last-admin protection), Role–Permission matrix, Audit log feed.
- Connector card, Knowledge actions/batch/dropdown/filter, Navigation — all gated by permissions.
- User nav shows role label; role pill utilities in `frontend/lib/role-styles.ts`.
- Tailwind config extended to scan `./lib/**` for class names.

### Docker & Dev

- Alembic migrations bundled into `Dockerfile.backend` — schema upgrades run on container startup.
- `docker-compose.host-backend.yml` override for dev-local mode (backend on host, OpenSearch in Docker).
- Single-worker constraint documented in `AGENTS.md` (in-memory cache is per-process; use Redis for horizontal scale).

### Tests

- Unit tests reorganized into packages: `tests/unit/api`, `tests/unit/api/admin`, `tests/unit/config`, `tests/unit/db`, `tests/unit/db/migrations`, `tests/unit/dependencies`, `tests/unit/services` — each with `__init__.py`.
- Test DB isolation: per-test SQLite in-memory DB with Alembic migrations applied before app startup.
- New test suites covering: bootstrap race conditions, RBAC seed idempotency, permission enforcement (Phase 2 gate tests), admin endpoint access control (Phase 3), kill-switch behavior, storage-mode routing (conversation persistence, session ownership, workspace config), runtime JSON→DB migrations (chat history, config YAML, legacy users), and workspace mirror lifecycle.

---

## Configuration Flags

| Variable | Default | Description |
|---|---|---|
| `OPENRAG_STORAGE_MODE` | `db` | `db` / `hybrid` / `files` |
| `OPENRAG_RBAC_ENFORCE` | `false` | Set `true` to enforce RBAC permission checks |
| `UVICORN_WORKERS` | `1` | Must be 1 when using in-memory cache |

## Testing

```bash
# Enable DB storage and RBAC for testing
export OPENRAG_STORAGE_MODE=db
export OPENRAG_RBAC_ENFORCE=true
```

---


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Database-backed RBAC with Users & Roles admin UI, role assignment/revocation, role-permissions matrix, and audit log feed.
  * Permission-driven UI: settings, connectors, knowledge, uploads, navigation, and actions now honor permissions.
  * Persistent conversation/chat history and workspace config stored in DB; onboarding-status public endpoint.

* **Configuration**
  * New env options for cache backend, storage mode (db/hybrid/files), and RBAC enforcement kill-switch.

* **Documentation**
  * Operational constraints and dev-local Docker guidance added.

* **Chore**
  * .gitignore updated to ignore SQLite DB files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->