### PR TITLE
fix: Encode IBM API key as Basic auth header

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -626,6 +626,8 @@ async def get_api_key_user_async(
 
     Raises HTTP 401 if no valid credentials are provided.
     """
+    import base64
+    # IBM auth path: X-Username + X-Api-Key forwarded by the MCP via the SDK
     from config.settings import IBM_AUTH_ENABLED
 
     # IBM auth path: X-Username + X-Api-Key forwarded by the MCP via the SDK
@@ -633,16 +635,22 @@ async def get_api_key_user_async(
         ibm_username = request.headers.get("X-Username")
         ibm_api_key = request.headers.get("X-Api-Key")
         if ibm_username and ibm_api_key:
+            # check if ibm api key is base 64 encoded
+            userpass = f"{ibm_username}:{ibm_api_key}"
+            ibm_api_key_b64 = base64.b64encode(userpass.encode("utf-8")).decode("utf-8")
+       
+       
             user = User(
                 user_id=ibm_username,
                 email=ibm_username,
                 name=ibm_username,
                 picture=None,
                 provider="ibm_ams",
-                jwt_token=None,
+                jwt_token=f"Basic {ibm_api_key_b64}",
                 opensearch_username=ibm_username,
-                opensearch_credentials=ibm_api_key,
+                opensearch_credentials=ibm_api_key_b64,
             )
+            request.state.user = user
             return await _attach_db_user_id(request, user)
 
     # API key path

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -627,6 +627,7 @@ async def get_api_key_user_async(
     Raises HTTP 401 if no valid credentials are provided.
     """
     import base64
+
     # IBM auth path: X-Username + X-Api-Key forwarded by the MCP via the SDK
     from config.settings import IBM_AUTH_ENABLED
 
@@ -638,8 +639,7 @@ async def get_api_key_user_async(
             # check if ibm api key is base 64 encoded
             userpass = f"{ibm_username}:{ibm_api_key}"
             ibm_api_key_b64 = base64.b64encode(userpass.encode("utf-8")).decode("utf-8")
-       
-       
+
             user = User(
                 user_id=ibm_username,
                 email=ibm_username,


### PR DESCRIPTION
Add base64 encoding for the IBM auth path: import base64, construct a Basic auth token from X-Username and X-Api-Key (username:apikey), and store it in user.jwt_token and user.opensearch_credentials. Also set request.state.user before attaching the DB user ID so downstream code can access the created user object.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API key credential handling for IBM MCP forwarding to properly encode authentication pairs, ensuring secure and consistent credential formatting across the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1664?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->