### PR TITLE
fix: remove hack dir from the operator image build

### DIFF
--- a/kubernetes/operator/Dockerfile
+++ b/kubernetes/operator/Dockerfile
@@ -7,7 +7,6 @@ RUN go mod download
 COPY api/ api/
 COPY cmd/ cmd/
 COPY internal/ internal/
-COPY hack/ hack/
 
 RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager cmd/main.go
 


### PR DESCRIPTION
remove hack dir from the operator image build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Docker image by removing unnecessary build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->