### PR TITLE
fix: enhance error handling for Google Drive file downloads with SSL retries

### DIFF
--- a/src/connectors/google_drive/connector.py
+++ b/src/connectors/google_drive/connector.py
@@ -1,6 +1,7 @@
 import asyncio
 import io
 import os
+import ssl
 import time
 from collections import deque
 from collections.abc import Iterable
@@ -509,34 +510,49 @@ class GoogleDriveConnector(BaseConnector):
                 # Binary download (get_media also doesn't accept the Drive flags)
                 request = self.service.files().get_media(fileId=file_id)
 
-            # Download the file with error handling for misclassified Google Docs
-            fh = io.BytesIO()
-            downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
-            done = False
-
-            try:
-                while not done:
-                    status, done = downloader.next_chunk()
-                    # Optional: you can log progress via status.progress()
-            except HttpError as e:
-                # If download fails with "fileNotDownloadable", it's a Docs Editor file
-                # that wasn't properly detected. Retry with export_media.
-                if "fileNotDownloadable" in str(e) and mime_type not in exportable_types:
-                    logger.warning(
-                        f"Download failed for {file_id} ({mime_type}) with fileNotDownloadable error. "
-                        f"Retrying with export_media (file might be a Google Doc)"
-                    )
-                    export_mime = "application/pdf"
-                    request = self.service.files().export_media(
-                        fileId=file_id, mimeType=export_mime
-                    )
-                    fh = io.BytesIO()
-                    downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
-                    done = False
-                    while not done:
-                        status, done = downloader.next_chunk()
-                else:
-                    raise
+            # Download the file with error handling for misclassified Google Docs and
+            # transient SSL/network errors. Each SSL retry recreates the downloader
+            # from scratch to avoid partial-buffer state.
+            _max_retries = 3
+            for _attempt in range(_max_retries):
+                fh = io.BytesIO()
+                downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
+                done = False
+                try:
+                    try:
+                        while not done:
+                            status, done = downloader.next_chunk()
+                    except HttpError as e:
+                        # If download fails with "fileNotDownloadable", it's a Docs Editor file
+                        # that wasn't properly detected. Retry with export_media.
+                        if "fileNotDownloadable" in str(e) and mime_type not in exportable_types:
+                            logger.warning(
+                                f"Download failed for {file_id} ({mime_type}) with fileNotDownloadable error. "
+                                f"Retrying with export_media (file might be a Google Doc)"
+                            )
+                            export_mime = "application/pdf"
+                            request = self.service.files().export_media(
+                                fileId=file_id, mimeType=export_mime
+                            )
+                            fh = io.BytesIO()
+                            downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
+                            done = False
+                            while not done:
+                                status, done = downloader.next_chunk()
+                        else:
+                            raise
+                    break  # download succeeded
+                except (ssl.SSLError, ConnectionResetError, TimeoutError) as e:
+                    if _attempt < _max_retries - 1:
+                        _delay = 2.0 ** _attempt
+                        logger.warning(
+                            "[GoogleDrive] Transient network error for %s (attempt %d/%d), "
+                            "retrying in %.1fs: %s",
+                            file_id, _attempt + 1, _max_retries, _delay, e,
+                        )
+                        time.sleep(_delay)
+                    else:
+                        raise
 
         data = fh.getvalue()
         logger.debug("[GoogleDrive] _download_file_bytes: done, %d bytes", len(data))

--- a/src/connectors/google_drive/connector.py
+++ b/src/connectors/google_drive/connector.py
@@ -510,53 +510,62 @@ class GoogleDriveConnector(BaseConnector):
                 # Binary download (get_media also doesn't accept the Drive flags)
                 request = self.service.files().get_media(fileId=file_id)
 
-            # Download the file with error handling for misclassified Google Docs and
-            # transient SSL/network errors. Each SSL retry recreates the downloader
-            # from scratch to avoid partial-buffer state.
-            _max_retries = 3
-            for _attempt in range(_max_retries):
-                fh = io.BytesIO()
-                downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
-                done = False
+        # Download the file with error handling for misclassified Google Docs and
+        # transient SSL/network errors. Each SSL retry recreates the downloader
+        # from scratch to avoid partial-buffer state.
+        _max_retries = 3
+        for _attempt in range(_max_retries):
+            fh = io.BytesIO()
+            downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
+            done = False
+            _should_retry = False
+            _delay = 0.0
+            _err: Exception | None = None
+            try:
                 try:
-                    try:
-                        while not done:
-                            status, done = downloader.next_chunk()
-                    except HttpError as e:
-                        # If download fails with "fileNotDownloadable", it's a Docs Editor file
-                        # that wasn't properly detected. Retry with export_media.
-                        if "fileNotDownloadable" in str(e) and mime_type not in exportable_types:
-                            logger.warning(
-                                f"Download failed for {file_id} ({mime_type}) with fileNotDownloadable error. "
-                                f"Retrying with export_media (file might be a Google Doc)"
-                            )
-                            export_mime = "application/pdf"
+                    while not done:
+                        status, done = downloader.next_chunk()
+                except HttpError as e:
+                    # If download fails with "fileNotDownloadable", it's a Docs Editor file
+                    # that wasn't properly detected. Retry with export_media.
+                    if "fileNotDownloadable" in str(e) and mime_type not in exportable_types:
+                        logger.warning(
+                            f"Download failed for {file_id} ({mime_type}) with fileNotDownloadable error. "
+                            f"Retrying with export_media (file might be a Google Doc)"
+                        )
+                        export_mime = "application/pdf"
+                        with self._lock:
                             request = self.service.files().export_media(
                                 fileId=file_id, mimeType=export_mime
                             )
-                            fh = io.BytesIO()
-                            downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
-                            done = False
-                            while not done:
-                                status, done = downloader.next_chunk()
-                        else:
-                            raise
-                    break  # download succeeded
-                except (ssl.SSLError, ConnectionResetError, TimeoutError) as e:
-                    if _attempt < _max_retries - 1:
-                        _delay = 2.0**_attempt
-                        logger.warning(
-                            "[GoogleDrive] Transient network error for %s (attempt %d/%d), "
-                            "retrying in %.1fs: %s",
-                            file_id,
-                            _attempt + 1,
-                            _max_retries,
-                            _delay,
-                            e,
-                        )
-                        time.sleep(_delay)
+                        fh = io.BytesIO()
+                        downloader = MediaIoBaseDownload(fh, request, chunksize=1024 * 1024)
+                        done = False
+                        while not done:
+                            status, done = downloader.next_chunk()
                     else:
                         raise
+                break  # download succeeded
+            except (ssl.SSLError, ConnectionResetError, TimeoutError) as e:
+                _should_retry = _attempt < _max_retries - 1
+                _delay = 2.0**_attempt
+                _err = e
+
+            if _should_retry and _err is not None:
+                logger.warning(
+                    "[GoogleDrive] Transient network error for %s (attempt %d/%d), "
+                    "retrying in %.1fs: %s",
+                    file_id,
+                    _attempt + 1,
+                    _max_retries,
+                    _delay,
+                    _err,
+                )
+                time.sleep(_delay)
+                continue
+
+            if _err is not None:
+                raise _err
 
         data = fh.getvalue()
         logger.debug("[GoogleDrive] _download_file_bytes: done, %d bytes", len(data))

--- a/src/connectors/google_drive/connector.py
+++ b/src/connectors/google_drive/connector.py
@@ -544,11 +544,15 @@ class GoogleDriveConnector(BaseConnector):
                     break  # download succeeded
                 except (ssl.SSLError, ConnectionResetError, TimeoutError) as e:
                     if _attempt < _max_retries - 1:
-                        _delay = 2.0 ** _attempt
+                        _delay = 2.0**_attempt
                         logger.warning(
                             "[GoogleDrive] Transient network error for %s (attempt %d/%d), "
                             "retrying in %.1fs: %s",
-                            file_id, _attempt + 1, _max_retries, _delay, e,
+                            file_id,
+                            _attempt + 1,
+                            _max_retries,
+                            _delay,
+                            e,
                         )
                         time.sleep(_delay)
                     else:


### PR DESCRIPTION
This pull request improves the reliability of file downloads in the Google Drive connector by adding robust retry logic for transient SSL and network errors during the file download process. The main changes are as follows:

**Resilience improvements for file downloads:**

* Added retry logic to `_download_file_bytes` to handle transient `ssl.SSLError`, `ConnectionResetError`, and `TimeoutError` exceptions, with exponential backoff and logging for each retry attempt. Each retry re-creates the downloader to avoid partial-buffer state. [[1]](diffhunk://#diff-4cb4bd9f7d67ca12b3c2ac07f05cd9cf9b4cc47bfbd37ba8cfd7e219a485e2baL512-L520) [[2]](diffhunk://#diff-4cb4bd9f7d67ca12b3c2ac07f05cd9cf9b4cc47bfbd37ba8cfd7e219a485e2baR544-R555)
* Imported the `ssl` module to support the new error handling.ss

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Google Drive download reliability with automatic retries and backoff for transient network errors
  * Non-downloadable document types now automatically convert to compatible formats (e.g., export to PDF) to allow download
  * Reduced failures from temporary connectivity or transfer interruptions, improving overall download success rate

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->