### PR TITLE
fix: [RBAC Migration]Hydrate workspace config at startup

### DIFF
--- a/src/app/lifespan.py
+++ b/src/app/lifespan.py
@@ -224,9 +224,7 @@ async def run_shutdown(app: FastAPI):
         task.cancel()
     if background_tasks:
         await asyncio.gather(*background_tasks, return_exceptions=True)
-        logger.info(
-            "Background tasks cancelled at shutdown", count=len(background_tasks)
-        )
+        logger.info("Background tasks cancelled at shutdown", count=len(background_tasks))
 
     # Drain any pending workspace_config DB-mirror tasks before we
     # tear down the engine. Without this, a save_config triggered

--- a/src/app/lifespan.py
+++ b/src/app/lifespan.py
@@ -176,6 +176,13 @@ async def run_startup(app: FastAPI):
         logger.error("Runtime DB migration failed", error=str(e))
         raise
 
+    try:
+        wcs = services.get("workspace_config_service")
+        if wcs is not None:
+            await wcs.hydrate_on_startup()
+    except Exception as e:
+        logger.error("Workspace config hydration failed at startup", error=str(e))
+
     await TelemetryClient.send_event(Category.APPLICATION_STARTUP, MessageId.ORB_APP_STARTED)
 
     # FastMCP requires its own lifespan to be entered before requests

--- a/src/services/workspace_config_service.py
+++ b/src/services/workspace_config_service.py
@@ -137,6 +137,19 @@ class WorkspaceConfigService:
         self._cm._config = None
         return await self.load_config()
 
+    async def hydrate_on_startup(self) -> None:
+        """Eagerly populate ``config_manager._config`` from the DB at
+        lifespan startup.
+
+        Without this, in `db` mode a restart leaves ``_config = None``
+        and the synchronous ``get_openrag_config()`` falls back to
+        defaults (no yaml exists) — so ``/api/settings`` reports
+        ``onboarding.current_step=0`` and the frontend flashes the
+        wizard on every restart. ``load_config()`` is itself mode-aware,
+        so this is safe to call unconditionally.
+        """
+        await self.load_config()
+
     async def is_onboarded(self) -> bool:
         mode = get_storage_mode()
         if mode == "files":

--- a/src/services/workspace_config_service.py
+++ b/src/services/workspace_config_service.py
@@ -291,8 +291,8 @@ class WorkspaceConfigService:
             cm._db_mirror_original_save = cm.save_config_file  # type: ignore[attr-defined]
             cm._db_mirror_original_update_ob = cm.update_onboarding_state  # type: ignore[attr-defined]
 
-        original_save = cm._db_mirror_original_save
-        original_update_ob = cm._db_mirror_original_update_ob
+        original_save = cm._db_mirror_original_save  # type: ignore[attr-defined]
+        original_update_ob = cm._db_mirror_original_update_ob  # type: ignore[attr-defined]
 
         def patched_save(config=None, preserve_edited: bool = False) -> bool:
             mode = get_storage_mode()

--- a/src/services/workspace_config_service.py
+++ b/src/services/workspace_config_service.py
@@ -25,7 +25,7 @@ In `files` mode the patch is not installed.
 from __future__ import annotations
 
 import asyncio
-from typing import Any, Optional
+from typing import Any
 
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
@@ -168,7 +168,7 @@ class WorkspaceConfigService:
             return False  # no yaml fallback in pure-db mode
         return self._cm.load_config().edited
 
-    async def get_onboarding_step(self) -> Optional[Any]:
+    async def get_onboarding_step(self) -> Any | None:
         """Returns the legacy step indicator — usually an int index from
         the OnboardingState dataclass, sometimes None. Treat as opaque."""
         mode = get_storage_mode()
@@ -194,10 +194,10 @@ class WorkspaceConfigService:
 
     async def save_config(
         self,
-        config: Optional[OpenRAGConfig] = None,
+        config: OpenRAGConfig | None = None,
         *,
         preserve_edited: bool = False,
-        actor_user_id: Optional[str] = None,
+        actor_user_id: str | None = None,
     ) -> bool:
         mode = get_storage_mode()
 
@@ -230,7 +230,7 @@ class WorkspaceConfigService:
 
     async def update_onboarding_state(
         self,
-        actor_user_id: Optional[str] = None,
+        actor_user_id: str | None = None,
         **kwargs: Any,
     ) -> bool:
         mode = get_storage_mode()
@@ -334,7 +334,7 @@ class WorkspaceConfigService:
 
     def _apply_in_memory(
         self,
-        config: Optional[OpenRAGConfig],
+        config: OpenRAGConfig | None,
         preserve_edited: bool,
     ) -> None:
         """Mirror the in-process effects of ``ConfigManager.save_config_file``
@@ -386,7 +386,7 @@ class WorkspaceConfigService:
         self,
         config: OpenRAGConfig,
         *,
-        actor_user_id: Optional[str] = None,
+        actor_user_id: str | None = None,
     ) -> None:
         config_dict = config.to_dict()
 


### PR DESCRIPTION
Add WorkspaceConfigService.hydrate_on_startup() which calls load_config() to eagerly populate the config manager from the DB during application startup. Call this method from the app lifespan (run_startup) and log errors if hydration fails. This prevents a DB-mode restart from leaving the in-memory config unset and causing the frontend onboarding wizard to reappear; load_config() is mode-aware, so invoking it unconditionally is safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now eagerly preloads workspace configuration at startup so stored settings are available immediately after restart.

* **Bug Fixes**
  * Prevents unexpected fallback to defaults or onboarding when a DB-backed config exists but wasn't yet loaded.

* **Chores**
  * Reduced shutdown log verbosity for background-task cancellation.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1575)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->