### PR TITLE
fix: sec finding - make default curl behaviour to validate server cert

### DIFF
--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -134,10 +134,11 @@ else
     fi
     
     echo "Using certificate validation with CA cert: $OPENSEARCH_CA_CERT"
-    CURL_OPTS="--cacert $OPENSEARCH_CA_CERT"
+    CURL_OPTS="--cacert"
+    CURL_CERT_PATH="$OPENSEARCH_CA_CERT"
 fi
 
-until curl -s $CURL_OPTS https://localhost:9200 >/dev/null; do
+until curl -s $CURL_OPTS ${CURL_CERT_PATH:+"$CURL_CERT_PATH"} https://localhost:9200 >/dev/null; do
     sleep 5
     ELAPSED=$((ELAPSED + 5))
     if [ $ELAPSED -ge $TIMEOUT ]; then

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -1,6 +1,37 @@
 #!/bin/bash
 set -e
 
+# Parse command line arguments
+SKIP_CERT_VALIDATION=false
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --skip-cert-validation|--insecure)
+            SKIP_CERT_VALIDATION=true
+            echo "WARNING: Certificate validation disabled via command line flag"
+            echo "WARNING: This should only be used in trusted development environments"
+            shift
+            ;;
+        -h|--help)
+            echo "Usage: $0 [OPTIONS]"
+            echo ""
+            echo "Options:"
+            echo "  --skip-cert-validation  Skip SSL certificate validation (INSECURE)"
+            echo "                          Only use in trusted development environments"
+            echo "  -h, --help             Show this help message"
+            echo ""
+            echo "Environment Variables:"
+            echo "  OPENSEARCH_CA_CERT     Path to OpenSearch CA certificate"
+            echo "                         (default: securityconfig/root-ca.pem)"
+            exit 0
+            ;;
+        *)
+            echo "Unknown option: $1"
+            echo "Run '$0 --help' for usage information"
+            exit 1
+            ;;
+    esac
+done
+
 # Go to project root
 cd "$(dirname "$0")/.."
 
@@ -47,7 +78,35 @@ fi
 echo "Waiting for OpenSearch..."
 TIMEOUT=300
 ELAPSED=0
-until curl -s -k https://localhost:9200 >/dev/null; do
+
+# Determine curl options based on validation mode
+if [ "$SKIP_CERT_VALIDATION" = "true" ]; then
+    echo "WARNING: Skipping certificate validation (insecure mode)"
+    CURL_OPTS="-k"
+else
+    # Strict mode: Require proper certificate setup
+    OPENSEARCH_CA_CERT="${OPENSEARCH_CA_CERT:-securityconfig/root-ca.pem}"
+    
+    if [ ! -f "$OPENSEARCH_CA_CERT" ]; then
+        echo "ERROR: OpenSearch CA certificate not found at: $OPENSEARCH_CA_CERT"
+        echo "ERROR: Certificate validation is required for secure operation"
+        echo ""
+        echo "To fix this issue, you must:"
+        echo "  1. Extract the CA certificate from OpenSearch container, OR"
+        echo "  2. Provide a valid CA certificate at: $OPENSEARCH_CA_CERT, OR"
+        echo "  3. Set OPENSEARCH_CA_CERT environment variable to the cert path"
+        echo ""
+        echo "For development/testing ONLY, you can bypass validation with:"
+        echo "  $0 --skip-cert-validation"
+        echo ""
+        exit 1
+    fi
+    
+    echo "Using certificate validation with CA cert: $OPENSEARCH_CA_CERT"
+    CURL_OPTS="--cacert $OPENSEARCH_CA_CERT"
+fi
+
+until curl -s $CURL_OPTS https://localhost:9200 >/dev/null; do
     sleep 5
     ELAPSED=$((ELAPSED + 5))
     if [ $ELAPSED -ge $TIMEOUT ]; then

--- a/scripts/setup-e2e.sh
+++ b/scripts/setup-e2e.sh
@@ -75,6 +75,37 @@ if [ "$CI" = "true" ] && [[ "$OSTYPE" != "darwin"* ]]; then
     chmod -R 777 config data keys opensearch-data openrag-documents 2>/dev/null || true
 fi
 
+# Extract CA certificate from OpenSearch container for secure HTTPS communication
+echo "Extracting OpenSearch CA certificate..."
+CERT_EXTRACT_TIMEOUT=60
+CERT_EXTRACT_ELAPSED=0
+
+# Wait for OpenSearch container to be running and certificate to be available
+until ${CONTAINER_RUNTIME} exec os test -f /usr/share/opensearch/config/root-ca.pem 2>/dev/null; do
+    sleep 2
+    CERT_EXTRACT_ELAPSED=$((CERT_EXTRACT_ELAPSED + 2))
+    if [ $CERT_EXTRACT_ELAPSED -ge $CERT_EXTRACT_TIMEOUT ]; then
+        echo "WARNING: Could not extract CA certificate from OpenSearch container within ${CERT_EXTRACT_TIMEOUT}s"
+        echo "WARNING: Certificate validation will be skipped"
+        SKIP_CERT_VALIDATION=true
+        break
+    fi
+    echo "Waiting for OpenSearch certificate... (${CERT_EXTRACT_ELAPSED}s/${CERT_EXTRACT_TIMEOUT}s)"
+done
+
+# Extract the certificate if available
+if [ "$SKIP_CERT_VALIDATION" != "true" ]; then
+    mkdir -p securityconfig
+    if ${CONTAINER_RUNTIME} cp os:/usr/share/opensearch/config/root-ca.pem securityconfig/root-ca.pem 2>/dev/null; then
+        echo "Successfully extracted CA certificate to securityconfig/root-ca.pem"
+        chmod 644 securityconfig/root-ca.pem
+    else
+        echo "WARNING: Failed to extract CA certificate from container"
+        echo "WARNING: Certificate validation will be skipped"
+        SKIP_CERT_VALIDATION=true
+    fi
+fi
+
 echo "Waiting for OpenSearch..."
 TIMEOUT=300
 ELAPSED=0


### PR DESCRIPTION
Description:
- Validate server certificate by default for curl requests / #70873

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--skip-cert-validation` / `--insecure` flags to toggle TLS certificate validation for OpenSearch readiness checks.
  * Readiness setup now auto-falls back to insecure mode if certificate extraction times out or fails.

* **Chores**
  * Improved TLS handling to choose validation options dynamically and added clearer, actionable error messages when strict validation cannot proceed.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1701?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->