### PR TITLE
refactor: Create and use onboarding state hook

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -8,6 +8,7 @@ import { Button } from "@/components/ui/button";
 import { useIsCloudBrand } from "@/contexts/brand-context";
 import { type EndpointType, useChat } from "@/contexts/chat-context";
 import { useTask } from "@/contexts/task-context";
+import { useOnboardingState } from "@/hooks/use-onboarding-state";
 import { useChatStreaming } from "@/hooks/useChatStreaming";
 import { trackLLMCall } from "@/lib/analytics";
 import { FILE_CONFIRMATION, FILES_REGEX } from "@/lib/constants";
@@ -572,13 +573,7 @@ function ChatPage() {
     }
   }, [placeholderConversation, currentConversationId]);
 
-  // Check onboarding completion
-
-  // Check if onboarding is complete (current_step >= 4 means complete)
-  const TOTAL_ONBOARDING_STEPS = 4;
-  const isOnboardingComplete =
-    settings?.onboarding?.current_step !== undefined &&
-    settings.onboarding.current_step >= TOTAL_ONBOARDING_STEPS;
+  const { isOnboardingComplete } = useOnboardingState();
 
   // Prepare filters for nudges (same as chat)
   const processedFiltersForNudges = parsedFilterData?.filters

--- a/frontend/contexts/chat-context.tsx
+++ b/frontend/contexts/chat-context.tsx
@@ -10,8 +10,8 @@ import {
   useRef,
   useState,
 } from "react";
-import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import { INITIAL_ASSISTANT_MESSAGE } from "@/app/chat/_types/types";
+import { useOnboardingState } from "@/hooks/use-onboarding-state";
 
 export type EndpointType = "chat" | "langflow";
 
@@ -122,31 +122,10 @@ export function ChatProvider({ children }: ChatProviderProps) {
   const [hasChatError, setChatError] = useState(false);
   const [loading, setLoading] = useState(false);
 
-  // Get settings to check if onboarding was completed (settings.edited)
-  const { data: settings } = useGetSettingsQuery();
+  const { isOnboardingComplete } = useOnboardingState();
 
-  // Check if onboarding is complete
-  // Onboarding is complete if:
-  // 1. settings.edited is true (backend confirms onboarding was completed)
-  // 2. AND onboarding step key is null (local onboarding flow is done)
-  const [isOnboardingComplete, setIsOnboardingComplete] = useState(() => {
-    if (typeof window === "undefined") return false;
-    // Default to false if settings not loaded yet
-    return false;
-  });
-
-  // Sync onboarding completion state with settings from backend
-  useEffect(() => {
-    const TOTAL_ONBOARDING_STEPS = 4;
-    // Onboarding is complete if current_step >= 4
-    const isComplete =
-      settings?.onboarding?.current_step !== undefined &&
-      settings.onboarding.current_step >= TOTAL_ONBOARDING_STEPS;
-    setIsOnboardingComplete(isComplete);
-  }, [settings?.onboarding?.current_step]);
-
-  const setOnboardingComplete = useCallback((complete: boolean) => {
-    setIsOnboardingComplete(complete);
+  const setOnboardingComplete = useCallback((_complete: boolean) => {
+    // no-op: onboarding completion is now derived from settings via useOnboardingState
   }, []);
 
   // Listen for ingestion failures and set chat error flag

--- a/frontend/contexts/task-context.tsx
+++ b/frontend/contexts/task-context.tsx
@@ -12,13 +12,13 @@ import {
 } from "react";
 import { toast } from "sonner";
 import { useCancelTaskMutation } from "@/app/api/mutations/useCancelTaskMutation";
-import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import {
   type Task,
   type TaskFileEntry,
   useGetTasksQuery,
 } from "@/app/api/queries/useGetTasksQuery";
 import { useAuth } from "@/contexts/auth-context";
+import { useOnboardingState } from "@/hooks/use-onboarding-state";
 import { trackProcessFailure, trackProcessSuccess } from "@/lib/analytics";
 import { hasFailedFileEntries, isTerminalFailedTask } from "@/lib/task-utils";
 
@@ -123,18 +123,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
     },
   });
 
-  // Get settings to check if onboarding is active
-  const { data: settings } = useGetSettingsQuery();
-
-  // Helper function to check if onboarding is active
-  const isOnboardingActive = useCallback(() => {
-    const TOTAL_ONBOARDING_STEPS = 4;
-    // Onboarding is active if current_step < 4
-    return (
-      settings?.onboarding?.current_step !== undefined &&
-      settings.onboarding.current_step < TOTAL_ONBOARDING_STEPS
-    );
-  }, [settings?.onboarding?.current_step]);
+  const { isOnboardingActive } = useOnboardingState();
 
   const refetchSearch = useCallback(() => {
     queryClient.invalidateQueries({
@@ -366,7 +355,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
               successfulFiles !== 1 ? "s" : ""
             } uploaded successfully`;
           }
-          if (!isOnboardingActive()) {
+          if (!isOnboardingActive) {
             toast.success("Task completed", {
               description,
               action: {
@@ -417,7 +406,7 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
           !isTerminalFailedTask(previousTask) &&
           isTerminalFailedTask(currentTask)
         ) {
-          if (!isOnboardingActive()) {
+          if (!isOnboardingActive) {
             selectTask(currentTask.task_id);
             setIsMenuOpen(true);
             setIsRecentTasksExpanded(true);

--- a/frontend/hooks/use-onboarding-state.ts
+++ b/frontend/hooks/use-onboarding-state.ts
@@ -6,10 +6,12 @@ import { TOTAL_ONBOARDING_STEPS } from "@/lib/constants";
 export function useOnboardingState() {
   const { data: settings } = useGetSettingsQuery();
   const currentStep = settings?.onboarding?.current_step;
+  const isValidStep =
+    typeof currentStep === "number" && Number.isFinite(currentStep);
   const isOnboardingComplete =
-    currentStep !== undefined && currentStep >= TOTAL_ONBOARDING_STEPS;
+    isValidStep && currentStep >= TOTAL_ONBOARDING_STEPS;
   const isOnboardingActive =
-    currentStep !== undefined && currentStep < TOTAL_ONBOARDING_STEPS;
+    isValidStep && currentStep < TOTAL_ONBOARDING_STEPS;
 
   return { isOnboardingComplete, isOnboardingActive, currentStep };
 }

--- a/frontend/hooks/use-onboarding-state.ts
+++ b/frontend/hooks/use-onboarding-state.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
+import { TOTAL_ONBOARDING_STEPS } from "@/lib/constants";
+
+export function useOnboardingState() {
+  const { data: settings } = useGetSettingsQuery();
+  const currentStep = settings?.onboarding?.current_step;
+  const isOnboardingComplete =
+    currentStep !== undefined && currentStep >= TOTAL_ONBOARDING_STEPS;
+  const isOnboardingActive =
+    currentStep !== undefined && currentStep < TOTAL_ONBOARDING_STEPS;
+
+  return { isOnboardingComplete, isOnboardingActive, currentStep };
+}


### PR DESCRIPTION
Creates `use-onboarding-state` hook to consolidate onboarding state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized onboarding state across the app for consistent behavior.
  * Nudges and task-completion/failure notifications now respect the centralized onboarding status.
  * Onboarding completion is now derived from the central state (removes local/manual completion handling).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1606)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->