### PR TITLE
fix: update OAuth prompt to consent for connector mutation

### DIFF
--- a/frontend/app/api/mutations/useConnectConnectorMutation.ts
+++ b/frontend/app/api/mutations/useConnectConnectorMutation.ts
@@ -86,7 +86,7 @@ export const useConnectConnectorMutation = () => {
             result.oauth_config.redirect_uri,
           )}&` +
           `access_type=offline&` +
-          `prompt=select_account&` +
+          `prompt=consent&` +
           `state=${encodeURIComponent(state)}`;
 
         window.location.href = authUrl;

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -190,7 +190,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
             `scope=${result.oauth_config.scopes.join(" ")}&` +
             `redirect_uri=${encodeURIComponent(result.oauth_config.redirect_uri)}&` +
             `access_type=offline&` +
-            `prompt=select_account&` +
+            `prompt=consent&` +
             `state=${encodeURIComponent(state)}`;
 
           console.log("Redirecting to OAuth URL:", authUrl);


### PR DESCRIPTION
After OpenRAG restarts, the Google Drive connector loses its usable OAuth state. Because the OAuth flow uses prompt=select_account instead of forcing consent when needed, Google does not return a new refresh_token on reconnect. If OpenRAG did not persist the original refresh token, or overwrites it with an OAuth response that does not include one, the connector can no longer refresh expired access tokens. As a result, Google Drive appears disconnected after the access token expires.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated OAuth authorization prompt behavior during user login and connector setup.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1657?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->