### PR TITLE
fix: Ensure Langflow .env variable definitions from LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT

### DIFF
--- a/kubernetes/operator/internal/controller/env.go
+++ b/kubernetes/operator/internal/controller/env.go
@@ -69,6 +69,14 @@ func NewEnvVarManager() *EnvVarManager {
 			"FILESIZE":                 "0",
 			"SELECTED_EMBEDDING_MODEL": "",
 
+			// OpenSearch defaults (for variables in LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT)
+			"OPENSEARCH_PASSWORD":   "None",
+			"OPENSEARCH_URL":        "None",
+			"OPENSEARCH_INDEX_NAME": "None",
+
+			// Docling defaults (for variables in LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT)
+			"DOCLING_SERVE_URL": "None",
+
 			// Provider API keys (defaults to None, overridden by CR spec)
 			"OPENAI_API_KEY":     "None",
 			"ANTHROPIC_API_KEY":  "None",
@@ -214,6 +222,34 @@ func (m *EnvVarManager) BuildEnvFileContent(envVars map[string]string) string {
 		b.WriteString("\n")
 	}
 	return b.String()
+}
+
+// EnsureRequiredEnvVars ensures all variables listed in LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT
+// exist in the envVars map with at least a "None" value. This is critical because Langflow components
+// expect these variables to be present in the environment, and the list can be customized via CR spec,
+// operator env vars (OPTLF_LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT), or defaults.
+func (m *EnvVarManager) EnsureRequiredEnvVars(envVars map[string]string) {
+	// Get the list of required variables
+	requiredVarsStr, exists := envVars["LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT"]
+	if !exists || requiredVarsStr == "" {
+		return
+	}
+
+	// Parse comma-separated list
+	requiredVars := strings.Split(requiredVarsStr, ",")
+
+	// Ensure each variable exists with at least "None" value
+	for _, varName := range requiredVars {
+		varName = strings.TrimSpace(varName)
+		if varName == "" {
+			continue
+		}
+
+		// Only add if not already present
+		if _, exists := envVars[varName]; !exists {
+			envVars[varName] = "None"
+		}
+	}
 }
 
 // Generates a base64-encoded string of exactly 32 bytes for Fernet

--- a/kubernetes/operator/internal/controller/env_example_test.go
+++ b/kubernetes/operator/internal/controller/env_example_test.go
@@ -43,7 +43,7 @@ func Example_envVarPriority() {
 	// LANGFLOW_WORKERS: 8 (from operator env)
 	// LANGFLOW_LOG_LEVEL: ERROR (from CR spec)
 	//
-	// .env file would contain 1380 bytes
+	// .env file would contain 1475 bytes
 }
 
 // Example showing how different components use different prefixes

--- a/kubernetes/operator/internal/controller/env_test.go
+++ b/kubernetes/operator/internal/controller/env_test.go
@@ -350,15 +350,12 @@ func TestEnvVarManager_EnsureRequiredEnvVars_Integration(t *testing.T) {
 	manager.EnsureRequiredEnvVars(envVars)
 
 	// Parse the required variables list
-	requiredVars := []string{}
-	for _, v := range []string{"JWT", "OPENRAG_QUERY_FILTER", "OPENSEARCH_PASSWORD", "OPENSEARCH_URL",
+	requiredVars := []string{"JWT", "OPENRAG_QUERY_FILTER", "OPENSEARCH_PASSWORD", "OPENSEARCH_URL",
 		"OPENSEARCH_INDEX_NAME", "DOCLING_SERVE_URL", "DOCLING_TASK_ID", "OWNER", "OWNER_NAME",
 		"OWNER_EMAIL", "CONNECTOR_TYPE", "DOCUMENT_ID", "SOURCE_URL", "ALLOWED_USERS",
 		"ALLOWED_GROUPS", "FILENAME", "MIMETYPE", "FILESIZE", "SELECTED_EMBEDDING_MODEL",
 		"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "WATSONX_API_KEY", "WATSONX_ENDPOINT",
-		"WATSONX_PROJECT_ID", "OLLAMA_BASE_URL"} {
-		requiredVars = append(requiredVars, v)
-	}
+		"WATSONX_PROJECT_ID", "OLLAMA_BASE_URL"}
 
 	// Verify all required variables exist in the envVars map
 	for _, varName := range requiredVars {

--- a/kubernetes/operator/internal/controller/env_test.go
+++ b/kubernetes/operator/internal/controller/env_test.go
@@ -218,3 +218,176 @@ func TestEnvVarManager_NewEnvVarManagerDefaults(t *testing.T) {
 	// Verify Frontend defaults (empty for now)
 	assert.NotNil(t, manager.DefaultOpenRagFEEnvVars)
 }
+
+func TestEnvVarManager_EnsureRequiredEnvVars(t *testing.T) {
+	tests := []struct {
+		name           string
+		inputEnvVars   map[string]string
+		expectedResult map[string]string
+		description    string
+	}{
+		{
+			name: "adds missing variables with None",
+			inputEnvVars: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1,VAR2,VAR3",
+				"VAR1": "existing_value",
+			},
+			expectedResult: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1,VAR2,VAR3",
+				"VAR1": "existing_value",
+				"VAR2": "None",
+				"VAR3": "None",
+			},
+			description: "Should add VAR2 and VAR3 with 'None' value, preserve VAR1",
+		},
+		{
+			name: "handles whitespace in variable list",
+			inputEnvVars: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1, VAR2 , VAR3",
+			},
+			expectedResult: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1, VAR2 , VAR3",
+				"VAR1": "None",
+				"VAR2": "None",
+				"VAR3": "None",
+			},
+			description: "Should trim whitespace from variable names",
+		},
+		{
+			name: "skips empty variable names",
+			inputEnvVars: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1,,VAR2,  ,VAR3",
+			},
+			expectedResult: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1,,VAR2,  ,VAR3",
+				"VAR1": "None",
+				"VAR2": "None",
+				"VAR3": "None",
+			},
+			description: "Should skip empty strings and whitespace-only entries",
+		},
+		{
+			name: "does nothing when LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT is missing",
+			inputEnvVars: map[string]string{
+				"VAR1": "value1",
+			},
+			expectedResult: map[string]string{
+				"VAR1": "value1",
+			},
+			description: "Should not modify envVars when the list variable is missing",
+		},
+		{
+			name: "does nothing when LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT is empty",
+			inputEnvVars: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "",
+				"VAR1": "value1",
+			},
+			expectedResult: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "",
+				"VAR1": "value1",
+			},
+			description: "Should not modify envVars when the list is empty",
+		},
+		{
+			name: "preserves existing values including empty strings",
+			inputEnvVars: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1,VAR2,VAR3",
+				"VAR1": "",
+				"VAR2": "0",
+			},
+			expectedResult: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "VAR1,VAR2,VAR3",
+				"VAR1": "",
+				"VAR2": "0",
+				"VAR3": "None",
+			},
+			description: "Should preserve empty string and '0' values, only add missing VAR3",
+		},
+		{
+			name: "handles real-world variable list",
+			inputEnvVars: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "JWT,OPENSEARCH_PASSWORD,OPENSEARCH_URL,DOCLING_SERVE_URL",
+				"JWT":                 "token123",
+				"OPENSEARCH_PASSWORD": "secret",
+			},
+			expectedResult: map[string]string{
+				"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "JWT,OPENSEARCH_PASSWORD,OPENSEARCH_URL,DOCLING_SERVE_URL",
+				"JWT":                 "token123",
+				"OPENSEARCH_PASSWORD": "secret",
+				"OPENSEARCH_URL":      "None",
+				"DOCLING_SERVE_URL":   "None",
+			},
+			description: "Should add missing OpenSearch and Docling variables",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			manager := &EnvVarManager{}
+
+			// Call the function
+			manager.EnsureRequiredEnvVars(tt.inputEnvVars)
+
+			// Verify the result
+			assert.Equal(t, tt.expectedResult, tt.inputEnvVars, tt.description)
+		})
+	}
+}
+
+func TestEnvVarManager_EnsureRequiredEnvVars_Integration(t *testing.T) {
+	// Test with the actual default configuration
+	manager := NewEnvVarManager()
+
+	// Get the default Langflow env vars
+	envVars := manager.GetLangflowEnvVars(nil)
+
+	// Verify LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT exists
+	requiredVarsStr, exists := envVars["LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT"]
+	assert.True(t, exists, "LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT should exist in defaults")
+	assert.NotEmpty(t, requiredVarsStr, "LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT should not be empty")
+
+	// Call EnsureRequiredEnvVars
+	manager.EnsureRequiredEnvVars(envVars)
+
+	// Parse the required variables list
+	requiredVars := []string{}
+	for _, v := range []string{"JWT", "OPENRAG_QUERY_FILTER", "OPENSEARCH_PASSWORD", "OPENSEARCH_URL",
+		"OPENSEARCH_INDEX_NAME", "DOCLING_SERVE_URL", "DOCLING_TASK_ID", "OWNER", "OWNER_NAME",
+		"OWNER_EMAIL", "CONNECTOR_TYPE", "DOCUMENT_ID", "SOURCE_URL", "ALLOWED_USERS",
+		"ALLOWED_GROUPS", "FILENAME", "MIMETYPE", "FILESIZE", "SELECTED_EMBEDDING_MODEL",
+		"OPENAI_API_KEY", "ANTHROPIC_API_KEY", "WATSONX_API_KEY", "WATSONX_ENDPOINT",
+		"WATSONX_PROJECT_ID", "OLLAMA_BASE_URL"} {
+		requiredVars = append(requiredVars, v)
+	}
+
+	// Verify all required variables exist in the envVars map
+	for _, varName := range requiredVars {
+		_, exists := envVars[varName]
+		assert.True(t, exists, "Variable %s should exist in envVars", varName)
+		// Note: Some variables may have empty string as their default value (e.g., DOCUMENT_ID, SOURCE_URL, SELECTED_EMBEDDING_MODEL)
+		// The important thing is that they exist in the map
+	}
+
+	// Verify the newly added defaults are present
+	assert.Equal(t, "None", envVars["OPENSEARCH_PASSWORD"], "OPENSEARCH_PASSWORD should have default 'None'")
+	assert.Equal(t, "None", envVars["OPENSEARCH_URL"], "OPENSEARCH_URL should have default 'None'")
+	assert.Equal(t, "None", envVars["OPENSEARCH_INDEX_NAME"], "OPENSEARCH_INDEX_NAME should have default 'None'")
+	assert.Equal(t, "None", envVars["DOCLING_SERVE_URL"], "DOCLING_SERVE_URL should have default 'None'")
+}
+
+func TestEnvVarManager_EnsureRequiredEnvVars_CustomList(t *testing.T) {
+	// Test with a custom LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT value
+	manager := &EnvVarManager{
+		DefaultLangflowEnvVars: map[string]string{
+			"LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT": "CUSTOM_VAR1,CUSTOM_VAR2",
+			"CUSTOM_VAR1": "value1",
+		},
+	}
+
+	envVars := manager.GetLangflowEnvVars(nil)
+	manager.EnsureRequiredEnvVars(envVars)
+
+	// Verify custom variables are handled
+	assert.Equal(t, "value1", envVars["CUSTOM_VAR1"], "CUSTOM_VAR1 should preserve existing value")
+	assert.Equal(t, "None", envVars["CUSTOM_VAR2"], "CUSTOM_VAR2 should be added with 'None'")
+}

--- a/kubernetes/operator/internal/controller/openrag_controller.go
+++ b/kubernetes/operator/internal/controller/openrag_controller.go
@@ -501,7 +501,16 @@ func (r *OpenRAGReconciler) buildLangflowEnv(ctx context.Context, o *openragv1al
 	}
 
 	// Docling configuration from CR spec
-	if d := o.Spec.Docling; d != nil {
+	// Priority: DoclingComponents (operator-managed) > Docling (external)
+	if dc := o.Spec.DoclingComponents; dc != nil && dc.Enabled && dc.Serve != nil {
+		// Use operator-managed docling-serve
+		port := int32(5001)
+		if dc.Serve.Port > 0 {
+			port = dc.Serve.Port
+		}
+		envVars["DOCLING_SERVE_URL"] = fmt.Sprintf("http://%s:%d", getServiceName(o, "ds"), port)
+	} else if d := o.Spec.Docling; d != nil {
+		// Use external docling service
 		scheme := d.Scheme
 		if scheme == "" {
 			scheme = "http"
@@ -512,6 +521,10 @@ func (r *OpenRAGReconciler) buildLangflowEnv(ctx context.Context, o *openragv1al
 		}
 		envVars["DOCLING_SERVE_URL"] = fmt.Sprintf("%s://%s:%d", scheme, d.Host, port)
 	}
+
+	// Ensure all variables in LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT exist with at least "None" value
+	// This is critical because the list can be customized via CR spec, operator env vars, or defaults
+	r.EnvVarManager.EnsureRequiredEnvVars(envVars)
 
 	// Convert map to .env file format
 	return r.EnvVarManager.BuildEnvFileContent(envVars), nil


### PR DESCRIPTION
Description:
✅ Dynamic reconciliation - Works with any value of LANGFLOW_VARIABLES_TO_GET_FROM_ENVIRONMENT (from defaults, operator env with OPTLF_ prefix, or CR spec)

✅ Backward compatible - Doesn't change existing behavior for variables that already have values

✅ Prevents missing variable errors - Langflow components will always find the variables they expect

✅ Consistent DOCLING_SERVE_URL - Both backend and Langflow use the same URL with proper priority:

Operator-managed Docling (DoclingComponents) > External Docling > Default "None"
✅ Handles edge cases - Empty strings, whitespace, missing list, custom lists all work correctly

✅ Three-level priority maintained - CR spec > Operator env > Defaults (unchanged)

Files Modified
[kubernetes/operator/internal/controller/env.go](vscode-webview://138m185tbe23vmp6svig9et2ikf2tbjja7o9gksh0qnbugrmhuej/kubernetes/operator/internal/controller/env.go) - Added defaults and helper function
[kubernetes/operator/internal/controller/openrag_controller.go](vscode-webview://138m185tbe23vmp6svig9et2ikf2tbjja7o9gksh0qnbugrmhuej/kubernetes/operator/internal/controller/openrag_controller.go) - Integrated helper and fixed DOCLING_SERVE_URL logic
[kubernetes/operator/internal/controller/env_test.go](vscode-webview://138m185tbe23vmp6svig9et2ikf2tbjja7o9gksh0qnbugrmhuej/kubernetes/operator/internal/controller/env_test.go) - Added comprehensive unit tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Langflow environment variables are now auto-populated when missing (includes OpenSearch and Docling keys) to ensure consistent .env generation.
  * Docling integration now prefers operator-managed service settings when available for selecting the service URL.

* **Tests**
  * Added unit and integration tests covering env-var parsing, trimming/skipping logic, preservation of existing values, and custom-list behavior; example output expectations updated.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1667?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->