### PR TITLE
fix: Add Trash2 icon and fix Tabs import

### DIFF
--- a/frontend/components/knowledge-batch-actions-bar.tsx
+++ b/frontend/components/knowledge-batch-actions-bar.tsx
@@ -1,4 +1,4 @@
-import { X } from "lucide-react";
+import { Trash2, X } from "lucide-react";
 
 import { usePermissions } from "@/hooks/use-permissions";
 

--- a/frontend/components/ui/settings-tabs.tsx
+++ b/frontend/components/ui/settings-tabs.tsx
@@ -1,7 +1,7 @@
 "use client";
 
+import * as TabsPrimitive from "@radix-ui/react-tabs";
 import { cva, type VariantProps } from "class-variance-authority";
-import { Tabs as TabsPrimitive } from "radix-ui";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";


### PR DESCRIPTION
Import Trash2 from lucide-react in knowledge-batch-actions-bar to support delete UI actions. Correct the Tabs import in settings-tabs to use the proper @radix-ui/react-tabs namespace import (was importing from 'radix-ui').

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal dependencies and import structures for improved code organization and compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1615)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->