### PR TITLE
fix: Copy flows directory into Docker image

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -7,6 +7,8 @@ RUN pip install uv \
     && pip uninstall -y litellm \
     && mkdir -p /app/langflow-data
 
+COPY flows/ /app/flows/
+
 # Copy the entrypoint before switching to root so the COPY runs as uid=1000
 # (which owns /app), then switch to root so the entrypoint can correct
 # bind-mount permissions at runtime before dropping back to uid=1000.


### PR DESCRIPTION
Add a COPY instruction to include the local flows/ directory at /app/flows in the image so bundled flows are available at runtime. Placed before the entrypoint/ownership handling to ensure the files are copied with the intended UID/permissions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configuration to include the flows directory in deployments, ensuring proper packaging of flow files in containerized environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->