### PR TITLE
refactor: Split settings into package and refactor

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,8 +97,25 @@ exclude = ["flows/components"]
 select = ["E", "F", "I", "B", "UP"]
 ignore = ["E501"]  # line-length handled by formatter
 
+# FastAPI's idiomatic dependency-injection pattern uses `Depends(...)` and
+# our `require_permission(...)` as call expressions in default-argument
+# position. B008 flags these as bugs ("function call in argument default")
+# but for FastAPI they are by design — the framework introspects them at
+# request time. Whitelist the call sites instead of sprinkling noqa
+# comments across every handler.
 [tool.ruff.lint.flake8-bugbear]
-extend-immutable-calls = ["fastapi.Depends", "fastapi.params.Depends", "Depends"]
+extend-immutable-calls = [
+    "fastapi.Depends",
+    "fastapi.Query",
+    "fastapi.Path",
+    "fastapi.Body",
+    "fastapi.Header",
+    "fastapi.Cookie",
+    "fastapi.File",
+    "fastapi.Form",
+    "fastapi.Security",
+    "dependencies.require_permission",
+]
 
 # `bootstrap` must be the first import in any module that uses it
 # (it loads .env and configures structlog before anything else can
@@ -124,5 +141,15 @@ ignore_missing_imports = true
 no_strict_optional = true
 warn_unused_ignores = true
 exclude = ["flows/components"]
+
+# FastAPI handlers in this module declare a Pydantic response model as
+# their return type but legitimately return `JSONResponse(...)` on error
+# paths. The runtime accepts both, but the annotation can't be widened to
+# `SomeResponse | JSONResponse` because FastAPI then tries to derive an
+# OpenAPI schema from the union and fails. Suppress only the resulting
+# return-value mismatches in this one file.
+[[tool.mypy.overrides]]
+module = "api.settings.endpoints"
+disable_error_code = ["return-value"]
 
 

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -3,18 +3,17 @@
 import json
 import os
 import tempfile
-from typing import List, Optional
 
 from fastapi import Depends, File, Form, UploadFile
 from fastapi.responses import JSONResponse
 
 from config.settings import DISABLE_INGEST_WITH_LANGFLOW
 from dependencies import (
+    get_current_user,
     get_document_service,
     get_langflow_file_service,
     get_session_manager,
     get_task_service,
-    get_current_user,
 )
 from session_manager import User
 from utils.logging_config import get_logger
@@ -23,10 +22,10 @@ logger = get_logger(__name__)
 
 
 async def upload_ingest_router(
-    file: List[UploadFile] = File(...),
-    session_id: Optional[str] = Form(None),
-    settings_json: Optional[str] = Form(None, alias="settings"),
-    tweaks_json: Optional[str] = Form(None, alias="tweaks"),
+    file: list[UploadFile] = File(...),
+    session_id: str | None = Form(None),
+    settings_json: str | None = Form(None, alias="settings"),
+    tweaks_json: str | None = Form(None, alias="tweaks"),
     replace_duplicates: str = Form("true"),
     create_filter: str = Form("false"),
     document_service=Depends(get_document_service),
@@ -74,7 +73,7 @@ async def upload_ingest_router(
 
 
 async def _langflow_upload_ingest_task(
-    upload_files: List[UploadFile],
+    upload_files: list[UploadFile],
     session_id,
     settings_json,
     tweaks_json,
@@ -125,7 +124,9 @@ async def _langflow_upload_ingest_task(
                     f.write(content)
                 temp_file_paths.append(temp_path)
 
-            file_path_to_original_filename = dict(zip(temp_file_paths, original_filenames))
+            file_path_to_original_filename = dict(
+                zip(temp_file_paths, original_filenames, strict=True)
+            )
 
             task_id = await task_service.create_langflow_upload_task(
                 user_id=user_id,

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -50,6 +50,7 @@ async def upload_ingest_router(
         logger.debug("Routing to traditional OpenRAG upload")
         # Route to traditional upload — just take the first file
         from api.upload import upload as traditional_upload_fn
+
         return await traditional_upload_fn(
             file=file[0] if file else None,
             document_service=document_service,
@@ -154,6 +155,7 @@ async def _langflow_upload_ingest_task(
 
         except Exception:
             from utils.file_utils import safe_unlink
+
             for temp_path in temp_file_paths:
                 safe_unlink(temp_path)
             raise
@@ -161,6 +163,7 @@ async def _langflow_upload_ingest_task(
     except Exception as e:
         logger.error("Task-based langflow upload_ingest failed", error=str(e))
         import traceback
+
         logger.error("Full traceback", traceback=traceback.format_exc())
         error_msg = str(e)
         if "AuthenticationException" in error_msg or "access denied" in error_msg.lower():

--- a/src/api/settings/__init__.py
+++ b/src/api/settings/__init__.py
@@ -1,0 +1,88 @@
+"""Settings/onboarding endpoint package.
+
+The original `src/api/settings.py` (2081 lines) was split into focused
+submodules. This `__init__.py` preserves the public-import contract every
+external caller relies on:
+
+* `src/app/routes/internal.py` registers each endpoint via
+  `from api import settings; app.add_api_route(..., settings.<name>, ...)`.
+* `src/api/v1/settings.py` imports `SettingsUpdateBody` and (lazily)
+  `update_settings`.
+* `src/services/startup_orchestrator.py` lazily imports
+  `reapply_all_settings` for flow-reset re-sync.
+
+Adding a new endpoint to this package: define it in `endpoints.py`, then
+re-export it here.
+"""
+
+from api.settings.endpoints import (
+    get_settings,
+    onboarding,
+    refresh_openrag_docs,
+    rollback_onboarding,
+    update_docling_preset,
+    update_onboarding_state,
+    update_settings,
+)
+from api.settings.langflow_sync import reapply_all_settings
+from api.settings.models import (
+    AgentConfig,
+    AnthropicProviderConfig,
+    AssistantMessage,
+    DoclingPresetBody,
+    DoclingPresetResponse,
+    IngestionDefaultsConfig,
+    KnowledgeConfig,
+    OllamaProviderConfig,
+    OnboardingBody,
+    OnboardingResponse,
+    OnboardingStateBody,
+    OnboardingStateConfig,
+    OnboardingStateResponse,
+    OpenAIProviderConfig,
+    ProvidersConfig,
+    RefreshOpenRAGDocsResponse,
+    RollbackBody,
+    RollbackResponse,
+    SettingsResponse,
+    SettingsUpdateBody,
+    SettingsUpdateResponse,
+    WatsonXProviderConfig,
+)
+
+__all__ = [
+    # Endpoints
+    "get_settings",
+    "update_settings",
+    "onboarding",
+    "update_onboarding_state",
+    "rollback_onboarding",
+    "update_docling_preset",
+    "refresh_openrag_docs",
+    # Internal orchestrator (called from services/startup_orchestrator.py)
+    "reapply_all_settings",
+    # Pydantic models (some are imported externally; re-export all for parity
+    # with the pre-split flat module's surface)
+    "SettingsUpdateBody",
+    "OnboardingBody",
+    "AssistantMessage",
+    "OnboardingStateBody",
+    "DoclingPresetBody",
+    "OnboardingStateConfig",
+    "OpenAIProviderConfig",
+    "AnthropicProviderConfig",
+    "WatsonXProviderConfig",
+    "OllamaProviderConfig",
+    "ProvidersConfig",
+    "KnowledgeConfig",
+    "AgentConfig",
+    "IngestionDefaultsConfig",
+    "SettingsResponse",
+    "OnboardingResponse",
+    "RefreshOpenRAGDocsResponse",
+    "DoclingPresetResponse",
+    "OnboardingStateResponse",
+    "SettingsUpdateResponse",
+    "RollbackResponse",
+    "RollbackBody",
+]

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1,229 +1,93 @@
-from dependencies import get_models_service
+"""FastAPI endpoint handlers for /settings, /onboarding, /onboarding/state,
+/onboarding/rollback, /settings/docling-preset, and /openrag-docs/refresh.
+
+Lifted verbatim from the original `src/api/settings.py`. Models live in
+`api.settings.models`; provider/filter helpers in `api.settings.helpers`;
+Langflow-sync helpers in `api.settings.langflow_sync`. No behavior change.
+"""
+
 import asyncio
 import json
-import platform
-from fastapi import Depends, Request, HTTPException
+
+from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel, Field
-from utils.logging_config import get_logger
-from utils.telemetry import TelemetryClient, Category, MessageId
-from utils.version_utils import OPENRAG_VERSION
+
+from api.provider_validation import validate_provider_setup
+from api.settings.helpers import (
+    _affected_embedding_models,
+    _create_openrag_docs_filter,
+    _embedding_conflict_response,
+    _first_configured_embedding_provider,
+    _first_configured_llm_provider,
+    _get_flows_service,
+)
+from api.settings.langflow_sync import (
+    _background_tasks,
+    _run_async_post_save_langflow_updates,
+    _update_langflow_docling_settings,
+    _update_langflow_global_variables,
+    _update_langflow_model_values,
+    _update_langflow_system_prompt,
+    _update_mcp_server_urls,
+)
+from api.settings.models import (
+    AgentConfig,
+    AnthropicProviderConfig,
+    DoclingPresetBody,
+    DoclingPresetResponse,
+    IngestionDefaultsConfig,
+    KnowledgeConfig,
+    OllamaProviderConfig,
+    OnboardingBody,
+    OnboardingResponse,
+    OnboardingStateBody,
+    OnboardingStateConfig,
+    OnboardingStateResponse,
+    OpenAIProviderConfig,
+    ProvidersConfig,
+    RefreshOpenRAGDocsResponse,
+    RollbackBody,
+    RollbackResponse,
+    SettingsResponse,
+    SettingsUpdateBody,
+    SettingsUpdateResponse,
+    WatsonXProviderConfig,
+)
 from config.settings import (
     DEFAULT_DOCS_URL,
+    ENVIRONMENT,
     INGEST_SAMPLE_DATA,
-    LANGFLOW_URL,
     LANGFLOW_CHAT_FLOW_ID,
     LANGFLOW_INGEST_FLOW_ID,
     LANGFLOW_PUBLIC_URL,
+    LANGFLOW_URL,
     LOCALHOST_URL,
     OPENRAG_INGEST_VIA_CHAT,
     SEGMENT_WRITE_KEY,
-    ENVIRONMENT,
     clients,
-    get_openrag_config,
     config_manager,
-    is_no_auth_mode,
+    get_openrag_config,
 )
-from typing import List, Optional, Any, Dict
-
-from api.provider_validation import validate_provider_setup
-from utils.langflow_utils import LangflowNotReadyError, wait_for_langflow
 from dependencies import (
-    get_session_manager,
-    get_flows_service,
-    get_task_service,
+    get_chat_service,
     get_current_user,
     get_document_service,
-    get_langflow_file_service,
+    get_flows_service,
     get_knowledge_filter_service,
-    get_chat_service,
+    get_langflow_file_service,
+    get_models_service,
+    get_session_manager,
+    get_task_service,
     require_permission,
 )
 from services.docling_service import DoclingConfig, get_docling_preset_configs
 from session_manager import User
+from utils.langflow_utils import LangflowNotReadyError, wait_for_langflow
+from utils.logging_config import get_logger
+from utils.telemetry import Category, MessageId, TelemetryClient
+from utils.version_utils import OPENRAG_VERSION
 
 logger = get_logger(__name__)
-_background_tasks: set[asyncio.Task] = set()
-
-
-class SettingsUpdateBody(BaseModel):
-    llm_model: Optional[str] = Field(None, min_length=1)
-    llm_provider: Optional[str] = Field(None, pattern="^(openai|anthropic|watsonx|ollama)$")
-    system_prompt: Optional[str] = None
-    chunk_size: Optional[int] = Field(None, gt=0)
-    chunk_overlap: Optional[int] = Field(None, ge=0)
-    table_structure: Optional[bool] = None
-    ocr: Optional[bool] = None
-    picture_descriptions: Optional[bool] = None
-    embedding_model: Optional[str] = Field(None, min_length=1)
-    embedding_provider: Optional[str] = Field(None, pattern="^(openai|watsonx|ollama)$")
-    index_name: Optional[str] = Field(None, min_length=1)
-    openai_api_key: Optional[str] = Field(None, min_length=1)
-    anthropic_api_key: Optional[str] = Field(None, min_length=1)
-    watsonx_api_key: Optional[str] = Field(None, min_length=1)
-    watsonx_endpoint: Optional[str] = Field(None, min_length=1)
-    watsonx_project_id: Optional[str] = Field(None, min_length=1)
-    ollama_endpoint: Optional[str] = Field(None, min_length=1)
-    remove_ollama_config: Optional[bool] = None
-    remove_openai_config: Optional[bool] = None
-    remove_anthropic_config: Optional[bool] = None
-    remove_watsonx_config: Optional[bool] = None
-    # Explicit confirmation that the caller accepts removing a provider whose
-    # embedding models are still in use by indexed documents. Without this,
-    # the backend returns 409 and the frontend prompts the user.
-    force_remove: Optional[bool] = False
-
-
-class OnboardingBody(BaseModel):
-    llm_provider: Optional[str] = Field(None, pattern="^(openai|anthropic|watsonx|ollama)$")
-    llm_model: Optional[str] = Field(None, min_length=1)
-    embedding_provider: Optional[str] = Field(None, pattern="^(openai|watsonx|ollama)$")
-    embedding_model: Optional[str] = Field(None, min_length=1)
-    openai_api_key: Optional[str] = Field(None, min_length=1)
-    anthropic_api_key: Optional[str] = Field(None, min_length=1)
-    watsonx_api_key: Optional[str] = Field(None, min_length=1)
-    watsonx_endpoint: Optional[str] = Field(None, min_length=1)
-    watsonx_project_id: Optional[str] = Field(None, min_length=1)
-    ollama_endpoint: Optional[str] = Field(None, min_length=1)
-
-
-class AssistantMessage(BaseModel):
-    role: str
-    content: str
-    timestamp: str
-
-
-class OnboardingStateBody(BaseModel):
-    current_step: Optional[int] = None
-    assistant_message: Optional[AssistantMessage] = None
-    selected_nudge: Optional[str] = None
-    card_steps: Optional[Dict[str, Any]] = None
-    upload_steps: Optional[Dict[str, Any]] = None
-    openrag_docs_filter_id: Optional[str] = None
-    user_doc_filter_id: Optional[str] = None
-    openrag_docs_ingested_version: Optional[str] = None
-    openrag_docs_remote_signature: Optional[str] = None
-
-
-class DoclingPresetBody(BaseModel):
-    preset: Optional[str] = None
-    table_structure: Optional[bool] = None
-    ocr: Optional[bool] = None
-    picture_descriptions: Optional[bool] = None
-
-
-class OnboardingStateConfig(BaseModel):
-    current_step: Optional[int]
-    assistant_message: Optional[AssistantMessage]
-    selected_nudge: Optional[str]
-    card_steps: Optional[Dict[str, Any]]
-    upload_steps: Optional[Dict[str, Any]]
-    openrag_docs_filter_id: Optional[str]
-    user_doc_filter_id: Optional[str]
-    openrag_docs_ingested_version: Optional[str]
-    openrag_docs_remote_signature: Optional[str]
-
-class OpenAIProviderConfig(BaseModel):
-    has_api_key: bool
-    configured: bool
-
-class AnthropicProviderConfig(BaseModel):
-    has_api_key: bool
-    configured: bool
-
-class WatsonXProviderConfig(BaseModel):
-    has_api_key: bool
-    endpoint: Optional[str]
-    project_id: Optional[str]
-    configured: bool
-
-class OllamaProviderConfig(BaseModel):
-    endpoint: Optional[str]
-    configured: bool
-
-class ProvidersConfig(BaseModel):
-    openai: OpenAIProviderConfig
-    anthropic: AnthropicProviderConfig
-    watsonx: WatsonXProviderConfig
-    ollama: OllamaProviderConfig
-
-class KnowledgeConfig(BaseModel):
-    embedding_model: Optional[str]
-    embedding_provider: Optional[str]
-    chunk_size: Optional[int]
-    chunk_overlap: Optional[int]
-    table_structure: Optional[bool]
-    ocr: Optional[bool]
-    picture_descriptions: Optional[bool]
-    index_name: Optional[str]
-
-class AgentConfig(BaseModel):
-    llm_model: Optional[str]
-    llm_provider: Optional[str]
-    system_prompt: Optional[str]
-
-class IngestionDefaultsConfig(BaseModel):
-    chunkSize: Optional[int]
-    chunkOverlap: Optional[int]
-    separator: Optional[str]
-    embeddingModel: Optional[str]
-
-class SettingsResponse(BaseModel):
-    langflow_url: str
-    flow_id: Optional[str]
-    ingest_flow_id: Optional[str]
-    langflow_public_url: Optional[str]
-    edited: bool
-    onboarding: OnboardingStateConfig
-    providers: ProvidersConfig
-    knowledge: KnowledgeConfig
-    agent: AgentConfig
-    localhost_url: str
-    langflow_edit_url: Optional[str] = None
-    langflow_ingest_edit_url: Optional[str] = None
-    ingestion_defaults: Optional[IngestionDefaultsConfig] = None
-    ingest_via_chat: bool = False
-    segment_write_key: Optional[str] = None
-    environment: Optional[str] = None
-
-
-class OnboardingResponse(BaseModel):
-    message: str
-    edited: bool
-    sample_data_ingested: bool
-    openrag_docs_filter_id: Optional[str] = None
-    task_id: Optional[str] = None
-
-
-class RefreshOpenRAGDocsResponse(BaseModel):
-    message: str
-    refreshed: bool
-
-class DoclingPresetResponse(BaseModel):
-    message: str
-    settings: dict
-    preset_config: DoclingConfig
-
-
-class OnboardingStateResponse(BaseModel):
-    message: str
-    updated_fields: List[str]
-
-class SettingsUpdateResponse(BaseModel):
-    message: str
-
-class RollbackResponse(BaseModel):
-    message: str
-    cancelled_tasks: int
-    deleted_files: int
-    reset_flows: int
-    deleted_conversations: int
-
-class RollbackBody(BaseModel):
-    embedding_only: bool = False
-
-
-# Docling preset configurations
 
 
 async def get_settings(
@@ -245,7 +109,9 @@ async def get_settings(
 
         langflow_ingest_edit_url = None
         if LANGFLOW_PUBLIC_URL and LANGFLOW_INGEST_FLOW_ID:
-            langflow_ingest_edit_url = f"{LANGFLOW_PUBLIC_URL.rstrip('/')}/flow/{LANGFLOW_INGEST_FLOW_ID}"
+            langflow_ingest_edit_url = (
+                f"{LANGFLOW_PUBLIC_URL.rstrip('/')}/flow/{LANGFLOW_INGEST_FLOW_ID}"
+            )
 
         ingestion_defaults_obj = None
         # Fetch ingestion flow configuration to get actual component defaults
@@ -268,31 +134,29 @@ async def get_settings(
 
                     if flow_data.get("data", {}).get("nodes"):
                         for node in flow_data["data"]["nodes"]:
-                            node_template = (
-                                node.get("data", {}).get("node", {}).get("template", {})
-                            )
+                            node_template = node.get("data", {}).get("node", {}).get("template", {})
 
                             # Split Text component (SplitText-QIKhg)
                             if node.get("id") == "SplitText-QIKhg":
                                 if node_template.get("chunk_size", {}).get("value"):
-                                    ingestion_defaults["chunkSize"] = node_template[
-                                        "chunk_size"
-                                    ]["value"]
+                                    ingestion_defaults["chunkSize"] = node_template["chunk_size"][
+                                        "value"
+                                    ]
                                 if node_template.get("chunk_overlap", {}).get("value"):
                                     ingestion_defaults["chunkOverlap"] = node_template[
                                         "chunk_overlap"
                                     ]["value"]
                                 if node_template.get("separator", {}).get("value"):
-                                    ingestion_defaults["separator"] = node_template[
-                                        "separator"
-                                    ]["value"]
+                                    ingestion_defaults["separator"] = node_template["separator"][
+                                        "value"
+                                    ]
 
                             # OpenAI Embeddings component (OpenAIEmbeddings-joRJ6)
                             elif node.get("id") == "OpenAIEmbeddings-joRJ6":
                                 if node_template.get("model", {}).get("value"):
-                                    ingestion_defaults["embeddingModel"] = (
-                                        node_template["model"]["value"]
-                                    )
+                                    ingestion_defaults["embeddingModel"] = node_template["model"][
+                                        "value"
+                                    ]
 
                     ingestion_defaults_obj = IngestionDefaultsConfig(**ingestion_defaults)
 
@@ -363,121 +227,7 @@ async def get_settings(
 
     except Exception as e:
         logger.error(f"Failed to retrieve settings: {str(e)}")
-        return JSONResponse(
-            {"error": f"Failed to retrieve settings: {str(e)}"}, status_code=500
-        )
-
-
-def _first_configured_llm_provider(config, excluding: str) -> str:
-    """Return the first configured LLM provider that isn't `excluding`."""
-    for p in ["openai", "anthropic", "watsonx", "ollama"]:
-        if p != excluding and getattr(config.providers, p).configured:
-            return p
-    return "openai"
-
-
-def _first_configured_embedding_provider(config, excluding: str) -> str:
-    """Return the first configured embedding provider (openai/watsonx/ollama) that isn't `excluding`."""
-    for p in ["openai", "watsonx", "ollama"]:
-        if p != excluding and getattr(config.providers, p).configured:
-            return p
-    return "openai"
-
-
-async def _affected_embedding_models(
-    provider: str,
-    session_manager,
-    user,
-    models_service,
-) -> List[Dict[str, Any]]:
-    """Find embedding models present in the corpus that belong to ``provider``.
-
-    Used to warn users before they remove a provider whose embedding models
-    were used to index documents — otherwise semantic search silently breaks
-    for those docs. Returns a list of ``{"model": str, "doc_count": int}``.
-
-    Conservative on errors (returns empty list) so infra issues don't block
-    provider removal.
-    """
-    from services.models_service import ModelsService
-    from config.settings import get_index_name
-
-    provider_lower = provider.lower()
-    if provider_lower == "anthropic":
-        # Anthropic doesn't serve embedding models — nothing to warn about.
-        return []
-
-    try:
-        # Refresh so the registry reflects currently-configured providers
-        # before we use it to attribute models.
-        await models_service.update_model_registry()
-        registry = ModelsService._model_provider_registry
-
-        # Use the admin client so DLS does not scope the aggregation to the
-        # requesting user's documents. Provider removal is a global operation
-        # that affects all tenants, so we must see every document's embedding
-        # model regardless of ownership.
-        agg_result = await clients.opensearch.search(
-            index=get_index_name(),
-            body={
-                "size": 0,
-                "aggs": {
-                    "embedding_models": {
-                        "terms": {"field": "embedding_model", "size": 50}
-                    }
-                },
-            },
-            params={"terminate_after": 0},
-        )
-        buckets = (
-            agg_result.get("aggregations", {})
-            .get("embedding_models", {})
-            .get("buckets", [])
-        )
-
-        affected: List[Dict[str, Any]] = []
-        for bucket in buckets:
-            model = bucket.get("key")
-            if not model:
-                continue
-            mapped = registry.get(model)
-            # Narrow fallback: the watsonx registry bootstrap requires the
-            # provider still be configured, so models from an about-to-be-
-            # removed watsonx can still be attributed via the "ibm/" prefix.
-            if mapped is None and provider_lower == "watsonx" and model.startswith("ibm/"):
-                mapped = "watsonx"
-            if mapped == provider_lower:
-                affected.append({"model": model, "doc_count": bucket.get("doc_count", 0)})
-        return affected
-    except Exception as e:
-        logger.warning(
-            "Could not determine affected embedding models for provider removal",
-            provider=provider,
-            error=str(e),
-        )
-        return []
-
-
-def _embedding_conflict_response(
-    provider_label: str, provider_key: str, affected: List[Dict[str, Any]]
-) -> JSONResponse:
-    """Shared 409 response when removing a provider whose embedding models are
-    still referenced by indexed documents."""
-    model_names = [a["model"] for a in affected]
-    return JSONResponse(
-        {
-            "error": (
-                f"Removing {provider_label} will disable semantic search on "
-                f"documents indexed with: {', '.join(model_names)}. "
-                f"Re-ingest affected documents with another embedding model, "
-                f"or retry with force_remove=true to proceed anyway."
-            ),
-            "code": "embedding_provider_in_use",
-            "affected_provider": provider_key,
-            "affected_models": affected,
-        },
-        status_code=409,
-    )
+        return JSONResponse({"error": f"Failed to retrieve settings: {str(e)}"}, status_code=500)
 
 
 async def update_settings(
@@ -494,9 +244,7 @@ async def update_settings(
         # Check if config is marked as edited
         if not current_config.edited:
             return JSONResponse(
-                {
-                    "error": "Configuration must be marked as edited before updates are allowed"
-                },
+                {"error": "Configuration must be marked as edited before updates are allowed"},
                 status_code=403,
             )
 
@@ -514,7 +262,7 @@ async def update_settings(
             "watsonx_project_id",
             "ollama_endpoint",
         ]
-        
+
         should_validate = any(getattr(body, field) is not None for field in provider_fields)
 
         if should_validate:
@@ -523,8 +271,16 @@ async def update_settings(
 
                 # Validate LLM provider if being changed
                 if body.llm_provider is not None or body.llm_model is not None:
-                    llm_provider = body.llm_provider if body.llm_provider is not None else current_config.agent.llm_provider
-                    llm_model = body.llm_model if body.llm_model is not None else current_config.agent.llm_model
+                    llm_provider = (
+                        body.llm_provider
+                        if body.llm_provider is not None
+                        else current_config.agent.llm_provider
+                    )
+                    llm_model = (
+                        body.llm_model
+                        if body.llm_model is not None
+                        else current_config.agent.llm_model
+                    )
 
                     # Get the provider config (with any updates from the request)
                     llm_provider_config = current_config.providers.get_provider_config(llm_provider)
@@ -534,7 +290,10 @@ async def update_settings(
                     endpoint = getattr(llm_provider_config, "endpoint", None)
                     project_id = getattr(llm_provider_config, "project_id", None)
 
-                    if getattr(body, f"{llm_provider}_api_key", None) is not None and getattr(body, f"{llm_provider}_api_key", None).strip():
+                    if (
+                        getattr(body, f"{llm_provider}_api_key", None) is not None
+                        and getattr(body, f"{llm_provider}_api_key", None).strip()
+                    ):
                         api_key = getattr(body, f"{llm_provider}_api_key", None)
                     if getattr(body, f"{llm_provider}_endpoint", None) is not None:
                         endpoint = getattr(body, f"{llm_provider}_endpoint", None)
@@ -552,18 +311,31 @@ async def update_settings(
 
                 # Validate embedding provider if being changed
                 if body.embedding_provider is not None or body.embedding_model is not None:
-                    embedding_provider = body.embedding_provider if body.embedding_provider is not None else current_config.knowledge.embedding_provider
-                    embedding_model = body.embedding_model if body.embedding_model is not None else current_config.knowledge.embedding_model
+                    embedding_provider = (
+                        body.embedding_provider
+                        if body.embedding_provider is not None
+                        else current_config.knowledge.embedding_provider
+                    )
+                    embedding_model = (
+                        body.embedding_model
+                        if body.embedding_model is not None
+                        else current_config.knowledge.embedding_model
+                    )
 
                     # Get the provider config (with any updates from the request)
-                    embedding_provider_config = current_config.providers.get_provider_config(embedding_provider)
+                    embedding_provider_config = current_config.providers.get_provider_config(
+                        embedding_provider
+                    )
 
                     # Apply any updates from the request
                     api_key = getattr(embedding_provider_config, "api_key", None)
                     endpoint = getattr(embedding_provider_config, "endpoint", None)
                     project_id = getattr(embedding_provider_config, "project_id", None)
 
-                    if getattr(body, f"{embedding_provider}_api_key", None) is not None and getattr(body, f"{embedding_provider}_api_key", None).strip():
+                    if (
+                        getattr(body, f"{embedding_provider}_api_key", None) is not None
+                        and getattr(body, f"{embedding_provider}_api_key", None).strip()
+                    ):
                         api_key = getattr(body, f"{embedding_provider}_api_key", None)
                     if getattr(body, f"{embedding_provider}_endpoint", None) is not None:
                         endpoint = getattr(body, f"{embedding_provider}_endpoint", None)
@@ -577,7 +349,9 @@ async def update_settings(
                         endpoint=endpoint,
                         project_id=project_id,
                     )
-                    logger.info(f"Embedding provider validation successful for {embedding_provider}")
+                    logger.info(
+                        f"Embedding provider validation successful for {embedding_provider}"
+                    )
 
             except Exception as e:
                 logger.error(f"Provider validation failed: {str(e)}")
@@ -593,8 +367,7 @@ async def update_settings(
             current_config.agent.llm_model = body.llm_model
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_LLM_MODEL
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_LLM_MODEL
             )
             logger.info(f"LLM model changed from {old_model} to {body.llm_model}")
 
@@ -603,8 +376,7 @@ async def update_settings(
             current_config.agent.llm_provider = body.llm_provider
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_LLM_PROVIDER
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_LLM_PROVIDER
             )
             logger.info(f"LLM provider changed from {old_provider} to {body.llm_provider}")
 
@@ -612,8 +384,7 @@ async def update_settings(
             current_config.agent.system_prompt = body.system_prompt
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_SYSTEM_PROMPT
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_SYSTEM_PROMPT
             )
 
             # Also update the chat flow with the new system prompt
@@ -632,8 +403,7 @@ async def update_settings(
             current_config.knowledge.embedding_model = new_embedding_model
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_EMBED_MODEL
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_EMBED_MODEL
             )
             logger.info(f"Embedding model changed from {old_model} to {new_embedding_model}")
 
@@ -642,17 +412,17 @@ async def update_settings(
             current_config.knowledge.embedding_provider = body.embedding_provider
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_EMBED_PROVIDER
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_EMBED_PROVIDER
             )
-            logger.info(f"Embedding provider changed from {old_provider} to {body.embedding_provider}")
+            logger.info(
+                f"Embedding provider changed from {old_provider} to {body.embedding_provider}"
+            )
 
         if body.table_structure is not None:
             current_config.knowledge.table_structure = body.table_structure
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_DOCLING_UPDATED
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_DOCLING_UPDATED
             )
 
             # Also update the flow with the new docling settings
@@ -666,8 +436,7 @@ async def update_settings(
             current_config.knowledge.ocr = body.ocr
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_DOCLING_UPDATED
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_DOCLING_UPDATED
             )
 
             # Also update the flow with the new docling settings
@@ -681,8 +450,7 @@ async def update_settings(
             current_config.knowledge.picture_descriptions = body.picture_descriptions
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_DOCLING_UPDATED
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_DOCLING_UPDATED
             )
 
             # Also update the flow with the new docling settings
@@ -693,51 +461,51 @@ async def update_settings(
                 logger.error(f"Failed to update docling settings in flow: {str(e)}")
 
         if body.chunk_size is not None:
-            effective_overlap = body.chunk_overlap if body.chunk_overlap is not None else current_config.knowledge.chunk_overlap
+            effective_overlap = (
+                body.chunk_overlap
+                if body.chunk_overlap is not None
+                else current_config.knowledge.chunk_overlap
+            )
             if effective_overlap >= body.chunk_size:
                 raise HTTPException(
-                    status_code=422,
-                    detail="chunk_overlap must be less than chunk_size"
+                    status_code=422, detail="chunk_overlap must be less than chunk_size"
                 )
             current_config.knowledge.chunk_size = body.chunk_size
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_CHUNK_UPDATED
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_CHUNK_UPDATED
             )
 
             # Also update the ingest flow with the new chunk size
             try:
                 flows_service = _get_flows_service()
                 await flows_service.update_ingest_flow_chunk_size(body.chunk_size)
-                logger.info(
-                    f"Successfully updated ingest flow chunk size to {body.chunk_size}"
-                )
+                logger.info(f"Successfully updated ingest flow chunk size to {body.chunk_size}")
             except Exception as e:
                 logger.error(f"Failed to update ingest flow chunk size: {str(e)}")
                 # Don't fail the entire settings update if flow update fails
                 # The config will still be saved
 
         if body.chunk_overlap is not None:
-            effective_chunk_size = body.chunk_size if body.chunk_size is not None else current_config.knowledge.chunk_size
+            effective_chunk_size = (
+                body.chunk_size
+                if body.chunk_size is not None
+                else current_config.knowledge.chunk_size
+            )
             if body.chunk_overlap >= effective_chunk_size:
                 raise HTTPException(
-                    status_code=422,
-                    detail="chunk_overlap must be less than chunk_size"
+                    status_code=422, detail="chunk_overlap must be less than chunk_size"
                 )
             current_config.knowledge.chunk_overlap = body.chunk_overlap
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_CHUNK_UPDATED
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_CHUNK_UPDATED
             )
 
             # Also update the ingest flow with the new chunk overlap
             try:
                 flows_service = _get_flows_service()
-                await flows_service.update_ingest_flow_chunk_overlap(
-                    body.chunk_overlap
-                )
+                await flows_service.update_ingest_flow_chunk_overlap(body.chunk_overlap)
                 logger.info(
                     f"Successfully updated ingest flow chunk overlap to {body.chunk_overlap}"
                 )
@@ -750,14 +518,15 @@ async def update_settings(
             current_config.knowledge.index_name = new_index_name
             config_updated = True
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_INDEX_NAME_UPDATED
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_INDEX_NAME_UPDATED
             )
             logger.info(f"Index name changed from {old_index_name} to {new_index_name}")
 
             # Also update global variable with new index name
             try:
-                await clients._create_langflow_global_variable("OPENSEARCH_INDEX_NAME", new_index_name, modify=True)
+                await clients._create_langflow_global_variable(
+                    "OPENSEARCH_INDEX_NAME", new_index_name, modify=True
+                )
                 logger.info(
                     f"Successfully updated global variable with new index name {new_index_name}"
                 )
@@ -813,7 +582,9 @@ async def update_settings(
             )
             if not other_providers_configured:
                 return JSONResponse(
-                    {"error": "Cannot remove Ollama configuration: configure another model provider first."},
+                    {
+                        "error": "Cannot remove Ollama configuration: configure another model provider first."
+                    },
                     status_code=400,
                 )
             if not body.force_remove:
@@ -825,10 +596,14 @@ async def update_settings(
             current_config.providers.ollama.endpoint = ""
             current_config.providers.ollama.configured = False
             if current_config.agent.llm_provider == "ollama":
-                current_config.agent.llm_provider = _first_configured_llm_provider(current_config, "ollama")
+                current_config.agent.llm_provider = _first_configured_llm_provider(
+                    current_config, "ollama"
+                )
                 current_config.agent.llm_model = ""
             if current_config.knowledge.embedding_provider == "ollama":
-                current_config.knowledge.embedding_provider = _first_configured_embedding_provider(current_config, "ollama")
+                current_config.knowledge.embedding_provider = _first_configured_embedding_provider(
+                    current_config, "ollama"
+                )
                 current_config.knowledge.embedding_model = ""
             config_updated = True
             provider_updated = True
@@ -841,7 +616,9 @@ async def update_settings(
             )
             if not other_providers_configured:
                 return JSONResponse(
-                    {"error": "Cannot remove OpenAI configuration: configure another model provider first."},
+                    {
+                        "error": "Cannot remove OpenAI configuration: configure another model provider first."
+                    },
                     status_code=400,
                 )
             if not body.force_remove:
@@ -871,7 +648,9 @@ async def update_settings(
             )
             if not other_providers_configured:
                 return JSONResponse(
-                    {"error": "Cannot remove Anthropic configuration: configure another model provider first."},
+                    {
+                        "error": "Cannot remove Anthropic configuration: configure another model provider first."
+                    },
                     status_code=400,
                 )
             current_config.providers.anthropic.api_key = ""
@@ -892,7 +671,9 @@ async def update_settings(
             )
             if not other_providers_configured:
                 return JSONResponse(
-                    {"error": "Cannot remove IBM watsonx.ai configuration: configure another model provider first."},
+                    {
+                        "error": "Cannot remove IBM watsonx.ai configuration: configure another model provider first."
+                    },
                     status_code=400,
                 )
             if not body.force_remove:
@@ -900,9 +681,7 @@ async def update_settings(
                     "watsonx", session_manager, user, models_service
                 )
                 if affected:
-                    return _embedding_conflict_response(
-                        "IBM watsonx.ai", "watsonx", affected
-                    )
+                    return _embedding_conflict_response("IBM watsonx.ai", "watsonx", affected)
             current_config.providers.watsonx.api_key = ""
             current_config.providers.watsonx.endpoint = ""
             current_config.providers.watsonx.project_id = ""
@@ -920,20 +699,15 @@ async def update_settings(
 
         if provider_updated:
             await TelemetryClient.send_event(
-                Category.SETTINGS_OPERATIONS,
-                MessageId.ORB_SETTINGS_PROVIDER_CREDS
+                Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_PROVIDER_CREDS
             )
 
         if not config_updated:
-            return JSONResponse(
-                {"error": "No valid fields provided for update"}, status_code=400
-            )
+            return JSONResponse({"error": "No valid fields provided for update"}, status_code=400)
 
         # Save the updated configuration
         if not config_manager.save_config_file(current_config):
-            return JSONResponse(
-                {"error": "Failed to save configuration"}, status_code=500
-            )
+            return JSONResponse({"error": "Failed to save configuration"}, status_code=500)
 
         # Refresh patched client immediately so subsequent requests pick up latest config.
         await clients.refresh_patched_client()
@@ -962,26 +736,19 @@ async def update_settings(
             _background_tasks.add(task)
             task.add_done_callback(_background_tasks.discard)
 
-
         set_fields = [k for k, v in body.model_dump().items() if v is not None]
-        logger.info(
-            "Configuration updated successfully", updated_fields=set_fields
-        )
+        logger.info("Configuration updated successfully", updated_fields=set_fields)
         await TelemetryClient.send_event(
-            Category.SETTINGS_OPERATIONS,
-            MessageId.ORB_SETTINGS_UPDATED
+            Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_UPDATED
         )
         return SettingsUpdateResponse(message="Configuration updated successfully")
 
     except Exception as e:
         logger.error("Failed to update settings", error=str(e))
         await TelemetryClient.send_event(
-            Category.SETTINGS_OPERATIONS,
-            MessageId.ORB_SETTINGS_UPDATE_FAILED
+            Category.SETTINGS_OPERATIONS, MessageId.ORB_SETTINGS_UPDATE_FAILED
         )
-        return JSONResponse(
-            {"error": f"Failed to update settings: {str(e)}"}, status_code=500
-        )
+        return JSONResponse({"error": f"Failed to update settings: {str(e)}"}, status_code=500)
 
 
 async def onboarding(
@@ -1022,7 +789,7 @@ async def onboarding(
             await TelemetryClient.send_event(
                 Category.ONBOARDING,
                 MessageId.ORB_ONBOARD_LLM_MODEL,
-                metadata={"llm_model": llm_model_selected}
+                metadata={"llm_model": llm_model_selected},
             )
             logger.info(f"LLM model selected during onboarding: {llm_model_selected}")
 
@@ -1033,7 +800,7 @@ async def onboarding(
             await TelemetryClient.send_event(
                 Category.ONBOARDING,
                 MessageId.ORB_ONBOARD_LLM_PROVIDER,
-                metadata={"llm_provider": llm_provider_selected}
+                metadata={"llm_provider": llm_provider_selected},
             )
             logger.info(f"LLM provider selected during onboarding: {llm_provider_selected}")
 
@@ -1048,7 +815,7 @@ async def onboarding(
             await TelemetryClient.send_event(
                 Category.ONBOARDING,
                 MessageId.ORB_ONBOARD_EMBED_MODEL,
-                metadata={"embedding_model": embedding_model_selected}
+                metadata={"embedding_model": embedding_model_selected},
             )
             logger.info(f"Embedding model selected during onboarding: {embedding_model_selected}")
 
@@ -1059,9 +826,11 @@ async def onboarding(
             await TelemetryClient.send_event(
                 Category.ONBOARDING,
                 MessageId.ORB_ONBOARD_EMBED_PROVIDER,
-                metadata={"embedding_provider": embedding_provider_selected}
+                metadata={"embedding_provider": embedding_provider_selected},
             )
-            logger.info(f"Embedding provider selected during onboarding: {embedding_provider_selected}")
+            logger.info(
+                f"Embedding provider selected during onboarding: {embedding_provider_selected}"
+            )
 
         # Update provider-specific credentials
         if body.openai_api_key:
@@ -1104,7 +873,12 @@ async def onboarding(
             elif llm_provider == "anthropic" and current_config.providers.anthropic.api_key:
                 current_config.providers.anthropic.configured = True
                 logger.info("Marked Anthropic as configured (chosen as LLM provider)")
-            elif llm_provider == "watsonx" and current_config.providers.watsonx.api_key and current_config.providers.watsonx.endpoint and current_config.providers.watsonx.project_id:
+            elif (
+                llm_provider == "watsonx"
+                and current_config.providers.watsonx.api_key
+                and current_config.providers.watsonx.endpoint
+                and current_config.providers.watsonx.project_id
+            ):
                 current_config.providers.watsonx.configured = True
                 logger.info("Marked WatsonX as configured (chosen as LLM provider)")
             elif llm_provider == "ollama" and current_config.providers.ollama.endpoint:
@@ -1117,7 +891,12 @@ async def onboarding(
             if embedding_provider == "openai" and current_config.providers.openai.api_key:
                 current_config.providers.openai.configured = True
                 logger.info("Marked OpenAI as configured (chosen as embedding provider)")
-            elif embedding_provider == "watsonx" and current_config.providers.watsonx.api_key and current_config.providers.watsonx.endpoint and current_config.providers.watsonx.project_id:
+            elif (
+                embedding_provider == "watsonx"
+                and current_config.providers.watsonx.api_key
+                and current_config.providers.watsonx.endpoint
+                and current_config.providers.watsonx.project_id
+            ):
                 current_config.providers.watsonx.configured = True
                 logger.info("Marked WatsonX as configured (chosen as embedding provider)")
             elif embedding_provider == "ollama" and current_config.providers.ollama.endpoint:
@@ -1126,28 +905,23 @@ async def onboarding(
 
         should_ingest_sample_data = INGEST_SAMPLE_DATA
         if should_ingest_sample_data:
-            await TelemetryClient.send_event(
-                Category.ONBOARDING,
-                MessageId.ORB_ONBOARD_SAMPLE_DATA
-            )
+            await TelemetryClient.send_event(Category.ONBOARDING, MessageId.ORB_ONBOARD_SAMPLE_DATA)
             logger.info("Sample data ingestion enabled via environment variable")
 
         if not config_updated:
-            return JSONResponse(
-                {"error": "No valid fields provided for update"}, status_code=400
-            )
+            return JSONResponse({"error": "No valid fields provided for update"}, status_code=400)
 
         # Validate provider setup before initializing OpenSearch index
         # Use full validation with completion tests (test_completion=True) to ensure provider health during onboarding
         try:
-            from api.provider_validation import validate_provider_setup
-
             # Validate LLM provider if set
             if body.llm_provider or body.llm_model:
                 llm_provider = current_config.agent.llm_provider.lower()
                 llm_provider_config = current_config.get_llm_provider_config()
 
-                logger.info(f"Validating LLM provider setup for {llm_provider} (full validation with completion test)")
+                logger.info(
+                    f"Validating LLM provider setup for {llm_provider} (full validation with completion test)"
+                )
                 await validate_provider_setup(
                     provider=llm_provider,
                     api_key=getattr(llm_provider_config, "api_key", None),
@@ -1156,14 +930,18 @@ async def onboarding(
                     project_id=getattr(llm_provider_config, "project_id", None),
                     test_completion=True,  # Full validation with completion test - ensures provider health
                 )
-                logger.info(f"LLM provider setup validation completed successfully for {llm_provider}")
+                logger.info(
+                    f"LLM provider setup validation completed successfully for {llm_provider}"
+                )
 
             # Validate embedding provider if set
             if body.embedding_provider or body.embedding_model:
                 embedding_provider = current_config.knowledge.embedding_provider.lower()
                 embedding_provider_config = current_config.get_embedding_provider_config()
 
-                logger.info(f"Validating embedding provider setup for {embedding_provider} (full validation with completion test)")
+                logger.info(
+                    f"Validating embedding provider setup for {embedding_provider} (full validation with completion test)"
+                )
                 await validate_provider_setup(
                     provider=embedding_provider,
                     api_key=getattr(embedding_provider_config, "api_key", None),
@@ -1172,7 +950,9 @@ async def onboarding(
                     project_id=getattr(embedding_provider_config, "project_id", None),
                     test_completion=True,  # Full validation with completion test - ensures provider health
                 )
-                logger.info(f"Embedding provider setup validation completed successfully for {embedding_provider}")
+                logger.info(
+                    f"Embedding provider setup validation completed successfully for {embedding_provider}"
+                )
         except Exception as e:
             logger.error(f"Provider validation failed: {str(e)}")
             return JSONResponse(
@@ -1188,34 +968,55 @@ async def onboarding(
             logger.error(message, error=str(e))
 
             return JSONResponse(
-                {
-                    "error": message
-                },
+                {"error": message},
                 status_code=503,
             )
 
         # Set Langflow global variables and model values based on provider configuration
         try:
             # Check if any provider-related fields were provided
-            provider_fields_provided = any([
-                body.openai_api_key, body.anthropic_api_key,
-                body.watsonx_api_key, body.watsonx_endpoint, body.watsonx_project_id,
-                body.ollama_endpoint
-            ])
+            provider_fields_provided = any(
+                [
+                    body.openai_api_key,
+                    body.anthropic_api_key,
+                    body.watsonx_api_key,
+                    body.watsonx_endpoint,
+                    body.watsonx_project_id,
+                    body.ollama_endpoint,
+                ]
+            )
 
             # Update global variables if any provider fields were provided
             # or if existing config has values (for OpenAI/Anthropic that might already be set)
-            if (provider_fields_provided or
-                current_config.providers.openai.api_key != "" or
-                current_config.providers.anthropic.api_key != "" or
-                current_config.providers.any_configured()):
+            if (
+                provider_fields_provided
+                or current_config.providers.openai.api_key != ""
+                or current_config.providers.anthropic.api_key != ""
+                or current_config.providers.any_configured()
+            ):
                 await _update_langflow_global_variables(current_config, flows_service=flows_service)
 
             if body.embedding_provider or body.embedding_model:
-                await _update_mcp_server_urls(current_config, session_manager=session_manager, flows_service=flows_service)
+                await _update_mcp_server_urls(
+                    current_config,
+                    session_manager=session_manager,
+                    flows_service=flows_service,
+                )
 
-            if body.llm_provider or body.llm_model or body.embedding_provider or body.embedding_model:
-                await _update_langflow_model_values(current_config, flows_service, embedding_model=body.embedding_model, embedding_provider=body.embedding_provider, llm_model=body.llm_model, llm_provider=body.llm_provider)
+            if (
+                body.llm_provider
+                or body.llm_model
+                or body.embedding_provider
+                or body.embedding_model
+            ):
+                await _update_langflow_model_values(
+                    current_config,
+                    flows_service,
+                    embedding_model=body.embedding_model,
+                    embedding_provider=body.embedding_provider,
+                    llm_model=body.llm_model,
+                    llm_provider=body.llm_provider,
+                )
 
         except Exception as e:
             logger.error(
@@ -1229,16 +1030,15 @@ async def onboarding(
         # Initialize the OpenSearch index if embedding model is configured
         if body.embedding_model or body.embedding_provider:
             try:
+                from config.settings import IBM_AUTH_ENABLED
+                from config.settings import clients as app_clients
                 from main import init_index
-                from config.settings import IBM_AUTH_ENABLED, clients as app_clients
 
                 opensearch_client = None
                 if IBM_AUTH_ENABLED and user and user.jwt_token:
                     opensearch_client = app_clients.create_user_opensearch_client(user.jwt_token)
 
-                logger.info(
-                    "Initializing OpenSearch index after onboarding configuration"
-                )
+                logger.info("Initializing OpenSearch index after onboarding configuration")
                 admin_username = user.user_id if IBM_AUTH_ENABLED and user else None
                 await init_index(opensearch_client, admin_username=admin_username)
                 logger.info("OpenSearch index initialization completed successfully")
@@ -1248,9 +1048,7 @@ async def onboarding(
                     error=str(e),
                 )
                 return JSONResponse(
-                    {
-                        "error": str(e),
-                    },
+                    {"error": str(e)},
                     status_code=500,
                 )
 
@@ -1262,9 +1060,13 @@ async def onboarding(
 
                     if not config_manager.save_config_file(current_config):
                         logger.error("Failed to save embedding model to config")
-                        return JSONResponse({"error": "Failed to save configuration"}, status_code=500)
+                        return JSONResponse(
+                            {"error": "Failed to save configuration"}, status_code=500
+                        )
 
-                    ingestion_jwt = user.jwt_token if IBM_AUTH_ENABLED and user and user.jwt_token else None
+                    ingestion_jwt = (
+                        user.jwt_token if IBM_AUTH_ENABLED and user and user.jwt_token else None
+                    )
 
                     task_id = await ingest_default_documents_when_ready(
                         document_service,
@@ -1289,12 +1091,10 @@ async def onboarding(
                     logger.info("Sample data ingestion completed successfully")
 
                 except Exception as e:
-                    logger.error(
-                        "Failed to complete sample data ingestion", error=str(e)
-                    )
+                    logger.error("Failed to complete sample data ingestion", error=str(e))
                     return JSONResponse(
                         {"error": f"Failed to ingest sample documents: {str(e)}"},
-                        status_code=500
+                        status_code=500,
                     )
 
         if config_manager.save_config_file(current_config):
@@ -1321,23 +1121,18 @@ async def onboarding(
             await TelemetryClient.send_event(
                 Category.ONBOARDING,
                 MessageId.ORB_ONBOARD_CONFIG_EDITED,
-                metadata=onboarding_metadata
+                metadata=onboarding_metadata,
             )
             await TelemetryClient.send_event(
                 Category.ONBOARDING,
                 MessageId.ORB_ONBOARD_COMPLETE,
-                metadata=onboarding_metadata
+                metadata=onboarding_metadata,
             )
             logger.info("Configuration marked as edited after onboarding")
 
         else:
-            await TelemetryClient.send_event(
-                Category.ONBOARDING,
-                MessageId.ORB_ONBOARD_FAILED
-            )
-            return JSONResponse(
-                {"error": "Failed to save configuration"}, status_code=500
-            )
+            await TelemetryClient.send_event(Category.ONBOARDING, MessageId.ORB_ONBOARD_FAILED)
+            return JSONResponse({"error": "Failed to save configuration"}, status_code=500)
 
         # Refresh cached patched client so latest credentials take effect immediately
         await clients.refresh_patched_client()
@@ -1365,9 +1160,7 @@ async def onboarding(
                     if not config_manager.save_config_file(current_config):
                         logger.error("Failed to save openrag_docs_filter_id to config")
             except Exception as e:
-                logger.error(
-                    "Failed to create OpenRAG Docs knowledge filter", error=str(e)
-                )
+                logger.error("Failed to create OpenRAG Docs knowledge filter", error=str(e))
                 # Don't fail onboarding if filter creation fails
 
         return OnboardingResponse(
@@ -1380,341 +1173,11 @@ async def onboarding(
 
     except Exception as e:
         logger.error("Failed to update onboarding settings", error=str(e))
-        await TelemetryClient.send_event(
-            Category.ONBOARDING,
-            MessageId.ORB_ONBOARD_FAILED
-        )
+        await TelemetryClient.send_event(Category.ONBOARDING, MessageId.ORB_ONBOARD_FAILED)
         return JSONResponse(
             {"error": str(e)},
             status_code=500,
         )
-
-
-async def _create_openrag_docs_filter(
-    knowledge_filter_service, session_manager, user
-):
-    """Create the OpenRAG Docs knowledge filter for onboarding"""
-    import uuid
-    import json
-    from datetime import datetime
-
-    if not knowledge_filter_service:
-        logger.error("Knowledge filter service not available")
-        return None
-
-    # Get JWT token
-    jwt_token = user.jwt_token
-
-    # Guard against duplicates: check if a filter named "OpenRAG Docs" already exists
-    try:
-        opensearch_client = session_manager.get_user_opensearch_client(
-            user.user_id, jwt_token
-        )
-        from services.knowledge_filter_service import KNOWLEDGE_FILTERS_INDEX_NAME
-        existing = await opensearch_client.search(
-            index=KNOWLEDGE_FILTERS_INDEX_NAME,
-            body={
-                "query": {"match_phrase": {"name": "OpenRAG Docs"}},
-                "_source": ["id"],
-                "size": 1,
-            },
-        )
-        hits = existing.get("hits", {}).get("hits", [])
-        if hits:
-            existing_id = hits[0]["_source"].get("id")
-            logger.info(
-                "OpenRAG Docs filter already exists, skipping creation",
-                existing_id=existing_id,
-            )
-            return existing_id
-    except Exception as e:
-        logger.warning(
-            "Could not check for existing OpenRAG Docs filter, proceeding with creation",
-            error=str(e),
-        )
-
-    # In no-auth mode, set owner to None so filter is visible to all users
-    # In auth mode, use the actual user as owner
-    if is_no_auth_mode():
-        owner_user_id = None
-    else:
-        owner_user_id = user.user_id
-
-    # Create the filter document
-    filter_id = str(uuid.uuid4())
-    query_data = json.dumps({
-        "query": "",
-        "filters": {
-            # URL-based docs ingestion produces many source URLs.
-            # Filter by connector type to target OpenRAG docs only.
-            "data_sources": ["*"],
-            "document_types": ["*"],
-            "owners": ["*"],
-            "connector_types": ["openrag_docs"],
-        },
-        "limit": 10,
-        "scoreThreshold": 0,
-        "color": "blue",
-        "icon": "book",
-    })
-
-    filter_doc = {
-        "id": filter_id,
-        "name": "OpenRAG Docs",
-        "description": "Filter for OpenRAG documentation",
-        "query_data": query_data,
-        "owner": owner_user_id,
-        "allowed_users": [],
-        "allowed_groups": [],
-        "created_at": datetime.utcnow().isoformat(),
-        "updated_at": datetime.utcnow().isoformat(),
-    }
-
-    result = await knowledge_filter_service.create_knowledge_filter(
-        filter_doc, user_id=user.user_id, jwt_token=jwt_token
-    )
-
-    if result.get("success"):
-        return filter_id
-    else:
-        logger.error("Failed to create OpenRAG Docs filter", error=result.get("error"))
-        return None
-
-
-def _get_flows_service():
-    """Helper function to get flows service instance"""
-    from services.flows_service import FlowsService
-
-    return FlowsService()
-
-
-async def _update_langflow_global_variables(config, flows_service=None):
-    """Update Langflow global variables for all configured providers"""
-    try:
-        # WatsonX global variables
-        if config.providers.watsonx.api_key:
-            await clients._create_langflow_global_variable(
-                "WATSONX_APIKEY", config.providers.watsonx.api_key, modify=True
-            )
-            logger.info("Set WATSONX_APIKEY global variable in Langflow")
-
-        if config.providers.watsonx.project_id:
-            await clients._create_langflow_global_variable(
-                "WATSONX_PROJECT_ID", config.providers.watsonx.project_id, modify=True
-            )
-            logger.info("Set WATSONX_PROJECT_ID global variable in Langflow")
-
-        if config.providers.watsonx.endpoint:
-            await clients._create_langflow_global_variable(
-                "WATSONX_URL", config.providers.watsonx.endpoint, modify=True
-            )
-            logger.info("Set WATSONX_URL global variable in Langflow")
-
-        # OpenAI global variables
-        if config.providers.openai.api_key:
-            await clients._create_langflow_global_variable(
-                "OPENAI_API_KEY", config.providers.openai.api_key, modify=True
-            )
-            logger.info("Set OPENAI_API_KEY global variable in Langflow")
-
-        # Anthropic global variables
-        if config.providers.anthropic.api_key:
-            await clients._create_langflow_global_variable(
-                "ANTHROPIC_API_KEY", config.providers.anthropic.api_key, modify=True
-            )
-            logger.info("Set ANTHROPIC_API_KEY global variable in Langflow")
-
-        # Ollama global variables
-        if config.providers.ollama.endpoint:
-            if not flows_service:
-                flows_service = _get_flows_service()
-
-            endpoint = await flows_service.resolve_ollama_url(config.providers.ollama.endpoint, force_refresh=True)
-            await clients._create_langflow_global_variable(
-                "OLLAMA_BASE_URL", endpoint, modify=True
-            )
-            logger.info("Set OLLAMA_BASE_URL global variable in Langflow")
-
-        if config.knowledge.embedding_model:
-            await clients._create_langflow_global_variable(
-                "SELECTED_EMBEDDING_MODEL", config.knowledge.embedding_model, modify=True
-            )
-            logger.info(
-                f"Set SELECTED_EMBEDDING_MODEL global variable to {config.knowledge.embedding_model}"
-            )
-
-    except Exception as e:
-        logger.error(f"Failed to update Langflow global variables: {str(e)}")
-        raise
-
-
-async def _run_async_post_save_langflow_updates(
-    session_manager,
-    update_mcp_servers: bool,
-    update_model_values: bool,
-    models_service=None,
-) -> None:
-    """Apply post-save Langflow synchronization asynchronously."""
-    try:
-        current_config = get_openrag_config()
-        flows_service = _get_flows_service()
-
-        # Refresh model registry so get_litellm_model_name(strict=True) sees the
-        # updated provider list — force_remove skips _affected_embedding_models which
-        # is the usual registry refresh trigger.
-        if models_service is not None:
-            await models_service.update_model_registry()
-
-        # Update global variables
-        await _update_langflow_global_variables(
-            current_config, flows_service=flows_service
-        )
-
-        # Update LLM client credentials when embedding selection changes
-        if update_mcp_servers:
-            await _update_mcp_server_urls(
-                current_config, session_manager, flows_service=flows_service
-            )
-
-        # Update model values if provider/model changed (including removals/fallbacks)
-        if update_model_values:
-            await _update_langflow_model_values(
-                current_config,
-                flows_service,
-                llm_model=current_config.agent.llm_model,
-                llm_provider=current_config.agent.llm_provider,
-                embedding_model=current_config.knowledge.embedding_model,
-                embedding_provider=current_config.knowledge.embedding_provider,
-            )
-
-        logger.info("Completed asynchronous Langflow post-save sync")
-    except Exception as e:
-        # Do not fail user request if async sync fails; keep parity with existing behavior.
-        logger.error(f"Failed to update Langflow settings asynchronously: {str(e)}")
-
-
-async def _update_mcp_server_urls(config, session_manager=None, flows_service=None):
-    """Update MCP server URLs (patch localhost and convert to streamable HTTP)."""
-    try:
-        from services.langflow_mcp_service import LangflowMCPService
-
-        mcp_service = LangflowMCPService()
-        result = await mcp_service.update_all_mcp_server_urls()
-        logger.info("Updated MCP server URLs after settings change", **result)
-
-    except Exception as mcp_error:
-        logger.warning(f"Failed to update MCP server URLs after settings change: {str(mcp_error)}")
-        # Don't fail the entire settings update if MCP update fails
-
-
-async def _update_langflow_model_values(config, flows_service, llm_model=None, llm_provider=None, embedding_model=None, embedding_provider=None):
-    """Update model values across Langflow flows for all configured providers"""
-    try:
-
-        if llm_model or llm_provider:
-            effective_llm_provider = (llm_provider or config.agent.llm_provider).lower()
-            if llm_provider and llm_provider.lower() != config.agent.llm_provider.lower():
-                effective_llm_model = llm_model  # do not fall back; force caller to specify
-            else:
-                effective_llm_model = llm_model or config.agent.llm_model
-            result = await flows_service.change_langflow_model_value(
-                effective_llm_provider,
-                llm_model=effective_llm_model,
-                force_llm_update=True
-            )
-
-            logger.info(
-                f"Successfully updated Langflow flows for LLM provider {effective_llm_provider}",
-                result=result
-            )
-
-        if embedding_model or embedding_provider:
-            effective_embedding_provider = (embedding_provider or config.knowledge.embedding_provider).lower()
-            if embedding_provider and embedding_provider.lower() != config.knowledge.embedding_provider.lower():
-                effective_embedding_model = embedding_model  # do not fall back; force caller to specify
-            else:
-                effective_embedding_model = embedding_model or config.knowledge.embedding_model
-            result = await flows_service.change_langflow_model_value(
-                effective_embedding_provider,
-                embedding_model=effective_embedding_model,
-                force_embedding_update=True
-            )
-
-            logger.info(
-                f"Successfully updated Langflow flows for embedding provider {effective_embedding_provider}",
-                result=result
-            )
-
-        if not (embedding_model or embedding_provider or llm_model or llm_provider):
-            # 2. Update ALL configured embedding providers
-            embedding_providers = []
-            if config.providers.openai.configured:
-                embedding_providers.append("openai")
-            if config.providers.watsonx.configured:
-                embedding_providers.append("watsonx")
-            if config.providers.ollama.configured:
-                embedding_providers.append("ollama")
-
-            current_embedding_provider = config.knowledge.embedding_provider.lower()
-            for provider in embedding_providers:
-                # Use configured model for current provider, or None (first available) for others
-                embedding_model = (
-                    config.knowledge.embedding_model
-                    if provider == current_embedding_provider
-                    else None
-                )
-                await flows_service.change_langflow_model_value(
-                        provider,
-                        embedding_model=embedding_model,
-                        force_embedding_update=True
-                    )
-                logger.info(
-                    f"Successfully updated Langflow flows for embedding provider {provider}"
-                )
-    except Exception as e:
-        logger.error(f"Failed to update Langflow model values: {str(e)}")
-        raise
-
-
-async def _update_langflow_system_prompt(config, flows_service):
-    """Update system prompt in chat flow"""
-    try:
-        llm_provider = config.agent.llm_provider.lower()
-        await flows_service.update_chat_flow_system_prompt(
-            config.agent.system_prompt, llm_provider
-        )
-        logger.info("Successfully updated chat flow system prompt")
-    except Exception as e:
-        logger.error(f"Failed to update chat flow system prompt: {str(e)}")
-        raise
-
-
-async def _update_langflow_docling_settings(config, flows_service):
-    """Update docling settings in ingest flow"""
-    try:
-        preset_config = get_docling_preset_configs(
-            table_structure=config.knowledge.table_structure,
-            ocr=config.knowledge.ocr,
-            picture_descriptions=config.knowledge.picture_descriptions,
-        )
-        await flows_service.update_flow_docling_preset("custom", preset_config)
-        logger.info("Successfully updated docling settings in ingest flow")
-    except Exception as e:
-        logger.error(f"Failed to update docling settings: {str(e)}")
-        raise
-
-
-async def _update_langflow_chunk_settings(config, flows_service):
-    """Update chunk size and overlap in ingest flow"""
-    try:
-        await flows_service.update_ingest_flow_chunk_size(config.knowledge.chunk_size)
-        logger.info(f"Successfully updated ingest flow chunk size to {config.knowledge.chunk_size}")
-
-        await flows_service.update_ingest_flow_chunk_overlap(config.knowledge.chunk_overlap)
-        logger.info(f"Successfully updated ingest flow chunk overlap to {config.knowledge.chunk_overlap}")
-    except Exception as e:
-        logger.error(f"Failed to update chunk settings: {str(e)}")
-        raise
 
 
 async def update_onboarding_state(
@@ -1744,9 +1207,7 @@ async def update_onboarding_state(
         )
 
     except json.JSONDecodeError:
-        return JSONResponse(
-            {"error": "Invalid JSON in request body"}, status_code=400
-        )
+        return JSONResponse({"error": "Invalid JSON in request body"}, status_code=400)
     except Exception as e:
         logger.error(f"Error updating onboarding state: {str(e)}")
         return JSONResponse(
@@ -1755,57 +1216,9 @@ async def update_onboarding_state(
         )
 
 
-async def reapply_all_settings(session_manager = None):
-    """
-    Reapply all current configuration settings to Langflow flows and global variables.
-    This is called when flows are detected to have been reset.
-    """
-    try:
-        config = get_openrag_config()
-        flows_service = _get_flows_service()
-
-        logger.info("Reapplying all settings to Langflow flows and global variables")
-
-        # Update MCP server URLs (patch localhost and convert to streamable HTTP)
-        await _update_mcp_server_urls(config, session_manager, flows_service=flows_service)
-
-        # Update all Langflow settings using helper functions
-        try:
-            await _update_langflow_global_variables(config, flows_service=flows_service)
-        except Exception as e:
-            logger.error(f"Failed to update Langflow global variables: {str(e)}")
-            # Continue with other updates even if global variables fail
-
-        try:
-            await _update_langflow_model_values(config, flows_service)
-        except Exception as e:
-            logger.error(f"Failed to update Langflow model values: {str(e)}")
-
-        try:
-            await _update_langflow_system_prompt(config, flows_service)
-        except Exception as e:
-            logger.error(f"Failed to update Langflow system prompt: {str(e)}")
-
-        try:
-            await _update_langflow_docling_settings(config, flows_service)
-        except Exception as e:
-            logger.error(f"Failed to update Langflow docling settings: {str(e)}")
-
-        try:
-            await _update_langflow_chunk_settings(config, flows_service)
-        except Exception as e:
-            logger.error(f"Failed to update Langflow chunk settings: {str(e)}")
-
-        logger.info("Successfully reapplied all settings to Langflow flows")
-
-    except Exception as e:
-        logger.error(f"Failed to reapply settings: {str(e)}")
-        raise
-
-
 async def rollback_onboarding(
     request: Request,
-    body: Optional[RollbackBody] = None,
+    body: RollbackBody | None = None,
     session_manager=Depends(get_session_manager),
     task_service=Depends(get_task_service),
     knowledge_filter_service=Depends(get_knowledge_filter_service),
@@ -1840,7 +1253,8 @@ async def rollback_onboarding(
 
         # Delete knowledge filters created during onboarding
         try:
-            async def remove_filter(filter_id: Optional[str]):
+
+            async def remove_filter(filter_id: str | None):
                 if filter_id and knowledge_filter_service:
                     try:
                         result = await knowledge_filter_service.delete_knowledge_filter(
@@ -1850,15 +1264,17 @@ async def rollback_onboarding(
                             logger.info(f"Deleted knowledge filter {filter_id}")
                         else:
                             error_msg = result.get("error") if result else "Unknown error"
-                            logger.warning(f"Could not delete knowledge filter {filter_id}: {error_msg}")
+                            logger.warning(
+                                f"Could not delete knowledge filter {filter_id}: {error_msg}"
+                            )
                     except Exception as e:
                         logger.warning(f"Exception deleting knowledge filter {filter_id}: {str(e)}")
 
-            if getattr(current_config.onboarding, 'openrag_docs_filter_id', None):
+            if getattr(current_config.onboarding, "openrag_docs_filter_id", None):
                 await remove_filter(current_config.onboarding.openrag_docs_filter_id)
                 current_config.onboarding.openrag_docs_filter_id = None
-                
-            if getattr(current_config.onboarding, 'user_doc_filter_id', None):
+
+            if getattr(current_config.onboarding, "user_doc_filter_id", None):
                 await remove_filter(current_config.onboarding.user_doc_filter_id)
                 current_config.onboarding.user_doc_filter_id = None
         except Exception as e:
@@ -1866,6 +1282,7 @@ async def rollback_onboarding(
 
         # Cancel all active tasks and collect successfully ingested files
         from session_manager import AnonymousUser
+
         anonymous_user_id = AnonymousUser().user_id
 
         for task_data in all_tasks:
@@ -1882,7 +1299,7 @@ async def rollback_onboarding(
                 except Exception as e:
                     logger.error(f"Failed to cancel task {task_id}: {str(e)}")
 
-            # Delete all files associated with any task, regardless of whether 
+            # Delete all files associated with any task, regardless of whether
             # the task failed or completed, to ensure no partial chunks remain in OpenSearch.
             files = task_data.get("files", {})
             if isinstance(files, dict):
@@ -1894,28 +1311,37 @@ async def rollback_onboarding(
                                 opensearch_client = session_manager.get_user_opensearch_client(
                                     user.user_id, user.jwt_token
                                 )
-                                from utils.opensearch_queries import build_filename_delete_body
                                 from config.settings import get_index_name
+                                from utils.opensearch_queries import (
+                                    build_filename_delete_body,
+                                )
 
                                 delete_query = build_filename_delete_body(filename)
                                 result = await opensearch_client.delete_by_query(
                                     index=get_index_name(),
                                     body=delete_query,
-                                    conflicts="proceed"
+                                    conflicts="proceed",
                                 )
                                 deleted_count = result.get("deleted", 0)
                                 if deleted_count > 0:
                                     deleted_files.append(filename)
-                                    logger.info(f"Deleted {deleted_count} chunks for filename {filename}")
+                                    logger.info(
+                                        f"Deleted {deleted_count} chunks for filename {filename}"
+                                    )
                             except Exception as e:
                                 logger.error(f"Failed to delete documents for {filename}: {str(e)}")
 
             # Wipe the task completely from memory so the frontend doesn't see it anymore
             for check_user_id in [user.user_id, anonymous_user_id]:
-                if check_user_id in task_service.task_store and task_id in task_service.task_store[check_user_id]:
+                if (
+                    check_user_id in task_service.task_store
+                    and task_id in task_service.task_store[check_user_id]
+                ):
                     task_service._task_locks.pop(task_id, None)
                     task_service.task_store[check_user_id].pop(task_id, None)
-                    logger.info(f"Purged task {task_id} completely from task_store for user {check_user_id}")
+                    logger.info(
+                        f"Purged task {task_id} completely from task_store for user {check_user_id}"
+                    )
 
         # 4. Reset Langflow flows to their original state
         reset_flows_count = 0
@@ -1926,7 +1352,9 @@ async def rollback_onboarding(
                     reset_flows_count += 1
                     logger.info(f"Successfully reset {flow_type} flow during rollback")
                 else:
-                    logger.warning(f"Failed to reset {flow_type} flow during rollback: {result.get('error')}")
+                    logger.warning(
+                        f"Failed to reset {flow_type} flow during rollback: {result.get('error')}"
+                    )
             except Exception as e:
                 logger.error(f"Error resetting {flow_type} flow during rollback: {e}")
 
@@ -1963,6 +1391,7 @@ async def rollback_onboarding(
         # Save the rolled back configuration manually
         try:
             import yaml
+
             config_file = config_manager.config_file
 
             # Ensure directory exists
@@ -1975,7 +1404,9 @@ async def rollback_onboarding(
             # Update cached config
             config_manager._config = current_config
 
-            logger.info(f"Successfully saved rolled back configuration with edited={current_config.edited}")
+            logger.info(
+                f"Successfully saved rolled back configuration with edited={current_config.edited}"
+            )
         except Exception as e:
             logger.error(f"Failed to save rolled back configuration: {e}")
             return JSONResponse(
@@ -1987,24 +1418,19 @@ async def rollback_onboarding(
             f"Cancelled {len(cancelled_tasks)} tasks, deleted {len(deleted_files)} files, "
             f"reset {reset_flows_count} flows, deleted {deleted_conversations_count} conversations"
         )
-        await TelemetryClient.send_event(
-            Category.ONBOARDING,
-            MessageId.ORB_ONBOARD_ROLLBACK
-        )
+        await TelemetryClient.send_event(Category.ONBOARDING, MessageId.ORB_ONBOARD_ROLLBACK)
 
         return RollbackResponse(
             message="Onboarding configuration rolled back successfully",
             cancelled_tasks=len(cancelled_tasks),
             deleted_files=len(deleted_files),
             reset_flows=reset_flows_count,
-            deleted_conversations=deleted_conversations_count
+            deleted_conversations=deleted_conversations_count,
         )
 
     except Exception as e:
         logger.error("Failed to rollback onboarding configuration", error=str(e))
-        return JSONResponse(
-            {"error": f"Failed to rollback onboarding: {str(e)}"}, status_code=500
-        )
+        return JSONResponse({"error": f"Failed to rollback onboarding: {str(e)}"}, status_code=500)
 
 
 async def update_docling_preset(
@@ -2044,16 +1470,20 @@ async def update_docling_preset(
             if preset not in preset_map:
                 raise HTTPException(
                     status_code=400,
-                    detail=f"Invalid preset '{preset}'. Valid presets: {', '.join(preset_map.keys())}"
+                    detail=f"Invalid preset '{preset}'. Valid presets: {', '.join(preset_map.keys())}",
                 )
 
             settings_toggles = preset_map[preset]
         else:
             # Support new toggle-based API
             settings_toggles = {
-                "table_structure": body.table_structure if body.table_structure is not None else False,
+                "table_structure": (
+                    body.table_structure if body.table_structure is not None else False
+                ),
                 "ocr": body.ocr if body.ocr is not None else False,
-                "picture_descriptions": body.picture_descriptions if body.picture_descriptions is not None else False,
+                "picture_descriptions": (
+                    body.picture_descriptions if body.picture_descriptions is not None else False
+                ),
             }
 
         # Get the preset configuration
@@ -2074,7 +1504,9 @@ async def update_docling_preset(
 
     except Exception as e:
         logger.error("Failed to update docling settings", error=str(e))
-        raise HTTPException(status_code=500, detail=f"Failed to update docling settings: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to update docling settings: {str(e)}"
+        ) from e
 
 
 async def refresh_openrag_docs(
@@ -2111,4 +1543,4 @@ async def refresh_openrag_docs(
         raise HTTPException(
             status_code=500,
             detail=f"Failed to refresh OpenRAG docs: {str(e)}",
-        )
+        ) from e

--- a/src/api/settings/helpers.py
+++ b/src/api/settings/helpers.py
@@ -1,0 +1,192 @@
+"""General helpers for the settings/onboarding endpoints.
+
+Provider-fallback selection, embedding-model conflict detection (used to
+warn before removing a provider whose embeddings are still indexed), the
+OpenRAG-docs knowledge-filter creator, and a flows-service factory.
+
+Lifted verbatim from the original `src/api/settings.py` (lines 371–480 and
+1388–1455). No behavior change.
+"""
+
+from typing import Any
+
+from fastapi.responses import JSONResponse
+
+from config.settings import clients, is_no_auth_mode
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _first_configured_llm_provider(config, excluding: str) -> str:
+    """Return the first configured LLM provider that isn't `excluding`."""
+    for p in ["openai", "anthropic", "watsonx", "ollama"]:
+        if p != excluding and getattr(config.providers, p).configured:
+            return p
+    return "openai"
+
+
+def _first_configured_embedding_provider(config, excluding: str) -> str:
+    """Return the first configured embedding provider (openai/watsonx/ollama) that isn't `excluding`."""
+    for p in ["openai", "watsonx", "ollama"]:
+        if p != excluding and getattr(config.providers, p).configured:
+            return p
+    return "openai"
+
+
+async def _affected_embedding_models(
+    provider: str,
+    session_manager,
+    user,
+    models_service,
+) -> list[dict[str, Any]]:
+    """Find embedding models present in the corpus that belong to ``provider``.
+
+    Used to warn users before they remove a provider whose embedding models
+    were used to index documents — otherwise semantic search silently breaks
+    for those docs. Returns a list of ``{"model": str, "doc_count": int}``.
+
+    Conservative on errors (returns empty list) so infra issues don't block
+    provider removal.
+    """
+    from config.settings import get_index_name
+    from services.models_service import ModelsService
+
+    provider_lower = provider.lower()
+    if provider_lower == "anthropic":
+        # Anthropic doesn't serve embedding models — nothing to warn about.
+        return []
+
+    try:
+        # Refresh so the registry reflects currently-configured providers
+        # before we use it to attribute models.
+        await models_service.update_model_registry()
+        registry = ModelsService._model_provider_registry
+
+        # Use the admin client so DLS does not scope the aggregation to the
+        # requesting user's documents. Provider removal is a global operation
+        # that affects all tenants, so we must see every document's embedding
+        # model regardless of ownership.
+        agg_result = await clients.opensearch.search(
+            index=get_index_name(),
+            body={
+                "size": 0,
+                "aggs": {"embedding_models": {"terms": {"field": "embedding_model", "size": 50}}},
+            },
+            params={"terminate_after": 0},
+        )
+        buckets = agg_result.get("aggregations", {}).get("embedding_models", {}).get("buckets", [])
+
+        affected: list[dict[str, Any]] = []
+        for bucket in buckets:
+            model = bucket.get("key")
+            if not model:
+                continue
+            mapped = registry.get(model)
+            # Narrow fallback: the watsonx registry bootstrap requires the
+            # provider still be configured, so models from an about-to-be-
+            # removed watsonx can still be attributed via the "ibm/" prefix.
+            if mapped is None and provider_lower == "watsonx" and model.startswith("ibm/"):
+                mapped = "watsonx"
+            if mapped == provider_lower:
+                affected.append({"model": model, "doc_count": bucket.get("doc_count", 0)})
+        return affected
+    except Exception as e:
+        logger.warning(
+            "Could not determine affected embedding models for provider removal",
+            provider=provider,
+            error=str(e),
+        )
+        return []
+
+
+def _embedding_conflict_response(
+    provider_label: str, provider_key: str, affected: list[dict[str, Any]]
+) -> JSONResponse:
+    """Shared 409 response when removing a provider whose embedding models are
+    still referenced by indexed documents."""
+    model_names = [a["model"] for a in affected]
+    return JSONResponse(
+        {
+            "error": (
+                f"Removing {provider_label} will disable semantic search on "
+                f"documents indexed with: {', '.join(model_names)}. "
+                f"Re-ingest affected documents with another embedding model, "
+                f"or retry with force_remove=true to proceed anyway."
+            ),
+            "code": "embedding_provider_in_use",
+            "affected_provider": provider_key,
+            "affected_models": affected,
+        },
+        status_code=409,
+    )
+
+
+async def _create_openrag_docs_filter(knowledge_filter_service, session_manager, user):
+    """Create the OpenRAG Docs knowledge filter for onboarding"""
+    import json
+    import uuid
+    from datetime import datetime
+
+    if not knowledge_filter_service:
+        logger.error("Knowledge filter service not available")
+        return None
+
+    # Get JWT token
+    jwt_token = user.jwt_token
+
+    # In no-auth mode, set owner to None so filter is visible to all users
+    # In auth mode, use the actual user as owner
+    if is_no_auth_mode():
+        owner_user_id = None
+    else:
+        owner_user_id = user.user_id
+
+    # Create the filter document
+    filter_id = str(uuid.uuid4())
+    query_data = json.dumps(
+        {
+            "query": "",
+            "filters": {
+                # URL-based docs ingestion produces many source URLs.
+                # Filter by connector type to target OpenRAG docs only.
+                "data_sources": ["*"],
+                "document_types": ["*"],
+                "owners": ["*"],
+                "connector_types": ["openrag_docs"],
+            },
+            "limit": 10,
+            "scoreThreshold": 0,
+            "color": "blue",
+            "icon": "book",
+        }
+    )
+
+    filter_doc = {
+        "id": filter_id,
+        "name": "OpenRAG Docs",
+        "description": "Filter for OpenRAG documentation",
+        "query_data": query_data,
+        "owner": owner_user_id,
+        "allowed_users": [],
+        "allowed_groups": [],
+        "created_at": datetime.utcnow().isoformat(),
+        "updated_at": datetime.utcnow().isoformat(),
+    }
+
+    result = await knowledge_filter_service.create_knowledge_filter(
+        filter_doc, user_id=user.user_id, jwt_token=jwt_token
+    )
+
+    if result.get("success"):
+        return filter_id
+    else:
+        logger.error("Failed to create OpenRAG Docs filter", error=result.get("error"))
+        return None
+
+
+def _get_flows_service():
+    """Helper function to get flows service instance"""
+    from services.flows_service import FlowsService
+
+    return FlowsService()

--- a/src/api/settings/langflow_sync.py
+++ b/src/api/settings/langflow_sync.py
@@ -1,0 +1,308 @@
+"""Langflow synchronization helpers for settings/onboarding flows.
+
+Pushes the latest user config (provider creds, model selection, system
+prompt, docling toggles, chunk sizes, MCP server URLs) into Langflow
+flows and global variables. Also exposes `reapply_all_settings`, called
+from `services/startup_orchestrator.py` when flow-reset detection
+triggers a full re-sync.
+
+Lifted verbatim from the original `src/api/settings.py` (lines 46,
+1458–1684, 1725–1770). No behavior change.
+"""
+
+import asyncio
+
+from api.settings.helpers import _get_flows_service
+from config.settings import clients, get_openrag_config
+from services.docling_service import get_docling_preset_configs
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Strong refs to in-flight async post-save sync tasks so they aren't
+# garbage-collected mid-flight when the originating request returns.
+_background_tasks: set[asyncio.Task] = set()
+
+
+async def _update_langflow_global_variables(config, flows_service=None):
+    """Update Langflow global variables for all configured providers"""
+    try:
+        # WatsonX global variables
+        if config.providers.watsonx.api_key:
+            await clients._create_langflow_global_variable(
+                "WATSONX_APIKEY", config.providers.watsonx.api_key, modify=True
+            )
+            logger.info("Set WATSONX_APIKEY global variable in Langflow")
+
+        if config.providers.watsonx.project_id:
+            await clients._create_langflow_global_variable(
+                "WATSONX_PROJECT_ID", config.providers.watsonx.project_id, modify=True
+            )
+            logger.info("Set WATSONX_PROJECT_ID global variable in Langflow")
+
+        if config.providers.watsonx.endpoint:
+            await clients._create_langflow_global_variable(
+                "WATSONX_URL", config.providers.watsonx.endpoint, modify=True
+            )
+            logger.info("Set WATSONX_URL global variable in Langflow")
+
+        # OpenAI global variables
+        if config.providers.openai.api_key:
+            await clients._create_langflow_global_variable(
+                "OPENAI_API_KEY", config.providers.openai.api_key, modify=True
+            )
+            logger.info("Set OPENAI_API_KEY global variable in Langflow")
+
+        # Anthropic global variables
+        if config.providers.anthropic.api_key:
+            await clients._create_langflow_global_variable(
+                "ANTHROPIC_API_KEY", config.providers.anthropic.api_key, modify=True
+            )
+            logger.info("Set ANTHROPIC_API_KEY global variable in Langflow")
+
+        # Ollama global variables
+        if config.providers.ollama.endpoint:
+            if not flows_service:
+                flows_service = _get_flows_service()
+
+            endpoint = await flows_service.resolve_ollama_url(
+                config.providers.ollama.endpoint, force_refresh=True
+            )
+            await clients._create_langflow_global_variable("OLLAMA_BASE_URL", endpoint, modify=True)
+            logger.info("Set OLLAMA_BASE_URL global variable in Langflow")
+
+        if config.knowledge.embedding_model:
+            await clients._create_langflow_global_variable(
+                "SELECTED_EMBEDDING_MODEL", config.knowledge.embedding_model, modify=True
+            )
+            logger.info(
+                f"Set SELECTED_EMBEDDING_MODEL global variable to {config.knowledge.embedding_model}"
+            )
+
+    except Exception as e:
+        logger.error(f"Failed to update Langflow global variables: {str(e)}")
+        raise
+
+
+async def _run_async_post_save_langflow_updates(
+    session_manager,
+    update_mcp_servers: bool,
+    update_model_values: bool,
+    models_service=None,
+) -> None:
+    """Apply post-save Langflow synchronization asynchronously."""
+    try:
+        current_config = get_openrag_config()
+        flows_service = _get_flows_service()
+
+        # Refresh model registry so get_litellm_model_name(strict=True) sees the
+        # updated provider list — force_remove skips _affected_embedding_models which
+        # is the usual registry refresh trigger.
+        if models_service is not None:
+            await models_service.update_model_registry()
+
+        # Update global variables
+        await _update_langflow_global_variables(current_config, flows_service=flows_service)
+
+        # Update LLM client credentials when embedding selection changes
+        if update_mcp_servers:
+            await _update_mcp_server_urls(
+                current_config, session_manager, flows_service=flows_service
+            )
+
+        # Update model values if provider/model changed (including removals/fallbacks)
+        if update_model_values:
+            await _update_langflow_model_values(
+                current_config,
+                flows_service,
+                llm_model=current_config.agent.llm_model,
+                llm_provider=current_config.agent.llm_provider,
+                embedding_model=current_config.knowledge.embedding_model,
+                embedding_provider=current_config.knowledge.embedding_provider,
+            )
+
+        logger.info("Completed asynchronous Langflow post-save sync")
+    except Exception as e:
+        # Do not fail user request if async sync fails; keep parity with existing behavior.
+        logger.error(f"Failed to update Langflow settings asynchronously: {str(e)}")
+
+
+async def _update_mcp_server_urls(config, session_manager=None, flows_service=None):
+    """Update MCP server URLs (patch localhost and convert to streamable HTTP)."""
+    try:
+        from services.langflow_mcp_service import LangflowMCPService
+
+        mcp_service = LangflowMCPService()
+        result = await mcp_service.update_all_mcp_server_urls()
+        logger.info("Updated MCP server URLs after settings change", **result)
+
+    except Exception as mcp_error:
+        logger.warning(f"Failed to update MCP server URLs after settings change: {str(mcp_error)}")
+        # Don't fail the entire settings update if MCP update fails
+
+
+async def _update_langflow_model_values(
+    config,
+    flows_service,
+    llm_model=None,
+    llm_provider=None,
+    embedding_model=None,
+    embedding_provider=None,
+):
+    """Update model values across Langflow flows for all configured providers"""
+    try:
+        if llm_model or llm_provider:
+            effective_llm_provider = (llm_provider or config.agent.llm_provider).lower()
+            if llm_provider and llm_provider.lower() != config.agent.llm_provider.lower():
+                effective_llm_model = llm_model  # do not fall back; force caller to specify
+            else:
+                effective_llm_model = llm_model or config.agent.llm_model
+            result = await flows_service.change_langflow_model_value(
+                effective_llm_provider, llm_model=effective_llm_model, force_llm_update=True
+            )
+
+            logger.info(
+                f"Successfully updated Langflow flows for LLM provider {effective_llm_provider}",
+                result=result,
+            )
+
+        if embedding_model or embedding_provider:
+            effective_embedding_provider = (
+                embedding_provider or config.knowledge.embedding_provider
+            ).lower()
+            if (
+                embedding_provider
+                and embedding_provider.lower() != config.knowledge.embedding_provider.lower()
+            ):
+                effective_embedding_model = (
+                    embedding_model  # do not fall back; force caller to specify
+                )
+            else:
+                effective_embedding_model = embedding_model or config.knowledge.embedding_model
+            result = await flows_service.change_langflow_model_value(
+                effective_embedding_provider,
+                embedding_model=effective_embedding_model,
+                force_embedding_update=True,
+            )
+
+            logger.info(
+                f"Successfully updated Langflow flows for embedding provider {effective_embedding_provider}",
+                result=result,
+            )
+
+        if not (embedding_model or embedding_provider or llm_model or llm_provider):
+            # 2. Update ALL configured embedding providers
+            embedding_providers = []
+            if config.providers.openai.configured:
+                embedding_providers.append("openai")
+            if config.providers.watsonx.configured:
+                embedding_providers.append("watsonx")
+            if config.providers.ollama.configured:
+                embedding_providers.append("ollama")
+
+            current_embedding_provider = config.knowledge.embedding_provider.lower()
+            for provider in embedding_providers:
+                # Use configured model for current provider, or None (first available) for others
+                embedding_model = (
+                    config.knowledge.embedding_model
+                    if provider == current_embedding_provider
+                    else None
+                )
+                await flows_service.change_langflow_model_value(
+                    provider, embedding_model=embedding_model, force_embedding_update=True
+                )
+                logger.info(
+                    f"Successfully updated Langflow flows for embedding provider {provider}"
+                )
+    except Exception as e:
+        logger.error(f"Failed to update Langflow model values: {str(e)}")
+        raise
+
+
+async def _update_langflow_system_prompt(config, flows_service):
+    """Update system prompt in chat flow"""
+    try:
+        llm_provider = config.agent.llm_provider.lower()
+        await flows_service.update_chat_flow_system_prompt(config.agent.system_prompt, llm_provider)
+        logger.info("Successfully updated chat flow system prompt")
+    except Exception as e:
+        logger.error(f"Failed to update chat flow system prompt: {str(e)}")
+        raise
+
+
+async def _update_langflow_docling_settings(config, flows_service):
+    """Update docling settings in ingest flow"""
+    try:
+        preset_config = get_docling_preset_configs(
+            table_structure=config.knowledge.table_structure,
+            ocr=config.knowledge.ocr,
+            picture_descriptions=config.knowledge.picture_descriptions,
+        )
+        await flows_service.update_flow_docling_preset("custom", preset_config)
+        logger.info("Successfully updated docling settings in ingest flow")
+    except Exception as e:
+        logger.error(f"Failed to update docling settings: {str(e)}")
+        raise
+
+
+async def _update_langflow_chunk_settings(config, flows_service):
+    """Update chunk size and overlap in ingest flow"""
+    try:
+        await flows_service.update_ingest_flow_chunk_size(config.knowledge.chunk_size)
+        logger.info(f"Successfully updated ingest flow chunk size to {config.knowledge.chunk_size}")
+
+        await flows_service.update_ingest_flow_chunk_overlap(config.knowledge.chunk_overlap)
+        logger.info(
+            f"Successfully updated ingest flow chunk overlap to {config.knowledge.chunk_overlap}"
+        )
+    except Exception as e:
+        logger.error(f"Failed to update chunk settings: {str(e)}")
+        raise
+
+
+async def reapply_all_settings(session_manager=None):
+    """
+    Reapply all current configuration settings to Langflow flows and global variables.
+    This is called when flows are detected to have been reset.
+    """
+    try:
+        config = get_openrag_config()
+        flows_service = _get_flows_service()
+
+        logger.info("Reapplying all settings to Langflow flows and global variables")
+
+        # Update MCP server URLs (patch localhost and convert to streamable HTTP)
+        await _update_mcp_server_urls(config, session_manager, flows_service=flows_service)
+
+        # Update all Langflow settings using helper functions
+        try:
+            await _update_langflow_global_variables(config, flows_service=flows_service)
+        except Exception as e:
+            logger.error(f"Failed to update Langflow global variables: {str(e)}")
+            # Continue with other updates even if global variables fail
+
+        try:
+            await _update_langflow_model_values(config, flows_service)
+        except Exception as e:
+            logger.error(f"Failed to update Langflow model values: {str(e)}")
+
+        try:
+            await _update_langflow_system_prompt(config, flows_service)
+        except Exception as e:
+            logger.error(f"Failed to update Langflow system prompt: {str(e)}")
+
+        try:
+            await _update_langflow_docling_settings(config, flows_service)
+        except Exception as e:
+            logger.error(f"Failed to update Langflow docling settings: {str(e)}")
+
+        try:
+            await _update_langflow_chunk_settings(config, flows_service)
+        except Exception as e:
+            logger.error(f"Failed to update Langflow chunk settings: {str(e)}")
+
+        logger.info("Successfully reapplied all settings to Langflow flows")
+
+    except Exception as e:
+        logger.error(f"Failed to reapply settings: {str(e)}")
+        raise

--- a/src/api/settings/models.py
+++ b/src/api/settings/models.py
@@ -1,0 +1,202 @@
+"""Pydantic request and response models for the settings/onboarding endpoints.
+
+Lifted verbatim from the original `src/api/settings.py` (lines 49–223). No
+shape changes — every external caller sees the same fields and validators
+they did before. See `src/api/settings/__init__.py` for re-exports.
+"""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from services.docling_service import DoclingConfig
+
+
+class SettingsUpdateBody(BaseModel):
+    llm_model: str | None = Field(None, min_length=1)
+    llm_provider: str | None = Field(None, pattern="^(openai|anthropic|watsonx|ollama)$")
+    system_prompt: str | None = None
+    chunk_size: int | None = Field(None, gt=0)
+    chunk_overlap: int | None = Field(None, ge=0)
+    table_structure: bool | None = None
+    ocr: bool | None = None
+    picture_descriptions: bool | None = None
+    embedding_model: str | None = Field(None, min_length=1)
+    embedding_provider: str | None = Field(None, pattern="^(openai|watsonx|ollama)$")
+    index_name: str | None = Field(None, min_length=1)
+    openai_api_key: str | None = Field(None, min_length=1)
+    anthropic_api_key: str | None = Field(None, min_length=1)
+    watsonx_api_key: str | None = Field(None, min_length=1)
+    watsonx_endpoint: str | None = Field(None, min_length=1)
+    watsonx_project_id: str | None = Field(None, min_length=1)
+    ollama_endpoint: str | None = Field(None, min_length=1)
+    remove_ollama_config: bool | None = None
+    remove_openai_config: bool | None = None
+    remove_anthropic_config: bool | None = None
+    remove_watsonx_config: bool | None = None
+    # Explicit confirmation that the caller accepts removing a provider whose
+    # embedding models are still in use by indexed documents. Without this,
+    # the backend returns 409 and the frontend prompts the user.
+    force_remove: bool | None = False
+
+
+class OnboardingBody(BaseModel):
+    llm_provider: str | None = Field(None, pattern="^(openai|anthropic|watsonx|ollama)$")
+    llm_model: str | None = Field(None, min_length=1)
+    embedding_provider: str | None = Field(None, pattern="^(openai|watsonx|ollama)$")
+    embedding_model: str | None = Field(None, min_length=1)
+    openai_api_key: str | None = Field(None, min_length=1)
+    anthropic_api_key: str | None = Field(None, min_length=1)
+    watsonx_api_key: str | None = Field(None, min_length=1)
+    watsonx_endpoint: str | None = Field(None, min_length=1)
+    watsonx_project_id: str | None = Field(None, min_length=1)
+    ollama_endpoint: str | None = Field(None, min_length=1)
+
+
+class AssistantMessage(BaseModel):
+    role: str
+    content: str
+    timestamp: str
+
+
+class OnboardingStateBody(BaseModel):
+    current_step: int | None = None
+    assistant_message: AssistantMessage | None = None
+    selected_nudge: str | None = None
+    card_steps: dict[str, Any] | None = None
+    upload_steps: dict[str, Any] | None = None
+    openrag_docs_filter_id: str | None = None
+    user_doc_filter_id: str | None = None
+    openrag_docs_ingested_version: str | None = None
+    openrag_docs_remote_signature: str | None = None
+
+
+class DoclingPresetBody(BaseModel):
+    preset: str | None = None
+    table_structure: bool | None = None
+    ocr: bool | None = None
+    picture_descriptions: bool | None = None
+
+
+class OnboardingStateConfig(BaseModel):
+    current_step: int | None
+    assistant_message: AssistantMessage | None
+    selected_nudge: str | None
+    card_steps: dict[str, Any] | None
+    upload_steps: dict[str, Any] | None
+    openrag_docs_filter_id: str | None
+    user_doc_filter_id: str | None
+    openrag_docs_ingested_version: str | None
+    openrag_docs_remote_signature: str | None
+
+
+class OpenAIProviderConfig(BaseModel):
+    has_api_key: bool
+    configured: bool
+
+
+class AnthropicProviderConfig(BaseModel):
+    has_api_key: bool
+    configured: bool
+
+
+class WatsonXProviderConfig(BaseModel):
+    has_api_key: bool
+    endpoint: str | None
+    project_id: str | None
+    configured: bool
+
+
+class OllamaProviderConfig(BaseModel):
+    endpoint: str | None
+    configured: bool
+
+
+class ProvidersConfig(BaseModel):
+    openai: OpenAIProviderConfig
+    anthropic: AnthropicProviderConfig
+    watsonx: WatsonXProviderConfig
+    ollama: OllamaProviderConfig
+
+
+class KnowledgeConfig(BaseModel):
+    embedding_model: str | None
+    embedding_provider: str | None
+    chunk_size: int | None
+    chunk_overlap: int | None
+    table_structure: bool | None
+    ocr: bool | None
+    picture_descriptions: bool | None
+    index_name: str | None
+
+
+class AgentConfig(BaseModel):
+    llm_model: str | None
+    llm_provider: str | None
+    system_prompt: str | None
+
+
+class IngestionDefaultsConfig(BaseModel):
+    chunkSize: int | None
+    chunkOverlap: int | None
+    separator: str | None
+    embeddingModel: str | None
+
+
+class SettingsResponse(BaseModel):
+    langflow_url: str
+    flow_id: str | None
+    ingest_flow_id: str | None
+    langflow_public_url: str | None
+    edited: bool
+    onboarding: OnboardingStateConfig
+    providers: ProvidersConfig
+    knowledge: KnowledgeConfig
+    agent: AgentConfig
+    localhost_url: str
+    langflow_edit_url: str | None = None
+    langflow_ingest_edit_url: str | None = None
+    ingestion_defaults: IngestionDefaultsConfig | None = None
+    ingest_via_chat: bool = False
+    segment_write_key: str | None = None
+    environment: str | None = None
+
+
+class OnboardingResponse(BaseModel):
+    message: str
+    edited: bool
+    sample_data_ingested: bool
+    openrag_docs_filter_id: str | None = None
+    task_id: str | None = None
+
+
+class RefreshOpenRAGDocsResponse(BaseModel):
+    message: str
+    refreshed: bool
+
+
+class DoclingPresetResponse(BaseModel):
+    message: str
+    settings: dict
+    preset_config: DoclingConfig
+
+
+class OnboardingStateResponse(BaseModel):
+    message: str
+    updated_fields: list[str]
+
+
+class SettingsUpdateResponse(BaseModel):
+    message: str
+
+
+class RollbackResponse(BaseModel):
+    message: str
+    cancelled_tasks: int
+    deleted_files: int
+    reset_flows: int
+    deleted_conversations: int
+
+
+class RollbackBody(BaseModel):
+    embedding_only: bool = False


### PR DESCRIPTION
Split the large src/api/settings.py into a settings package (endpoints, models, helpers, langflow_sync) and added src/api/settings/__init__.py to preserve the original public import surface. Renamed the original file to src/api/settings/endpoints.py and moved Pydantic models and Langflow/provider helper logic into dedicated modules. Updated imports and made numerous small formatting/rewrites (wrapping, logging, minor refactors) without behavioral changes. Also updated pyproject.toml to whitelist common FastAPI call-sites for Ruff/Bugbear and add a mypy override for api.settings.endpoints. Minor tweaks to src/api/router.py (spacing and traceback logging) included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Reorganized settings modules for improved code structure and clearer separation of concerns.
  * Enhanced Langflow synchronization to better handle provider and model configuration updates during settings changes.

* **Bug Fixes**
  * Improved error responses and validation in settings endpoints.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1570)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->