### PR TITLE
chore:  add operator make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,6 +231,8 @@ help_docker: ## Show Docker and container commands
 	@echo "  $(PURPLE)make build-be$(NC)        - Build backend Docker image only"
 	@echo "  $(PURPLE)make build-fe$(NC)        - Build frontend Docker image only"
 	@echo "  $(PURPLE)make build-lf$(NC)        - Build Langflow Docker image only"
+	@echo "  $(PURPLE)make kind-build-load-apps$(NC) - Build app images and load into kind (KIND_CLUSTER_NAME=openrag)"
+	@echo "  $(PURPLE)make kind-load-app-images$(NC) - Load already-built app images into kind"
 	@echo ''
 	@echo "$(PURPLE)Container Management:$(NC)"
 	@echo "  $(PURPLE)make stop$(NC)            - Stop and remove all OpenRAG containers"
@@ -640,6 +642,20 @@ build-lf: ## Build Langflow Docker image
 	@echo "$(YELLOW)Building Langflow image...$(NC)"
 	$(CONTAINER_RUNTIME) build -t langflowai/openrag-langflow:latest -f Dockerfile.langflow .
 	@echo "$(PURPLE)Langflow image built.$(NC)"
+
+# kind cluster name for local Kubernetes (see kubernetes/operator/README.md)
+KIND_CLUSTER_NAME ?= openrag
+
+kind-load-app-images: ## Load OpenRAG app images into a kind cluster (Colima/Docker)
+	@command -v kind >/dev/null 2>&1 || { echo "$(RED)kind is not installed$(NC)"; exit 1; }
+	@echo "$(YELLOW)Loading app images into kind cluster '$(KIND_CLUSTER_NAME)'...$(NC)"
+	kind load docker-image langflowai/openrag-backend:latest --name $(KIND_CLUSTER_NAME)
+	kind load docker-image langflowai/openrag-frontend:latest --name $(KIND_CLUSTER_NAME)
+	kind load docker-image langflowai/openrag-langflow:latest --name $(KIND_CLUSTER_NAME)
+	@echo "$(PURPLE)Images loaded. Restart pods if they already exist:$(NC)"
+	@echo "  kubectl rollout restart deployment -n my-tenant openrag-fe openrag-be openrag-lf"
+
+kind-build-load-apps: build-be build-fe build-lf kind-load-app-images ## Build app images and load into kind
 
 ######################
 # LOGGING

--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ endef
 ######################
 # PHONY TARGETS
 ######################
-.PHONY: help check_tools help_docker help_dev help_test help_local help_utils \
+.PHONY: help check_tools help_docker help_dev help_test help_local help_utils help_operator \
        dev dev-cpu dev-local dev-local-cpu dev-local-build-lf dev-local-build-lf-cpu stop clean build logs \
        shell-backend shell-frontend install \
        test test-unit test-integration test-ci test-ci-local test-sdk test-os-jwt lint \
@@ -181,6 +181,59 @@ help: ## Show main help with common commands
 	@echo "  $(PURPLE)make help_test$(NC)       - Testing commands"
 	@echo "  $(PURPLE)make help_local$(NC)      - Local development commands"
 	@echo "  $(PURPLE)make help_utils$(NC)      - Utility commands (logs, cleanup, etc.)"
+	@echo "  $(PURPLE)make help_operator$(NC)   - Kubernetes operator & kind commands"
+	@echo ''
+	@echo "$(PURPLE)═══════════════════════════════════════════════════════════════════$(NC)"
+	@echo ''
+
+OPERATOR_DIR := kubernetes/operator
+
+help_operator: ## Show Kubernetes operator and kind local cluster commands
+	@echo ''
+	@echo "$(PURPLE)═══════════════════════════════════════════════════════════════════$(NC)"
+	@echo "$(PURPLE)              KUBERNETES OPERATOR & KIND COMMANDS                   $(NC)"
+	@echo "$(PURPLE)═══════════════════════════════════════════════════════════════════$(NC)"
+	@echo ''
+	@echo "$(PURPLE)Docs:$(NC) $(OPERATOR_DIR)/README.md"
+	@echo ''
+	@echo "$(PURPLE)App images → kind (from repo root, Colima/Docker):$(NC)"
+	@echo "  $(PURPLE)make kind-build-load-apps$(NC)  - Build backend/frontend/langflow + load into kind"
+	@echo "  $(PURPLE)make kind-load-app-images$(NC)  - Load already-built app images into kind"
+	@echo "                         $(CYAN)KIND_CLUSTER_NAME$(NC)=$(KIND_CLUSTER_NAME) (default: openrag)"
+	@echo ''
+	@echo "$(PURPLE)Operator binary & CRD ($(OPERATOR_DIR)):$(NC)"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make deps$(NC)       - Install controller-gen, kustomize, envtest"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make install$(NC)    - Install OpenRAG CRD into current cluster"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make run$(NC)        - Run operator on host (uses kubeconfig)"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make build$(NC)      - Compile operator to bin/manager"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make test$(NC)       - Operator unit tests (envtest)"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make lint$(NC)       - golangci-lint"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make manifests$(NC)  - Regenerate CRD/RBAC YAML"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make generate$(NC)   - Regenerate DeepCopy code"
+	@echo ''
+	@echo "$(PURPLE)Operator in-cluster:$(NC)"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make deploy$(NC)     - Deploy operator (IMG=...)"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make undeploy$(NC)   - Remove operator deployment"
+	@echo "  $(PURPLE)cd $(OPERATOR_DIR) && make docker-build$(NC) - Build operator image (IMG=...)"
+	@echo "  $(PURPLE)kind load docker-image openrag-operator:dev --name openrag$(NC)"
+	@echo "  $(PURPLE)helm install openrag-operator ./kubernetes/helm/operator -n openrag-control --create-namespace$(NC)"
+	@echo ''
+	@echo "$(PURPLE)Sample OpenRAG CR (after make run or make deploy):$(NC)"
+	@echo "  $(PURPLE)kubectl create namespace my-tenant$(NC)"
+	@echo "  $(PURPLE)kubectl apply -f $(OPERATOR_DIR)/config/samples/openrag_v1alpha1_openrag-kind-local.yaml$(NC)"
+	@echo "                         (low CPU + imagePullPolicy: Never for local images)"
+	@echo "  $(PURPLE)kubectl get pods -n my-tenant$(NC)"
+	@echo "  $(PURPLE)kubectl rollout restart deployment -n my-tenant openrag-fe openrag-be openrag-lf$(NC)"
+	@echo "                         (after rebuilding and reloading images)"
+	@echo ''
+	@echo "$(PURPLE)Typical kind + local images workflow:$(NC)"
+	@echo "  1. $(CYAN)kind create cluster --name openrag$(NC)"
+	@echo "  2. $(CYAN)make kind-build-load-apps$(NC)"
+	@echo "  3. $(CYAN)cd $(OPERATOR_DIR) && make install && make run$(NC)"
+	@echo "  4. $(CYAN)kubectl create namespace my-tenant$(NC)"
+	@echo "  5. $(CYAN)kubectl apply -f $(OPERATOR_DIR)/config/samples/openrag_v1alpha1_openrag-kind-local.yaml$(NC)"
+	@echo ''
+	@echo "$(PURPLE)All operator Makefile targets:$(NC) $(CYAN)cd $(OPERATOR_DIR) && make help$(NC)"
 	@echo ''
 	@echo "$(PURPLE)═══════════════════════════════════════════════════════════════════$(NC)"
 	@echo ''

--- a/kubernetes/operator/README.md
+++ b/kubernetes/operator/README.md
@@ -108,7 +108,53 @@ make install
 Run the operator locally:
 
 ```bash
-go run cmd/main.go
+make run
+```
+
+Apply a sample CR (create the namespace first; the operator does not create it when `metadata.namespace` equals `targetNamespace`):
+
+```bash
+kubectl create namespace my-tenant
+# kind/Colima clusters usually have only 2 CPUs — use the kind-local sample:
+kubectl apply -f config/samples/openrag_v1alpha1_openrag-kind-local.yaml
+kubectl get pods -n my-tenant
+```
+
+On a 2-CPU kind node, the default sample (`openrag_v1alpha1_openrag.yaml`) requests 1500m CPU for frontend+backend+langflow and langflow will stay `Pending` with `Insufficient cpu`.
+
+### Build app images locally and use them in kind (Colima/Docker)
+
+From the **repository root** (not `kubernetes/operator/`):
+
+```bash
+# Build backend, frontend, langflow and load into the kind node
+make kind-build-load-apps
+
+# In another terminal: operator + CR (kind-local sets imagePullPolicy: Never)
+cd kubernetes/operator
+make install
+make run
+
+kubectl create namespace my-tenant
+kubectl apply -f config/samples/openrag_v1alpha1_openrag-kind-local.yaml
+```
+
+Images are tagged the same as upstream (`langflowai/openrag-*:latest`) so the kind-local sample does not need custom names. `imagePullPolicy: Never` forces the cluster to use the copies loaded with `kind load docker-image`.
+
+After you change code and rebuild:
+
+```bash
+make kind-build-load-apps   # or build only what changed, then make kind-load-app-images
+kubectl rollout restart deployment -n my-tenant openrag-fe openrag-be openrag-lf
+```
+
+Optional: build/load the **operator** image the same way:
+
+```bash
+cd kubernetes/operator
+make docker-build IMG=openrag-operator:dev
+kind load docker-image openrag-operator:dev --name openrag
+make deploy IMG=openrag-operator:dev   # instead of make run
 ```
 
 ### 5. Tear down

--- a/kubernetes/operator/config/samples/openrag_v1alpha1_openrag-kind-local.yaml
+++ b/kubernetes/operator/config/samples/openrag_v1alpha1_openrag-kind-local.yaml
@@ -1,0 +1,65 @@
+# OpenRAG sample for local kind/Colima clusters (typically 2 CPUs).
+#
+# Build and load images from the repo root (Docker/Colima):
+#   make kind-build-load-apps
+#   # or: make build-be build-fe build-lf && make kind-load-app-images
+#
+# Apply (operator must be running via `make run` or deployed):
+#   kubectl create namespace my-tenant
+#   kubectl apply -f config/samples/openrag_v1alpha1_openrag-kind-local.yaml
+#
+# After rebuilding images, reload into kind and restart workloads:
+#   make kind-load-app-images
+#   kubectl rollout restart deployment -n my-tenant openrag-fe openrag-be openrag-lf
+#
+# imagePullPolicy: Never — use images pre-loaded with `kind load docker-image` (do not pull from registry).
+apiVersion: openr.ag/v1alpha1
+kind: OpenRAG
+metadata:
+  name: my-openrag
+  namespace: my-tenant
+spec:
+  targetNamespace: my-tenant
+
+  frontend:
+    image: langflowai/openrag-frontend:latest
+    imagePullPolicy: Never
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "256Mi"
+      limits:
+        cpu: "500m"
+        memory: "1Gi"
+
+  backend:
+    image: langflowai/openrag-backend:latest
+    imagePullPolicy: Never
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        cpu: "1"
+        memory: "4Gi"
+    storage:
+      enabled: true
+      size: "1Gi"
+
+  langflow:
+    image: langflowai/openrag-langflow:latest
+    imagePullPolicy: Never
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "512Mi"
+      limits:
+        cpu: "1"
+        memory: "2Gi"
+    storage:
+      enabled: true
+      size: "1Gi"
+    flowsRef: release-saas-0.1
+
+  networkPolicy:
+    enabled: false

--- a/kubernetes/operator/config/samples/openrag_v1alpha1_openrag.yaml
+++ b/kubernetes/operator/config/samples/openrag_v1alpha1_openrag.yaml
@@ -1,3 +1,4 @@
+# For local kind/Colima (2-CPU nodes), use openrag_v1alpha1_openrag-kind-local.yaml instead.
 apiVersion: openr.ag/v1alpha1
 kind: OpenRAG
 metadata:


### PR DESCRIPTION
This pull request adds comprehensive support for local Kubernetes development using `kind` and Docker/Colima, including new Makefile targets and documentation to streamline building, loading, and deploying OpenRAG app and operator images into a local cluster. It introduces a new sample CR optimized for low-resource environments and clarifies workflows for local testing.

**Makefile and CLI improvements:**

* Added new `kind-build-load-apps` and `kind-load-app-images` targets to the `Makefile` for building OpenRAG app images and loading them into a local `kind` cluster. Also updated help output to document these commands and added a new `help_operator` target with a detailed operator workflow summary. [[1]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L97-R97) [[2]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R184-R236) [[3]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R287-R288) [[4]](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R699-R712)

**Documentation updates:**

* Updated `kubernetes/operator/README.md` to document the local `kind` workflow, including building/loading images, applying the new sample CR, and restarting deployments after rebuilding images. Also added instructions for building and loading the operator image for in-cluster use.

**Kubernetes operator samples:**

* Added a new sample CR `openrag_v1alpha1_openrag-kind-local.yaml` with reduced CPU/memory requests and `imagePullPolicy: Never` for use in local clusters with pre-loaded images.
* Updated the default sample CR `openrag_v1alpha1_openrag.yaml` to direct local users to the new kind-specific sample.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added make commands for building and loading application images into local Kubernetes kind clusters
  * Added sample configuration file for deploying OpenRAG on local kind/Colima clusters with optimized settings for low-resource environments

* **Documentation**
  * Updated local operator setup instructions with simplified and streamlined workflow

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1628?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->