### PR TITLE
fix: Avoid email UNIQUE race by omitting email

### DIFF
--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -124,10 +124,7 @@ async def ensure_user_row(session: AsyncSession, user: User) -> UserRow:
         # both observe an empty table.
         by_email = await user_repo.get_by_email(user.email) if user.email else None
         if by_email is not None:
-            if (
-                by_email.oauth_provider == provider
-                and by_email.oauth_subject == subject
-            ):
+            if by_email.oauth_provider == provider and by_email.oauth_subject == subject:
                 # Concurrent insert of the *same* identity — safe to reuse.
                 await user_repo.update_last_login(by_email.id)
                 return by_email
@@ -139,8 +136,7 @@ async def ensure_user_row(session: AsyncSession, user: User) -> UserRow:
             # the request never fails on a UNIQUE constraint. The email stays
             # attached to the first identity that claimed it.
             logger.warning(
-                "email already owned by another identity; "
-                "creating user row without email",
+                "email already owned by another identity; creating user row without email",
                 provider=provider,
                 subject=subject,
                 existing_provider=by_email.oauth_provider,

--- a/src/services/user_service.py
+++ b/src/services/user_service.py
@@ -107,36 +107,61 @@ async def ensure_user_row(session: AsyncSession, user: User) -> UserRow:
     except IntegrityError:
         # The collision could be on any of the three unique constraints:
         # (oauth_provider, oauth_subject), email_lookup_hash, or id (PK).
+        # By the time the flush raises, the peer transaction that lost the
+        # race has committed, so the re-fetches below see its row.
         await session.rollback()
 
-        # Case 1: (oauth_provider, oauth_subject) race — a peer process beat us
-        # to the INSERT for this exact identity.
+        # Case 1: (oauth_provider, oauth_subject) race — a peer beat us to the
+        # INSERT for this exact identity.
         existing = await user_repo.get_by_oauth(provider, subject)
         if existing:
             await user_repo.update_last_login(existing.id)
             return existing
 
-        # Case 2: email_lookup_hash race — same email already inserted (most
-        # common for the synthetic anonymous@localhost user in no-auth mode when
-        # two concurrent requests both observe an empty table). Look up by email;
-        # if the row's (provider, subject) matches ours it's a concurrent insert
-        # of the same identity and we can safely return it.
-        if user.email:
-            by_email = await user_repo.get_by_email(user.email)
+        # Case 2: email_lookup_hash collision — some row already owns this
+        # email (email_lookup_hash is UNIQUE). Most common for the synthetic
+        # anonymous@localhost user in no-auth mode when two concurrent requests
+        # both observe an empty table.
+        by_email = await user_repo.get_by_email(user.email) if user.email else None
+        if by_email is not None:
             if (
-                by_email
-                and by_email.oauth_provider == provider
+                by_email.oauth_provider == provider
                 and by_email.oauth_subject == subject
             ):
+                # Concurrent insert of the *same* identity — safe to reuse.
                 await user_repo.update_last_login(by_email.id)
                 return by_email
 
-        # Case 3: PK collision across providers (a different identity already
-        # occupies id=subject). Retry with a UUID; (provider, subject) differs
-        # from the conflicting row so the INSERT will succeed.
-        # If the collision was on email_lookup_hash for a genuinely different
-        # identity (two real users sharing an email) this insert also fails —
-        # that propagates to the caller as intended.
+            # A *different* identity already owns this email (e.g. the same
+            # person signing in through a second provider). Re-inserting with
+            # the same email is futile — it would collide on email_lookup_hash
+            # again — so create this distinct principal *without* the email so
+            # the request never fails on a UNIQUE constraint. The email stays
+            # attached to the first identity that claimed it.
+            logger.warning(
+                "email already owned by another identity; "
+                "creating user row without email",
+                provider=provider,
+                subject=subject,
+                existing_provider=by_email.oauth_provider,
+                existing_subject=by_email.oauth_subject,
+            )
+            row = UserRow(
+                id=str(uuid.uuid4()),
+                oauth_provider=provider,
+                oauth_subject=subject,
+                email=None,
+                display_name=user.name,
+                picture_url=user.picture,
+            )
+            await user_repo.add(row)
+            await _assign_bootstrap_or_default(session, role_repo, audit_repo, row.id)
+            return row
+
+        # Case 3: pure PK collision (id==subject already occupied by a
+        # different identity, no email conflict). Retry with a UUID;
+        # (provider, subject) differs from the conflicting row so the INSERT
+        # succeeds.
         new_id = str(uuid.uuid4())
         row = UserRow(
             id=new_id,

--- a/tests/integration/sdk/conftest.py
+++ b/tests/integration/sdk/conftest.py
@@ -78,7 +78,10 @@ async def client():
     from openrag_sdk import OpenRAGClient
 
     api_key = await _fetch_api_key()
-    c = OpenRAGClient(api_key=api_key, base_url=_base_url)
+    # The SDK defaults to a 30s timeout for *all* requests. Streaming chat on a
+    # cold CI box (model spin-up + flow init before the first byte) routinely
+    # exceeds that, surfacing as httpx.ReadTimeout. Use a generous timeout here.
+    c = OpenRAGClient(api_key=api_key, base_url=_base_url, timeout=120.0)
     yield c
     await c.close()
 

--- a/tests/unit/services/test_bootstrap_race.py
+++ b/tests/unit/services/test_bootstrap_race.py
@@ -170,6 +170,50 @@ async def test_concurrent_signins_same_user_no_integrity_error(
 
 
 @pytest.mark.asyncio
+async def test_same_email_different_provider_no_integrity_error(session_factory):
+    """Two *different* identities that share an email must not crash on the
+    email_lookup_hash UNIQUE constraint.
+
+    Previous bug: after the email collision, the IntegrityError handler
+    retried the INSERT with a fresh UUID id but the *same* email, which hit
+    the same UNIQUE constraint again and propagated an uncaught
+    `sqlite3.IntegrityError: UNIQUE constraint failed: users.email_lookup_hash`.
+
+    The second identity is now persisted without the email so the request
+    succeeds; the email stays attached to the first claimant.
+    """
+    async def signin(provider: str, subject: str) -> str:
+        async with session_factory() as session:
+            row = await ensure_user_row(
+                session,
+                User(
+                    user_id=subject,
+                    email="shared@example.com",
+                    name=subject,
+                    provider=provider,
+                ),
+            )
+            await session.commit()
+            return row.id
+
+    first_id = await signin("google", "g-sub")
+    # Same email, different provider/subject — must not raise.
+    second_id = await signin("github", "gh-sub")
+
+    assert first_id != second_id
+
+    async with session_factory() as session:
+        from db.repositories import UserRepo
+
+        repo = UserRepo(session)
+        rows = await repo.list_all()
+        # Exactly the email's first claimant keeps the lookup hash.
+        with_email = [r for r in rows if r.email_lookup_hash]
+    assert len(rows) == 2, f"expected 2 distinct user rows, got {len(rows)}"
+    assert len(with_email) == 1, "only the first identity should hold the email"
+
+
+@pytest.mark.asyncio
 async def test_cache_keys_are_per_provider_subject_pair(
     session_factory, monkeypatch
 ):

--- a/tests/unit/services/test_bootstrap_race.py
+++ b/tests/unit/services/test_bootstrap_race.py
@@ -52,6 +52,7 @@ async def test_bootstrap_race_yields_single_admin(session_factory):
     request). The post-grant rollback must observe the second admin
     and demote whichever caller is not min(user_id).
     """
+
     async def signin(user_id: str) -> None:
         async with session_factory() as session:
             await ensure_user_row(
@@ -82,6 +83,7 @@ async def test_bootstrap_race_yields_single_admin(session_factory):
 async def test_bootstrap_loser_falls_through_to_default_role(session_factory):
     """The demoted bootstrap loser must still end up with the default
     role, not zero roles."""
+
     async def signin(user_id: str) -> None:
         async with session_factory() as session:
             await ensure_user_row(
@@ -124,9 +126,7 @@ async def test_no_race_single_signin_unchanged(session_factory):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_signins_same_user_no_integrity_error(
-    session_factory, monkeypatch
-):
+async def test_concurrent_signins_same_user_no_integrity_error(session_factory, monkeypatch):
     """Five concurrent `_ensure_db_user` calls for the SAME anonymous
     user must not raise IntegrityError on email_lookup_hash. The
     previous bug: both callers observed an empty users table, both
@@ -141,9 +141,11 @@ async def test_concurrent_signins_same_user_no_integrity_error(
     # _ensure_db_user reads `db.engine.SessionLocal`, so wire it to
     # our test session_factory.
     import db.engine as _engine_mod
+
     monkeypatch.setattr(_engine_mod, "SessionLocal", session_factory, raising=False)
 
-    from dependencies import _ensure_db_user, _ENSURED_USER_IDS, _ENSURE_LOCKS
+    from dependencies import _ENSURE_LOCKS, _ENSURED_USER_IDS, _ensure_db_user
+
     _ENSURED_USER_IDS.clear()
     _ENSURE_LOCKS.clear()
 
@@ -165,6 +167,7 @@ async def test_concurrent_signins_same_user_no_integrity_error(
     # …and exactly one user row exists.
     async with session_factory() as session:
         from db.repositories import UserRepo
+
         rows = await UserRepo(session).list_all()
     assert len(rows) == 1, f"expected 1 anonymous user row, got {len(rows)}"
 
@@ -182,6 +185,7 @@ async def test_same_email_different_provider_no_integrity_error(session_factory)
     The second identity is now persisted without the email so the request
     succeeds; the email stays attached to the first claimant.
     """
+
     async def signin(provider: str, subject: str) -> str:
         async with session_factory() as session:
             row = await ensure_user_row(
@@ -214,9 +218,7 @@ async def test_same_email_different_provider_no_integrity_error(session_factory)
 
 
 @pytest.mark.asyncio
-async def test_cache_keys_are_per_provider_subject_pair(
-    session_factory, monkeypatch
-):
+async def test_cache_keys_are_per_provider_subject_pair(session_factory, monkeypatch):
     """Two users with the SAME oauth_subject string but DIFFERENT
     providers must NOT share a cache slot. Pre-fix the cache was keyed
     on user.user_id alone, so e.g. AnonymousUser (provider="none",
@@ -224,9 +226,11 @@ async def test_cache_keys_are_per_provider_subject_pair(
     issued the same subject string.
     """
     import db.engine as _engine_mod
+
     monkeypatch.setattr(_engine_mod, "SessionLocal", session_factory, raising=False)
 
-    from dependencies import _ensure_db_user, _ENSURED_USER_IDS, _ENSURE_LOCKS
+    from dependencies import _ENSURE_LOCKS, _ENSURED_USER_IDS, _ensure_db_user
+
     _ENSURED_USER_IDS.clear()
     _ENSURE_LOCKS.clear()
 
@@ -263,29 +267,25 @@ async def test_cache_keys_are_per_provider_subject_pair(
 
 
 @pytest.mark.asyncio
-async def test_invalidate_pops_only_target_identity(
-    session_factory, monkeypatch
-):
+async def test_invalidate_pops_only_target_identity(session_factory, monkeypatch):
     """invalidate_user_ensured_cache(provider, subject) must pop only
     the matching identity's cache + lock entries — not the whole cache."""
     import db.engine as _engine_mod
+
     monkeypatch.setattr(_engine_mod, "SessionLocal", session_factory, raising=False)
 
     from dependencies import (
-        _ensure_db_user,
-        _ENSURED_USER_IDS,
         _ENSURE_LOCKS,
+        _ENSURED_USER_IDS,
+        _ensure_db_user,
         invalidate_user_ensured_cache,
     )
+
     _ENSURED_USER_IDS.clear()
     _ENSURE_LOCKS.clear()
 
-    await _ensure_db_user(
-        User(user_id="alice-sub", email="a@x", name="A", provider="google")
-    )
-    await _ensure_db_user(
-        User(user_id="bob-sub", email="b@x", name="B", provider="ibm")
-    )
+    await _ensure_db_user(User(user_id="alice-sub", email="a@x", name="A", provider="google"))
+    await _ensure_db_user(User(user_id="bob-sub", email="b@x", name="B", provider="ibm"))
     assert {"google:alice-sub", "ibm:bob-sub"} <= set(_ENSURED_USER_IDS.keys())
 
     invalidate_user_ensured_cache("google", "alice-sub")


### PR DESCRIPTION
Improve IntegrityError handling in ensure_user_row to handle email_lookup_hash collisions: if the email is already owned by a different identity, log a warning and create the new user row without the email (so the request succeeds and the original claimant keeps the email). Keep the existing retry-on-PK-collision behavior (retry with UUID) and preserve the oauth-provider/subject fast-path. Add a unit test (test_same_email_different_provider_no_integrity_error) to cover two different providers sharing an email and ensure only the first claimant retains the email. Also increase the integration SDK client's timeout to 120s to avoid ReadTimeouts on CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved authentication error handling to support users who attempt to create or authenticate with the same email address across different authentication providers, preventing account creation failures and ensuring seamless access.

* **Tests**
  * Enhanced test infrastructure reliability by increasing timeout allowances for integration tests in slower continuous integration environments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1693?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->