### PR TITLE
feat: Revert "feat: operator dockhub publish"

### DIFF
--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -46,20 +46,13 @@ jobs:
 
       - uses: docker/setup-buildx-action@v3
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Build and push ${{ matrix.arch }} to GHCR
+      - name: Build and push ${{ matrix.arch }}
         uses: docker/build-push-action@v6
         with:
           context: kubernetes/operator
@@ -69,16 +62,6 @@ jobs:
           tags: ${{ env.IMAGE }}:${{ steps.tag.outputs.value }}-${{ matrix.arch }}
           cache-from: type=gha,scope=operator-${{ matrix.arch }}
           cache-to: type=gha,mode=max,scope=operator-${{ matrix.arch }}
-
-      - name: Build and push ${{ matrix.arch }} to Docker Hub
-        uses: docker/build-push-action@v6
-        with:
-          context: kubernetes/operator
-          file: kubernetes/operator/Dockerfile
-          platforms: ${{ matrix.platform }}
-          push: true
-          tags: langflowai/openrag-operator:${{ steps.tag.outputs.value }}-${{ matrix.arch }}
-          cache-from: type=gha,scope=operator-${{ matrix.arch }}
 
   manifest:
     name: Create multi-arch manifest
@@ -99,20 +82,13 @@ jobs:
             echo "value=${GITHUB_REF_NAME#operator/}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@v3
+      - uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Push multi-arch manifest to GHCR
+      - name: Push multi-arch manifest
         run: |
           TAG=${{ steps.tag.outputs.value }}
           docker buildx imagetools create \
@@ -120,15 +96,6 @@ jobs:
             -t ${{ env.IMAGE }}:latest \
             ${{ env.IMAGE }}:${TAG}-amd64 \
             ${{ env.IMAGE }}:${TAG}-arm64
-
-      - name: Push multi-arch manifest to Docker Hub
-        run: |
-          TAG=${{ steps.tag.outputs.value }}
-          docker buildx imagetools create \
-            -t langflowai/openrag-operator:${TAG} \
-            -t langflowai/openrag-operator:latest \
-            langflowai/openrag-operator:${TAG}-amd64 \
-            langflowai/openrag-operator:${TAG}-arm64
 
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2

--- a/kubernetes/operator/README.md
+++ b/kubernetes/operator/README.md
@@ -268,17 +268,17 @@ git push origin operator/v0.1.0
 
 This triggers the `.github/workflows/operator-release.yml` workflow which:
 1. Builds multi-architecture images (linux/amd64, linux/arm64)
-2. Pushes to **both** GHCR and Docker Hub
-3. Creates multi-arch manifests with `:latest` tag
+2. Pushes to `ghcr.io/<owner>/openrag-operator:v0.1.0`
+3. Creates a multi-arch manifest with `:latest` tag
 4. Creates a GitHub release with release notes
 
 **Manual trigger:**
 You can also trigger the release workflow manually from the GitHub Actions UI with a custom tag.
 
-**Image locations:**
-- **GHCR**: `ghcr.io/langflow-ai/openrag-operator`
-- **Docker Hub**: `langflowai/openrag-operator`
-- **Tags**: `v0.1.0`, `v0.1.0-amd64`, `v0.1.0-arm64`, `latest`
+**Image location:**
+- Registry: `ghcr.io`
+- Repository: `ghcr.io/langflow-ai/openrag-operator`
+- Tags: `v0.1.0`, `v0.1.0-amd64`, `v0.1.0-arm64`, `latest`
 
 ### Helm Chart Publishing
 


### PR DESCRIPTION
Reverts langflow-ai/openrag#1537

Stick with GHRC docker image publish only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure Changes**
  * Operator image publishing workflow updated to use GitHub Container Registry (GHCR) exclusively, discontinuing Docker Hub publication.
  * Multi-architecture manifest creation now configured for GHCR-only releases.

* **Documentation**
  * Release process documentation updated to reflect GHCR-only image publishing strategy.
  * Image location and tagging documentation updated with current registry reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->