### PR TITLE
fix: add more default envs for or and lf pods

### DIFF
--- a/kubernetes/helm/operator/values.yaml
+++ b/kubernetes/helm/operator/values.yaml
@@ -7,7 +7,7 @@ image:
   repository: ghcr.io/langflow-ai/openrag-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "v0.0.3"
+  tag: "latest"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/kubernetes/helm/operator/values.yaml
+++ b/kubernetes/helm/operator/values.yaml
@@ -7,7 +7,7 @@ image:
   repository: ghcr.io/langflow-ai/openrag-operator
   pullPolicy: IfNotPresent
   # Overrides the image tag whose default is the chart appVersion.
-  tag: "latest"
+  tag: "v0.0.3"
 
 imagePullSecrets: []
 nameOverride: ""

--- a/kubernetes/operator/internal/controller/env.go
+++ b/kubernetes/operator/internal/controller/env.go
@@ -70,20 +70,28 @@ func NewEnvVarManager() *EnvVarManager {
 			"SELECTED_EMBEDDING_MODEL": "",
 
 			// Provider API keys (defaults to None, overridden by CR spec)
-			"OPENAI_API_KEY":    "None",
-			"ANTHROPIC_API_KEY": "None",
-			"WATSONX_API_KEY":   "None",
-			"OLLAMA_BASE_URL":   "None",
+			"OPENAI_API_KEY":     "None",
+			"ANTHROPIC_API_KEY":  "None",
+			"WATSONX_API_KEY":    "None",
+			"OLLAMA_BASE_URL":    "None",
+			"WATSONX_ENDPOINT":   "https://us-south.ml.cloud.ibm.com",
+			"WATSONX_PROJECT_ID": "None",
+			"LLM_MODEL":          "ibm/granite-3-2-8b-instruct",
+			"LLM_PROVIDER":       "watsonx",
 		},
 		DefaultOpenRagBEEnvVars: map[string]string{
 			// Langflow connection
-			"LANGFLOW_URL":             "http://langflow:7860",
-			"LANGFLOW_TIMEOUT":         "2400",
-			"LANGFLOW_CONNECT_TIMEOUT": "30",
-			"LANGFLOW_AUTO_LOGIN":      "true",
-			"LANGFLOW_KEY_RETRIES":     "15",
-			"LANGFLOW_KEY_RETRY_DELAY": "2",
-			"LANGFLOW_KEY":             "",
+			"LANGFLOW_URL":                "http://langflow:7860",
+			"LANGFLOW_TIMEOUT":            "2400",
+			"LANGFLOW_CONNECT_TIMEOUT":    "30",
+			"LANGFLOW_AUTO_LOGIN":         "true",
+			"LANGFLOW_KEY_RETRIES":        "15",
+			"LANGFLOW_KEY_RETRY_DELAY":    "2",
+			"LANGFLOW_KEY":                "",
+			"LANGFLOW_INGEST_FLOW_ID":     "",
+			"LANGFLOW_URL_INGEST_FLOW_ID": "",
+			"LANGFLOW_CHAT_FLOW_ID":       "",
+			"NUDGES_FLOW_ID":              "",
 
 			// Backend data paths
 			"OPENRAG_DATA_PATH":         "/app/backend-data",
@@ -114,6 +122,14 @@ func NewEnvVarManager() *EnvVarManager {
 
 			// Segment analytics (default empty, set via CR or operator env)
 			"SEGMENT_WRITE_KEY": "",
+
+			// Embedding model configuration
+			"EMBEDDING_MODEL":    "",
+			"EMBEDDING_PROVIDER": "",
+
+			"WATSONX_API_KEY":    "",
+			"WATSONX_ENDPOINT":   "",
+			"WATSONX_PROJECT_ID": "",
 		},
 		DefaultOpenRagFEEnvVars: map[string]string{
 			// Frontend environment variables will be added here

--- a/kubernetes/operator/internal/controller/env_example_test.go
+++ b/kubernetes/operator/internal/controller/env_example_test.go
@@ -43,7 +43,7 @@ func Example_envVarPriority() {
 	// LANGFLOW_WORKERS: 8 (from operator env)
 	// LANGFLOW_LOG_LEVEL: ERROR (from CR spec)
 	//
-	// .env file would contain 1246 bytes
+	// .env file would contain 1380 bytes
 }
 
 // Example showing how different components use different prefixes


### PR DESCRIPTION
add more default envs for or and lf pods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated operator image tag to v0.0.3
  * Expanded default environment variables with Langflow provider configurations, Watsonx settings, and embedding model options
  * Updated test output expectations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->