### PR TITLE
feat: add feedback tracking for assistant messages

### DIFF
--- a/frontend/app/chat/_components/assistant-message.tsx
+++ b/frontend/app/chat/_components/assistant-message.tsx
@@ -38,6 +38,7 @@ interface AssistantMessageProps {
   isInitialGreeting?: boolean;
   usage?: TokenUsageType;
   timestamp?: Date;
+  showFeedback?: boolean;
 }
 
 export function AssistantMessage({
@@ -56,6 +57,7 @@ export function AssistantMessage({
   isInitialGreeting = false,
   usage,
   timestamp,
+  showFeedback = true,
 }: AssistantMessageProps) {
   const trackFeedback = (feedback: "like" | "dislike") => {
     trackButton({
@@ -165,7 +167,7 @@ export function AssistantMessage({
               }
             />
             {usage && !isStreaming && <TokenUsage usage={usage} />}
-            {!isInitialGreeting && (
+            {!isInitialGreeting && showFeedback && (
               <MessageActions trackFeedback={trackFeedback} />
             )}
           </motion.div>

--- a/frontend/app/chat/_components/assistant-message.tsx
+++ b/frontend/app/chat/_components/assistant-message.tsx
@@ -11,6 +11,7 @@ const MarkdownRenderer = dynamic(
   { ssr: false },
 );
 
+import { trackButton } from "@/lib/analytics";
 import { cn } from "@/lib/utils";
 import type {
   FunctionCall,
@@ -18,6 +19,7 @@ import type {
 } from "../_types/types";
 import { FunctionCalls } from "./function-calls";
 import { Message } from "./message";
+import MessageActions from "./message-actions";
 import { TokenUsage } from "./token-usage";
 
 interface AssistantMessageProps {
@@ -35,6 +37,7 @@ interface AssistantMessageProps {
   delay?: number;
   isInitialGreeting?: boolean;
   usage?: TokenUsageType;
+  timestamp?: Date;
 }
 
 export function AssistantMessage({
@@ -52,7 +55,18 @@ export function AssistantMessage({
   delay = 0.2,
   isInitialGreeting = false,
   usage,
+  timestamp,
 }: AssistantMessageProps) {
+  const trackFeedback = (feedback: "like" | "dislike") => {
+    trackButton({
+      action: feedback,
+      elementId: "message-feedback",
+      namespace: "chat",
+      CTA: feedback === "like" ? "Like Message" : "Dislike Message",
+      timestamp: timestamp?.getTime(),
+    });
+  };
+
   return (
     <motion.div
       initial={animate ? { opacity: 0, y: -20 } : { opacity: 1, y: 0 }}
@@ -151,6 +165,9 @@ export function AssistantMessage({
               }
             />
             {usage && !isStreaming && <TokenUsage usage={usage} />}
+            {!isInitialGreeting && (
+              <MessageActions trackFeedback={trackFeedback} />
+            )}
           </motion.div>
         </div>
       </Message>

--- a/frontend/app/chat/_components/assistant-message.tsx
+++ b/frontend/app/chat/_components/assistant-message.tsx
@@ -167,7 +167,7 @@ export function AssistantMessage({
               }
             />
             {usage && !isStreaming && <TokenUsage usage={usage} />}
-            {!isInitialGreeting && showFeedback && (
+            {!isInitialGreeting && showFeedback && !isStreaming && (
               <MessageActions trackFeedback={trackFeedback} />
             )}
           </motion.div>

--- a/frontend/app/chat/_components/message-actions.tsx
+++ b/frontend/app/chat/_components/message-actions.tsx
@@ -22,6 +22,8 @@ const MessageActions = ({ trackFeedback }: MessageActionsProps) => {
       <Button
         variant="ghost"
         size="icon"
+        aria-label="Like"
+        aria-pressed={feedbackSelected === "like"}
         className={
           feedbackSelected !== "like"
             ? "text-muted-foreground hover:text-foreground"
@@ -36,6 +38,8 @@ const MessageActions = ({ trackFeedback }: MessageActionsProps) => {
       <Button
         variant="ghost"
         size="icon"
+        aria-label="Dislike"
+        aria-pressed={feedbackSelected === "dislike"}
         className={
           feedbackSelected !== "dislike"
             ? "text-muted-foreground hover:text-foreground"

--- a/frontend/app/chat/_components/message-actions.tsx
+++ b/frontend/app/chat/_components/message-actions.tsx
@@ -1,0 +1,54 @@
+import { ThumbsDown, ThumbsUp } from "lucide-react";
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+
+interface MessageActionsProps {
+  trackFeedback: (feedback: "like" | "dislike") => void;
+}
+
+const MessageActions = ({ trackFeedback }: MessageActionsProps) => {
+  const [feedbackSelected, setFeedbackSelected] = useState<
+    "like" | "dislike" | null
+  >(null);
+
+  const handleFeedback = (feedback: "like" | "dislike") => {
+    if (feedbackSelected === feedback) return; // Prevent multiple tracking events for the same feedback
+    trackFeedback(feedback);
+    setFeedbackSelected(feedback);
+  };
+
+  return (
+    <div className="flex space-x-2 mt-2">
+      <Button
+        variant="ghost"
+        size="icon"
+        className={
+          feedbackSelected !== "like"
+            ? "text-muted-foreground hover:text-foreground"
+            : ""
+        }
+        onClick={() => handleFeedback("like")}
+      >
+        <ThumbsUp
+          className={`h-4 w-4 ${feedbackSelected === "like" ? "fill-current" : ""}`}
+        />
+      </Button>
+      <Button
+        variant="ghost"
+        size="icon"
+        className={
+          feedbackSelected !== "dislike"
+            ? "text-muted-foreground hover:text-foreground"
+            : ""
+        }
+        onClick={() => handleFeedback("dislike")}
+      >
+        <ThumbsDown
+          className={`h-4 w-4 ${feedbackSelected === "dislike" ? "fill-current" : ""}`}
+        />
+      </Button>
+    </div>
+  );
+};
+
+export default MessageActions;

--- a/frontend/app/chat/_types/types.ts
+++ b/frontend/app/chat/_types/types.ts
@@ -21,6 +21,12 @@ export interface Message {
   usage?: TokenUsage;
 }
 
+export const INITIAL_ASSISTANT_MESSAGE: Message = {
+  role: "assistant",
+  content: "How can I assist?",
+  timestamp: new Date(),
+};
+
 export interface FunctionCall {
   name: string;
   arguments?: Record<string, unknown>;

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -29,6 +29,7 @@ import type {
   RequestBody,
   ToolCallResult,
 } from "./_types/types";
+import { INITIAL_ASSISTANT_MESSAGE } from "./_types/types";
 
 function ChatPage() {
   const isDebugMode = process.env.NEXT_PUBLIC_OPENRAG_DEBUG === "true";
@@ -52,11 +53,7 @@ function ChatPage() {
     setConversationFilter,
   } = useChat();
   const [messages, setMessages] = useState<Message[]>([
-    {
-      role: "assistant",
-      content: "How can I assist?",
-      timestamp: new Date(),
-    },
+    INITIAL_ASSISTANT_MESSAGE,
   ]);
   const [input, setInput] = useState("");
   const { loading, setLoading } = useLoadingStore();
@@ -328,13 +325,7 @@ function ChatPage() {
       // Abort any in-flight streaming so it doesn't bleed into new chat
       abortStream();
       // Reset chat UI even if context state was already 'new'
-      setMessages([
-        {
-          role: "assistant",
-          content: "How can I assist?",
-          timestamp: new Date(),
-        },
-      ]);
+      setMessages([INITIAL_ASSISTANT_MESSAGE]);
       setInput("");
       setExpandedFunctionCalls(new Set());
       setIsFilterHighlighted(false);
@@ -572,13 +563,7 @@ function ChatPage() {
   useEffect(() => {
     if (placeholderConversation && currentConversationId === null) {
       console.log("Starting new conversation");
-      setMessages([
-        {
-          role: "assistant",
-          content: "How can I assist?",
-          timestamp: new Date(),
-        },
-      ]);
+      setMessages([INITIAL_ASSISTANT_MESSAGE]);
       lastLoadedConversationRef.current = null;
 
       // Focus input when starting a new conversation
@@ -1142,9 +1127,10 @@ function ChatPage() {
                             isInitialGreeting={
                               index === 0 &&
                               messages.length === 1 &&
-                              message.content === "How can I assist?"
+                              message === INITIAL_ASSISTANT_MESSAGE
                             }
                             usage={message.usage}
+                            timestamp={message.timestamp}
                           />
                         )}
                       </div>

--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -1127,7 +1127,8 @@ function ChatPage() {
                             isInitialGreeting={
                               index === 0 &&
                               messages.length === 1 &&
-                              message === INITIAL_ASSISTANT_MESSAGE
+                              message.content ===
+                                INITIAL_ASSISTANT_MESSAGE.content
                             }
                             usage={message.usage}
                             timestamp={message.timestamp}

--- a/frontend/app/onboarding/_components/onboarding-content.tsx
+++ b/frontend/app/onboarding/_components/onboarding-content.tsx
@@ -287,6 +287,7 @@ export function OnboardingContent({
                 onToggle={() => {}}
                 isStreaming={!!streamingMessage}
                 isCompleted={currentStep > 3}
+                showFeedback={false}
               />
             )}
 

--- a/frontend/contexts/chat-context.tsx
+++ b/frontend/contexts/chat-context.tsx
@@ -11,6 +11,7 @@ import {
   useState,
 } from "react";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
+import { INITIAL_ASSISTANT_MESSAGE } from "@/app/chat/_types/types";
 
 export type EndpointType = "chat" | "langflow";
 
@@ -22,7 +23,7 @@ interface ConversationDocument {
 interface ConversationMessage {
   role: string;
   content: string;
-  timestamp?: string;
+  timestamp?: Date;
   response_id?: string;
 }
 
@@ -340,13 +341,7 @@ export function ChatProvider({ children }: ChatProviderProps) {
       response_id: "new-conversation-" + Date.now(),
       title: "New conversation",
       endpoint: endpoint,
-      messages: [
-        {
-          role: "assistant",
-          content: "How can I assist?",
-          timestamp: new Date().toISOString(),
-        },
-      ],
+      messages: [INITIAL_ASSISTANT_MESSAGE],
       created_at: new Date().toISOString(),
       last_activity: new Date().toISOString(),
     };

--- a/frontend/contexts/chat-context.tsx
+++ b/frontend/contexts/chat-context.tsx
@@ -23,7 +23,7 @@ interface ConversationDocument {
 interface ConversationMessage {
   role: string;
   content: string;
-  timestamp?: Date;
+  timestamp?: string;
   response_id?: string;
 }
 
@@ -341,7 +341,13 @@ export function ChatProvider({ children }: ChatProviderProps) {
       response_id: "new-conversation-" + Date.now(),
       title: "New conversation",
       endpoint: endpoint,
-      messages: [INITIAL_ASSISTANT_MESSAGE],
+      messages: [
+        {
+          role: "assistant",
+          content: INITIAL_ASSISTANT_MESSAGE.content,
+          timestamp: new Date().toISOString(),
+        },
+      ],
       created_at: new Date().toISOString(),
       last_activity: new Date().toISOString(),
     };

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -11,7 +15,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx",
+    "jsx": "preserve",
     "incremental": true,
     "plugins": [
       {
@@ -19,7 +23,9 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     }
   },
   "include": [
@@ -29,5 +35,7 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -23,9 +19,7 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     }
   },
   "include": [
@@ -35,7 +29,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }


### PR DESCRIPTION
Adds a new like/dislike option for tracking purposes on assistant messages.

<img width="283" height="98" alt="Screenshot 2026-05-13 at 2 45 57 PM" src="https://github.com/user-attachments/assets/9f1d7148-73c1-4fd7-aab0-aab8aa75ffc5" />

Adds a `INITIAL_ASSISTANT_MESSAGE` option now used when creating new chats and the new `MessageActions` shouldn't be shown there.

it also won't show during onboarding


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Users can now provide feedback on assistant messages using like/dislike buttons.

* **Improvements**
  * Feedback controls display intelligently (hidden for initial greeting, streaming messages, and onboarding).
  * Standardized initial assistant greeting and timestamp handling for more consistent message behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1597)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->