### PR TITLE
feat: Include openrag-documents in backend image

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -47,6 +47,7 @@ COPY cloud_securityconfig/ ./cloud_securityconfig/
 # starts empty (no users / conversations / session_ownership tables).
 COPY alembic.ini ./
 COPY alembic/ ./alembic/
+COPY openrag-documents/ ./openrag-documents/
 
 # -----------------------------------------------------------------------------
 # Stage: runtime (minimal image)


### PR DESCRIPTION
Add a COPY instruction to Dockerfile.backend to include the openrag-documents/ directory in the build. This ensures the documents are present in the backend image for use at build/runtime (e.g., migrations or serveable assets).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated backend deployment configuration to ensure document data is properly staged and available in the runtime environment.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1585)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->