### PR TITLE
feat: add infra-admin plane gated by OPENRAG_ENABLE_INFRA_ENDPOINTS

### DIFF
--- a/src/api/infra/__init__.py
+++ b/src/api/infra/__init__.py
@@ -1,0 +1,15 @@
+"""Infra-admin plane.
+
+Higher-privilege endpoints (OpenSearch security setup, post-bootstrap user
+provisioning) gated by either:
+
+  * a configurable JWT claim (SaaS / on_prem mode), or
+  * HTTP Basic auth (OSS mode)
+
+This plane bypasses the DB-resident RBAC at /api/admin/* entirely so an
+operator can bootstrap a fresh install before any user rows exist.
+"""
+
+from api.infra.endpoints import router
+
+__all__ = ["router"]

--- a/src/api/infra/auth.py
+++ b/src/api/infra/auth.py
@@ -1,0 +1,217 @@
+"""Auth dependency for the /api/infra/* plane.
+
+Pure JWT-claim (SaaS / on_prem) or HTTP Basic (OSS). No DB lookup, no
+RBAC. Returns an `InfraAdmin` dataclass identifying the principal so
+handlers can attribute audit_log rows.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import secrets
+from dataclasses import dataclass
+from typing import Any, Callable, Literal
+
+from fastapi import Depends, HTTPException, Request
+
+from config import settings as app_settings
+from dependencies import get_session_manager
+from utils.logging_config import get_logger
+from utils.run_mode_utils import get_run_mode, is_run_mode_oss
+
+logger = get_logger(__name__)
+
+
+@dataclass(frozen=True)
+class InfraAdmin:
+    """A principal authorized to call the infra plane."""
+
+    subject: str  # JWT `sub` (or `user_id`) or basic-auth username
+    source: Literal["jwt", "basic"]
+
+
+def _flatten_claim(claim: Any) -> set[str]:
+    """Reduce a JWT claim to a flat set of strings for membership testing.
+
+    Handles the common shapes operators throw at us:
+      * ``"Manager"`` -> ``{"Manager"}``
+      * ``["Manager", "User"]`` -> ``{"Manager", "User"}``
+      * ``[{"name": "Manager"}, {"name": "User"}]`` -> ``{"Manager", "User"}``
+      * ``{"name": "Manager"}`` -> ``{"Manager"}``
+
+    Anything else returns ``set()`` and is logged at INFO with the claim's
+    type so operators can debug an IdP that hands us a stranger shape.
+    """
+    if claim is None:
+        return set()
+    if isinstance(claim, str):
+        return {claim}
+    if isinstance(claim, list):
+        out: set[str] = set()
+        for item in claim:
+            if isinstance(item, str):
+                out.add(item)
+            elif isinstance(item, dict) and isinstance(item.get("name"), str):
+                out.add(item["name"])
+        return out
+    if isinstance(claim, dict) and isinstance(claim.get("name"), str):
+        return {claim["name"]}
+    logger.info(
+        "Infra admin JWT claim has unrecognized shape; treating as empty",
+        claim_type=type(claim).__name__,
+    )
+    return set()
+
+
+def _accepted_claim_values() -> set[str]:
+    raw = app_settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES or ""
+    return {v.strip() for v in raw.split(",") if v.strip()}
+
+
+def _bearer_token(request: Request) -> str | None:
+    header = request.headers.get("Authorization", "")
+    if header.startswith("Bearer "):
+        return header[len("Bearer ") :]
+    return None
+
+
+def _verify_jwt(request: Request, session_manager) -> InfraAdmin:
+    token = request.cookies.get("auth_token") or _bearer_token(request)
+    if not token:
+        raise HTTPException(status_code=401, detail={"error": "infra_auth_required"})
+    payload = session_manager.verify_token(token)
+    if not payload:
+        raise HTTPException(status_code=401, detail={"error": "invalid_token"})
+
+    claim_name = app_settings.OPENRAG_INFRA_ADMIN_CLAIM
+    accepted = _accepted_claim_values()
+    if not accepted:
+        # Misconfiguration: claim values list is empty. Fail closed so
+        # we don't silently let everyone with a valid token through.
+        raise HTTPException(
+            status_code=503,
+            detail={"error": "infra_admin_claim_values_unset"},
+        )
+
+    have = _flatten_claim(payload.get(claim_name))
+    if not (have & accepted):
+        raise HTTPException(status_code=403, detail={"error": "infra_role_required"})
+
+    subject = (
+        payload.get("sub")
+        or payload.get("user_id")
+        or payload.get("preferred_username")
+        or "unknown"
+    )
+    return InfraAdmin(subject=str(subject), source="jwt")
+
+
+def _scheme_from_request(request: Request) -> str:
+    """Effective scheme, honoring X-Forwarded-Proto from a TLS-terminating proxy."""
+    forwarded = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+    if forwarded:
+        return forwarded
+    return (request.url.scheme or "").lower()
+
+
+def _is_local_host(request: Request) -> bool:
+    host = (request.client.host if request.client else "") or ""
+    return host in {"127.0.0.1", "::1", "localhost"}
+
+
+def _enforce_https_or_local(request: Request) -> None:
+    if app_settings.OPENRAG_INFRA_ALLOW_INSECURE:
+        return
+    if _scheme_from_request(request) == "https":
+        return
+    if _is_local_host(request):
+        return
+    raise HTTPException(
+        status_code=426,
+        detail={
+            "error": "https_required",
+            "message": (
+                "Infra basic auth requires HTTPS. Set OPENRAG_INFRA_ALLOW_INSECURE=true "
+                "to permit plain HTTP (only behind a trusted proxy)."
+            ),
+        },
+    )
+
+
+def _verify_basic(request: Request) -> InfraAdmin:
+    _enforce_https_or_local(request)
+
+    header = request.headers.get("Authorization", "")
+    if not header.startswith("Basic "):
+        raise HTTPException(
+            status_code=401,
+            detail={"error": "basic_auth_required"},
+            headers={"WWW-Authenticate": 'Basic realm="infra"'},
+        )
+
+    encoded = header[len("Basic ") :].strip()
+    try:
+        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
+    except (binascii.Error, UnicodeDecodeError):
+        raise HTTPException(
+            status_code=401,
+            detail={"error": "invalid_basic_auth"},
+            headers={"WWW-Authenticate": 'Basic realm="infra"'},
+        )
+
+    if ":" not in decoded:
+        raise HTTPException(
+            status_code=401,
+            detail={"error": "invalid_basic_auth"},
+            headers={"WWW-Authenticate": 'Basic realm="infra"'},
+        )
+
+    username, password = decoded.split(":", 1)
+
+    expected_user = (
+        app_settings.OPENRAG_INFRA_ADMIN_USER or app_settings.OPENSEARCH_USERNAME or ""
+    )
+    expected_pw = (
+        app_settings.OPENRAG_INFRA_ADMIN_PASSWORD or app_settings.OPENSEARCH_PASSWORD or ""
+    )
+    if not expected_user or not expected_pw:
+        raise HTTPException(
+            status_code=503,
+            detail={"error": "infra_admin_credentials_not_configured"},
+        )
+
+    if not (
+        secrets.compare_digest(username, expected_user)
+        and secrets.compare_digest(password, expected_pw)
+    ):
+        raise HTTPException(
+            status_code=401,
+            detail={"error": "invalid_credentials"},
+            headers={"WWW-Authenticate": 'Basic realm="infra"'},
+        )
+
+    return InfraAdmin(subject=username, source="basic")
+
+
+def require_infra_admin() -> Callable[..., Any]:
+    """FastAPI dependency factory — matches the shape of require_permission().
+
+    Dispatches on run-mode at request time so that mode changes (e.g. an
+    operator flipping OPENRAG_RUN_MODE for a smoke test) take effect on the
+    next request rather than requiring a restart.
+    """
+
+    async def _dep(
+        request: Request,
+        session_manager=Depends(get_session_manager),
+    ) -> InfraAdmin:
+        if is_run_mode_oss():
+            return _verify_basic(request)
+        # saas / on_prem (and anything unrecognized, which run_mode_utils
+        # defaults to "oss" — so this branch is genuinely just JWT modes).
+        if get_run_mode() == "oss":
+            return _verify_basic(request)
+        return _verify_jwt(request, session_manager)
+
+    return _dep

--- a/src/api/infra/auth.py
+++ b/src/api/infra/auth.py
@@ -152,9 +152,7 @@ def _decode_jwt(request: Request, session_manager) -> Optional[dict]:
 def _verify_jwt(request: Request, session_manager) -> InfraAdmin:
     payload = _decode_jwt(request, session_manager)
     if not payload:
-        raise HTTPException(
-            status_code=401, detail={"error": "infra_auth_required"}
-        )
+        raise HTTPException(status_code=401, detail={"error": "infra_auth_required"})
 
     accepted = _accepted_claim_values()
     if not accepted:
@@ -168,9 +166,7 @@ def _verify_jwt(request: Request, session_manager) -> InfraAdmin:
     claim_name = app_settings.OPENRAG_INFRA_ADMIN_CLAIM
     have = _flatten_claim(payload.get(claim_name))
     if not (have & accepted):
-        raise HTTPException(
-            status_code=403, detail={"error": "infra_role_required"}
-        )
+        raise HTTPException(status_code=403, detail={"error": "infra_role_required"})
 
     subject = (
         payload.get("sub")
@@ -189,9 +185,7 @@ def _verify_jwt(request: Request, session_manager) -> InfraAdmin:
 
 def _scheme_from_request(request: Request) -> str:
     """Effective scheme, honoring X-Forwarded-Proto from a TLS-terminating proxy."""
-    forwarded = (
-        request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
-    )
+    forwarded = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
     if forwarded:
         return forwarded
     return (request.url.scheme or "").lower()
@@ -222,9 +216,7 @@ def _enforce_https_or_local(request: Request) -> None:
     )
 
 
-def _verify_basic(
-    request: Request, credentials: Optional[HTTPBasicCredentials]
-) -> InfraAdmin:
+def _verify_basic(request: Request, credentials: Optional[HTTPBasicCredentials]) -> InfraAdmin:
     _enforce_https_or_local(request)
 
     if credentials is None:
@@ -234,13 +226,9 @@ def _verify_basic(
             headers={"WWW-Authenticate": 'Basic realm="infra"'},
         )
 
-    expected_user = (
-        app_settings.OPENRAG_INFRA_ADMIN_USER or app_settings.OPENSEARCH_USERNAME or ""
-    )
+    expected_user = app_settings.OPENRAG_INFRA_ADMIN_USER or app_settings.OPENSEARCH_USERNAME or ""
     expected_pw = (
-        app_settings.OPENRAG_INFRA_ADMIN_PASSWORD
-        or app_settings.OPENSEARCH_PASSWORD
-        or ""
+        app_settings.OPENRAG_INFRA_ADMIN_PASSWORD or app_settings.OPENSEARCH_PASSWORD or ""
     )
     if not expected_user or not expected_pw:
         raise HTTPException(

--- a/src/api/infra/auth.py
+++ b/src/api/infra/auth.py
@@ -1,34 +1,56 @@
 """Auth dependency for the /api/infra/* plane.
 
-Pure JWT-claim (SaaS / on_prem) or HTTP Basic (OSS). No DB lookup, no
-RBAC. Returns an `InfraAdmin` dataclass identifying the principal so
-handlers can attribute audit_log rows.
+Dispatch is purely on OPENRAG_RUN_MODE:
+
+  * oss     -> HTTP Basic against OPENRAG_INFRA_ADMIN_USER /
+               OPENRAG_INFRA_ADMIN_PASSWORD (fallback to OPENSEARCH_USERNAME /
+               OPENSEARCH_PASSWORD). Uses FastAPI's HTTPBasic security.
+  * saas /
+    on_prem -> JWT mode. Reads the token from:
+                 - Authorization: Bearer <jwt>, OR
+                 - auth_token cookie (native OpenRAG JWT), OR
+                 - IBM session cookie (decoded without signature verification
+                   because Traefik / the upstream proxy validates it).
+               Then checks that OPENRAG_INFRA_ADMIN_CLAIM contains a value
+               from OPENRAG_INFRA_ADMIN_CLAIM_VALUES.
+
+No DB lookup, no RBAC. Returns an InfraAdmin dataclass so handlers can
+attribute audit_log rows.
 """
 
 from __future__ import annotations
 
-import base64
-import binascii
 import secrets
 from dataclasses import dataclass
-from typing import Any, Callable, Literal
+from typing import Any, Callable, Literal, Optional
 
 from fastapi import Depends, HTTPException, Request
+from fastapi.security import HTTPBasic, HTTPBasicCredentials
 
 from config import settings as app_settings
 from dependencies import get_session_manager
 from utils.logging_config import get_logger
-from utils.run_mode_utils import get_run_mode, is_run_mode_oss
+from utils.run_mode_utils import is_run_mode_oss
 
 logger = get_logger(__name__)
+
+
+# auto_error=False so we can raise a custom 401 detail body rather than
+# FastAPI's default "Not authenticated" string.
+_basic = HTTPBasic(realm="infra", auto_error=False)
 
 
 @dataclass(frozen=True)
 class InfraAdmin:
     """A principal authorized to call the infra plane."""
 
-    subject: str  # JWT `sub` (or `user_id`) or basic-auth username
+    subject: str  # JWT `sub` (or `user_id` / `username`) or basic-auth username
     source: Literal["jwt", "basic"]
+
+
+# ---------------------------------------------------------------------------
+# Claim flattening
+# ---------------------------------------------------------------------------
 
 
 def _flatten_claim(claim: Any) -> set[str]:
@@ -69,22 +91,71 @@ def _accepted_claim_values() -> set[str]:
     return {v.strip() for v in raw.split(",") if v.strip()}
 
 
-def _bearer_token(request: Request) -> str | None:
+# ---------------------------------------------------------------------------
+# JWT path (saas / on_prem)
+# ---------------------------------------------------------------------------
+
+
+def _bearer_token(request: Request) -> Optional[str]:
     header = request.headers.get("Authorization", "")
     if header.startswith("Bearer "):
         return header[len("Bearer ") :]
     return None
 
 
-def _verify_jwt(request: Request, session_manager) -> InfraAdmin:
-    token = request.cookies.get("auth_token") or _bearer_token(request)
-    if not token:
-        raise HTTPException(status_code=401, detail={"error": "infra_auth_required"})
-    payload = session_manager.verify_token(token)
-    if not payload:
-        raise HTTPException(status_code=401, detail={"error": "invalid_token"})
+def _ibm_session_cookie(request: Request) -> Optional[str]:
+    """Return the IBM session cookie value, if present.
 
-    claim_name = app_settings.OPENRAG_INFRA_ADMIN_CLAIM
+    The cookie name is configurable via IBM_SESSION_COOKIE_NAME. We read it
+    regardless of IBM_AUTH_ENABLED — the dispatch is on run-mode, and if a
+    CPD/IBM-fronted deployment sets the cookie we honour it. Decoding is
+    performed without signature verification because Traefik / the upstream
+    proxy validates the JWT before the backend ever sees it.
+    """
+    cookie_name = getattr(app_settings, "IBM_SESSION_COOKIE_NAME", None)
+    if not cookie_name:
+        return None
+    return request.cookies.get(cookie_name)
+
+
+def _decode_jwt(request: Request, session_manager) -> Optional[dict]:
+    """Try every supported JWT decoding strategy. Returns the payload or None.
+
+    Order:
+      1. Native OpenRAG JWT (Authorization: Bearer or auth_token cookie)
+         via session_manager.verify_token — fully signature-verified.
+      2. IBM session cookie via auth.ibm_auth.decode_ibm_jwt — UNVERIFIED;
+         trusts the upstream proxy. Only consulted when the native path
+         returns nothing.
+    """
+    native_token = _bearer_token(request) or request.cookies.get("auth_token")
+    if native_token:
+        try:
+            payload = session_manager.verify_token(native_token)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("Native JWT verify raised", error=str(exc))
+            payload = None
+        if payload:
+            return payload
+
+    ibm_token = _ibm_session_cookie(request)
+    if ibm_token:
+        # Imported lazily so the auth module has no hard dependency on the
+        # ibm_auth submodule for non-IBM deployments.
+        from auth.ibm_auth import decode_ibm_jwt
+
+        return decode_ibm_jwt(ibm_token)
+
+    return None
+
+
+def _verify_jwt(request: Request, session_manager) -> InfraAdmin:
+    payload = _decode_jwt(request, session_manager)
+    if not payload:
+        raise HTTPException(
+            status_code=401, detail={"error": "infra_auth_required"}
+        )
+
     accepted = _accepted_claim_values()
     if not accepted:
         # Misconfiguration: claim values list is empty. Fail closed so
@@ -94,22 +165,33 @@ def _verify_jwt(request: Request, session_manager) -> InfraAdmin:
             detail={"error": "infra_admin_claim_values_unset"},
         )
 
+    claim_name = app_settings.OPENRAG_INFRA_ADMIN_CLAIM
     have = _flatten_claim(payload.get(claim_name))
     if not (have & accepted):
-        raise HTTPException(status_code=403, detail={"error": "infra_role_required"})
+        raise HTTPException(
+            status_code=403, detail={"error": "infra_role_required"}
+        )
 
     subject = (
         payload.get("sub")
         or payload.get("user_id")
+        or payload.get("username")
         or payload.get("preferred_username")
         or "unknown"
     )
     return InfraAdmin(subject=str(subject), source="jwt")
 
 
+# ---------------------------------------------------------------------------
+# Basic-auth path (oss)
+# ---------------------------------------------------------------------------
+
+
 def _scheme_from_request(request: Request) -> str:
     """Effective scheme, honoring X-Forwarded-Proto from a TLS-terminating proxy."""
-    forwarded = request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+    forwarded = (
+        request.headers.get("x-forwarded-proto", "").split(",")[0].strip().lower()
+    )
     if forwarded:
         return forwarded
     return (request.url.scheme or "").lower()
@@ -132,48 +214,33 @@ def _enforce_https_or_local(request: Request) -> None:
         detail={
             "error": "https_required",
             "message": (
-                "Infra basic auth requires HTTPS. Set OPENRAG_INFRA_ALLOW_INSECURE=true "
-                "to permit plain HTTP (only behind a trusted proxy)."
+                "Infra basic auth requires HTTPS. Set "
+                "OPENRAG_INFRA_ALLOW_INSECURE=true to permit plain HTTP "
+                "(only behind a trusted proxy)."
             ),
         },
     )
 
 
-def _verify_basic(request: Request) -> InfraAdmin:
+def _verify_basic(
+    request: Request, credentials: Optional[HTTPBasicCredentials]
+) -> InfraAdmin:
     _enforce_https_or_local(request)
 
-    header = request.headers.get("Authorization", "")
-    if not header.startswith("Basic "):
+    if credentials is None:
         raise HTTPException(
             status_code=401,
             detail={"error": "basic_auth_required"},
             headers={"WWW-Authenticate": 'Basic realm="infra"'},
         )
 
-    encoded = header[len("Basic ") :].strip()
-    try:
-        decoded = base64.b64decode(encoded, validate=True).decode("utf-8")
-    except (binascii.Error, UnicodeDecodeError):
-        raise HTTPException(
-            status_code=401,
-            detail={"error": "invalid_basic_auth"},
-            headers={"WWW-Authenticate": 'Basic realm="infra"'},
-        )
-
-    if ":" not in decoded:
-        raise HTTPException(
-            status_code=401,
-            detail={"error": "invalid_basic_auth"},
-            headers={"WWW-Authenticate": 'Basic realm="infra"'},
-        )
-
-    username, password = decoded.split(":", 1)
-
     expected_user = (
         app_settings.OPENRAG_INFRA_ADMIN_USER or app_settings.OPENSEARCH_USERNAME or ""
     )
     expected_pw = (
-        app_settings.OPENRAG_INFRA_ADMIN_PASSWORD or app_settings.OPENSEARCH_PASSWORD or ""
+        app_settings.OPENRAG_INFRA_ADMIN_PASSWORD
+        or app_settings.OPENSEARCH_PASSWORD
+        or ""
     )
     if not expected_user or not expected_pw:
         raise HTTPException(
@@ -182,8 +249,8 @@ def _verify_basic(request: Request) -> InfraAdmin:
         )
 
     if not (
-        secrets.compare_digest(username, expected_user)
-        and secrets.compare_digest(password, expected_pw)
+        secrets.compare_digest(credentials.username, expected_user)
+        and secrets.compare_digest(credentials.password, expected_pw)
     ):
         raise HTTPException(
             status_code=401,
@@ -191,7 +258,12 @@ def _verify_basic(request: Request) -> InfraAdmin:
             headers={"WWW-Authenticate": 'Basic realm="infra"'},
         )
 
-    return InfraAdmin(subject=username, source="basic")
+    return InfraAdmin(subject=credentials.username, source="basic")
+
+
+# ---------------------------------------------------------------------------
+# Public dependency factory
+# ---------------------------------------------------------------------------
 
 
 def require_infra_admin() -> Callable[..., Any]:
@@ -200,18 +272,20 @@ def require_infra_admin() -> Callable[..., Any]:
     Dispatches on run-mode at request time so that mode changes (e.g. an
     operator flipping OPENRAG_RUN_MODE for a smoke test) take effect on the
     next request rather than requiring a restart.
+
+      * oss  -> HTTP Basic (FastAPI HTTPBasic).
+      * non-oss (saas / on_prem / anything else) -> JWT with role-claim check.
+        IBM_AUTH_ENABLED is NOT consulted; the JWT decoder transparently
+        falls back to the IBM session cookie when present.
     """
 
     async def _dep(
         request: Request,
+        credentials: Optional[HTTPBasicCredentials] = Depends(_basic),
         session_manager=Depends(get_session_manager),
     ) -> InfraAdmin:
         if is_run_mode_oss():
-            return _verify_basic(request)
-        # saas / on_prem (and anything unrecognized, which run_mode_utils
-        # defaults to "oss" — so this branch is genuinely just JWT modes).
-        if get_run_mode() == "oss":
-            return _verify_basic(request)
+            return _verify_basic(request, credentials)
         return _verify_jwt(request, session_manager)
 
     return _dep

--- a/src/api/infra/endpoints.py
+++ b/src/api/infra/endpoints.py
@@ -99,9 +99,7 @@ async def _replace_user_roles(
     for name in role_names:
         role = await role_repo.get_by_name(name)
         if role is None:
-            raise HTTPException(
-                status_code=400, detail={"error": "unknown_role", "name": name}
-            )
+            raise HTTPException(status_code=400, detail={"error": "unknown_role", "name": name})
         resolved_ids.append(role.id)
 
     current_roles = await role_repo.list_user_roles(user_id)
@@ -112,15 +110,11 @@ async def _replace_user_roles(
     # set doesn't include it, refuse when they're the only one left.
     if current_admin and not target_admin:
         if await role_repo.count_admins() <= 1:
-            raise HTTPException(
-                status_code=400, detail={"error": "cannot_remove_last_admin"}
-            )
+            raise HTTPException(status_code=400, detail={"error": "cannot_remove_last_admin"})
 
     # Drop existing UserRole rows, then re-assign. Done in one transaction
     # so the role set is never partially applied.
-    await session.execute(
-        UserRole.__table__.delete().where(UserRole.user_id == user_id)
-    )
+    await session.execute(UserRole.__table__.delete().where(UserRole.user_id == user_id))
     for rid in resolved_ids:
         await role_repo.assign_role(user_id, rid, granted_by=actor.subject)
     return role_names
@@ -165,8 +159,7 @@ async def opensearch_status(
     elif not configured_in_db and not role_present:
         status = "unconfigured"
         message = (
-            "OpenSearch security has not been configured. "
-            "Run POST /api/infra/opensearch/setup."
+            "OpenSearch security has not been configured. Run POST /api/infra/opensearch/setup."
         )
     elif not configured_in_db and role_present:
         # Role exists (possibly applied by a prior install or out-of-band)
@@ -313,9 +306,7 @@ async def create_user(
         actor_user_id=None,
         target_type="user",
         target_id=row.id,
-        audit_metadata=_audit_metadata(
-            actor, {"email": body.email, "roles": assigned_roles}
-        ),
+        audit_metadata=_audit_metadata(actor, {"email": body.email, "roles": assigned_roles}),
         ip=request.client.host if request.client else None,
     )
     await session.commit()
@@ -428,9 +419,7 @@ async def delete_user(
     roles = await role_repo.list_user_roles(user_id)
     if any(r.name == "admin" for r in roles):
         if await role_repo.count_admins() <= 1:
-            raise HTTPException(
-                status_code=400, detail={"error": "cannot_delete_last_admin"}
-            )
+            raise HTTPException(status_code=400, detail={"error": "cannot_delete_last_admin"})
 
     deleted_provider = row.oauth_provider
     deleted_subject = row.oauth_subject
@@ -440,13 +429,9 @@ async def delete_user(
     # migration sets ON DELETE SET NULL but this is belt-and-suspenders
     # for deployments that haven't applied it.)
     await session.execute(
-        update(AuditLog)
-        .where(AuditLog.actor_user_id == user_id)
-        .values(actor_user_id=None)
+        update(AuditLog).where(AuditLog.actor_user_id == user_id).values(actor_user_id=None)
     )
-    await session.execute(
-        UserRole.__table__.delete().where(UserRole.user_id == user_id)
-    )
+    await session.execute(UserRole.__table__.delete().where(UserRole.user_id == user_id))
     from db.models import UserPreferences
 
     await session.execute(

--- a/src/api/infra/endpoints.py
+++ b/src/api/infra/endpoints.py
@@ -1,0 +1,468 @@
+"""Infra-admin endpoints.
+
+Mounted at /api/infra/* (via the Next.js proxy that strips the /api prefix,
+this module exposes /infra/* to FastAPI itself — same convention used by
+api/admin/rbac.py).
+
+All handlers depend on require_infra_admin() rather than require_permission(),
+bypassing DB-resident RBAC entirely so the plane is usable before any user
+rows exist.
+
+Audit rows are written with actor_user_id=None because the principal here
+may not (yet) correspond to a row in the users table. The subject and source
+are stored in audit_metadata under {actor, source}; the "infra." event prefix
+is the discriminator.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import update
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from api.infra.auth import InfraAdmin, require_infra_admin
+from api.infra.schemas import (
+    OpenSearchStatus,
+    UserCreateBody,
+    UserOut,
+    UserPatchBody,
+    UserRolesReplaceBody,
+)
+from config.settings import clients
+from db.models import AuditLog, User as UserRow, UserRole
+from db.repositories import AuditRepo, RoleRepo, UserRepo
+from db.repositories._helpers import email_lookup_hash
+from dependencies import get_db_session, get_rbac_service, invalidate_user_ensured_cache
+from services.opensearch_setup_status import (
+    get_last_setup_at,
+    get_openrag_user_role,
+    is_opensearch_security_configured,
+    mark_opensearch_security_configured,
+)
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Mounted under /infra; the Next.js proxy strips /api before forwarding.
+router = APIRouter(prefix="/infra", tags=["infra"])
+
+
+# Serialize concurrent setup attempts in this process. setup_opensearch_security
+# does a read-modify-write on the all_access mapping and would otherwise race.
+# Multi-worker deployments are still racy at the cluster level — operators
+# should treat the endpoint as "fire once."
+_setup_lock = asyncio.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _user_to_out(session: AsyncSession, row: UserRow) -> UserOut:
+    role_repo = RoleRepo(session)
+    roles = await role_repo.list_user_roles(row.id)
+    return UserOut(
+        id=row.id,
+        oauth_provider=row.oauth_provider,
+        oauth_subject=row.oauth_subject,
+        email=row.email,
+        display_name=row.display_name,
+        picture_url=row.picture_url,
+        is_active=row.is_active,
+        roles=[r.name for r in roles],
+        created_at=row.created_at.isoformat() if row.created_at else None,
+        last_login=row.last_login.isoformat() if row.last_login else None,
+    )
+
+
+def _audit_metadata(actor: InfraAdmin, extra: dict | None = None) -> dict:
+    md = {"actor": actor.subject, "source": actor.source}
+    if extra:
+        md.update(extra)
+    return md
+
+
+async def _replace_user_roles(
+    session: AsyncSession,
+    user_id: str,
+    role_names: List[str],
+    actor: InfraAdmin,
+) -> List[str]:
+    role_repo = RoleRepo(session)
+
+    resolved_ids: list[str] = []
+    for name in role_names:
+        role = await role_repo.get_by_name(name)
+        if role is None:
+            raise HTTPException(
+                status_code=400, detail={"error": "unknown_role", "name": name}
+            )
+        resolved_ids.append(role.id)
+
+    current_roles = await role_repo.list_user_roles(user_id)
+    current_admin = any(r.name == "admin" for r in current_roles)
+    target_admin = "admin" in role_names
+
+    # Last-admin guard. If the user currently holds admin and the new role
+    # set doesn't include it, refuse when they're the only one left.
+    if current_admin and not target_admin:
+        if await role_repo.count_admins() <= 1:
+            raise HTTPException(
+                status_code=400, detail={"error": "cannot_remove_last_admin"}
+            )
+
+    # Drop existing UserRole rows, then re-assign. Done in one transaction
+    # so the role set is never partially applied.
+    await session.execute(
+        UserRole.__table__.delete().where(UserRole.user_id == user_id)
+    )
+    for rid in resolved_ids:
+        await role_repo.assign_role(user_id, rid, granted_by=actor.subject)
+    return role_names
+
+
+# ---------------------------------------------------------------------------
+# OpenSearch status + setup
+# ---------------------------------------------------------------------------
+
+
+@router.get("/opensearch/status", response_model=OpenSearchStatus)
+async def opensearch_status(
+    actor: InfraAdmin = Depends(require_infra_admin()),
+) -> OpenSearchStatus:
+    """Report the OpenSearch security setup state.
+
+    Always returns HTTP 200 — this endpoint is informational, not a gate.
+    Frontend should poll and surface a banner when status != "healthy".
+    """
+    configured_in_db = await is_opensearch_security_configured()
+    last_setup = await get_last_setup_at()
+
+    role_present = False
+    live_error: str | None = None
+    try:
+        body = await get_openrag_user_role(clients.opensearch)
+        role_present = body is not None
+    except Exception as exc:  # noqa: BLE001
+        live_error = str(exc)
+
+    drift = configured_in_db and not role_present and live_error is None
+
+    if live_error:
+        status = "degraded"
+        message = f"OpenSearch unreachable: {live_error}"
+    elif drift:
+        status = "degraded"
+        message = (
+            "DB-recorded setup but the openrag_user_role is missing in OpenSearch. "
+            "Run POST /api/infra/opensearch/setup to repair."
+        )
+    elif not configured_in_db and not role_present:
+        status = "unconfigured"
+        message = (
+            "OpenSearch security has not been configured. "
+            "Run POST /api/infra/opensearch/setup."
+        )
+    elif not configured_in_db and role_present:
+        # Role exists (possibly applied by a prior install or out-of-band)
+        # but the DB row was never written. Treat as healthy; the setup
+        # endpoint will record the row on next run.
+        status = "healthy"
+        message = (
+            "OpenSearch security is configured (DB status row absent). "
+            "POST /api/infra/opensearch/setup to record the state."
+        )
+    else:
+        status = "healthy"
+        message = "OpenSearch security configured"
+
+    return OpenSearchStatus(
+        status=status,
+        configured=configured_in_db,
+        last_setup_at=last_setup.isoformat() if last_setup else None,
+        drift=drift,
+        message=message,
+    )
+
+
+@router.post("/opensearch/setup", response_model=OpenSearchStatus)
+async def opensearch_setup(
+    request: Request,
+    actor: InfraAdmin = Depends(require_infra_admin()),
+    session: AsyncSession = Depends(get_db_session),
+) -> OpenSearchStatus:
+    """Run OpenSearch security setup. Idempotent — also handles DLS updates.
+
+    Always reads the YAML config and PUTs to OpenSearch, then refreshes the
+    migration_status row. Concurrent calls in the same process serialize on
+    an asyncio.Lock to avoid the all_access read-modify-write race.
+    """
+    from utils.opensearch_utils import setup_opensearch_security
+
+    async with _setup_lock:
+        try:
+            await setup_opensearch_security(clients.opensearch)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("infra.opensearch.setup failed", error=str(exc))
+            await AuditRepo(session).write(
+                event="infra.opensearch.setup.failed",
+                actor_user_id=None,
+                target_type="opensearch",
+                target_id="security",
+                audit_metadata=_audit_metadata(actor, {"error": str(exc)}),
+                ip=request.client.host if request.client else None,
+            )
+            await session.commit()
+            raise HTTPException(
+                status_code=500,
+                detail={"error": "opensearch_setup_failed", "message": str(exc)},
+            )
+
+        await mark_opensearch_security_configured(notes=f"triggered_by={actor.source}")
+        await AuditRepo(session).write(
+            event="infra.opensearch.setup",
+            actor_user_id=None,
+            target_type="opensearch",
+            target_id="security",
+            audit_metadata=_audit_metadata(actor),
+            ip=request.client.host if request.client else None,
+        )
+        await session.commit()
+
+    return await opensearch_status(actor=actor)
+
+
+# ---------------------------------------------------------------------------
+# User CRUD
+# ---------------------------------------------------------------------------
+
+
+@router.get("/users", response_model=List[UserOut])
+async def list_users(
+    limit: int = 100,
+    offset: int = 0,
+    actor: InfraAdmin = Depends(require_infra_admin()),
+    session: AsyncSession = Depends(get_db_session),
+) -> List[UserOut]:
+    rows = await UserRepo(session).list_all(limit=limit, offset=offset)
+    return [await _user_to_out(session, r) for r in rows]
+
+
+@router.get("/users/{user_id}", response_model=UserOut)
+async def get_user(
+    user_id: str,
+    actor: InfraAdmin = Depends(require_infra_admin()),
+    session: AsyncSession = Depends(get_db_session),
+) -> UserOut:
+    row = await UserRepo(session).get_by_id(user_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail={"error": "user_not_found"})
+    return await _user_to_out(session, row)
+
+
+@router.post("/users", response_model=UserOut, status_code=201)
+async def create_user(
+    body: UserCreateBody,
+    request: Request,
+    actor: InfraAdmin = Depends(require_infra_admin()),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> UserOut:
+    """Create a user explicitly. The bootstrap path now that
+    OPENRAG_AUTO_FIRST_ADMIN can disable the implicit first-user-admin rule.
+
+    Accepts optional oauth_provider/oauth_subject so an operator can
+    pre-register a user matching the JWT subject the IdP will issue later.
+    Otherwise we synthesize provider="infra_provisioned" + subject=uuid.
+    """
+    if not body.email:
+        raise HTTPException(status_code=400, detail={"error": "email_required"})
+
+    user_repo = UserRepo(session)
+    if await user_repo.get_by_email(body.email):
+        raise HTTPException(status_code=409, detail={"error": "email_exists"})
+
+    provider = body.oauth_provider or "infra_provisioned"
+    subject = body.oauth_subject or str(uuid.uuid4())
+
+    if await user_repo.get_by_oauth(provider, subject):
+        raise HTTPException(status_code=409, detail={"error": "oauth_identity_exists"})
+
+    user_id = subject
+    row = UserRow(
+        id=user_id,
+        oauth_provider=provider,
+        oauth_subject=subject,
+        email=body.email,
+        email_lookup_hash=email_lookup_hash(body.email),
+        display_name=body.display_name,
+    )
+    await user_repo.add(row)
+
+    assigned_roles: list[str] = []
+    if body.roles:
+        assigned_roles = await _replace_user_roles(session, row.id, body.roles, actor)
+
+    await AuditRepo(session).write(
+        event="infra.user.created",
+        actor_user_id=None,
+        target_type="user",
+        target_id=row.id,
+        audit_metadata=_audit_metadata(
+            actor, {"email": body.email, "roles": assigned_roles}
+        ),
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate(row.id)
+    return await _user_to_out(session, row)
+
+
+@router.patch("/users/{user_id}", response_model=UserOut)
+async def patch_user(
+    user_id: str,
+    body: UserPatchBody,
+    request: Request,
+    actor: InfraAdmin = Depends(require_infra_admin()),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> UserOut:
+    user_repo = UserRepo(session)
+    role_repo = RoleRepo(session)
+    row = await user_repo.get_by_id(user_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail={"error": "user_not_found"})
+
+    changed: dict = {}
+
+    if body.is_active is False and row.is_active:
+        current_roles = await role_repo.list_user_roles(user_id)
+        if any(r.name == "admin" for r in current_roles):
+            if await role_repo.count_admins() <= 1:
+                raise HTTPException(
+                    status_code=400, detail={"error": "cannot_deactivate_last_admin"}
+                )
+
+    if body.is_active is not None and body.is_active != row.is_active:
+        row.is_active = body.is_active
+        changed["is_active"] = body.is_active
+
+    if body.display_name is not None and body.display_name != row.display_name:
+        row.display_name = body.display_name
+        changed["display_name"] = body.display_name
+
+    if body.roles is not None:
+        applied = await _replace_user_roles(session, row.id, body.roles, actor)
+        changed["roles"] = applied
+
+    if changed:
+        session.add(row)
+        await AuditRepo(session).write(
+            event="infra.user.updated",
+            actor_user_id=None,
+            target_type="user",
+            target_id=row.id,
+            audit_metadata=_audit_metadata(actor, {"changes": changed}),
+            ip=request.client.host if request.client else None,
+        )
+        await session.commit()
+        rbac.invalidate(row.id)
+        invalidate_user_ensured_cache(row.oauth_provider, row.oauth_subject)
+
+    return await _user_to_out(session, row)
+
+
+@router.put("/users/{user_id}/roles", response_model=UserOut)
+async def replace_user_roles(
+    user_id: str,
+    body: UserRolesReplaceBody,
+    request: Request,
+    actor: InfraAdmin = Depends(require_infra_admin()),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+) -> UserOut:
+    """Replace the user's full role set in a single call.
+
+    Different shape from /api/admin's per-role POST/DELETE pair — convenient
+    for operators scripting bulk changes.
+    """
+    user_repo = UserRepo(session)
+    row = await user_repo.get_by_id(user_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail={"error": "user_not_found"})
+
+    applied = await _replace_user_roles(session, row.id, body.roles, actor)
+
+    await AuditRepo(session).write(
+        event="infra.user.roles_replaced",
+        actor_user_id=None,
+        target_type="user",
+        target_id=row.id,
+        audit_metadata=_audit_metadata(actor, {"roles": applied}),
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate(row.id)
+    return await _user_to_out(session, row)
+
+
+@router.delete("/users/{user_id}")
+async def delete_user(
+    user_id: str,
+    request: Request,
+    actor: InfraAdmin = Depends(require_infra_admin()),
+    session: AsyncSession = Depends(get_db_session),
+    rbac=Depends(get_rbac_service),
+):
+    user_repo = UserRepo(session)
+    role_repo = RoleRepo(session)
+    row = await user_repo.get_by_id(user_id)
+    if row is None:
+        raise HTTPException(status_code=404, detail={"error": "user_not_found"})
+
+    roles = await role_repo.list_user_roles(user_id)
+    if any(r.name == "admin" for r in roles):
+        if await role_repo.count_admins() <= 1:
+            raise HTTPException(
+                status_code=400, detail={"error": "cannot_delete_last_admin"}
+            )
+
+    deleted_provider = row.oauth_provider
+    deleted_subject = row.oauth_subject
+
+    # Null out any historical audit_log rows that reference this user so
+    # the delete event we write below survives the FK cascade. (The 0005
+    # migration sets ON DELETE SET NULL but this is belt-and-suspenders
+    # for deployments that haven't applied it.)
+    await session.execute(
+        update(AuditLog)
+        .where(AuditLog.actor_user_id == user_id)
+        .values(actor_user_id=None)
+    )
+    await session.execute(
+        UserRole.__table__.delete().where(UserRole.user_id == user_id)
+    )
+    from db.models import UserPreferences
+
+    await session.execute(
+        UserPreferences.__table__.delete().where(UserPreferences.user_id == user_id)
+    )
+    await session.delete(row)
+
+    await AuditRepo(session).write(
+        event="infra.user.deleted",
+        actor_user_id=None,
+        target_type="user",
+        target_id=user_id,
+        audit_metadata=_audit_metadata(actor),
+        ip=request.client.host if request.client else None,
+    )
+    await session.commit()
+    rbac.invalidate(user_id)
+    invalidate_user_ensured_cache(deleted_provider, deleted_subject)
+    return {"success": True}

--- a/src/api/infra/schemas.py
+++ b/src/api/infra/schemas.py
@@ -1,0 +1,46 @@
+"""Pydantic shapes for the /api/infra/* plane."""
+
+from __future__ import annotations
+
+from typing import List, Literal, Optional
+
+from pydantic import BaseModel, Field
+
+
+class OpenSearchStatus(BaseModel):
+    status: Literal["healthy", "degraded", "unconfigured"]
+    configured: bool
+    last_setup_at: Optional[str] = None
+    drift: bool = False
+    message: str = ""
+
+
+class UserCreateBody(BaseModel):
+    email: str
+    display_name: Optional[str] = None
+    roles: List[str] = Field(default_factory=list)
+    oauth_provider: Optional[str] = None
+    oauth_subject: Optional[str] = None
+
+
+class UserPatchBody(BaseModel):
+    is_active: Optional[bool] = None
+    display_name: Optional[str] = None
+    roles: Optional[List[str]] = None
+
+
+class UserRolesReplaceBody(BaseModel):
+    roles: List[str]
+
+
+class UserOut(BaseModel):
+    id: str
+    oauth_provider: str
+    oauth_subject: str
+    email: Optional[str] = None
+    display_name: Optional[str] = None
+    picture_url: Optional[str] = None
+    is_active: bool
+    roles: List[str]
+    created_at: Optional[str] = None
+    last_login: Optional[str] = None

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -413,8 +413,7 @@ def register_internal_routes(app: FastAPI):
         import logging
 
         logging.getLogger(__name__).info(
-            "Infra-admin plane enabled at /api/infra/* "
-            "(OPENRAG_ENABLE_INFRA_ENDPOINTS=true)"
+            "Infra-admin plane enabled at /api/infra/* (OPENRAG_ENABLE_INFRA_ENDPOINTS=true)"
         )
 
     # ===== API Key Management Endpoints (JWT auth for UI) =====

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -399,6 +399,24 @@ def register_internal_routes(app: FastAPI):
     # Public — must work pre-auth so the onboarding wizard can render.
     app.include_router(config_api.router)
 
+    # ===== Infra-admin plane — gated by master flag =====
+    # /api/infra/* uses JWT-claim or basic-auth, NOT RBAC. Opt-in via env so
+    # default OSS installs are unchanged. Mounting happens here (and not in
+    # the infra package's import) so the master flag's effect is contained to
+    # a single line a reviewer can audit.
+    from config.settings import OPENRAG_ENABLE_INFRA_ENDPOINTS
+
+    if OPENRAG_ENABLE_INFRA_ENDPOINTS:
+        from api.infra import router as infra_router
+
+        app.include_router(infra_router)
+        import logging
+
+        logging.getLogger(__name__).info(
+            "Infra-admin plane enabled at /api/infra/* "
+            "(OPENRAG_ENABLE_INFRA_ENDPOINTS=true)"
+        )
+
     # ===== API Key Management Endpoints (JWT auth for UI) =====
     app.add_api_route("/keys", api_keys.list_keys_endpoint, methods=["GET"], tags=["internal"])
     app.add_api_route("/keys", api_keys.create_key_endpoint, methods=["POST"], tags=["internal"])

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -144,6 +144,37 @@ OPENRAG_INGEST_VIA_CHAT = os.getenv("OPENRAG_INGEST_VIA_CHAT", "false").lower() 
     "yes",
 )
 
+# ── Infra-admin plane (master flag + sub-flags) ──────────────────────────
+# Master kill-switch for the /api/infra/* router and the startup-gating
+# behaviour it enables. When false, the entire infra plane is inert:
+# router not mounted, startup auto-setup behaves as today, first-user-admin
+# runs as today. The two AUTO_* flags below are only consulted when this
+# master flag is true.
+OPENRAG_ENABLE_INFRA_ENDPOINTS = os.getenv("OPENRAG_ENABLE_INFRA_ENDPOINTS", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+OPENRAG_AUTO_OPENSEARCH_SETUP = os.getenv("OPENRAG_AUTO_OPENSEARCH_SETUP", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+OPENRAG_AUTO_FIRST_ADMIN = os.getenv("OPENRAG_AUTO_FIRST_ADMIN", "true").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+OPENRAG_INFRA_ADMIN_CLAIM = os.getenv("OPENRAG_INFRA_ADMIN_CLAIM", "roles")
+OPENRAG_INFRA_ADMIN_CLAIM_VALUES = os.getenv("OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager")
+OPENRAG_INFRA_ADMIN_USER = os.getenv("OPENRAG_INFRA_ADMIN_USER")
+OPENRAG_INFRA_ADMIN_PASSWORD = os.getenv("OPENRAG_INFRA_ADMIN_PASSWORD")
+OPENRAG_INFRA_ALLOW_INSECURE = os.getenv("OPENRAG_INFRA_ALLOW_INSECURE", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
+
 # Ingest sample data configuration
 INGEST_SAMPLE_DATA = os.getenv("INGEST_SAMPLE_DATA", "true").lower() in ("true", "1", "yes")
 

--- a/src/services/opensearch_setup_status.py
+++ b/src/services/opensearch_setup_status.py
@@ -1,0 +1,90 @@
+"""Persistence + drift detection for the OpenSearch security setup state.
+
+Status is tracked as a row in the existing `migration_status` table under
+the name "opensearch_security_v1". This keeps a single source of truth for
+"has the OpenSearch DLS / role / role-mapping bootstrap been applied" that
+the infra status endpoint can consult, regardless of whether the setup ran
+automatically at startup or was triggered manually via POST /api/infra/opensearch/setup.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import db.engine as _engine_mod
+from db.models import MigrationStatus
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+OPENSEARCH_SECURITY_V1 = "opensearch_security_v1"
+
+
+def _session_local():
+    """Resolve SessionLocal at call time so tests can monkeypatch db.engine."""
+    if _engine_mod.SessionLocal is None:
+        _engine_mod.init_engine()
+    assert _engine_mod.SessionLocal is not None
+    return _engine_mod.SessionLocal
+
+
+async def mark_opensearch_security_configured(notes: str = "") -> None:
+    """Upsert the migration_status row indicating setup has completed.
+
+    Safe to call multiple times — re-running setup refreshes `completed_at`
+    so the status endpoint reflects the latest successful run.
+    """
+    SessionLocal = _session_local()
+    async with SessionLocal() as session:
+        existing = await session.get(MigrationStatus, OPENSEARCH_SECURITY_V1)
+        if existing is None:
+            session.add(
+                MigrationStatus(
+                    name=OPENSEARCH_SECURITY_V1,
+                    completed_at=datetime.utcnow(),
+                    notes=notes[:2048],
+                )
+            )
+        else:
+            existing.completed_at = datetime.utcnow()
+            if notes:
+                existing.notes = notes[:2048]
+            session.add(existing)
+        await session.commit()
+
+
+async def get_last_setup_at() -> Optional[datetime]:
+    """Return the completed_at timestamp of the most recent setup, or None."""
+    SessionLocal = _session_local()
+    async with SessionLocal() as session:
+        row = await session.get(MigrationStatus, OPENSEARCH_SECURITY_V1)
+        return row.completed_at if row else None
+
+
+async def is_opensearch_security_configured() -> bool:
+    """True iff the migration_status row exists."""
+    return (await get_last_setup_at()) is not None
+
+
+async def get_openrag_user_role(opensearch_client) -> Optional[dict]:
+    """Return the live `openrag_user_role` body from OpenSearch, or None if absent.
+
+    Used by the infra status endpoint to detect drift between the DB-recorded
+    setup state and the actual OpenSearch security config. Returns None on 404
+    (role not found); re-raises other transport errors so the caller can
+    surface them as "degraded - unreachable".
+    """
+    try:
+        resp = await opensearch_client.transport.perform_request(
+            "GET", "/_plugins/_security/api/roles/openrag_user_role"
+        )
+    except Exception as exc:
+        msg = str(exc).lower()
+        if "404" in msg or "not_found" in msg or "not found" in msg:
+            return None
+        raise
+    if isinstance(resp, dict):
+        # OpenSearch returns either {"openrag_user_role": {...}} or {...}
+        return resp.get("openrag_user_role", resp)
+    return None

--- a/src/services/startup_orchestrator.py
+++ b/src/services/startup_orchestrator.py
@@ -70,9 +70,7 @@ async def startup_tasks(services):
         # Setup OpenSearch security (roles and mappings) after connection is established.
         # OPENRAG_AUTO_OPENSEARCH_SETUP is only consulted when the infra-endpoint
         # plane is enabled — otherwise today's auto-setup behaviour is preserved.
-        skip_auto_setup = (
-            OPENRAG_ENABLE_INFRA_ENDPOINTS and not OPENRAG_AUTO_OPENSEARCH_SETUP
-        )
+        skip_auto_setup = OPENRAG_ENABLE_INFRA_ENDPOINTS and not OPENRAG_AUTO_OPENSEARCH_SETUP
         if skip_auto_setup:
             logger.info(
                 "Auto OpenSearch security setup is disabled "

--- a/src/services/startup_orchestrator.py
+++ b/src/services/startup_orchestrator.py
@@ -9,6 +9,8 @@ server URLs, and reapplies user settings if Langflow flows were reset.
 from config.settings import (
     DISABLE_INGEST_WITH_LANGFLOW,
     FETCH_OPENRAG_DOCS_AT_STARTUP,
+    OPENRAG_AUTO_OPENSEARCH_SETUP,
+    OPENRAG_ENABLE_INFRA_ENDPOINTS,
     clients,
     get_openrag_config,
 )
@@ -65,17 +67,42 @@ async def startup_tasks(services):
         # Index will be created after onboarding when we know the embedding model
         await wait_for_opensearch()
 
-        # Setup OpenSearch security (roles and mappings) after connection is established
-        try:
-            from utils.opensearch_utils import setup_opensearch_security
-
-            await setup_opensearch_security(clients.opensearch)
-            logger.info("OpenSearch security configuration completed successfully")
-        except Exception as e:
-            logger.warning(
-                "Failed to setup OpenSearch security configuration - continuing anyway",
-                error=str(e),
+        # Setup OpenSearch security (roles and mappings) after connection is established.
+        # OPENRAG_AUTO_OPENSEARCH_SETUP is only consulted when the infra-endpoint
+        # plane is enabled — otherwise today's auto-setup behaviour is preserved.
+        skip_auto_setup = (
+            OPENRAG_ENABLE_INFRA_ENDPOINTS and not OPENRAG_AUTO_OPENSEARCH_SETUP
+        )
+        if skip_auto_setup:
+            logger.info(
+                "Auto OpenSearch security setup is disabled "
+                "(OPENRAG_AUTO_OPENSEARCH_SETUP=false). "
+                "Trigger it via POST /api/infra/opensearch/setup."
             )
+        else:
+            try:
+                from utils.opensearch_utils import setup_opensearch_security
+
+                await setup_opensearch_security(clients.opensearch)
+                logger.info("OpenSearch security configuration completed successfully")
+                # Record completion so the infra status endpoint reports
+                # "configured" regardless of how the setup was triggered.
+                try:
+                    from services.opensearch_setup_status import (
+                        mark_opensearch_security_configured,
+                    )
+
+                    await mark_opensearch_security_configured(notes="auto-startup")
+                except Exception as mark_error:
+                    logger.warning(
+                        "Failed to record opensearch_security_v1 migration status",
+                        error=str(mark_error),
+                    )
+            except Exception as e:
+                logger.warning(
+                    "Failed to setup OpenSearch security configuration - continuing anyway",
+                    error=str(e),
+                )
 
         if DISABLE_INGEST_WITH_LANGFLOW:
             await _ensure_opensearch_index()

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -143,8 +143,17 @@ async def _assign_bootstrap_or_default(
     audit_repo: AuditRepo,
     user_id: str,
 ) -> None:
+    # When the infra-endpoint plane is enabled AND first-admin auto-promotion
+    # is disabled, never assign the bootstrap admin role — the operator will
+    # create the admin explicitly via POST /api/infra/users. The master flag
+    # is checked first so default OSS installs keep today's behaviour even if
+    # OPENRAG_AUTO_FIRST_ADMIN is somehow stashed in the env.
+    from config.settings import OPENRAG_AUTO_FIRST_ADMIN, OPENRAG_ENABLE_INFRA_ENDPOINTS
+
+    skip_bootstrap = OPENRAG_ENABLE_INFRA_ENDPOINTS and not OPENRAG_AUTO_FIRST_ADMIN
+
     admin_count = await role_repo.count_admins()
-    if admin_count == 0:
+    if admin_count == 0 and not skip_bootstrap:
         admin_role = await role_repo.get_by_name("admin")
         if admin_role is None:
             logger.warning("admin role not seeded; skipping bootstrap assignment")

--- a/src/tui/config_fields.py
+++ b/src/tui/config_fields.py
@@ -273,6 +273,74 @@ CONFIG_SECTIONS: list[ConfigSection] = [
         ),
     ]),
 
+    # ── Infra Admin ─────────────────────────────────────────────
+    ConfigSection("Infra Admin", [
+        ConfigField(
+            "openrag_enable_infra_endpoints", "OPENRAG_ENABLE_INFRA_ENDPOINTS",
+            "Enable Infra Endpoints",
+            placeholder="false", default="false",
+            helper_text=(
+                "Master switch. When false, /api/infra/* is not mounted and "
+                "today's startup behaviour is preserved. The fields below "
+                "are only consulted when this is true."
+            ),
+        ),
+        ConfigField(
+            "openrag_auto_opensearch_setup", "OPENRAG_AUTO_OPENSEARCH_SETUP",
+            "Auto-run OpenSearch Setup",
+            placeholder="true", default="true",
+            helper_text=(
+                "Only consulted when infra endpoints are enabled. If false, "
+                "skip OpenSearch security setup at startup; trigger it via "
+                "POST /api/infra/opensearch/setup."
+            ),
+        ),
+        ConfigField(
+            "openrag_auto_first_admin", "OPENRAG_AUTO_FIRST_ADMIN",
+            "Auto-promote First User to Admin",
+            placeholder="true", default="true",
+            helper_text=(
+                "Only consulted when infra endpoints are enabled. If false, "
+                "first signed-in user gets the default role; create the "
+                "admin explicitly via POST /api/infra/users."
+            ),
+        ),
+        ConfigField(
+            "openrag_infra_admin_claim", "OPENRAG_INFRA_ADMIN_CLAIM",
+            "JWT Claim for Infra Access",
+            placeholder="roles", default="roles",
+            helper_text="JWT claim name that carries the role(s) (SaaS / on_prem mode).",
+        ),
+        ConfigField(
+            "openrag_infra_admin_claim_values", "OPENRAG_INFRA_ADMIN_CLAIM_VALUES",
+            "Accepted Claim Values",
+            placeholder="Manager", default="Manager",
+            helper_text="Comma-separated values; any match grants infra access.",
+        ),
+        ConfigField(
+            "openrag_infra_admin_user", "OPENRAG_INFRA_ADMIN_USER",
+            "OSS Basic-Auth Username",
+            placeholder="(falls back to OPENSEARCH_USERNAME)",
+            helper_text="OSS-only basic-auth username. Empty = fall back to OPENSEARCH_USERNAME.",
+        ),
+        ConfigField(
+            "openrag_infra_admin_password", "OPENRAG_INFRA_ADMIN_PASSWORD",
+            "OSS Basic-Auth Password",
+            placeholder="(falls back to OPENSEARCH_PASSWORD)",
+            secret=True,
+            helper_text="OSS-only basic-auth password. Empty = fall back to OPENSEARCH_PASSWORD.",
+        ),
+        ConfigField(
+            "openrag_infra_allow_insecure", "OPENRAG_INFRA_ALLOW_INSECURE",
+            "Allow Basic Auth over HTTP",
+            placeholder="false", default="false",
+            helper_text=(
+                "Permit OSS basic-auth over plain HTTP. Required only behind a "
+                "proxy that strips X-Forwarded-Proto and isn't on localhost."
+            ),
+        ),
+    ], advanced=True, gate_prompt="Configure Infra Admin endpoints?"),
+
     # ── Advanced ────────────────────────────────────────────────
     ConfigSection("Advanced", [
         ConfigField(

--- a/src/tui/config_fields.py
+++ b/src/tui/config_fields.py
@@ -44,311 +44,446 @@ class ConfigSection:
 
 CONFIG_SECTIONS: list[ConfigSection] = [
     # ── Security ────────────────────────────────────────────────
-    ConfigSection("Security", [
-        ConfigField(
-            "openrag_encryption_key", "OPENRAG_ENCRYPTION_KEY", "OpenRAG Master Key",
-            placeholder="Auto-generated secure Base64 key",
-            secret=True, required=True,
-            helper_text="32-byte Base64 key for securing your database credentials (auto-generates if empty)",
-        ),
-        ConfigField(
-            "openrag_tenant_id", "OPENRAG_TENANT_ID", "Tenant ID",
-            placeholder="openrag", default="openrag",
-            helper_text="Identifier for AAD tenant binding (default: openrag)",
-        ),
-        ConfigField(
-            "openrag_enforce_prerequisites", "OPENRAG_ENFORCE_PREREQUISITES", "Enforce Prerequisites",
-            placeholder="false", default="false",
-            advanced=True,
-            helper_text="If true, application will fail to start if the encryption key is missing",
-        ),
-    ]),
-
+    ConfigSection(
+        "Security",
+        [
+            ConfigField(
+                "openrag_encryption_key",
+                "OPENRAG_ENCRYPTION_KEY",
+                "OpenRAG Master Key",
+                placeholder="Auto-generated secure Base64 key",
+                secret=True,
+                required=True,
+                helper_text="32-byte Base64 key for securing your database credentials (auto-generates if empty)",
+            ),
+            ConfigField(
+                "openrag_tenant_id",
+                "OPENRAG_TENANT_ID",
+                "Tenant ID",
+                placeholder="openrag",
+                default="openrag",
+                helper_text="Identifier for AAD tenant binding (default: openrag)",
+            ),
+            ConfigField(
+                "openrag_enforce_prerequisites",
+                "OPENRAG_ENFORCE_PREREQUISITES",
+                "Enforce Prerequisites",
+                placeholder="false",
+                default="false",
+                advanced=True,
+                helper_text="If true, application will fail to start if the encryption key is missing",
+            ),
+        ],
+    ),
     # ── OpenSearch ──────────────────────────────────────────────
-    ConfigSection("OpenSearch", [
-        ConfigField(
-            "opensearch_password", "OPENSEARCH_PASSWORD", "Admin Password",
-            placeholder="Auto-generated secure password",
-            secret=True, required=True,
-            helper_text="Validate your password here: https://lowe.github.io/tryzxcvbn/",
-        ),
-        ConfigField(
-            "opensearch_username", "OPENSEARCH_USERNAME", "Admin Username",
-            placeholder="admin", default="admin",
-            helper_text="OpenSearch admin username (default: admin)",
-        ),
-        ConfigField(
-            "opensearch_host", "OPENSEARCH_HOST", "Host",
-            placeholder="opensearch", default="opensearch",
-            helper_text="Override for remote OpenSearch instances (default: opensearch)",
-        ),
-        ConfigField(
-            "opensearch_port", "OPENSEARCH_PORT", "Port",
-            placeholder="9200", default="9200",
-            helper_text="Override for remote OpenSearch instances (default: 9200)",
-        ),
-        ConfigField(
-            "opensearch_index_name", "OPENSEARCH_INDEX_NAME", "Index Name",
-            placeholder="documents", default="documents",
-            helper_text="Name of the index to use in OpenSearch",
-        ),
-    ]),
-
+    ConfigSection(
+        "OpenSearch",
+        [
+            ConfigField(
+                "opensearch_password",
+                "OPENSEARCH_PASSWORD",
+                "Admin Password",
+                placeholder="Auto-generated secure password",
+                secret=True,
+                required=True,
+                helper_text="Validate your password here: https://lowe.github.io/tryzxcvbn/",
+            ),
+            ConfigField(
+                "opensearch_username",
+                "OPENSEARCH_USERNAME",
+                "Admin Username",
+                placeholder="admin",
+                default="admin",
+                helper_text="OpenSearch admin username (default: admin)",
+            ),
+            ConfigField(
+                "opensearch_host",
+                "OPENSEARCH_HOST",
+                "Host",
+                placeholder="opensearch",
+                default="opensearch",
+                helper_text="Override for remote OpenSearch instances (default: opensearch)",
+            ),
+            ConfigField(
+                "opensearch_port",
+                "OPENSEARCH_PORT",
+                "Port",
+                placeholder="9200",
+                default="9200",
+                helper_text="Override for remote OpenSearch instances (default: 9200)",
+            ),
+            ConfigField(
+                "opensearch_index_name",
+                "OPENSEARCH_INDEX_NAME",
+                "Index Name",
+                placeholder="documents",
+                default="documents",
+                helper_text="Name of the index to use in OpenSearch",
+            ),
+        ],
+    ),
     # ── Langflow ────────────────────────────────────────────────
-    ConfigSection("Langflow", [
-        ConfigField(
-            "langflow_superuser_password", "LANGFLOW_SUPERUSER_PASSWORD",
-            "Admin Password",
-            placeholder="Langflow password", secret=True,
-            helper_text="Leave empty for autologin (no password required)",
-        ),
-        ConfigField(
-            "langflow_superuser", "LANGFLOW_SUPERUSER", "Admin Username",
-            placeholder="admin", default="admin",
-        ),
-        ConfigField(
-            "langflow_data_path", "LANGFLOW_DATA_PATH", "Data Path",
-            placeholder="~/.openrag/data/langflow-data",
-            default="$HOME/.openrag/data/langflow-data",
-            helper_text="Directory to persist Langflow flows and state across restarts",
-        ),
-        ConfigField(
-            "langflow_public_url", "LANGFLOW_PUBLIC_URL", "Public URL",
-            placeholder="http://localhost:7860",
-            helper_text="External URL for Langflow access",
-            advanced=True,
-        ),
-    ]),
-
+    ConfigSection(
+        "Langflow",
+        [
+            ConfigField(
+                "langflow_superuser_password",
+                "LANGFLOW_SUPERUSER_PASSWORD",
+                "Admin Password",
+                placeholder="Langflow password",
+                secret=True,
+                helper_text="Leave empty for autologin (no password required)",
+            ),
+            ConfigField(
+                "langflow_superuser",
+                "LANGFLOW_SUPERUSER",
+                "Admin Username",
+                placeholder="admin",
+                default="admin",
+            ),
+            ConfigField(
+                "langflow_data_path",
+                "LANGFLOW_DATA_PATH",
+                "Data Path",
+                placeholder="~/.openrag/data/langflow-data",
+                default="$HOME/.openrag/data/langflow-data",
+                helper_text="Directory to persist Langflow flows and state across restarts",
+            ),
+            ConfigField(
+                "langflow_public_url",
+                "LANGFLOW_PUBLIC_URL",
+                "Public URL",
+                placeholder="http://localhost:7860",
+                helper_text="External URL for Langflow access",
+                advanced=True,
+            ),
+        ],
+    ),
     # ── AI Providers ────────────────────────────────────────────
-    ConfigSection("AI Providers", [
-        ConfigField(
-            "openai_api_key", "OPENAI_API_KEY", "OpenAI API Key",
-            placeholder="sk-...", secret=True,
-            helper_text="Get a key: https://platform.openai.com/api-keys",
-            validator=validate_openai_api_key,
-            validator_error="Invalid OpenAI API key format (should start with sk-)",
-        ),
-        ConfigField(
-            "anthropic_api_key", "ANTHROPIC_API_KEY", "Anthropic API Key",
-            placeholder="sk-ant-...", secret=True,
-            helper_text="Get a key: https://console.anthropic.com/settings/keys",
-            validator=validate_anthropic_api_key,
-            validator_error="Invalid Anthropic API key format (should start with sk-ant-)",
-        ),
-        ConfigField(
-            "ollama_endpoint", "OLLAMA_ENDPOINT", "Ollama Base URL",
-            placeholder="http://localhost:11434",
-            helper_text="Endpoint of your Ollama server",
-            validator=validate_ollama_endpoint,
-            validator_error="Invalid Ollama endpoint URL format",
-        ),
-        ConfigField(
-            "watsonx_api_key", "WATSONX_API_KEY", "IBM watsonx.ai API Key",
-            placeholder="", secret=True,
-            helper_text="Get a key: https://cloud.ibm.com/iam/apikeys",
-        ),
-        ConfigField(
-            "watsonx_endpoint", "WATSONX_ENDPOINT", "IBM watsonx.ai Endpoint",
-            placeholder="https://us-south.ml.cloud.ibm.com",
-            helper_text="Example: https://us-south.ml.cloud.ibm.com",
-            validator=validate_watsonx_endpoint,
-            validator_error="Invalid watsonx.ai endpoint URL format",
-        ),
-        ConfigField(
-            "watsonx_project_id", "WATSONX_PROJECT_ID", "IBM watsonx.ai Project ID",
-            placeholder="",
-            helper_text="Find in your IBM Cloud project settings",
-        ),
-    ]),
-
+    ConfigSection(
+        "AI Providers",
+        [
+            ConfigField(
+                "openai_api_key",
+                "OPENAI_API_KEY",
+                "OpenAI API Key",
+                placeholder="sk-...",
+                secret=True,
+                helper_text="Get a key: https://platform.openai.com/api-keys",
+                validator=validate_openai_api_key,
+                validator_error="Invalid OpenAI API key format (should start with sk-)",
+            ),
+            ConfigField(
+                "anthropic_api_key",
+                "ANTHROPIC_API_KEY",
+                "Anthropic API Key",
+                placeholder="sk-ant-...",
+                secret=True,
+                helper_text="Get a key: https://console.anthropic.com/settings/keys",
+                validator=validate_anthropic_api_key,
+                validator_error="Invalid Anthropic API key format (should start with sk-ant-)",
+            ),
+            ConfigField(
+                "ollama_endpoint",
+                "OLLAMA_ENDPOINT",
+                "Ollama Base URL",
+                placeholder="http://localhost:11434",
+                helper_text="Endpoint of your Ollama server",
+                validator=validate_ollama_endpoint,
+                validator_error="Invalid Ollama endpoint URL format",
+            ),
+            ConfigField(
+                "watsonx_api_key",
+                "WATSONX_API_KEY",
+                "IBM watsonx.ai API Key",
+                placeholder="",
+                secret=True,
+                helper_text="Get a key: https://cloud.ibm.com/iam/apikeys",
+            ),
+            ConfigField(
+                "watsonx_endpoint",
+                "WATSONX_ENDPOINT",
+                "IBM watsonx.ai Endpoint",
+                placeholder="https://us-south.ml.cloud.ibm.com",
+                helper_text="Example: https://us-south.ml.cloud.ibm.com",
+                validator=validate_watsonx_endpoint,
+                validator_error="Invalid watsonx.ai endpoint URL format",
+            ),
+            ConfigField(
+                "watsonx_project_id",
+                "WATSONX_PROJECT_ID",
+                "IBM watsonx.ai Project ID",
+                placeholder="",
+                helper_text="Find in your IBM Cloud project settings",
+            ),
+        ],
+    ),
     # ── Google OAuth ────────────────────────────────────────────
-    ConfigSection("Google OAuth", [
-        ConfigField(
-            "google_oauth_client_id", "GOOGLE_OAUTH_CLIENT_ID", "Client ID",
-            placeholder="xxx.apps.googleusercontent.com",
-            helper_text="Create credentials: https://console.cloud.google.com/apis/credentials",
-        ),
-        ConfigField(
-            "google_oauth_client_secret", "GOOGLE_OAUTH_CLIENT_SECRET",
-            "Client Secret",
-            placeholder="", secret=True,
-        ),
-    ], advanced=True, gate_prompt="Configure Google OAuth?"),
-
+    ConfigSection(
+        "Google OAuth",
+        [
+            ConfigField(
+                "google_oauth_client_id",
+                "GOOGLE_OAUTH_CLIENT_ID",
+                "Client ID",
+                placeholder="xxx.apps.googleusercontent.com",
+                helper_text="Create credentials: https://console.cloud.google.com/apis/credentials",
+            ),
+            ConfigField(
+                "google_oauth_client_secret",
+                "GOOGLE_OAUTH_CLIENT_SECRET",
+                "Client Secret",
+                placeholder="",
+                secret=True,
+            ),
+        ],
+        advanced=True,
+        gate_prompt="Configure Google OAuth?",
+    ),
     # ── Microsoft Graph OAuth ───────────────────────────────────
-    ConfigSection("Microsoft Graph OAuth", [
-        ConfigField(
-            "microsoft_graph_oauth_client_id", "MICROSOFT_GRAPH_OAUTH_CLIENT_ID",
-            "Client ID",
-            placeholder="",
-            helper_text="Create app: https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
-        ),
-        ConfigField(
-            "microsoft_graph_oauth_client_secret",
-            "MICROSOFT_GRAPH_OAUTH_CLIENT_SECRET", "Client Secret",
-            placeholder="", secret=True,
-        ),
-    ], advanced=True, gate_prompt="Configure Microsoft Graph OAuth?"),
-
+    ConfigSection(
+        "Microsoft Graph OAuth",
+        [
+            ConfigField(
+                "microsoft_graph_oauth_client_id",
+                "MICROSOFT_GRAPH_OAUTH_CLIENT_ID",
+                "Client ID",
+                placeholder="",
+                helper_text="Create app: https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationsListBlade",
+            ),
+            ConfigField(
+                "microsoft_graph_oauth_client_secret",
+                "MICROSOFT_GRAPH_OAUTH_CLIENT_SECRET",
+                "Client Secret",
+                placeholder="",
+                secret=True,
+            ),
+        ],
+        advanced=True,
+        gate_prompt="Configure Microsoft Graph OAuth?",
+    ),
     # ── AWS ─────────────────────────────────────────────────────
-    ConfigSection("AWS", [
-        ConfigField(
-            "aws_access_key_id", "AWS_ACCESS_KEY_ID", "Access Key ID",
-            placeholder="",
-            helper_text="Create keys: https://console.aws.amazon.com/iam/home#/security_credentials",
-        ),
-        ConfigField(
-            "aws_secret_access_key", "AWS_SECRET_ACCESS_KEY", "Secret Access Key",
-            placeholder="", secret=True,
-        ),
-        ConfigField(
-            "aws_s3_endpoint", "AWS_S3_ENDPOINT", "S3 Endpoint URL (optional)",
-            placeholder="",
-            helper_text="Leave empty for AWS S3. For MinIO, R2, or other S3-compatible services, enter the endpoint URL.",
-        ),
-        ConfigField(
-            "aws_region", "AWS_REGION", "AWS Region (optional)",
-            placeholder="us-east-1",
-            default="us-east-1",
-            helper_text="AWS region (e.g. us-east-1, eu-west-1). Default: us-east-1.",
-        ),
-    ], advanced=True, gate_prompt="Configure AWS credentials?"),
-
+    ConfigSection(
+        "AWS",
+        [
+            ConfigField(
+                "aws_access_key_id",
+                "AWS_ACCESS_KEY_ID",
+                "Access Key ID",
+                placeholder="",
+                helper_text="Create keys: https://console.aws.amazon.com/iam/home#/security_credentials",
+            ),
+            ConfigField(
+                "aws_secret_access_key",
+                "AWS_SECRET_ACCESS_KEY",
+                "Secret Access Key",
+                placeholder="",
+                secret=True,
+            ),
+            ConfigField(
+                "aws_s3_endpoint",
+                "AWS_S3_ENDPOINT",
+                "S3 Endpoint URL (optional)",
+                placeholder="",
+                helper_text="Leave empty for AWS S3. For MinIO, R2, or other S3-compatible services, enter the endpoint URL.",
+            ),
+            ConfigField(
+                "aws_region",
+                "AWS_REGION",
+                "AWS Region (optional)",
+                placeholder="us-east-1",
+                default="us-east-1",
+                helper_text="AWS region (e.g. us-east-1, eu-west-1). Default: us-east-1.",
+            ),
+        ],
+        advanced=True,
+        gate_prompt="Configure AWS credentials?",
+    ),
     # ── IBM Cloud Object Storage ─────────────────────────────────
-    ConfigSection("IBM Cloud Object Storage", [
-        ConfigField(
-            "ibm_cos_api_key", "IBM_COS_API_KEY", "API Key",
-            placeholder="",
-            helper_text="Create API key at https://cloud.ibm.com/iam/apikeys",
-            secret=True,
-        ),
-        ConfigField(
-            "ibm_cos_service_instance_id", "IBM_COS_SERVICE_INSTANCE_ID",
-            "Service Instance ID (CRN)",
-            placeholder="crn:v1:bluemix:...",
-        ),
-        ConfigField(
-            "ibm_cos_endpoint", "IBM_COS_ENDPOINT", "Service Endpoint",
-            placeholder="https://s3.us-south.cloud-object-storage.appdomain.cloud",
-            helper_text="Endpoints: https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-endpoints",
-        ),
-        ConfigField(
-            "ibm_cos_hmac_access_key_id", "IBM_COS_HMAC_ACCESS_KEY_ID",
-            "HMAC Access Key ID (optional)",
-            placeholder="",
-        ),
-        ConfigField(
-            "ibm_cos_hmac_secret_access_key", "IBM_COS_HMAC_SECRET_ACCESS_KEY",
-            "HMAC Secret Access Key (optional)",
-            placeholder="", secret=True,
-        ),
-    ], advanced=True, gate_prompt="Configure IBM Cloud Object Storage?"),
-
+    ConfigSection(
+        "IBM Cloud Object Storage",
+        [
+            ConfigField(
+                "ibm_cos_api_key",
+                "IBM_COS_API_KEY",
+                "API Key",
+                placeholder="",
+                helper_text="Create API key at https://cloud.ibm.com/iam/apikeys",
+                secret=True,
+            ),
+            ConfigField(
+                "ibm_cos_service_instance_id",
+                "IBM_COS_SERVICE_INSTANCE_ID",
+                "Service Instance ID (CRN)",
+                placeholder="crn:v1:bluemix:...",
+            ),
+            ConfigField(
+                "ibm_cos_endpoint",
+                "IBM_COS_ENDPOINT",
+                "Service Endpoint",
+                placeholder="https://s3.us-south.cloud-object-storage.appdomain.cloud",
+                helper_text="Endpoints: https://cloud.ibm.com/docs/cloud-object-storage?topic=cloud-object-storage-endpoints",
+            ),
+            ConfigField(
+                "ibm_cos_hmac_access_key_id",
+                "IBM_COS_HMAC_ACCESS_KEY_ID",
+                "HMAC Access Key ID (optional)",
+                placeholder="",
+            ),
+            ConfigField(
+                "ibm_cos_hmac_secret_access_key",
+                "IBM_COS_HMAC_SECRET_ACCESS_KEY",
+                "HMAC Secret Access Key (optional)",
+                placeholder="",
+                secret=True,
+            ),
+        ],
+        advanced=True,
+        gate_prompt="Configure IBM Cloud Object Storage?",
+    ),
     # ── Langfuse ────────────────────────────────────────────────
-    ConfigSection("Langfuse", [
-        ConfigField(
-            "langfuse_secret_key", "LANGFUSE_SECRET_KEY", "Secret Key",
-            placeholder="sk-lf-...", secret=True,
-            helper_text="Get keys from your Langfuse project settings",
-        ),
-        ConfigField(
-            "langfuse_public_key", "LANGFUSE_PUBLIC_KEY", "Public Key",
-            placeholder="pk-lf-...", secret=True,
-        ),
-        ConfigField(
-            "langfuse_host", "LANGFUSE_HOST", "Host",
-            placeholder="https://cloud.langfuse.com",
-            helper_text="Leave empty for Langfuse Cloud, or set for self-hosted",
-        ),
-    ], gate_prompt="Configure Langfuse tracing?"),
-
+    ConfigSection(
+        "Langfuse",
+        [
+            ConfigField(
+                "langfuse_secret_key",
+                "LANGFUSE_SECRET_KEY",
+                "Secret Key",
+                placeholder="sk-lf-...",
+                secret=True,
+                helper_text="Get keys from your Langfuse project settings",
+            ),
+            ConfigField(
+                "langfuse_public_key",
+                "LANGFUSE_PUBLIC_KEY",
+                "Public Key",
+                placeholder="pk-lf-...",
+                secret=True,
+            ),
+            ConfigField(
+                "langfuse_host",
+                "LANGFUSE_HOST",
+                "Host",
+                placeholder="https://cloud.langfuse.com",
+                helper_text="Leave empty for Langfuse Cloud, or set for self-hosted",
+            ),
+        ],
+        gate_prompt="Configure Langfuse tracing?",
+    ),
     # ── Storage ─────────────────────────────────────────────────
-    ConfigSection("Storage", [
-        ConfigField(
-            "openrag_documents_paths", "OPENRAG_DOCUMENTS_PATHS", "Documents Paths",
-            placeholder="~/.openrag/documents",
-            default="$HOME/.openrag/documents",
-            helper_text="Directories containing documents to ingest (comma-separated)",
-        ),
-    ]),
-
+    ConfigSection(
+        "Storage",
+        [
+            ConfigField(
+                "openrag_documents_paths",
+                "OPENRAG_DOCUMENTS_PATHS",
+                "Documents Paths",
+                placeholder="~/.openrag/documents",
+                default="$HOME/.openrag/documents",
+                helper_text="Directories containing documents to ingest (comma-separated)",
+            ),
+        ],
+    ),
     # ── Infra Admin ─────────────────────────────────────────────
-    ConfigSection("Infra Admin", [
-        ConfigField(
-            "openrag_enable_infra_endpoints", "OPENRAG_ENABLE_INFRA_ENDPOINTS",
-            "Enable Infra Endpoints",
-            placeholder="false", default="false",
-            helper_text=(
-                "Master switch. When false, /api/infra/* is not mounted and "
-                "today's startup behaviour is preserved. The fields below "
-                "are only consulted when this is true."
+    ConfigSection(
+        "Infra Admin",
+        [
+            ConfigField(
+                "openrag_enable_infra_endpoints",
+                "OPENRAG_ENABLE_INFRA_ENDPOINTS",
+                "Enable Infra Endpoints",
+                placeholder="false",
+                default="false",
+                helper_text=(
+                    "Master switch. When false, /api/infra/* is not mounted and "
+                    "today's startup behaviour is preserved. The fields below "
+                    "are only consulted when this is true."
+                ),
             ),
-        ),
-        ConfigField(
-            "openrag_auto_opensearch_setup", "OPENRAG_AUTO_OPENSEARCH_SETUP",
-            "Auto-run OpenSearch Setup",
-            placeholder="true", default="true",
-            helper_text=(
-                "Only consulted when infra endpoints are enabled. If false, "
-                "skip OpenSearch security setup at startup; trigger it via "
-                "POST /api/infra/opensearch/setup."
+            ConfigField(
+                "openrag_auto_opensearch_setup",
+                "OPENRAG_AUTO_OPENSEARCH_SETUP",
+                "Auto-run OpenSearch Setup",
+                placeholder="true",
+                default="true",
+                helper_text=(
+                    "Only consulted when infra endpoints are enabled. If false, "
+                    "skip OpenSearch security setup at startup; trigger it via "
+                    "POST /api/infra/opensearch/setup."
+                ),
             ),
-        ),
-        ConfigField(
-            "openrag_auto_first_admin", "OPENRAG_AUTO_FIRST_ADMIN",
-            "Auto-promote First User to Admin",
-            placeholder="true", default="true",
-            helper_text=(
-                "Only consulted when infra endpoints are enabled. If false, "
-                "first signed-in user gets the default role; create the "
-                "admin explicitly via POST /api/infra/users."
+            ConfigField(
+                "openrag_auto_first_admin",
+                "OPENRAG_AUTO_FIRST_ADMIN",
+                "Auto-promote First User to Admin",
+                placeholder="true",
+                default="true",
+                helper_text=(
+                    "Only consulted when infra endpoints are enabled. If false, "
+                    "first signed-in user gets the default role; create the "
+                    "admin explicitly via POST /api/infra/users."
+                ),
             ),
-        ),
-        ConfigField(
-            "openrag_infra_admin_claim", "OPENRAG_INFRA_ADMIN_CLAIM",
-            "JWT Claim for Infra Access",
-            placeholder="roles", default="roles",
-            helper_text="JWT claim name that carries the role(s) (SaaS / on_prem mode).",
-        ),
-        ConfigField(
-            "openrag_infra_admin_claim_values", "OPENRAG_INFRA_ADMIN_CLAIM_VALUES",
-            "Accepted Claim Values",
-            placeholder="Manager", default="Manager",
-            helper_text="Comma-separated values; any match grants infra access.",
-        ),
-        ConfigField(
-            "openrag_infra_admin_user", "OPENRAG_INFRA_ADMIN_USER",
-            "OSS Basic-Auth Username",
-            placeholder="(falls back to OPENSEARCH_USERNAME)",
-            helper_text="OSS-only basic-auth username. Empty = fall back to OPENSEARCH_USERNAME.",
-        ),
-        ConfigField(
-            "openrag_infra_admin_password", "OPENRAG_INFRA_ADMIN_PASSWORD",
-            "OSS Basic-Auth Password",
-            placeholder="(falls back to OPENSEARCH_PASSWORD)",
-            secret=True,
-            helper_text="OSS-only basic-auth password. Empty = fall back to OPENSEARCH_PASSWORD.",
-        ),
-        ConfigField(
-            "openrag_infra_allow_insecure", "OPENRAG_INFRA_ALLOW_INSECURE",
-            "Allow Basic Auth over HTTP",
-            placeholder="false", default="false",
-            helper_text=(
-                "Permit OSS basic-auth over plain HTTP. Required only behind a "
-                "proxy that strips X-Forwarded-Proto and isn't on localhost."
+            ConfigField(
+                "openrag_infra_admin_claim",
+                "OPENRAG_INFRA_ADMIN_CLAIM",
+                "JWT Claim for Infra Access",
+                placeholder="roles",
+                default="roles",
+                helper_text="JWT claim name that carries the role(s) (SaaS / on_prem mode).",
             ),
-        ),
-    ], advanced=True, gate_prompt="Configure Infra Admin endpoints?"),
-
+            ConfigField(
+                "openrag_infra_admin_claim_values",
+                "OPENRAG_INFRA_ADMIN_CLAIM_VALUES",
+                "Accepted Claim Values",
+                placeholder="Manager",
+                default="Manager",
+                helper_text="Comma-separated values; any match grants infra access.",
+            ),
+            ConfigField(
+                "openrag_infra_admin_user",
+                "OPENRAG_INFRA_ADMIN_USER",
+                "OSS Basic-Auth Username",
+                placeholder="(falls back to OPENSEARCH_USERNAME)",
+                helper_text="OSS-only basic-auth username. Empty = fall back to OPENSEARCH_USERNAME.",
+            ),
+            ConfigField(
+                "openrag_infra_admin_password",
+                "OPENRAG_INFRA_ADMIN_PASSWORD",
+                "OSS Basic-Auth Password",
+                placeholder="(falls back to OPENSEARCH_PASSWORD)",
+                secret=True,
+                helper_text="OSS-only basic-auth password. Empty = fall back to OPENSEARCH_PASSWORD.",
+            ),
+            ConfigField(
+                "openrag_infra_allow_insecure",
+                "OPENRAG_INFRA_ALLOW_INSECURE",
+                "Allow Basic Auth over HTTP",
+                placeholder="false",
+                default="false",
+                helper_text=(
+                    "Permit OSS basic-auth over plain HTTP. Required only behind a "
+                    "proxy that strips X-Forwarded-Proto and isn't on localhost."
+                ),
+            ),
+        ],
+        advanced=True,
+        gate_prompt="Configure Infra Admin endpoints?",
+    ),
     # ── Advanced ────────────────────────────────────────────────
-    ConfigSection("Advanced", [
-        ConfigField(
-            "webhook_base_url", "WEBHOOK_BASE_URL", "Webhook Base URL",
-            placeholder="https://your-domain.com",
-            helper_text="External URL for continuous ingestion webhooks",
-        ),
-    ], advanced=True),
+    ConfigSection(
+        "Advanced",
+        [
+            ConfigField(
+                "webhook_base_url",
+                "WEBHOOK_BASE_URL",
+                "Webhook Base URL",
+                placeholder="https://your-domain.com",
+                helper_text="External URL for continuous ingestion webhooks",
+            ),
+        ],
+        advanced=True,
+    ),
 ]
 
 

--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -121,13 +121,14 @@ class EnvManager:
     """Manages environment configuration for OpenRAG."""
 
     assignment_pattern = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=")
-    
+
     def __init__(self, env_file: Optional[Path] = None):
         if env_file:
             self.env_file = env_file
         else:
             # Use centralized location for TUI .env file
             from utils.paths import get_tui_env_file, get_legacy_paths
+
             self.env_file = get_tui_env_file()
 
             # Check for legacy .env in current directory and migrate if needed
@@ -135,17 +136,17 @@ class EnvManager:
             if not self.env_file.exists() and legacy_env.exists():
                 try:
                     import shutil
+
                     self.env_file.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(legacy_env, self.env_file)
                     os.chmod(self.env_file, 0o600)
                     logger.info(f"Migrated .env from {legacy_env} to {self.env_file}")
 
-
                 except Exception as e:
                     logger.warning(f"Failed to migrate .env file: {e}")
 
         self.config = EnvConfig()
-        
+
     def generate_secure_password(self) -> str:
         """Generate a secure password for OpenSearch."""
         # Ensure at least one character from each category
@@ -175,6 +176,7 @@ class EnvManager:
     def generate_openrag_encryption_key(self) -> str:
         """Generate a secure AES-256 base64 master key for OpenRAG."""
         import base64
+
         return base64.b64encode(secrets.token_bytes(32)).decode("ascii")
 
     def _quote_env_value(self, value: str) -> str:
@@ -331,6 +333,7 @@ class EnvManager:
         if not self.config.openrag_version:
             try:
                 from ..utils.version_check import get_current_version
+
                 current_version = get_current_version()
                 if current_version != "unknown":
                     self.config.openrag_version = current_version
@@ -392,17 +395,13 @@ class EnvManager:
 
         # Validate documents paths only if provided (optional)
         if self.config.openrag_documents_paths:
-            is_valid, error_msg, _ = validate_documents_paths(
-                self.config.openrag_documents_paths
-            )
+            is_valid, error_msg, _ = validate_documents_paths(self.config.openrag_documents_paths)
             if not is_valid:
                 self.config.validation_errors["openrag_documents_paths"] = error_msg
 
         # Validate required fields
         if not validate_non_empty(self.config.opensearch_password):
-            self.config.validation_errors["opensearch_password"] = (
-                "OpenSearch password is required"
-            )
+            self.config.validation_errors["opensearch_password"] = "OpenSearch password is required"
 
         # Langflow secret key is auto-generated; no user input required
 
@@ -410,11 +409,8 @@ class EnvManager:
 
         if mode == "full":
             # Validate OAuth settings if provided
-            if (
+            if self.config.google_oauth_client_id and not validate_google_oauth_client_id(
                 self.config.google_oauth_client_id
-                and not validate_google_oauth_client_id(
-                    self.config.google_oauth_client_id
-                )
             ):
                 self.config.validation_errors["google_oauth_client_id"] = (
                     "Invalid Google OAuth client ID format"
@@ -435,12 +431,8 @@ class EnvManager:
                 )
 
             # Validate optional URLs if provided
-            if self.config.webhook_base_url and not validate_url(
-                self.config.webhook_base_url
-            ):
-                self.config.validation_errors["webhook_base_url"] = (
-                    "Invalid webhook URL format"
-                )
+            if self.config.webhook_base_url and not validate_url(self.config.webhook_base_url):
+                self.config.validation_errors["webhook_base_url"] = "Invalid webhook URL format"
 
             if self.config.langflow_public_url and not validate_url(
                 self.config.langflow_public_url
@@ -472,34 +464,59 @@ class EnvManager:
 
                 # Core settings
                 f.write("# Core settings\n")
-                f.write(f"LANGFLOW_SECRET_KEY={self._quote_env_value(self.config.langflow_secret_key)}\n")
+                f.write(
+                    f"LANGFLOW_SECRET_KEY={self._quote_env_value(self.config.langflow_secret_key)}\n"
+                )
                 # Only write LANGFLOW_SUPERUSER and password if password is set
                 if self.config.langflow_superuser_password:
-                    f.write(f"LANGFLOW_SUPERUSER={self._quote_env_value(self.config.langflow_superuser)}\n")
+                    f.write(
+                        f"LANGFLOW_SUPERUSER={self._quote_env_value(self.config.langflow_superuser)}\n"
+                    )
                     f.write(
                         f"LANGFLOW_SUPERUSER_PASSWORD={self._quote_env_value(self.config.langflow_superuser_password)}\n"
                     )
-                f.write(f"LANGFLOW_CHAT_FLOW_ID={self._quote_env_value(self.config.langflow_chat_flow_id)}\n")
+                f.write(
+                    f"LANGFLOW_CHAT_FLOW_ID={self._quote_env_value(self.config.langflow_chat_flow_id)}\n"
+                )
                 f.write(
                     f"LANGFLOW_INGEST_FLOW_ID={self._quote_env_value(self.config.langflow_ingest_flow_id)}\n"
                 )
-                f.write(f"LANGFLOW_URL_INGEST_FLOW_ID={self._quote_env_value(self.config.langflow_url_ingest_flow_id)}\n")
+                f.write(
+                    f"LANGFLOW_URL_INGEST_FLOW_ID={self._quote_env_value(self.config.langflow_url_ingest_flow_id)}\n"
+                )
                 f.write(f"NUDGES_FLOW_ID={self._quote_env_value(self.config.nudges_flow_id)}\n")
-                f.write(f"OPENRAG_ENCRYPTION_KEY={self._quote_env_value(self.config.openrag_encryption_key)}\n")
-                f.write(f"OPENRAG_TENANT_ID={self._quote_env_value(self.config.openrag_tenant_id)}\n")
-                f.write(f"OPENRAG_ENFORCE_PREREQUISITES={self._quote_env_value(self.config.openrag_enforce_prerequisites)}\n")
-                f.write(f"OPENSEARCH_PASSWORD={self._quote_env_value(self.config.opensearch_password)}\n")
+                f.write(
+                    f"OPENRAG_ENCRYPTION_KEY={self._quote_env_value(self.config.openrag_encryption_key)}\n"
+                )
+                f.write(
+                    f"OPENRAG_TENANT_ID={self._quote_env_value(self.config.openrag_tenant_id)}\n"
+                )
+                f.write(
+                    f"OPENRAG_ENFORCE_PREREQUISITES={self._quote_env_value(self.config.openrag_enforce_prerequisites)}\n"
+                )
+                f.write(
+                    f"OPENSEARCH_PASSWORD={self._quote_env_value(self.config.opensearch_password)}\n"
+                )
                 if self.config.opensearch_username and self.config.opensearch_username != "admin":
-                    f.write(f"OPENSEARCH_USERNAME={self._quote_env_value(self.config.opensearch_username)}\n")
+                    f.write(
+                        f"OPENSEARCH_USERNAME={self._quote_env_value(self.config.opensearch_username)}\n"
+                    )
                 if self.config.opensearch_host and self.config.opensearch_host != "opensearch":
-                    f.write(f"OPENSEARCH_HOST={self._quote_env_value(self.config.opensearch_host)}\n")
+                    f.write(
+                        f"OPENSEARCH_HOST={self._quote_env_value(self.config.opensearch_host)}\n"
+                    )
                 if self.config.opensearch_port and self.config.opensearch_port != "9200":
-                    f.write(f"OPENSEARCH_PORT={self._quote_env_value(self.config.opensearch_port)}\n")
-                f.write(f"OPENSEARCH_INDEX_NAME={self._quote_env_value(self.config.opensearch_index_name)}\n")
+                    f.write(
+                        f"OPENSEARCH_PORT={self._quote_env_value(self.config.opensearch_port)}\n"
+                    )
+                f.write(
+                    f"OPENSEARCH_INDEX_NAME={self._quote_env_value(self.config.opensearch_index_name)}\n"
+                )
 
                 # Expand $HOME in paths before writing to .env
                 # This ensures paths work with all compose implementations (docker, podman)
                 from utils.paths import expand_path
+
                 f.write(
                     f"OPENRAG_DOCUMENTS_PATHS={self._quote_env_value(expand_path(self.config.openrag_documents_paths))}\n"
                 )
@@ -527,11 +544,14 @@ class EnvManager:
                 )
                 # Set OPENRAG_VERSION to TUI version
                 if self.config.openrag_version:
-                    f.write(f"OPENRAG_VERSION={self._quote_env_value(self.config.openrag_version)}\n")
+                    f.write(
+                        f"OPENRAG_VERSION={self._quote_env_value(self.config.openrag_version)}\n"
+                    )
                 else:
                     # Fallback: try to get current version
                     try:
                         from ..utils.version_check import get_current_version
+
                         current_version = get_current_version()
                         if current_version != "unknown":
                             f.write(f"OPENRAG_VERSION={self._quote_env_value(current_version)}\n")
@@ -562,13 +582,19 @@ class EnvManager:
 
                 # Ingestion settings
                 f.write("# Ingestion settings\n")
-                f.write(f"DISABLE_INGEST_WITH_LANGFLOW={self._quote_env_value(self.config.disable_ingest_with_langflow)}\n")
-                f.write(f"INGEST_SAMPLE_DATA={self._quote_env_value(self.config.ingest_sample_data)}\n")
+                f.write(
+                    f"DISABLE_INGEST_WITH_LANGFLOW={self._quote_env_value(self.config.disable_ingest_with_langflow)}\n"
+                )
+                f.write(
+                    f"INGEST_SAMPLE_DATA={self._quote_env_value(self.config.ingest_sample_data)}\n"
+                )
                 f.write("\n")
 
                 # Langflow auth settings
                 f.write("# Langflow auth settings\n")
-                f.write(f"LANGFLOW_AUTO_LOGIN={self._quote_env_value(self.config.langflow_auto_login)}\n")
+                f.write(
+                    f"LANGFLOW_AUTO_LOGIN={self._quote_env_value(self.config.langflow_auto_login)}\n"
+                )
                 f.write(
                     f"LANGFLOW_NEW_USER_IS_ACTIVE={self._quote_env_value(self.config.langflow_new_user_is_active)}\n"
                 )
@@ -578,10 +604,7 @@ class EnvManager:
                 f.write("\n")
 
                 # OAuth settings
-                if (
-                    self.config.google_oauth_client_id
-                    or self.config.google_oauth_client_secret
-                ):
+                if self.config.google_oauth_client_id or self.config.google_oauth_client_secret:
                     f.write("# Google OAuth settings\n")
                     f.write(
                         f"GOOGLE_OAUTH_CLIENT_ID={self._quote_env_value(self.config.google_oauth_client_id)}\n"
@@ -652,17 +675,22 @@ class EnvManager:
                 # Infra-admin plane (only emit if explicitly enabled or any
                 # sub-field is set non-default; keeps default .env quiet).
                 infra_enabled = self.config.openrag_enable_infra_endpoints.lower() in (
-                    "true", "1", "yes"
+                    "true",
+                    "1",
+                    "yes",
                 )
-                infra_sub_set = any([
-                    self.config.openrag_infra_admin_user,
-                    self.config.openrag_infra_admin_password,
-                    self.config.openrag_auto_opensearch_setup.lower() not in ("true", "1", "yes"),
-                    self.config.openrag_auto_first_admin.lower() not in ("true", "1", "yes"),
-                    self.config.openrag_infra_admin_claim != "roles",
-                    self.config.openrag_infra_admin_claim_values != "Manager",
-                    self.config.openrag_infra_allow_insecure.lower() in ("true", "1", "yes"),
-                ])
+                infra_sub_set = any(
+                    [
+                        self.config.openrag_infra_admin_user,
+                        self.config.openrag_infra_admin_password,
+                        self.config.openrag_auto_opensearch_setup.lower()
+                        not in ("true", "1", "yes"),
+                        self.config.openrag_auto_first_admin.lower() not in ("true", "1", "yes"),
+                        self.config.openrag_infra_admin_claim != "roles",
+                        self.config.openrag_infra_admin_claim_values != "Manager",
+                        self.config.openrag_infra_allow_insecure.lower() in ("true", "1", "yes"),
+                    ]
+                )
                 if infra_enabled or infra_sub_set:
                     f.write("# Infra-admin plane\n")
                     f.write(
@@ -810,6 +838,7 @@ class EnvManager:
         """Ensure OPENRAG_VERSION is set in .env file to match TUI version."""
         try:
             from ..utils.version_check import get_current_version
+
             current_version = get_current_version()
             if current_version == "unknown":
                 return
@@ -836,7 +865,9 @@ class EnvManager:
                 for line in lines:
                     if line.strip().startswith("OPENRAG_VERSION"):
                         # Replace existing line
-                        new_lines.append(f"OPENRAG_VERSION={self._quote_env_value(current_version)}")
+                        new_lines.append(
+                            f"OPENRAG_VERSION={self._quote_env_value(current_version)}"
+                        )
                         updated = True
                     else:
                         new_lines.append(line)
@@ -848,19 +879,21 @@ class EnvManager:
                         if "LANGFLOW_DATA_PATH" in line:
                             insert_pos = i + 1
                             break
-                    new_lines.insert(insert_pos, f"OPENRAG_VERSION={self._quote_env_value(current_version)}")
+                    new_lines.insert(
+                        insert_pos, f"OPENRAG_VERSION={self._quote_env_value(current_version)}"
+                    )
 
                 fd = os.open(self.env_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
                 # Ensure pre-existing files get restricted permissions
                 os.chmod(self.env_file, 0o600)
-                with os.fdopen(fd, 'w') as f:
+                with os.fdopen(fd, "w") as f:
                     f.write("\n".join(new_lines) + "\n")
                     f.flush()
                     os.fsync(f.fileno())
             else:
                 # Create new .env file with just OPENRAG_VERSION
                 fd = os.open(self.env_file, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
-                with os.fdopen(fd, 'w') as f:
+                with os.fdopen(fd, "w") as f:
                     content = (
                         f"# OpenRAG Environment Configuration\n"
                         f"# Generated by OpenRAG TUI\n\n"

--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -103,6 +103,16 @@ class EnvConfig:
     # Container version (linked to TUI version)
     openrag_version: str = ""
 
+    # Infra-admin plane (master flag + sub-flags)
+    openrag_enable_infra_endpoints: str = "false"
+    openrag_auto_opensearch_setup: str = "true"
+    openrag_auto_first_admin: str = "true"
+    openrag_infra_admin_claim: str = "roles"
+    openrag_infra_admin_claim_values: str = "Manager"
+    openrag_infra_admin_user: str = ""
+    openrag_infra_admin_password: str = ""
+    openrag_infra_allow_insecure: str = "false"
+
     # Validation errors
     validation_errors: Dict[str, str] = field(default_factory=dict)
 
@@ -232,6 +242,14 @@ class EnvManager:
             "LANGFUSE_SECRET_KEY": "langfuse_secret_key",  # pragma: allowlist secret
             "LANGFUSE_PUBLIC_KEY": "langfuse_public_key",  # pragma: allowlist secret
             "LANGFUSE_HOST": "langfuse_host",
+            "OPENRAG_ENABLE_INFRA_ENDPOINTS": "openrag_enable_infra_endpoints",
+            "OPENRAG_AUTO_OPENSEARCH_SETUP": "openrag_auto_opensearch_setup",
+            "OPENRAG_AUTO_FIRST_ADMIN": "openrag_auto_first_admin",
+            "OPENRAG_INFRA_ADMIN_CLAIM": "openrag_infra_admin_claim",
+            "OPENRAG_INFRA_ADMIN_CLAIM_VALUES": "openrag_infra_admin_claim_values",
+            "OPENRAG_INFRA_ADMIN_USER": "openrag_infra_admin_user",
+            "OPENRAG_INFRA_ADMIN_PASSWORD": "openrag_infra_admin_password",  # pragma: allowlist secret
+            "OPENRAG_INFRA_ALLOW_INSECURE": "openrag_infra_allow_insecure",
         }
 
     def _collect_preserved_env_lines(self) -> list[str]:
@@ -629,6 +647,51 @@ class EnvManager:
                         f.write(f"{var_name}={self._quote_env_value(var_value)}\n")
 
                 if langfuse_written:
+                    f.write("\n")
+
+                # Infra-admin plane (only emit if explicitly enabled or any
+                # sub-field is set non-default; keeps default .env quiet).
+                infra_enabled = self.config.openrag_enable_infra_endpoints.lower() in (
+                    "true", "1", "yes"
+                )
+                infra_sub_set = any([
+                    self.config.openrag_infra_admin_user,
+                    self.config.openrag_infra_admin_password,
+                    self.config.openrag_auto_opensearch_setup.lower() not in ("true", "1", "yes"),
+                    self.config.openrag_auto_first_admin.lower() not in ("true", "1", "yes"),
+                    self.config.openrag_infra_admin_claim != "roles",
+                    self.config.openrag_infra_admin_claim_values != "Manager",
+                    self.config.openrag_infra_allow_insecure.lower() in ("true", "1", "yes"),
+                ])
+                if infra_enabled or infra_sub_set:
+                    f.write("# Infra-admin plane\n")
+                    f.write(
+                        f"OPENRAG_ENABLE_INFRA_ENDPOINTS={self._quote_env_value(self.config.openrag_enable_infra_endpoints)}\n"
+                    )
+                    f.write(
+                        f"OPENRAG_AUTO_OPENSEARCH_SETUP={self._quote_env_value(self.config.openrag_auto_opensearch_setup)}\n"
+                    )
+                    f.write(
+                        f"OPENRAG_AUTO_FIRST_ADMIN={self._quote_env_value(self.config.openrag_auto_first_admin)}\n"
+                    )
+                    f.write(
+                        f"OPENRAG_INFRA_ADMIN_CLAIM={self._quote_env_value(self.config.openrag_infra_admin_claim)}\n"
+                    )
+                    f.write(
+                        f"OPENRAG_INFRA_ADMIN_CLAIM_VALUES={self._quote_env_value(self.config.openrag_infra_admin_claim_values)}\n"
+                    )
+                    if self.config.openrag_infra_admin_user:
+                        f.write(
+                            f"OPENRAG_INFRA_ADMIN_USER={self._quote_env_value(self.config.openrag_infra_admin_user)}\n"
+                        )
+                    if self.config.openrag_infra_admin_password:
+                        f.write(
+                            f"OPENRAG_INFRA_ADMIN_PASSWORD={self._quote_env_value(self.config.openrag_infra_admin_password)}\n"
+                        )
+                    if self.config.openrag_infra_allow_insecure.lower() in ("true", "1", "yes"):
+                        f.write(
+                            f"OPENRAG_INFRA_ALLOW_INSECURE={self._quote_env_value(self.config.openrag_infra_allow_insecure)}\n"
+                        )
                     f.write("\n")
 
                 if preserved_custom_lines:

--- a/tests/unit/api/infra/test_infra_auth_dependency.py
+++ b/tests/unit/api/infra/test_infra_auth_dependency.py
@@ -1,0 +1,347 @@
+"""require_infra_admin dispatches on run mode.
+
+Covers both gate paths:
+  * SaaS / on_prem: JWT decoded via session_manager.verify_token, claim
+    contains an accepted value -> 200.
+  * OSS: HTTP Basic compared against OPENRAG_INFRA_ADMIN_USER /
+    OPENRAG_INFRA_ADMIN_PASSWORD (with fallback to OPENSEARCH_*).
+"""
+
+import base64
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import Depends, FastAPI
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from api.infra.auth import InfraAdmin, _flatten_claim, require_infra_admin  # noqa: E402
+from dependencies import get_session_manager  # noqa: E402
+
+
+class _StubSessionManager:
+    """Tiny stand-in for session_manager that returns a preset payload."""
+
+    def __init__(self, payload: dict | None):
+        self.payload = payload
+
+    def verify_token(self, token: str):  # noqa: ARG002 - signature parity
+        return self.payload
+
+
+def _basic_header(user: str, password: str) -> str:
+    raw = f"{user}:{password}".encode()
+    return "Basic " + base64.b64encode(raw).decode()
+
+
+def _build_app(payload: dict | None = None) -> FastAPI:
+    app = FastAPI()
+
+    def _stub() -> _StubSessionManager:
+        return _StubSessionManager(payload)
+
+    app.dependency_overrides[get_session_manager] = _stub
+
+    @app.get("/echo")
+    async def echo(actor: InfraAdmin = Depends(require_infra_admin())):
+        return {"subject": actor.subject, "source": actor.source}
+
+    return app
+
+
+# ---------------------------------------------------------------------------
+# _flatten_claim
+# ---------------------------------------------------------------------------
+
+
+def test_flatten_claim_handles_string():
+    assert _flatten_claim("Manager") == {"Manager"}
+
+
+def test_flatten_claim_handles_list_of_strings():
+    assert _flatten_claim(["Manager", "User"]) == {"Manager", "User"}
+
+
+def test_flatten_claim_handles_list_of_dicts():
+    assert _flatten_claim([{"name": "Manager"}, {"name": "User"}]) == {
+        "Manager",
+        "User",
+    }
+
+
+def test_flatten_claim_handles_dict_with_name():
+    assert _flatten_claim({"name": "Manager"}) == {"Manager"}
+
+
+def test_flatten_claim_returns_empty_for_unknown_shape():
+    assert _flatten_claim(42) == set()
+    assert _flatten_claim(None) == set()
+
+
+# ---------------------------------------------------------------------------
+# OSS basic-auth path
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def oss_app(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
+    )
+    return _build_app()
+
+
+@pytest.mark.asyncio
+async def test_oss_basic_auth_happy_path(oss_app):
+    transport = httpx.ASGITransport(app=oss_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get(
+            "/echo", headers={"Authorization": _basic_header("ops", "s3cret")}
+        )
+    assert r.status_code == 200, r.text
+    assert r.json() == {"subject": "ops", "source": "basic"}
+
+
+@pytest.mark.asyncio
+async def test_oss_basic_auth_wrong_password(oss_app):
+    transport = httpx.ASGITransport(app=oss_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get(
+            "/echo", headers={"Authorization": _basic_header("ops", "wrong")}
+        )
+    assert r.status_code == 401
+    assert r.headers.get("www-authenticate", "").startswith("Basic")
+
+
+@pytest.mark.asyncio
+async def test_oss_missing_authorization_header(oss_app):
+    transport = httpx.ASGITransport(app=oss_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_oss_falls_back_to_opensearch_credentials(monkeypatch):
+    """When dedicated infra creds are unset, OPENSEARCH_USERNAME/PASSWORD
+    are used."""
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "", raising=False)
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
+    )
+    monkeypatch.setattr("config.settings.OPENSEARCH_USERNAME", "admin", raising=False)
+    monkeypatch.setattr(
+        "config.settings.OPENSEARCH_PASSWORD", "fallback-pw", raising=False
+    )
+
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get(
+            "/echo",
+            headers={"Authorization": _basic_header("admin", "fallback-pw")},
+        )
+    assert r.status_code == 200
+    assert r.json()["source"] == "basic"
+
+
+@pytest.mark.asyncio
+async def test_oss_503_when_no_credentials_configured(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "", raising=False)
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False
+    )
+    monkeypatch.setattr("config.settings.OPENSEARCH_USERNAME", "", raising=False)
+    monkeypatch.setattr("config.settings.OPENSEARCH_PASSWORD", "", raising=False)
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
+    )
+
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get(
+            "/echo", headers={"Authorization": _basic_header("anyone", "anything")}
+        )
+    assert r.status_code == 503
+
+
+@pytest.mark.asyncio
+async def test_oss_refuses_plain_http_without_allow_flag(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", False, raising=False
+    )
+    # ASGITransport reports 127.0.0.1 as the client host (which short-circuits
+    # the HTTPS check), so force the local-host predicate to False to simulate
+    # a request originating from outside the loopback.
+    monkeypatch.setattr("api.infra.auth._is_local_host", lambda _request: False)
+
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get(
+            "/echo",
+            headers={"Authorization": _basic_header("ops", "s3cret")},
+        )
+    assert r.status_code == 426
+
+
+@pytest.mark.asyncio
+async def test_oss_honors_x_forwarded_proto_https(monkeypatch):
+    """Reverse proxy terminated TLS upstream sets X-Forwarded-Proto=https."""
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", False, raising=False
+    )
+    monkeypatch.setattr("api.infra.auth._is_local_host", lambda _request: False)
+
+    app = _build_app()
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get(
+            "/echo",
+            headers={
+                "Authorization": _basic_header("ops", "s3cret"),
+                "X-Forwarded-Proto": "https",
+            },
+        )
+    assert r.status_code == 200, r.text
+
+
+# ---------------------------------------------------------------------------
+# SaaS / on_prem JWT path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_saas_jwt_with_matching_claim(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
+    )
+
+    app = _build_app(payload={"sub": "uid-1", "roles": ["User", "Manager"]})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo", headers={"Authorization": "Bearer fake.jwt"})
+    assert r.status_code == 200, r.text
+    assert r.json() == {"subject": "uid-1", "source": "jwt"}
+
+
+@pytest.mark.asyncio
+async def test_saas_jwt_with_non_matching_claim(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
+    )
+
+    app = _build_app(payload={"sub": "uid-1", "roles": ["User"]})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo", headers={"Authorization": "Bearer fake.jwt"})
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_saas_jwt_missing_token(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
+    )
+
+    app = _build_app(payload=None)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo")
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_saas_jwt_invalid_token_returns_401(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
+    )
+
+    # verify_token returns None for invalid tokens
+    app = _build_app(payload=None)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo", headers={"Authorization": "Bearer bad.jwt"})
+    assert r.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_saas_jwt_multiple_accepted_values(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES",
+        "Manager,Operator",
+        raising=False,
+    )
+
+    app = _build_app(payload={"sub": "uid-9", "roles": ["Operator"]})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo", headers={"Authorization": "Bearer x"})
+    assert r.status_code == 200
+    assert r.json()["subject"] == "uid-9"
+
+
+@pytest.mark.asyncio
+async def test_saas_jwt_nested_dict_claim(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
+    )
+
+    app = _build_app(
+        payload={"sub": "uid-2", "roles": [{"name": "Manager"}, {"name": "User"}]}
+    )
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo", headers={"Authorization": "Bearer x"})
+    assert r.status_code == 200

--- a/tests/unit/api/infra/test_infra_auth_dependency.py
+++ b/tests/unit/api/infra/test_infra_auth_dependency.py
@@ -92,15 +92,9 @@ def test_flatten_claim_returns_empty_for_unknown_shape():
 @pytest_asyncio.fixture
 async def oss_app(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False)
     return _build_app()
 
 
@@ -108,9 +102,7 @@ async def oss_app(monkeypatch):
 async def test_oss_basic_auth_happy_path(oss_app):
     transport = httpx.ASGITransport(app=oss_app)
     async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        r = await c.get(
-            "/echo", headers={"Authorization": _basic_header("ops", "s3cret")}
-        )
+        r = await c.get("/echo", headers={"Authorization": _basic_header("ops", "s3cret")})
     assert r.status_code == 200, r.text
     assert r.json() == {"subject": "ops", "source": "basic"}
 
@@ -119,9 +111,7 @@ async def test_oss_basic_auth_happy_path(oss_app):
 async def test_oss_basic_auth_wrong_password(oss_app):
     transport = httpx.ASGITransport(app=oss_app)
     async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        r = await c.get(
-            "/echo", headers={"Authorization": _basic_header("ops", "wrong")}
-        )
+        r = await c.get("/echo", headers={"Authorization": _basic_header("ops", "wrong")})
     assert r.status_code == 401
     assert r.headers.get("www-authenticate", "").startswith("Basic")
 
@@ -140,16 +130,10 @@ async def test_oss_falls_back_to_opensearch_credentials(monkeypatch):
     are used."""
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
     monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "", raising=False)
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False)
     monkeypatch.setattr("config.settings.OPENSEARCH_USERNAME", "admin", raising=False)
-    monkeypatch.setattr(
-        "config.settings.OPENSEARCH_PASSWORD", "fallback-pw", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENSEARCH_PASSWORD", "fallback-pw", raising=False)
 
     app = _build_app()
     transport = httpx.ASGITransport(app=app)
@@ -166,36 +150,24 @@ async def test_oss_falls_back_to_opensearch_credentials(monkeypatch):
 async def test_oss_503_when_no_credentials_configured(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
     monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "", raising=False)
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False)
     monkeypatch.setattr("config.settings.OPENSEARCH_USERNAME", "", raising=False)
     monkeypatch.setattr("config.settings.OPENSEARCH_PASSWORD", "", raising=False)
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False)
 
     app = _build_app()
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        r = await c.get(
-            "/echo", headers={"Authorization": _basic_header("anyone", "anything")}
-        )
+        r = await c.get("/echo", headers={"Authorization": _basic_header("anyone", "anything")})
     assert r.status_code == 503
 
 
 @pytest.mark.asyncio
 async def test_oss_refuses_plain_http_without_allow_flag(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", False, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", False, raising=False)
     # ASGITransport reports 127.0.0.1 as the client host (which short-circuits
     # the HTTPS check), so force the local-host predicate to False to simulate
     # a request originating from outside the loopback.
@@ -215,15 +187,9 @@ async def test_oss_refuses_plain_http_without_allow_flag(monkeypatch):
 async def test_oss_honors_x_forwarded_proto_https(monkeypatch):
     """Reverse proxy terminated TLS upstream sets X-Forwarded-Proto=https."""
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", False, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", False, raising=False)
     monkeypatch.setattr("api.infra.auth._is_local_host", lambda _request: False)
 
     app = _build_app()
@@ -247,9 +213,7 @@ async def test_oss_honors_x_forwarded_proto_https(monkeypatch):
 @pytest.mark.asyncio
 async def test_saas_jwt_with_matching_claim(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False)
     monkeypatch.setattr(
         "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
     )
@@ -265,9 +229,7 @@ async def test_saas_jwt_with_matching_claim(monkeypatch):
 @pytest.mark.asyncio
 async def test_saas_jwt_with_non_matching_claim(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False)
     monkeypatch.setattr(
         "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
     )
@@ -311,9 +273,7 @@ async def test_saas_jwt_invalid_token_returns_401(monkeypatch):
 @pytest.mark.asyncio
 async def test_saas_jwt_multiple_accepted_values(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False)
     monkeypatch.setattr(
         "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES",
         "Manager,Operator",
@@ -331,16 +291,12 @@ async def test_saas_jwt_multiple_accepted_values(monkeypatch):
 @pytest.mark.asyncio
 async def test_saas_jwt_nested_dict_claim(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False)
     monkeypatch.setattr(
         "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
     )
 
-    app = _build_app(
-        payload={"sub": "uid-2", "roles": [{"name": "Manager"}, {"name": "User"}]}
-    )
+    app = _build_app(payload={"sub": "uid-2", "roles": [{"name": "Manager"}, {"name": "User"}]})
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
         r = await c.get("/echo", headers={"Authorization": "Bearer x"})
@@ -354,9 +310,7 @@ async def test_on_prem_falls_back_to_ibm_session_cookie(monkeypatch):
     Triggered purely by OPENRAG_RUN_MODE, no need for IBM_AUTH_ENABLED.
     """
     monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False)
     monkeypatch.setattr(
         "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
     )
@@ -417,9 +371,7 @@ async def test_on_prem_ibm_cookie_with_non_matching_role(monkeypatch):
 @pytest.mark.asyncio
 async def test_saas_503_when_claim_values_unset(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "", raising=False)
 
     app = _build_app(payload={"sub": "uid-x", "roles": ["Manager"]})
     transport = httpx.ASGITransport(app=app)

--- a/tests/unit/api/infra/test_infra_auth_dependency.py
+++ b/tests/unit/api/infra/test_infra_auth_dependency.py
@@ -345,3 +345,84 @@ async def test_saas_jwt_nested_dict_claim(monkeypatch):
     async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
         r = await c.get("/echo", headers={"Authorization": "Bearer x"})
     assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_on_prem_falls_back_to_ibm_session_cookie(monkeypatch):
+    """When no native JWT is present, the dependency decodes the IBM session
+    cookie (without signature verification — Traefik validates upstream).
+    Triggered purely by OPENRAG_RUN_MODE, no need for IBM_AUTH_ENABLED.
+    """
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM", "roles", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.IBM_SESSION_COOKIE_NAME",
+        "ibm-openrag-session",
+        raising=False,
+    )
+    # Stub the IBM JWT decoder; we don't care about real signatures here.
+    import auth.ibm_auth as ibm_auth_mod
+
+    monkeypatch.setattr(
+        ibm_auth_mod,
+        "decode_ibm_jwt",
+        lambda token: {"sub": "ibm-user-1", "roles": ["Manager"]},
+    )
+
+    # No native JWT path => session_manager.verify_token would be called with
+    # no token. The stub returns None for whatever we hand it.
+    app = _build_app(payload=None)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        c.cookies.set("ibm-openrag-session", "fake.ibm.jwt")
+        r = await c.get("/echo")
+
+    assert r.status_code == 200, r.text
+    assert r.json() == {"subject": "ibm-user-1", "source": "jwt"}
+
+
+@pytest.mark.asyncio
+async def test_on_prem_ibm_cookie_with_non_matching_role(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "Manager", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.IBM_SESSION_COOKIE_NAME",
+        "ibm-openrag-session",
+        raising=False,
+    )
+    import auth.ibm_auth as ibm_auth_mod
+
+    monkeypatch.setattr(
+        ibm_auth_mod,
+        "decode_ibm_jwt",
+        lambda token: {"sub": "ibm-user-2", "roles": ["User"]},
+    )
+
+    app = _build_app(payload=None)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        c.cookies.set("ibm-openrag-session", "fake.ibm.jwt")
+        r = await c.get("/echo")
+
+    assert r.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_saas_503_when_claim_values_unset(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_CLAIM_VALUES", "", raising=False
+    )
+
+    app = _build_app(payload={"sub": "uid-x", "roles": ["Manager"]})
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/echo", headers={"Authorization": "Bearer x"})
+    assert r.status_code == 503

--- a/tests/unit/api/infra/test_infra_master_flag.py
+++ b/tests/unit/api/infra/test_infra_master_flag.py
@@ -44,17 +44,11 @@ async def test_router_mounted_when_master_on(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
     # Force missing creds so the gate replies 503 (not 401); either non-404
     # proves the router IS mounted, which is the whole point of this test.
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_USER", "", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False)
     monkeypatch.setattr("config.settings.OPENSEARCH_USERNAME", "", raising=False)
     monkeypatch.setattr("config.settings.OPENSEARCH_PASSWORD", "", raising=False)
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False)
 
     import base64
 
@@ -68,9 +62,7 @@ async def test_router_mounted_when_master_on(monkeypatch):
     transport = httpx.ASGITransport(app=app)
     creds = "Basic " + base64.b64encode(b"any:any").decode()
     async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
-        r = await c.get(
-            "/infra/opensearch/status", headers={"Authorization": creds}
-        )
+        r = await c.get("/infra/opensearch/status", headers={"Authorization": creds})
 
     assert r.status_code != 404, "router must be present when master flag is on"
     # Specifically: with no creds configured we expect 503 (the explicit

--- a/tests/unit/api/infra/test_infra_master_flag.py
+++ b/tests/unit/api/infra/test_infra_master_flag.py
@@ -1,0 +1,78 @@
+"""The master flag (OPENRAG_ENABLE_INFRA_ENDPOINTS) controls whether the
+/api/infra/* router is mounted at all.
+
+This test exercises the conditional include_router() in app/routes/internal.py
+indirectly by replaying its logic in a tiny test app: the boolean check is
+the integration contract we care about — mounted vs not mounted.
+"""
+
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+from fastapi import FastAPI
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def _build_app(master_flag: bool) -> FastAPI:
+    """Mirror the conditional mount logic in internal.py."""
+    app = FastAPI()
+    if master_flag:
+        from api.infra import router as infra_router
+
+        app.include_router(infra_router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_router_not_mounted_when_master_off():
+    app = _build_app(master_flag=False)
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/infra/opensearch/status")
+    assert r.status_code == 404, "router must be absent when master flag is off"
+
+
+@pytest.mark.asyncio
+async def test_router_mounted_when_master_on(monkeypatch):
+    # OSS path so the test doesn't need a JWT signer.
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    # Force missing creds so the gate replies 503 (not 401); either non-404
+    # proves the router IS mounted, which is the whole point of this test.
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_USER", "", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "", raising=False
+    )
+    monkeypatch.setattr("config.settings.OPENSEARCH_USERNAME", "", raising=False)
+    monkeypatch.setattr("config.settings.OPENSEARCH_PASSWORD", "", raising=False)
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
+    )
+
+    import base64
+
+    app = _build_app(master_flag=True)
+    # session_manager is needed for the JWT path even though we hit OSS;
+    # the dependency resolver still wires it up.
+    from dependencies import get_session_manager
+
+    app.dependency_overrides[get_session_manager] = lambda: None
+
+    transport = httpx.ASGITransport(app=app)
+    creds = "Basic " + base64.b64encode(b"any:any").decode()
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get(
+            "/infra/opensearch/status", headers={"Authorization": creds}
+        )
+
+    assert r.status_code != 404, "router must be present when master flag is on"
+    # Specifically: with no creds configured we expect 503 (the explicit
+    # "infra_admin_credentials_not_configured" path).
+    assert r.status_code == 503

--- a/tests/unit/api/infra/test_infra_opensearch_status.py
+++ b/tests/unit/api/infra/test_infra_opensearch_status.py
@@ -1,0 +1,164 @@
+"""GET /api/infra/opensearch/status covers the four state branches:
+
+  * unconfigured - no DB row, no live role
+  * healthy      - DB row + live role
+  * drift        - DB row but no live role
+  * degraded     - OpenSearch unreachable / transport error
+
+Uses real OSS basic-auth on the wire so the dispatch path is exercised
+end-to-end. Live OpenSearch is mocked at clients.opensearch.
+"""
+
+import base64
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.models import MigrationStatus  # noqa: E402
+from dependencies import get_db_session, get_session_manager  # noqa: E402
+
+
+_BASIC = "Basic " + base64.b64encode(b"ops:s3cret").decode()
+
+
+@pytest_asyncio.fixture
+async def setup(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
+    )
+
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+
+    # opensearch_setup_status reads via db.engine.SessionLocal.
+    import db.engine as engine_mod
+
+    monkeypatch.setattr(engine_mod, "_engine", engine, raising=False)
+    monkeypatch.setattr(engine_mod, "SessionLocal", SessionLocal, raising=False)
+
+    fake_os = MagicMock()
+    fake_os.transport.perform_request = AsyncMock()
+    import config.settings as settings_mod
+
+    monkeypatch.setattr(settings_mod.clients, "opensearch", fake_os, raising=False)
+
+    from api.infra import endpoints as infra_endpoints
+
+    app = FastAPI()
+    app.include_router(infra_endpoints.router)
+
+    async def _db_session():
+        async with SessionLocal() as s:
+            yield s
+
+    app.dependency_overrides[get_db_session] = _db_session
+    # session_manager isn't actually used in OSS mode, but we need an
+    # override so FastAPI's Depends resolution doesn't try to load it
+    # from request.app.state.services (which we haven't populated).
+    app.dependency_overrides[get_session_manager] = lambda: None
+
+    yield app, SessionLocal, fake_os
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_unconfigured_when_db_empty_and_role_missing(setup):
+    app, _, fake_os = setup
+    fake_os.transport.perform_request.side_effect = Exception("404 not_found")
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/infra/opensearch/status", headers={"Authorization": _BASIC})
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "unconfigured"
+    assert body["configured"] is False
+    assert body["drift"] is False
+    assert body["last_setup_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_healthy_when_db_row_and_role_present(setup):
+    app, SessionLocal, fake_os = setup
+    fake_os.transport.perform_request.return_value = {
+        "openrag_user_role": {"index_permissions": []}
+    }
+
+    async with SessionLocal() as s:
+        s.add(MigrationStatus(name="opensearch_security_v1", notes="test"))
+        await s.commit()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/infra/opensearch/status", headers={"Authorization": _BASIC})
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "healthy"
+    assert body["configured"] is True
+    assert body["drift"] is False
+    assert body["last_setup_at"] is not None
+
+
+@pytest.mark.asyncio
+async def test_drift_when_db_says_yes_but_role_missing(setup):
+    app, SessionLocal, fake_os = setup
+    fake_os.transport.perform_request.side_effect = Exception("404 not_found")
+
+    async with SessionLocal() as s:
+        s.add(MigrationStatus(name="opensearch_security_v1", notes="test"))
+        await s.commit()
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/infra/opensearch/status", headers={"Authorization": _BASIC})
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["drift"] is True
+    assert "missing" in body["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_degraded_when_opensearch_unreachable(setup):
+    app, _, fake_os = setup
+    fake_os.transport.perform_request.side_effect = Exception(
+        "ConnectionError: cluster down"
+    )
+
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.get("/infra/opensearch/status", headers={"Authorization": _BASIC})
+
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["status"] == "degraded"
+    assert body["drift"] is False
+    assert "unreachable" in body["message"].lower()

--- a/tests/unit/api/infra/test_infra_opensearch_status.py
+++ b/tests/unit/api/infra/test_infra_opensearch_status.py
@@ -37,15 +37,9 @@ _BASIC = "Basic " + base64.b64encode(b"ops:s3cret").decode()
 @pytest_asyncio.fixture
 async def setup(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False)
 
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:",
@@ -149,9 +143,7 @@ async def test_drift_when_db_says_yes_but_role_missing(setup):
 @pytest.mark.asyncio
 async def test_degraded_when_opensearch_unreachable(setup):
     app, _, fake_os = setup
-    fake_os.transport.perform_request.side_effect = Exception(
-        "ConnectionError: cluster down"
-    )
+    fake_os.transport.perform_request.side_effect = Exception("ConnectionError: cluster down")
 
     transport = httpx.ASGITransport(app=app)
     async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:

--- a/tests/unit/api/infra/test_infra_user_create.py
+++ b/tests/unit/api/infra/test_infra_user_create.py
@@ -33,15 +33,9 @@ _BASIC = "Basic " + base64.b64encode(b"ops:s3cret").decode()
 @pytest_asyncio.fixture
 async def app(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False)
 
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:",
@@ -98,8 +92,10 @@ async def test_create_user_with_admin_role(app):
     # the infra principal and the roles requested.
     async with SessionLocal() as s:
         rows = (
-            await s.execute(select(AuditLog).where(AuditLog.event == "infra.user.created"))
-        ).scalars().all()
+            (await s.execute(select(AuditLog).where(AuditLog.event == "infra.user.created")))
+            .scalars()
+            .all()
+        )
         assert len(rows) == 1
         assert rows[0].actor_user_id is None
         assert rows[0].audit_metadata["actor"] == "ops"

--- a/tests/unit/api/infra/test_infra_user_create.py
+++ b/tests/unit/api/infra/test_infra_user_create.py
@@ -1,0 +1,197 @@
+"""POST /api/infra/users — creates a user with optional roles, audits, and
+rejects unknown role names. Uses real OSS basic-auth on the wire.
+"""
+
+import base64
+import sys
+from pathlib import Path
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.models import AuditLog  # noqa: E402
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from dependencies import get_db_session, get_rbac_service, get_session_manager  # noqa: E402
+from services.rbac_service import RBACService  # noqa: E402
+
+
+_BASIC = "Basic " + base64.b64encode(b"ops:s3cret").decode()
+
+
+@pytest_asyncio.fixture
+async def app(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_USER", "ops", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ADMIN_PASSWORD", "s3cret", raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_INFRA_ALLOW_INSECURE", True, raising=False
+    )
+
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as s:
+        await seed_roles_and_permissions(s)
+        await s.commit()
+
+    rbac = RBACService(SessionLocal)
+
+    from api.infra import endpoints as infra_endpoints
+
+    fastapi_app = FastAPI()
+    fastapi_app.include_router(infra_endpoints.router)
+
+    async def _db_session():
+        async with SessionLocal() as s:
+            yield s
+
+    fastapi_app.dependency_overrides[get_db_session] = _db_session
+    fastapi_app.dependency_overrides[get_rbac_service] = lambda: rbac
+    fastapi_app.dependency_overrides[get_session_manager] = lambda: None
+
+    yield fastapi_app, SessionLocal
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_create_user_with_admin_role(app):
+    fastapi_app, SessionLocal = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/infra/users",
+            json={
+                "email": "first.admin@example.com",
+                "display_name": "First Admin",
+                "roles": ["admin"],
+            },
+            headers={"Authorization": _BASIC},
+        )
+
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["email"] == "first.admin@example.com"
+    assert body["display_name"] == "First Admin"
+    assert body["roles"] == ["admin"]
+
+    # Audit row is written without actor_user_id, with metadata carrying
+    # the infra principal and the roles requested.
+    async with SessionLocal() as s:
+        rows = (
+            await s.execute(select(AuditLog).where(AuditLog.event == "infra.user.created"))
+        ).scalars().all()
+        assert len(rows) == 1
+        assert rows[0].actor_user_id is None
+        assert rows[0].audit_metadata["actor"] == "ops"
+        assert rows[0].audit_metadata["source"] == "basic"
+        assert rows[0].audit_metadata["roles"] == ["admin"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_role_rejected_with_400(app):
+    fastapi_app, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post(
+            "/infra/users",
+            json={"email": "x@example.com", "roles": ["not-a-role"]},
+            headers={"Authorization": _BASIC},
+        )
+
+    assert r.status_code == 400, r.text
+    body = r.json()
+    assert body["detail"]["error"] == "unknown_role"
+    assert body["detail"]["name"] == "not-a-role"
+
+
+@pytest.mark.asyncio
+async def test_duplicate_email_rejected_with_409(app):
+    fastapi_app, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r1 = await c.post(
+            "/infra/users",
+            json={"email": "dup@example.com", "roles": []},
+            headers={"Authorization": _BASIC},
+        )
+        assert r1.status_code == 201
+
+        r2 = await c.post(
+            "/infra/users",
+            json={"email": "dup@example.com", "roles": []},
+            headers={"Authorization": _BASIC},
+        )
+
+    assert r2.status_code == 409
+    assert r2.json()["detail"]["error"] == "email_exists"
+
+
+@pytest.mark.asyncio
+async def test_replace_roles_endpoint(app):
+    fastapi_app, SessionLocal = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        created = await c.post(
+            "/infra/users",
+            json={"email": "swap@example.com", "roles": ["user"]},
+            headers={"Authorization": _BASIC},
+        )
+        assert created.status_code == 201
+        user_id = created.json()["id"]
+
+        replaced = await c.put(
+            f"/infra/users/{user_id}/roles",
+            json={"roles": ["developer", "viewer"]},
+            headers={"Authorization": _BASIC},
+        )
+
+    assert replaced.status_code == 200, replaced.text
+    assert set(replaced.json()["roles"]) == {"developer", "viewer"}
+
+    async with SessionLocal() as s:
+        roles = await RoleRepo(s).list_user_roles(user_id)
+        assert {r.name for r in roles} == {"developer", "viewer"}
+
+
+@pytest.mark.asyncio
+async def test_cannot_remove_last_admin_via_replace(app):
+    fastapi_app, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        admin = await c.post(
+            "/infra/users",
+            json={"email": "only-admin@example.com", "roles": ["admin"]},
+            headers={"Authorization": _BASIC},
+        )
+        assert admin.status_code == 201
+        admin_id = admin.json()["id"]
+
+        # Try to demote the only admin
+        r = await c.put(
+            f"/infra/users/{admin_id}/roles",
+            json={"roles": ["user"]},
+            headers={"Authorization": _BASIC},
+        )
+
+    assert r.status_code == 400
+    assert r.json()["detail"]["error"] == "cannot_remove_last_admin"

--- a/tests/unit/services/test_auto_opensearch_setup_skipped.py
+++ b/tests/unit/services/test_auto_opensearch_setup_skipped.py
@@ -1,0 +1,30 @@
+"""Master flag + OPENRAG_AUTO_OPENSEARCH_SETUP gates the startup
+auto-setup call to setup_opensearch_security().
+
+This file unit-tests the gating decision in isolation; the orchestrator
+function itself is exercised by test_opensearch_security_setup.py.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+@pytest.mark.parametrize(
+    "master, auto, should_skip",
+    [
+        (False, True, False),  # default: setup runs
+        (False, False, False),  # master off => AUTO ignored, setup runs
+        (True, True, False),  # master on + AUTO on: setup runs
+        (True, False, True),  # master on + AUTO off: setup skipped
+    ],
+)
+def test_skip_decision_truth_table(master, auto, should_skip):
+    skip_auto_setup = master and not auto
+    assert skip_auto_setup is should_skip

--- a/tests/unit/services/test_first_admin_disabled.py
+++ b/tests/unit/services/test_first_admin_disabled.py
@@ -49,32 +49,22 @@ def _user(uid: str, email: str) -> User:
 
 @pytest.mark.asyncio
 async def test_master_off_preserves_first_user_admin(session, monkeypatch):
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", False, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", False, raising=False)
     # AUTO flag is false but irrelevant when master is off.
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False)
     monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
 
     row = await ensure_user_row(session, _user("uid-1", "first@example.com"))
     await session.commit()
 
     roles = {r.name for r in await RoleRepo(session).list_user_roles(row.id)}
-    assert roles == {"admin"}, (
-        "master flag off must preserve today's first-user-admin behaviour"
-    )
+    assert roles == {"admin"}, "master flag off must preserve today's first-user-admin behaviour"
 
 
 @pytest.mark.asyncio
 async def test_master_on_auto_true_still_promotes(session, monkeypatch):
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", True, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_AUTO_FIRST_ADMIN", True, raising=False)
     monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
 
     row = await ensure_user_row(session, _user("uid-2", "first@example.com"))
@@ -86,12 +76,8 @@ async def test_master_on_auto_true_still_promotes(session, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_master_on_auto_false_skips_admin(session, monkeypatch):
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False)
     monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
 
     row = await ensure_user_row(session, _user("uid-3", "first@example.com"))
@@ -106,12 +92,8 @@ async def test_anonymous_still_gets_noauth_role_under_skip(session, monkeypatch)
     """The skip-bootstrap branch falls through to the default-role path,
     which still honours OPENRAG_NOAUTH_ROLE for the synthetic anonymous user.
     """
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False
-    )
-    monkeypatch.setattr(
-        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False
-    )
+    monkeypatch.setattr("config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False)
+    monkeypatch.setattr("config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False)
     monkeypatch.setenv("OPENRAG_NOAUTH_ROLE", "viewer")
 
     row = await ensure_user_row(session, _user("anonymous", "anon@example.com"))

--- a/tests/unit/services/test_first_admin_disabled.py
+++ b/tests/unit/services/test_first_admin_disabled.py
@@ -1,0 +1,121 @@
+"""Master flag + OPENRAG_AUTO_FIRST_ADMIN gating of _assign_bootstrap_or_default.
+
+Behaviour matrix:
+
+  * master OFF (any AUTO value) -> first user gets admin (today's behaviour).
+  * master ON  + AUTO_FIRST_ADMIN=true  -> first user gets admin.
+  * master ON  + AUTO_FIRST_ADMIN=false -> first user gets default role.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlmodel import SQLModel
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import db.models  # noqa: E402,F401
+from db.repositories import RoleRepo  # noqa: E402
+from db.seed import seed_roles_and_permissions  # noqa: E402
+from services.user_service import ensure_user_row  # noqa: E402
+from session_manager import User  # noqa: E402
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    SessionLocal = async_sessionmaker(engine, expire_on_commit=False)
+    async with SessionLocal() as s:
+        await seed_roles_and_permissions(s)
+        await s.commit()
+        yield s
+    await engine.dispose()
+
+
+def _user(uid: str, email: str) -> User:
+    return User(user_id=uid, email=email, name=uid, provider="google")
+
+
+@pytest.mark.asyncio
+async def test_master_off_preserves_first_user_admin(session, monkeypatch):
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", False, raising=False
+    )
+    # AUTO flag is false but irrelevant when master is off.
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False
+    )
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+
+    row = await ensure_user_row(session, _user("uid-1", "first@example.com"))
+    await session.commit()
+
+    roles = {r.name for r in await RoleRepo(session).list_user_roles(row.id)}
+    assert roles == {"admin"}, (
+        "master flag off must preserve today's first-user-admin behaviour"
+    )
+
+
+@pytest.mark.asyncio
+async def test_master_on_auto_true_still_promotes(session, monkeypatch):
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", True, raising=False
+    )
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+
+    row = await ensure_user_row(session, _user("uid-2", "first@example.com"))
+    await session.commit()
+
+    roles = {r.name for r in await RoleRepo(session).list_user_roles(row.id)}
+    assert roles == {"admin"}
+
+
+@pytest.mark.asyncio
+async def test_master_on_auto_false_skips_admin(session, monkeypatch):
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False
+    )
+    monkeypatch.setenv("OPENRAG_DEFAULT_ROLE", "user")
+
+    row = await ensure_user_row(session, _user("uid-3", "first@example.com"))
+    await session.commit()
+
+    roles = {r.name for r in await RoleRepo(session).list_user_roles(row.id)}
+    assert roles == {"user"}, "infra endpoints will register the admin explicitly"
+
+
+@pytest.mark.asyncio
+async def test_anonymous_still_gets_noauth_role_under_skip(session, monkeypatch):
+    """The skip-bootstrap branch falls through to the default-role path,
+    which still honours OPENRAG_NOAUTH_ROLE for the synthetic anonymous user.
+    """
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_ENABLE_INFRA_ENDPOINTS", True, raising=False
+    )
+    monkeypatch.setattr(
+        "config.settings.OPENRAG_AUTO_FIRST_ADMIN", False, raising=False
+    )
+    monkeypatch.setenv("OPENRAG_NOAUTH_ROLE", "viewer")
+
+    row = await ensure_user_row(session, _user("anonymous", "anon@example.com"))
+    await session.commit()
+
+    roles = {r.name for r in await RoleRepo(session).list_user_roles(row.id)}
+    assert roles == {"viewer"}


### PR DESCRIPTION
Add a higher-privilege /api/infra/* router that bypasses the DB-resident
  RBAC at /api/admin/*: a configurable JWT claim grants access in SaaS /
  on_prem mode, HTTP Basic in OSS. Lets an operator bootstrap a fresh
  install before any user rows exist.

  The plane owns OpenSearch security setup + post-bootstrap user
  provisioning + (via the same idempotent endpoint) DLS config updates.
  A new migration_status row "opensearch_security_v1" tracks setup state;
  the status endpoint also probes OpenSearch for drift.

  Master flag OPENRAG_ENABLE_INFRA_ENDPOINTS (default false) gates the
  entire surface:
    - When false, the router is NOT mounted and today's startup behaviour
      is preserved exactly (auto-OpenSearch-setup + first-user-admin).
    - When true, OPENRAG_AUTO_OPENSEARCH_SETUP and OPENRAG_AUTO_FIRST_ADMIN
      become operator-controlled. The infra endpoint registers admins
      explicitly when first-user-admin is disabled.

  Default OSS installs see zero behaviour change.

  Endpoints (all gated by require_infra_admin()):
    GET    /api/infra/opensearch/status     - docling-style status report
    POST   /api/infra/opensearch/setup      - idempotent setup + DLS update
    GET    /api/infra/users                 - list users
    GET    /api/infra/users/{id}            - read user
    POST   /api/infra/users                 - create user with optional roles
    PATCH  /api/infra/users/{id}            - update is_active / display / roles
    PUT    /api/infra/users/{id}/roles      - replace full role set atomically
    DELETE /api/infra/users/{id}            - delete user (last-admin guarded)

  Audit rows use actor_user_id=None with {actor, source} in audit_metadata
  because the infra principal is not (yet) a row in the users table.

  New env vars:
    OPENRAG_ENABLE_INFRA_ENDPOINTS    master kill-switch (default: false)
    OPENRAG_AUTO_OPENSEARCH_SETUP     skip startup auto-setup (default: true)
    OPENRAG_AUTO_FIRST_ADMIN          skip first-user-admin (default: true)
    OPENRAG_INFRA_ADMIN_CLAIM         JWT claim name (default: roles)
    OPENRAG_INFRA_ADMIN_CLAIM_VALUES  comma-separated accepted values
                                      (default: Manager)
    OPENRAG_INFRA_ADMIN_USER          OSS basic-auth username (falls back to
                                      OPENSEARCH_USERNAME)
    OPENRAG_INFRA_ADMIN_PASSWORD      OSS basic-auth password (falls back to
                                      OPENSEARCH_PASSWORD)
    OPENRAG_INFRA_ALLOW_INSECURE      permit basic-auth over plain HTTP
                                      (default: false; localhost is exempt;
                                      honours X-Forwarded-Proto)