### PR TITLE
fix: Add autofix.ci workflow; remove autofix steps

### DIFF
--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -1,0 +1,78 @@
+# autofix.ci enforces that any workflow invoking `autofix-ci/action` is
+# named exactly `autofix.ci`. Keep this workflow narrowly scoped to
+# formatter autofix; strict lint and mypy checks live in
+# `.github/workflows/lint-backend.yml`.
+#
+# Setup: install https://github.com/apps/autofix-ci on the repo (free for
+# public repos) and enable auto-apply in the autofix.ci dashboard so the
+# App pushes the format commit directly.
+name: autofix.ci
+
+on:
+  pull_request:
+    paths:
+      - 'src/**/*.py'
+      - 'tests/**/*.py'
+      - 'pyproject.toml'
+      - 'uv.lock'
+      - '.github/workflows/autofix.ci.yml'
+
+concurrency:
+  group: autofix-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+# The autofix.ci GitHub App holds write capability separately; the
+# workflow token only needs read access to checkout and run ruff.
+permissions:
+  contents: read
+
+jobs:
+  autofix:
+    name: ruff format autofix
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+        with:
+          enable-cache: true
+
+      - name: Set up Python
+        run: uv python install 3.13
+
+      - name: Install dev dependencies
+        run: uv sync --group dev
+
+      - name: Compute changed Python files
+        id: changed
+        run: |
+          base="${{ github.event.pull_request.base.sha }}"
+          head="${{ github.event.pull_request.head.sha }}"
+          merge_base=$(git merge-base "$base" "$head")
+          mapfile -t files < <(git diff --name-only --diff-filter=ACMR "$merge_base" "$head" -- '*.py')
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "No Python files changed."
+            echo "files=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          printf '%s\n' "${files[@]}"
+          echo "files=${files[*]}" >> "$GITHUB_OUTPUT"
+
+      - name: Ruff format (in-place)
+        if: steps.changed.outputs.files != ''
+        run: uv run ruff format ${{ steps.changed.outputs.files }}
+
+      # Hands any working-tree changes from the previous step to autofix.ci.
+      # In auto-apply mode the App pushes a commit back to the PR branch;
+      # the action exits non-zero on the run that produced the diff, then
+      # the App's commit triggers a fresh CI cycle that passes.
+      - name: Apply ruff format autofix via autofix.ci
+        if: steps.changed.outputs.files != ''
+        uses: autofix-ci/action@v1.3.1
+        with:
+          commit-message: "style: ruff format (auto)"

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -14,13 +14,6 @@ concurrency:
   group: lint-backend-${{ github.ref }}
   cancel-in-progress: true
 
-# autofix.ci's GitHub App handles writes to the PR branch independently of
-# the workflow token, so the job itself only needs read access. Setup:
-# install https://github.com/apps/autofix-ci on the repo (free for public
-# repos) and enable auto-apply in the autofix.ci dashboard.
-permissions:
-  contents: read
-
 jobs:
   lint:
     name: Ruff and mypy on changed files
@@ -62,20 +55,6 @@ jobs:
           # Pass as a single space-separated string to subsequent steps.
           echo "files=${files[*]}" >> "$GITHUB_OUTPUT"
 
-      - name: Ruff format (in-place)
-        if: steps.changed.outputs.files != ''
-        run: uv run ruff format ${{ steps.changed.outputs.files }}
-
-      # Hands any working-tree changes from the previous step to autofix.ci.
-      # In auto-apply mode the App pushes a commit back to the PR branch;
-      # the action exits non-zero on the run that produced the diff, then
-      # the App's commit triggers a fresh CI cycle that passes.
-      - name: Apply ruff format autofix via autofix.ci
-        if: steps.changed.outputs.files != ''
-        uses: autofix-ci/action@v1.3.1
-        with:
-          commit-message: "style: ruff format (auto)"
-
       - name: Ruff lint (no autofix)
         if: steps.changed.outputs.files != ''
         run: |
@@ -84,6 +63,8 @@ jobs:
           # safe-classified fixes still include things like F401 (unused
           # imports), which can break side-effect imports used by the
           # connector registration pattern.
+          # Formatting is enforced + auto-applied by the separate
+          # `.github/workflows/autofix.ci.yml` workflow.
           uv run ruff check --no-fix --output-format=github ${{ steps.changed.outputs.files }}
 
       - name: Mypy


### PR DESCRIPTION
Introduce .github/workflows/autofix.ci.yml to run ruff format on changed Python files and apply fixes via the autofix-ci GitHub App. The new workflow checks out the PR, installs uv and Python, computes changed .py files, runs `ruff format` in-place, and calls autofix-ci/action to push formatted commits.

Update lint-backend.yml to remove the in-place formatting, autofix action, and the related read-only permissions, leaving the lint job focused on non-fixing ruff checks and mypy. This separates formatting auto-application from strict lint/mypy checks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated code formatting workflow that runs on pull requests with Python changes.
  * Refactored code quality pipeline to separate formatting from linting checks.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1574)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->