### PR TITLE
feat: auto fix FE biome linting with gh actions

### DIFF
--- a/.github/workflows/biome-autofix.yml
+++ b/.github/workflows/biome-autofix.yml
@@ -1,0 +1,42 @@
+name: Biome Auto-fix
+
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - "frontend/**"
+
+jobs:
+  autofix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Run Biome auto-fix
+        working-directory: frontend
+        run: npx biome check --write .
+
+      - name: Commit fixes
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git diff --quiet && echo "No changes to commit" || (
+            git add -A
+            git commit -m "style: apply biome auto-fixes [skip ci]"
+            git push
+          )


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically apply Biome code style fixes to the `frontend` directory on non-main branches. This helps maintain consistent code formatting and reduces manual effort for style corrections.

**Continuous Integration:**

* Added a `.github/workflows/biome-autofix.yml` workflow that runs Biome's auto-fix on any push to non-main branches affecting the `frontend` directory, commits any resulting changes, and pushes them back to the branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code style enforcement to the development workflow, ensuring consistent code formatting across the frontend codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->