### PR TITLE
feat: Show google_drive connector for cloud brand

### DIFF
--- a/frontend/app/settings/_components/connector-cards.tsx
+++ b/frontend/app/settings/_components/connector-cards.tsx
@@ -55,8 +55,7 @@ export default function ConnectorCards() {
   const connectors = queryConnectors
     .filter((c) => {
       if (c.type === "ibm_cos" || c.type === "aws_s3") return isIbmAuthMode;
-      if (isCloudBrand && (c.type === "google_drive" || c.type === "onedrive"))
-        return false;
+      if (isCloudBrand && c.type === "onedrive") return false;
       return true;
     })
     .map((c) => ({

--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -624,8 +624,7 @@ export function KnowledgeDropdown() {
   const cloudConnectorItems = Object.entries(cloudConnectors)
     .filter(([type, info]) => {
       if (!info.available) return false;
-      if (isCloudBrand && (type === "google_drive" || type === "onedrive"))
-        return false;
+      if (isCloudBrand && type === "onedrive") return false;
       return true;
     })
     .map(([type, info]) => ({


### PR DESCRIPTION
Remove google_drive from the cloud-brand exclusion so Google Drive connectors are visible when isCloudBrand is true. Applied the change in connector-cards.tsx and knowledge-dropdown.tsx (OneDrive remains excluded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector availability in cloud-branded deployments. Google Drive connector is now accessible to users, while OneDrive remains excluded. This change applies across connector settings and knowledge management sections of the application.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1650?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->