### PR TITLE
fix: remove flow download initContainer when flowRef is removed

### DIFF
--- a/kubernetes/operator/internal/controller/openrag_controller.go
+++ b/kubernetes/operator/internal/controller/openrag_controller.go
@@ -1101,6 +1101,8 @@ func (r *OpenRAGReconciler) langflowDeployment(o *openragv1alpha1.OpenRAG, targe
 		mounts = append(mounts, corev1.VolumeMount{Name: "langflow-data", MountPath: "/app/data"})
 	}
 
+	// Only create initContainer if FlowsRef is specified
+	// Use nil (not empty slice) to ensure initContainers are removed when FlowsRef is cleared
 	var initContainers []corev1.Container
 	if spec.FlowsRef != "" {
 		volumes = append(volumes, corev1.Volume{
@@ -1126,6 +1128,9 @@ func (r *OpenRAGReconciler) langflowDeployment(o *openragv1alpha1.OpenRAG, targe
 				},
 			},
 		}
+	} else {
+		// Explicitly set to nil when FlowsRef is empty to ensure initContainers are removed
+		initContainers = nil
 	}
 
 	// All sensitive values are now consolidated in the .env file


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kubernetes operator now properly removes init containers when the FlowsRef setting is cleared, ensuring accurate resource cleanup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1653?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->