### PR TITLE
fix: run OpenSearch security setup on every container start

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -417,7 +417,7 @@ dev: ensure-langflow-data ensure-backend-volumes ## Start full stack with GPU su
 
 dev-cpu: ensure-langflow-data ensure-backend-volumes ## Start full stack with CPU only
 	@echo "$(YELLOW)Starting OpenRAG with CPU only...$(NC)"
-	$(COMPOSE_CMD) up -d
+	$(COMPOSE_CMD) up -d --build
 	@echo "$(PURPLE)Services started!$(NC)"
 	@echo "   $(CYAN)Backend:$(NC)    http://openrag-backend"
 	@echo "   $(CYAN)Frontend:$(NC)   http://localhost:3000"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,10 @@ services:
       - discovery.type=single-node
       - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_PASSWORD}
       - OPENSEARCH_JAVA_OPTS=-Xms1g -Xmx1g
+    entrypoint:
+      - /bin/bash
+      - -c
+      - "/usr/share/opensearch/opensearch-docker-entrypoint.sh opensearch & /usr/share/opensearch/setup-security.sh; wait"
     # NOTE: do NOT add `extra_hosts: openrag-backend:host-gateway` here.
     # `extra_hosts` writes to /etc/hosts, which libc resolves BEFORE
     # docker DNS — so the alias overrides docker-compose service-name


### PR DESCRIPTION
## Problem

  `setup-security.sh` (which applies the OIDC config and role mappings via `securityadmin`) was only executed once — at initial container creation. On any `docker compose restart` or `--force-recreate`, it was never called again, leaving OpenSearch without the OIDC/JWT authentication config. This caused all JWT-authenticated requests (ingestion, search) to return `401 Unauthorized`.

Root cause chain:
  1. Container restart → `setup-security.sh` skipped → OIDC config not applied
  2. If JWKS was previously empty (e.g. wrong `JWT_SIGNING_KEY` format), OpenSearch cached the empty key set and never re-fetched, making JWT
  auth permanently broken until a restart
  3. After restart → same problem repeats

  ## Fix

  Override the OpenSearch container `entrypoint` in `docker-compose.yml` to run `setup-security.sh` on every start:

  ```sh
  opensearch-docker-entrypoint.sh opensearch & setup-security.sh; wait
```

  OpenSearch starts in the background, `setup-security.sh` waits for it to be ready then applies the OIDC config, and wait keeps the container alive. This is idempotent: re-applying the config has no side effects.

  Also adds `--build` to the `dev-cpu` make target to ensure local image changes are picked up.

  Test plan

  - `docker compose restart opensearch` → JWT auth still works after restart
  - `docker compose up -d --force-recreate opensearch` → JWT auth works on fresh container
  - Ingestion of URLs and PDFs succeeds after restart

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CPU-only development environment to rebuild Docker images on startup for consistency
  * OpenSearch service now automatically initializes security configuration during container startup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1641?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->