### PR TITLE
feat: Add orphan reconcile and bulk-delete helper

### DIFF
--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -90,6 +90,95 @@ async def get_synced_file_ids_for_connector(
         return [], []
 
 
+async def reconcile_orphans_for_connector_type(
+    connector_type: str,
+    user_id: str,
+    connector_service,
+    session_manager,
+    jwt_token: Optional[str],
+    existing_file_ids: List[str],
+) -> int:
+    """Delete OpenSearch chunks whose document_id is no longer present in the
+    union of remote file IDs across all active connections of this connector_type
+    for this user.
+
+    Strict gating: returns 0 (no deletes) if any active connection cannot be
+    listed cleanly — an unauthenticated connector or a listing exception aborts
+    the pass to avoid false-positive deletions.
+    """
+    if not existing_file_ids:
+        return 0
+
+    connections = await connector_service.connection_manager.list_connections(
+        user_id=user_id, connector_type=connector_type
+    )
+    active = [c for c in connections if c.is_active]
+    if not active:
+        logger.info(
+            "Skipping orphan reconcile — no active connections",
+            connector_type=connector_type,
+        )
+        return 0
+
+    remote_ids: set = set()
+    for conn in active:
+        try:
+            connector = await connector_service.get_connector(conn.connection_id)
+            if not connector or not connector.is_authenticated:
+                logger.info(
+                    "Skipping orphan reconcile — connection unauthenticated",
+                    connector_type=connector_type,
+                    connection_id=conn.connection_id,
+                )
+                return 0
+            page_token = None
+            while True:
+                page = await connector.list_files(page_token=page_token)
+                for f in page.get("files", []):
+                    fid = f.get("id")
+                    if fid:
+                        remote_ids.add(fid)
+                page_token = page.get("nextPageToken") or page.get("next_page_token")
+                if not page_token:
+                    break
+        except Exception as e:
+            logger.warning(
+                "Skipping orphan reconcile — listing failed",
+                connector_type=connector_type,
+                connection_id=conn.connection_id,
+                error=str(e),
+            )
+            return 0
+
+    orphans = [fid for fid in existing_file_ids if fid not in remote_ids]
+    if not orphans:
+        return 0
+
+    from .documents import delete_chunks_by_document_ids
+
+    try:
+        opensearch_client = session_manager.get_user_opensearch_client(
+            user_id, jwt_token
+        )
+        deleted = await delete_chunks_by_document_ids(
+            orphans, opensearch_client, get_index_name()
+        )
+        logger.info(
+            "Orphan reconcile complete",
+            connector_type=connector_type,
+            orphan_count=len(orphans),
+            deleted_chunks=deleted,
+        )
+        return deleted
+    except Exception as e:
+        logger.error(
+            "Orphan reconcile delete failed",
+            connector_type=connector_type,
+            orphan_count=len(orphans),
+            error=str(e),
+        )
+        return 0
+
 
 class ConnectorSyncBody(BaseModel):
     max_files: Optional[int] = None
@@ -287,6 +376,18 @@ async def connector_sync(
                     connector_type=connector_type,
                     file_count=len(existing_file_ids),
                 )
+                # Reconcile orphans (files deleted at the source) before re-syncing.
+                # Strict gating: skip when sync is capped — we'd see a partial remote
+                # listing and delete legitimate files.
+                if body.max_files is None:
+                    await reconcile_orphans_for_connector_type(
+                        connector_type=connector_type,
+                        user_id=user.user_id,
+                        connector_service=connector_service,
+                        session_manager=session_manager,
+                        jwt_token=jwt_token,
+                        existing_file_ids=existing_file_ids,
+                    )
                 task_id = await connector_service.sync_specific_files(
                     working_connection.connection_id,
                     user.user_id,
@@ -739,6 +840,17 @@ async def sync_all_connectors(
                         "Syncing specific files by document_id",
                         connector_type=connector_type,
                         file_count=len(existing_file_ids),
+                    )
+                    # Reconcile orphans (files deleted at the source) before re-syncing.
+                    # sync_all_connectors has no caps or filters, so gating reduces
+                    # to the strict checks inside the helper.
+                    await reconcile_orphans_for_connector_type(
+                        connector_type=connector_type,
+                        user_id=user.user_id,
+                        connector_service=connector_service,
+                        session_manager=session_manager,
+                        jwt_token=jwt_token,
+                        existing_file_ids=existing_file_ids,
                     )
                     task_id = await connector_service.sync_specific_files(
                         working_connection.connection_id,

--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -99,6 +99,21 @@ async def delete_documents_by_filename_core(
         )
 
 
+async def delete_chunks_by_document_ids(
+    document_ids: list[str],
+    opensearch_client,
+    index_name: str,
+) -> int:
+    """Bulk delete OpenSearch chunks by document_id. Returns deleted count."""
+    if not document_ids:
+        return 0
+    body = {"query": {"terms": {"document_id": document_ids}}}
+    res = await opensearch_client.delete_by_query(
+        index=index_name, body=body, conflicts="proceed"
+    )
+    return res.get("deleted", 0)
+
+
 async def _ensure_index_exists(jwt_token: str = None):
     """Create the OpenSearch index if it doesn't exist yet."""
     from main import init_index

--- a/src/connectors/service.py
+++ b/src/connectors/service.py
@@ -147,6 +147,9 @@ class ConnectorService:
                         "source": """
                             ctx._source.source_url = params.source_url;
                             ctx._source.connector_type = params.connector_type;
+                            if (params.filename != null) {
+                                ctx._source.filename = params.filename;
+                            }
                             if (params.created_time != null) {
                                 ctx._source.created_time = params.created_time;
                             }
@@ -160,6 +163,7 @@ class ConnectorService:
                         "params": {
                             "source_url": document.source_url,
                             "connector_type": connector_type,
+                            "filename": document.filename,
                             "created_time": document.created_time.isoformat()
                             if document.created_time
                             else None,

--- a/tests/unit/api/test_delete_chunks_by_document_ids.py
+++ b/tests/unit/api/test_delete_chunks_by_document_ids.py
@@ -1,0 +1,68 @@
+"""Unit tests for the bulk-delete helper used by the orphan-reconcile pass.
+
+Pins the contract of `src/api/documents.py::delete_chunks_by_document_ids`:
+- empty input is a no-op (no OpenSearch call)
+- non-empty input issues a single delete_by_query with terms(document_id, ...)
+- returns the count reported by OpenSearch
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.mark.asyncio
+async def test_empty_ids_short_circuits_without_calling_opensearch():
+    from api.documents import delete_chunks_by_document_ids
+
+    opensearch_client = AsyncMock()
+    deleted = await delete_chunks_by_document_ids(
+        [], opensearch_client, "test-index"
+    )
+
+    assert deleted == 0
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_issues_single_delete_by_query_with_terms_filter():
+    from api.documents import delete_chunks_by_document_ids
+
+    opensearch_client = AsyncMock()
+    opensearch_client.delete_by_query.return_value = {"deleted": 12}
+
+    ids = ["abc", "def", "ghi"]
+    deleted = await delete_chunks_by_document_ids(
+        ids, opensearch_client, "test-index"
+    )
+
+    assert deleted == 12
+    opensearch_client.delete_by_query.assert_awaited_once()
+    call = opensearch_client.delete_by_query.await_args
+    assert call.kwargs["index"] == "test-index"
+    assert call.kwargs["body"] == {"query": {"terms": {"document_id": ids}}}
+    # conflicts="proceed" so a concurrent reindex doesn't abort the bulk delete.
+    assert call.kwargs.get("conflicts") == "proceed"
+
+
+@pytest.mark.asyncio
+async def test_returns_zero_when_response_missing_deleted_field():
+    """Defensive: if OpenSearch returns an unexpected payload shape, we
+    should not crash — we surface 0 deletions."""
+    from api.documents import delete_chunks_by_document_ids
+
+    opensearch_client = AsyncMock()
+    opensearch_client.delete_by_query.return_value = {}  # no "deleted" key
+
+    deleted = await delete_chunks_by_document_ids(
+        ["abc"], opensearch_client, "test-index"
+    )
+
+    assert deleted == 0

--- a/tests/unit/api/test_reconcile_orphans_for_connector_type.py
+++ b/tests/unit/api/test_reconcile_orphans_for_connector_type.py
@@ -1,0 +1,340 @@
+"""Unit tests for `reconcile_orphans_for_connector_type` in `src/api/connectors.py`.
+
+This is the orphan-deletion safety net for the connector sync flow. The
+function must:
+- Compute orphans = indexed_ids - union(remote_ids across all active
+  connections of this connector_type for this user).
+- Apply STRICT gating: any unauthenticated connection or listing
+  exception aborts the pass with 0 deletes (false-negative > false-positive).
+- Preserve files that exist in any active connection of the type
+  (multi-connection isolation).
+"""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _make_connection(connection_id: str, is_active: bool = True):
+    """Lightweight stand-in for ConnectionConfig — only the attributes
+    reconcile_orphans_for_connector_type reads."""
+    return SimpleNamespace(connection_id=connection_id, is_active=is_active)
+
+
+def _make_connector(remote_file_ids, *, authenticated=True, raise_on_list=False):
+    """Build an AsyncMock connector that reports the given file IDs from
+    list_files() (single page, no pagination)."""
+    connector = MagicMock()
+    connector.is_authenticated = authenticated
+    if raise_on_list:
+        connector.list_files = AsyncMock(side_effect=RuntimeError("graph 503"))
+    else:
+        connector.list_files = AsyncMock(
+            return_value={"files": [{"id": fid} for fid in remote_file_ids]}
+        )
+    return connector
+
+
+def _make_service(connections, connector_lookup):
+    """Build a connector_service stub.
+
+    `connections` is the list returned by list_connections.
+    `connector_lookup` maps connection_id -> connector mock (or None).
+    """
+    service = MagicMock()
+    service.connection_manager = MagicMock()
+    service.connection_manager.list_connections = AsyncMock(return_value=connections)
+
+    async def _get_connector(connection_id):
+        return connector_lookup.get(connection_id)
+
+    service.get_connector = AsyncMock(side_effect=_get_connector)
+    return service
+
+
+def _make_session_manager(opensearch_client):
+    sm = MagicMock()
+    sm.get_user_opensearch_client = MagicMock(return_value=opensearch_client)
+    return sm
+
+
+@pytest.mark.asyncio
+async def test_empty_existing_file_ids_returns_zero_without_calls():
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    service = MagicMock()
+    service.connection_manager = MagicMock()
+    service.connection_manager.list_connections = AsyncMock()
+    sm = _make_session_manager(AsyncMock())
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=[],
+    )
+
+    assert deleted == 0
+    service.connection_manager.list_connections.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_active_connections_skips_reconcile():
+    """If every connection is inactive, we have no remote view — skip."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    inactive = [_make_connection("c1", is_active=False)]
+    service = _make_service(inactive, connector_lookup={})
+    opensearch_client = AsyncMock()
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b"],
+    )
+
+    assert deleted == 0
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_unauthenticated_connection_aborts_pass(monkeypatch):
+    """STRICT GATING: even one unauthenticated connector aborts the pass.
+    Otherwise we'd wrongly mark a file as an orphan because we couldn't
+    list the connection that holds it."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn = _make_connection("c1")
+    connector = _make_connector(remote_file_ids=[], authenticated=False)
+    service = _make_service([conn], connector_lookup={"c1": connector})
+    opensearch_client = AsyncMock()
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b"],
+    )
+
+    assert deleted == 0
+    connector.list_files.assert_not_awaited()
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_listing_exception_aborts_pass():
+    """STRICT GATING: a transient list_files error aborts the pass.
+    Better to leave orphans for one cycle than delete legitimate files."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn = _make_connection("c1")
+    connector = _make_connector(remote_file_ids=[], raise_on_list=True)
+    service = _make_service([conn], connector_lookup={"c1": connector})
+    opensearch_client = AsyncMock()
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b"],
+    )
+
+    assert deleted == 0
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_happy_path_deletes_orphans():
+    """Indexed has [a, b, c]; remote has [a, c] -> orphan = [b]."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn = _make_connection("c1")
+    connector = _make_connector(remote_file_ids=["a", "c"])
+    service = _make_service([conn], connector_lookup={"c1": connector})
+    opensearch_client = AsyncMock()
+    opensearch_client.delete_by_query.return_value = {"deleted": 7}
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b", "c"],
+    )
+
+    assert deleted == 7
+    opensearch_client.delete_by_query.assert_awaited_once()
+    body = opensearch_client.delete_by_query.await_args.kwargs["body"]
+    assert body == {"query": {"terms": {"document_id": ["b"]}}}
+
+
+@pytest.mark.asyncio
+async def test_no_orphans_skips_delete_call():
+    """If every indexed ID still exists remotely, we must not issue an
+    empty delete_by_query."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn = _make_connection("c1")
+    connector = _make_connector(remote_file_ids=["a", "b"])
+    service = _make_service([conn], connector_lookup={"c1": connector})
+    opensearch_client = AsyncMock()
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b"],
+    )
+
+    assert deleted == 0
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_multi_connection_union_preserves_files_present_in_any_connection():
+    """Multi-connection isolation:
+    - User has conn-A and conn-B (both SharePoint, different sites).
+    - Indexed has [a, b]. conn-A has [a]. conn-B has [b].
+    - Neither file is an orphan — both should be preserved."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn_a = _make_connection("conn-a")
+    conn_b = _make_connection("conn-b")
+    connector_a = _make_connector(remote_file_ids=["a"])
+    connector_b = _make_connector(remote_file_ids=["b"])
+    service = _make_service(
+        [conn_a, conn_b],
+        connector_lookup={"conn-a": connector_a, "conn-b": connector_b},
+    )
+    opensearch_client = AsyncMock()
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b"],
+    )
+
+    assert deleted == 0
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_multi_connection_one_offline_aborts_even_if_other_succeeds():
+    """If conn-A lists fine but conn-B is unauthenticated, we MUST NOT
+    treat files only in conn-B as orphans. Strict gating bails out."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn_a = _make_connection("conn-a")
+    conn_b = _make_connection("conn-b")
+    connector_a = _make_connector(remote_file_ids=["a"])
+    connector_b = _make_connector(remote_file_ids=[], authenticated=False)
+    service = _make_service(
+        [conn_a, conn_b],
+        connector_lookup={"conn-a": connector_a, "conn-b": connector_b},
+    )
+    opensearch_client = AsyncMock()
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b"],  # b would look like an orphan if we trusted conn-A alone
+    )
+
+    assert deleted == 0
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_paginated_listing_aggregates_all_pages():
+    """Remote listings are paginated. The reconcile must walk every page
+    before computing the orphan set, otherwise files on page 2 look like
+    orphans."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn = _make_connection("c1")
+    connector = MagicMock()
+    connector.is_authenticated = True
+    pages = [
+        {"files": [{"id": "a"}], "nextPageToken": "tok-1"},
+        {"files": [{"id": "b"}, {"id": "c"}]},  # last page, no token
+    ]
+    connector.list_files = AsyncMock(side_effect=pages)
+
+    service = _make_service([conn], connector_lookup={"c1": connector})
+    opensearch_client = AsyncMock()
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b", "c"],
+    )
+
+    assert deleted == 0
+    assert connector.list_files.await_count == 2
+    opensearch_client.delete_by_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_delete_failure_does_not_raise():
+    """If the bulk delete itself blows up, the helper must swallow it and
+    return 0. The caller (sync) should still proceed to re-sync surviving
+    files — leaving orphans is recoverable, raising is not."""
+    from api.connectors import reconcile_orphans_for_connector_type
+
+    conn = _make_connection("c1")
+    connector = _make_connector(remote_file_ids=["a"])
+    service = _make_service([conn], connector_lookup={"c1": connector})
+
+    opensearch_client = AsyncMock()
+    opensearch_client.delete_by_query.side_effect = RuntimeError(
+        "opensearch unavailable"
+    )
+    sm = _make_session_manager(opensearch_client)
+
+    deleted = await reconcile_orphans_for_connector_type(
+        connector_type="sharepoint",
+        user_id="alice",
+        connector_service=service,
+        session_manager=sm,
+        jwt_token=None,
+        existing_file_ids=["a", "b"],
+    )
+
+    assert deleted == 0

--- a/tests/unit/connectors/test_update_connector_metadata_filename.py
+++ b/tests/unit/connectors/test_update_connector_metadata_filename.py
@@ -1,0 +1,138 @@
+"""Connector rename fix: _update_connector_metadata must rewrite the indexed
+`filename` field so renamed source files don't leave their old name in
+OpenSearch chunks.
+
+Pins the painless script extension in src/connectors/service.py
+`_update_connector_metadata`.
+"""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _make_service():
+    """Build a ConnectorService whose only wired-up surface is what
+    _update_connector_metadata touches: an opensearch client (via
+    session_manager) and an index_name."""
+    from connectors.service import ConnectorService
+
+    service = ConnectorService.__new__(ConnectorService)
+    service.session_manager = MagicMock()
+    service.index_name = "test-index"
+
+    opensearch_client = AsyncMock()
+    service.session_manager.get_user_opensearch_client = MagicMock(
+        return_value=opensearch_client
+    )
+    return service, opensearch_client
+
+
+def _make_document(filename: str = "renamed.pdf"):
+    from connectors.base import ConnectorDocument, DocumentACL
+
+    return ConnectorDocument(
+        id="graph-item-id-stable",
+        filename=filename,
+        mimetype="application/pdf",
+        content=b"",
+        source_url="https://contoso.sharepoint.com/.../renamed.pdf",
+        acl=DocumentACL(owner="alice"),
+        modified_time=datetime(2026, 5, 7),
+        created_time=datetime(2026, 5, 1),
+        metadata={"site": "marketing"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_update_includes_filename_in_script_and_params(monkeypatch):
+    """The painless script must reference params.filename, and params must
+    carry document.filename as-is."""
+    service, opensearch_client = _make_service()
+
+    # update_document_acl is invoked first; stub it to a no-op so the test
+    # focuses on the metadata update_by_query.
+    async def _noop_acl(**_kwargs):
+        return {"status": "unchanged"}
+
+    monkeypatch.setattr("utils.acl_utils.update_document_acl", _noop_acl)
+
+    document = _make_document(filename="Report-FY26.docx")
+    await service._update_connector_metadata(
+        document, owner_user_id="alice", connector_type="sharepoint"
+    )
+
+    opensearch_client.update_by_query.assert_awaited_once()
+    call = opensearch_client.update_by_query.await_args
+    body = call.kwargs["body"]
+    script = body["script"]
+    params = script["params"]
+
+    assert "params.filename" in script["source"], (
+        "painless script must read params.filename so renamed files get "
+        "the new name written through to indexed chunks"
+    )
+    assert params["filename"] == "Report-FY26.docx"
+    # Sanity: scope is by document_id (the stable connector ID).
+    assert body["query"] == {"term": {"document_id": "graph-item-id-stable"}}
+
+
+@pytest.mark.asyncio
+async def test_filename_passed_raw_not_cleaned(monkeypatch):
+    """process_document_standard indexes chunks with the raw document.filename
+    (see src/connectors/service.py:80 + src/models/processors.py:323).
+    The metadata update must use the SAME raw value or chunks drift.
+    """
+    service, opensearch_client = _make_service()
+
+    async def _noop_acl(**_kwargs):
+        return {"status": "unchanged"}
+
+    monkeypatch.setattr("utils.acl_utils.update_document_acl", _noop_acl)
+
+    # A name with a quirky extension/suffix that clean_connector_filename
+    # would normalize. We pass it through verbatim.
+    raw_name = "Q4 Report (final).docx"
+    document = _make_document(filename=raw_name)
+
+    await service._update_connector_metadata(
+        document, owner_user_id="alice", connector_type="sharepoint"
+    )
+
+    params = opensearch_client.update_by_query.await_args.kwargs["body"]["script"][
+        "params"
+    ]
+    assert params["filename"] == raw_name
+
+
+@pytest.mark.asyncio
+async def test_filename_overwritten_for_existing_indexed_chunks(monkeypatch):
+    """End-to-end intent: when SharePoint rename triggers the unchanged ->
+    metadata-update path, the painless update writes the new filename.
+    Verified via the captured update_by_query body."""
+    service, opensearch_client = _make_service()
+
+    async def _noop_acl(**_kwargs):
+        return {"status": "unchanged"}
+
+    monkeypatch.setattr("utils.acl_utils.update_document_acl", _noop_acl)
+
+    # Simulate the post-rename state: same ID, new filename.
+    document = _make_document(filename="renamed-after-edit.pdf")
+    await service._update_connector_metadata(
+        document, owner_user_id="alice", connector_type="sharepoint"
+    )
+
+    body = opensearch_client.update_by_query.await_args.kwargs["body"]
+    # The script must carry the new filename in its params, AND the source
+    # must assign it onto _source.filename for every matching chunk.
+    assert body["script"]["params"]["filename"] == "renamed-after-edit.pdf"
+    assert "ctx._source.filename = params.filename" in body["script"]["source"]


### PR DESCRIPTION
Introduce a reconcile pass and supporting bulk-delete utility to remove OpenSearch chunks for files that no longer exist remotely.

- Add reconcile_orphans_for_connector_type (src/api/connectors.py): lists all active connections for a connector type, strictly gates on unauthenticated connections or listing errors (abort with 0 deletes), aggregates paginated remote file IDs, computes orphans (indexed IDs not present remotely) and invokes delete_chunks_by_document_ids. Integrated into connector_sync and sync_all_connectors (skips reconcile when sync is capped).
- Add delete_chunks_by_document_ids (src/api/documents.py): issues a single delete_by_query with terms(document_id, ...) and conflicts="proceed", returns deleted count, and short-circuits on empty input.
- Update connector metadata painless params (src/connectors/service.py): include filename param and assign ctx._source.filename = params.filename in the update script so renamed files update indexed chunks.
- Add unit tests: cover delete_chunks_by_document_ids, reconcile_orphans_for_connector_type (gating, pagination, multi-connection union, error handling), and connector metadata filename behavior.

Behavior notes: reconcile is conservative to avoid false-positive deletions; bulk delete is defensive and returns 0 on unexpected responses or failures.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Connector synchronization now automatically detects and removes documents from the search index when source files have been deleted, keeping your index clean and search results accurate.

* **Bug Fixes**
  * Improved filename metadata handling during connector updates to prevent unintended data loss from null or empty values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->