### PR TITLE
chore: Add ruff autofix step to CI workflows

### DIFF
--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -1,7 +1,7 @@
 # autofix.ci enforces that any workflow invoking `autofix-ci/action` is
-# named exactly `autofix.ci`. Applies ruff safe lint fixes and formatting
-# on changed files; strict lint (--no-fix) and mypy live in
-# `.github/workflows/lint-backend.yml`.
+# named exactly `autofix.ci`. Applies ruff safe lint fixes (excluding F401
+# to preserve side-effect imports) and formatting on changed files; strict
+# lint (--no-fix) and mypy live in `.github/workflows/lint-backend.yml`.
 #
 # Setup: install https://github.com/apps/autofix-ci on the repo (free for
 # public repos) and enable auto-apply in the autofix.ci dashboard so the
@@ -65,7 +65,8 @@ jobs:
 
       - name: Ruff lint fix (in-place)
         if: steps.changed.outputs.files != ''
-        run: uv run ruff check --fix ${{ steps.changed.outputs.files }}
+        continue-on-error: true
+        run: uv run ruff check --fix --extend-ignore F401 ${{ steps.changed.outputs.files }}
 
       - name: Ruff format (in-place)
         if: steps.changed.outputs.files != ''

--- a/.github/workflows/autofix.ci.yml
+++ b/.github/workflows/autofix.ci.yml
@@ -1,6 +1,6 @@
 # autofix.ci enforces that any workflow invoking `autofix-ci/action` is
-# named exactly `autofix.ci`. Keep this workflow narrowly scoped to
-# formatter autofix; strict lint and mypy checks live in
+# named exactly `autofix.ci`. Applies ruff safe lint fixes and formatting
+# on changed files; strict lint (--no-fix) and mypy live in
 # `.github/workflows/lint-backend.yml`.
 #
 # Setup: install https://github.com/apps/autofix-ci on the repo (free for
@@ -28,7 +28,7 @@ permissions:
 
 jobs:
   autofix:
-    name: ruff format autofix
+    name: ruff autofix
     runs-on: ubuntu-latest
 
     steps:
@@ -63,16 +63,20 @@ jobs:
           printf '%s\n' "${files[@]}"
           echo "files=${files[*]}" >> "$GITHUB_OUTPUT"
 
+      - name: Ruff lint fix (in-place)
+        if: steps.changed.outputs.files != ''
+        run: uv run ruff check --fix ${{ steps.changed.outputs.files }}
+
       - name: Ruff format (in-place)
         if: steps.changed.outputs.files != ''
         run: uv run ruff format ${{ steps.changed.outputs.files }}
 
-      # Hands any working-tree changes from the previous step to autofix.ci.
+      # Hands any working-tree changes from the previous steps to autofix.ci.
       # In auto-apply mode the App pushes a commit back to the PR branch;
       # the action exits non-zero on the run that produced the diff, then
       # the App's commit triggers a fresh CI cycle that passes.
-      - name: Apply ruff format autofix via autofix.ci
+      - name: Apply ruff autofix via autofix.ci
         if: steps.changed.outputs.files != ''
         uses: autofix-ci/action@v1.3.1
         with:
-          commit-message: "style: ruff format (auto)"
+          commit-message: "style: ruff autofix (auto)"

--- a/.github/workflows/lint-backend.yml
+++ b/.github/workflows/lint-backend.yml
@@ -63,8 +63,8 @@ jobs:
           # safe-classified fixes still include things like F401 (unused
           # imports), which can break side-effect imports used by the
           # connector registration pattern.
-          # Formatting is enforced + auto-applied by the separate
-          # `.github/workflows/autofix.ci.yml` workflow.
+          # Safe lint fixes and formatting are auto-applied by
+          # `.github/workflows/autofix.ci.yml`.
           uv run ruff check --no-fix --output-format=github ${{ steps.changed.outputs.files }}
 
       - name: Mypy


### PR DESCRIPTION
Add an in-place Ruff fix step to .github/workflows/autofix.ci.yml that runs uv run ruff check --fix on changed files, rename the job and autofix commit message to reflect "ruff autofix", and update comments to clarify that autofix.ci applies safe fixes and formatting. Also update .github/workflows/lint-backend.yml comments to state that safe lint fixes and formatting are auto-applied by autofix.ci while keeping strict lint (--no-fix) and mypy in the lint workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated automated checks to apply safe lint fixes and code formatting to changed Python files, making CI cleanup more comprehensive.
  * Clarified workflow notes so the expected auto-fix behavior is easier to understand.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->