### PR TITLE
chore: Add auth and security env vars to OpenRAG sample

### DIFF
--- a/kubernetes/operator/config/samples/openrag_v1alpha1_openrag.yaml
+++ b/kubernetes/operator/config/samples/openrag_v1alpha1_openrag.yaml
@@ -19,6 +19,11 @@ spec:
 
   backend:
     image: langflowai/openrag-backend:latest
+    env:
+      - name: AUTH_SERVER_URL
+        value: "" # Set to the platform auth server URL, e.g. https://auth-server.<namespace>.svc
+      - name: OPENRAG_BOOTSTRAP_OS_SECURITY_ON_STARTUP
+        value: "true"
     resources:
       requests:
         cpu: "500m"


### PR DESCRIPTION
Add AUTH_SERVER_URL and OPENRAG_BOOTSTRAP_OS_SECURITY_ON_STARTUP environment variables to the backend sample manifest. AUTH_SERVER_URL is left empty with an inline example to configure the platform auth server URL; OPENRAG_BOOTSTRAP_OS_SECURITY_ON_STARTUP is set to "true" to enable OS security bootstrap on startup. File updated: kubernetes/operator/config/samples/openrag_v1alpha1_openrag.yaml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable authentication server URL for backend services
  * Security initialization now automatically enabled on backend startup

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1692?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->