### PR TITLE
feat: backend pod status update operator

### DIFF
--- a/kubernetes/operator/internal/controller/openrag_controller.go
+++ b/kubernetes/operator/internal/controller/openrag_controller.go
@@ -32,6 +32,14 @@ const (
 	userSecretFinalizer = "openr.ag/user-secret-protection"
 	specHashAnnotation  = "openr.ag/spec-hash"
 	immutableAnnotation = "openr.ag/immutable"
+
+	// Condition types
+	conditionBackendReady = "BackendReady"
+
+	// Phase values
+	phaseReconciled = "Reconciled"
+	phaseRunning    = "Running"
+	phaseError      = "Error"
 )
 
 // OpenRAGReconciler reconciles an OpenRAG object.
@@ -123,46 +131,7 @@ func (r *OpenRAGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	// Update status to success
 	logger.Info("reconciled OpenRAG instance", "name", instance.Name, "targetNamespace", targetNS)
-	return r.updateStatusSuccess(ctx, instance)
-}
-
-// updateStatusSuccess updates the status to indicate successful reconciliation
-func (r *OpenRAGReconciler) updateStatusSuccess(ctx context.Context, instance *openragv1alpha1.OpenRAG) (ctrl.Result, error) {
-	const successMsg = "All resources reconciled successfully"
-	if instance.Status.Phase == "Running" &&
-		instance.Status.Message == successMsg &&
-		instance.Status.ObservedGeneration == instance.Generation {
-		return ctrl.Result{}, nil
-	}
-
-	instance.Status.Phase = "Running"
-	instance.Status.Message = successMsg
-	instance.Status.ObservedGeneration = instance.Generation
-	if err := r.Status().Update(ctx, instance); err != nil {
-		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
-	}
-
-	return ctrl.Result{}, nil
-}
-
-// updateStatusError updates the status to indicate reconciliation failure and schedules retry after 5 minutes
-func (r *OpenRAGReconciler) updateStatusError(ctx context.Context, instance *openragv1alpha1.OpenRAG, component string, reconcileErr error) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
-	instance.Status.Phase = "Error"
-	instance.Status.Message = fmt.Sprintf("Failed to reconcile %s: %s", component, reconcileErr.Error())
-	instance.Status.ObservedGeneration = instance.Generation
-
-	if err := r.Status().Update(ctx, instance); err != nil {
-		logger.Error(err, "failed to update status after error", "component", component, "reconcileError", reconcileErr.Error())
-		// Return original error even if status update fails
-		return ctrl.Result{}, reconcileErr
-	}
-
-	logger.Error(reconcileErr, "reconciliation failed, will retry in 5 minutes", "component", component)
-
-	// Requeue after 5 minutes on failure
-	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+	return r.updateStatusSuccess(ctx, instance, targetNS)
 }
 
 func (r *OpenRAGReconciler) handleDeletion(ctx context.Context, o *openragv1alpha1.OpenRAG) error {

--- a/kubernetes/operator/internal/controller/status.go
+++ b/kubernetes/operator/internal/controller/status.go
@@ -1,0 +1,120 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	openragv1alpha1 "github.com/langflow-ai/openrag-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// updateStatusSuccess updates the status to indicate successful reconciliation
+// Phase is set to "Reconciled" initially, then updated to "Running" if backend pod is ready
+func (r *OpenRAGReconciler) updateStatusSuccess(ctx context.Context, instance *openragv1alpha1.OpenRAG, targetNS string) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	// Update backend condition first
+	backendConditionStatus, err := r.updateBackendCondition(ctx, instance, targetNS)
+	if err != nil {
+		logger.Error(err, "failed to update backend condition")
+		// Continue anyway, don't fail reconciliation
+	}
+
+	// Determine phase based on backend readiness
+	phase := phaseReconciled
+	message := "All resources reconciled successfully, waiting for backend pod to be ready"
+	if backendConditionStatus == metav1.ConditionTrue {
+		phase = phaseRunning
+		message = "All resources reconciled successfully and backend is running"
+	}
+
+	instance.Status.Phase = phase
+	instance.Status.Message = message
+	instance.Status.ObservedGeneration = instance.Generation
+
+	if err := r.Status().Update(ctx, instance); err != nil {
+		return ctrl.Result{}, fmt.Errorf("failed to update status: %w", err)
+	}
+
+	// Requeue after 1 minute to check backend pod status
+	return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
+}
+
+// updateStatusError updates the status to indicate reconciliation failure and schedules retry after 5 minutes
+func (r *OpenRAGReconciler) updateStatusError(ctx context.Context, instance *openragv1alpha1.OpenRAG, component string, reconcileErr error) (ctrl.Result, error) {
+	logger := log.FromContext(ctx)
+
+	instance.Status.Phase = phaseError
+	instance.Status.Message = fmt.Sprintf("Failed to reconcile %s: %s", component, reconcileErr.Error())
+	instance.Status.ObservedGeneration = instance.Generation
+
+	if err := r.Status().Update(ctx, instance); err != nil {
+		logger.Error(err, "failed to update status after error", "component", component, "reconcileError", reconcileErr.Error())
+		// Return original error even if status update fails
+		return ctrl.Result{}, reconcileErr
+	}
+
+	logger.Error(reconcileErr, "reconciliation failed, will retry in 5 minutes", "component", component)
+
+	// Requeue after 5 minutes on failure
+	return ctrl.Result{RequeueAfter: 5 * time.Minute}, nil
+}
+
+// updateBackendCondition checks the backend deployment pod status and updates the BackendReady condition
+func (r *OpenRAGReconciler) updateBackendCondition(ctx context.Context, instance *openragv1alpha1.OpenRAG, targetNS string) (metav1.ConditionStatus, error) {
+	logger := log.FromContext(ctx)
+
+	deployment := &appsv1.Deployment{}
+	err := r.Get(ctx, client.ObjectKey{
+		Name:      resourceName("be"),
+		Namespace: targetNS,
+	}, deployment)
+
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// Backend deployment doesn't exist yet
+			meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+				Type:               conditionBackendReady,
+				Status:             metav1.ConditionUnknown,
+				Reason:             "DeploymentNotFound",
+				Message:            "Backend deployment not found",
+				ObservedGeneration: instance.Generation,
+			})
+			logger.Info("Backend deployment not found", "deployment", resourceName("be"))
+			return metav1.ConditionUnknown, nil
+		}
+		return metav1.ConditionUnknown, fmt.Errorf("failed to get backend deployment: %w", err)
+	}
+
+	reportedStatus := metav1.ConditionFalse
+	// Check if backend pod is ready (single replica)
+	if deployment.Status.ReadyReplicas > 0 && deployment.Status.ReadyReplicas == deployment.Status.Replicas {
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               conditionBackendReady,
+			Status:             metav1.ConditionTrue,
+			Reason:             "PodRunning",
+			Message:            "Backend pod is running and ready",
+			ObservedGeneration: instance.Generation,
+		})
+		reportedStatus = metav1.ConditionTrue
+		logger.Info("Backend pod is ready", "readyReplicas", deployment.Status.ReadyReplicas)
+	} else {
+		meta.SetStatusCondition(&instance.Status.Conditions, metav1.Condition{
+			Type:               conditionBackendReady,
+			Status:             metav1.ConditionFalse,
+			Reason:             "PodNotReady",
+			Message:            fmt.Sprintf("Backend pod not ready (ready: %d, desired: %d)", deployment.Status.ReadyReplicas, deployment.Status.Replicas),
+			ObservedGeneration: instance.Generation,
+		})
+		logger.Info("Backend pod not ready", "readyReplicas", deployment.Status.ReadyReplicas, "desiredReplicas", deployment.Status.Replicas)
+	}
+
+	return reportedStatus, nil
+}


### PR DESCRIPTION
Operator uses the phases to reflect the state of CR conciliation as well as the Backend pod running status

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced OpenRAG operator status tracking with improved reconciliation logic.
  * Added automatic reconciliation requeuing for better reliability.
  * Improved backend readiness condition monitoring and status reporting.
  * Enhanced error handling with detailed status messages and extended retry intervals.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1619?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->