### PR TITLE
chore: Add TypeScript typecheck CI job

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -27,3 +27,24 @@ jobs:
       - name: Biome check
         working-directory: frontend
         run: npm run lint
+
+  typecheck:
+    name: TypeScript type check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: TypeScript type check
+        working-directory: frontend
+        run: npm run typecheck

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,6 +10,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "biome check .",
+    "typecheck": "tsc --noEmit",
     "lint:fix": "biome check --write",
     "format": "biome format --write",
     "knip": "knip",


### PR DESCRIPTION
Add a new `typecheck` job to .github/workflows/lint-frontend.yml that sets up Node 20, installs frontend deps, and runs `npm run typecheck` to perform a TypeScript check in CI. Also add a `typecheck` script (`tsc --noEmit`) to frontend/package.json so the pipeline can run `tsc` without emitting files. This ensures TypeScript errors are caught during CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Chores**
- Type checking has been added to the automated pull request validation workflow. The new type checking process validates the frontend codebase on all pull requests as part of the continuous integration pipeline. Type validation now occurs automatically during the pull request phase, before code is reviewed and merged.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1616)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->