### PR TITLE
feat: retry broke after #1623 started deleting staged temp files

### DIFF
--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -594,20 +594,9 @@ class TaskService:
                 upload_task.status = TaskStatus.COMPLETED
                 upload_task.updated_at = time.time()
 
-            # Clean up temp files after all processing is complete
-            if hasattr(upload_task, "temp_file_paths") and upload_task.temp_file_paths:
-                from utils.file_utils import safe_unlink
-
-                for temp_path in upload_task.temp_file_paths:
-                    try:
-                        safe_unlink(temp_path)
-                        logger.debug("Cleaned up temp file", temp_path=temp_path)
-                    except Exception as cleanup_error:
-                        logger.warning(
-                            "Failed to clean up temp file after processing",
-                            temp_path=temp_path,
-                            error=str(cleanup_error),
-                        )
+            # Clean up upload temps that are not retryable; keep local RETRYABLE
+            # failures so retry can re-read the staged source file.
+            self._cleanup_upload_temp_files(upload_task)
 
             status: str = "FAILED"
 
@@ -1368,7 +1357,51 @@ class TaskService:
                     file_task.error = "Task cancelled by user"
                     file_task.updated_at = time.time()
 
+        self._cleanup_upload_temp_files(upload_task, force=True)
+
         return True
+
+    def _is_retryable_local_upload_temp(
+        self, upload_task: UploadTask, temp_path: str
+    ) -> bool:
+        """True when a staged temp belongs to a failed local RETRYABLE upload."""
+        file_task = upload_task.file_tasks.get(temp_path)
+        if file_task is None or file_task.status != TaskStatus.FAILED:
+            return False
+        if not os.path.isabs(temp_path):
+            return False
+        metadata = self._infer_failure_metadata(file_task)
+        return bool(metadata and metadata.get("actionable_by") == "RETRYABLE")
+
+    def _cleanup_upload_temp_files(
+        self, upload_task: UploadTask, *, force: bool = False
+    ) -> None:
+        """Remove staged upload temp files that are not retryable.
+
+        Keeps temps for failed local uploads classified as RETRYABLE so retry
+        can reuse the original source path. Use *force* to delete all temps
+        (e.g. user cancelled the task).
+        """
+        if not getattr(upload_task, "temp_file_paths", None):
+            return
+
+        from utils.file_utils import safe_unlink
+
+        retained: list[str] = []
+        for temp_path in upload_task.temp_file_paths:
+            if not force and self._is_retryable_local_upload_temp(upload_task, temp_path):
+                retained.append(temp_path)
+                continue
+            safe_unlink(temp_path)
+            if os.path.exists(temp_path):
+                retained.append(temp_path)
+                logger.warning(
+                    "Failed to clean up temp file after processing",
+                    temp_path=temp_path,
+                )
+            else:
+                logger.debug("Cleaned up temp file", temp_path=temp_path)
+        upload_task.temp_file_paths = retained
 
     async def shutdown(self):
         """Cleanup process pool and cancel all background tasks

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -388,7 +388,17 @@ class TaskService:
         if temp_file_paths:
             if upload_task.temp_file_paths is None:
                 upload_task.temp_file_paths = []
-            upload_task.temp_file_paths.extend(temp_file_paths)
+            normalized_temp_paths = [str(path) for path in temp_file_paths]
+            unknown_temp_paths = [
+                path for path in normalized_temp_paths if path not in upload_task.file_tasks
+            ]
+            if unknown_temp_paths:
+                logger.warning(
+                    "temp_file_paths do not match file_tasks keys; retry retention may fail",
+                    task_id=task_id,
+                    unknown_temp_paths=unknown_temp_paths,
+                )
+            upload_task.temp_file_paths.extend(normalized_temp_paths)
 
         # Start background processing
         background_task = asyncio.create_task(
@@ -1364,17 +1374,50 @@ class TaskService:
 
         return True
 
+    def _file_task_for_temp_path(
+        self, upload_task: UploadTask, temp_path: str
+    ) -> FileTask | None:
+        """Resolve the FileTask for a staged upload temp path."""
+        file_task = upload_task.file_tasks.get(temp_path)
+        if file_task is not None:
+            return file_task
+        for candidate in upload_task.file_tasks.values():
+            if candidate.file_path == temp_path:
+                return candidate
+        return None
+
     def _is_retryable_local_upload_temp(
         self, upload_task: UploadTask, temp_path: str
     ) -> bool:
-        """True when a staged temp belongs to a failed local RETRYABLE upload."""
-        file_task = upload_task.file_tasks.get(temp_path)
-        if file_task is None or file_task.status != TaskStatus.FAILED:
-            return False
+        """True when a staged temp belongs to a failed local RETRYABLE upload.
+
+        Local uploads use the staged path as the file_tasks key and
+        FileTask.file_path. When those diverge, this falls back to matching
+        FileTask.file_path. Unmapped absolute temps are retained (see
+        _should_retain_upload_temp) rather than deleted silently.
+        """
         if not os.path.isabs(temp_path):
+            return False
+        file_task = self._file_task_for_temp_path(upload_task, temp_path)
+        if file_task is None or file_task.status != TaskStatus.FAILED:
             return False
         metadata = self._infer_failure_metadata(file_task)
         return bool(metadata and metadata.get("actionable_by") == "RETRYABLE")
+
+    def _should_retain_upload_temp(
+        self, upload_task: UploadTask, temp_path: str
+    ) -> bool:
+        """Return True when an upload temp should be kept after processing."""
+        if self._is_retryable_local_upload_temp(upload_task, temp_path):
+            return True
+        if os.path.isabs(temp_path) and self._file_task_for_temp_path(upload_task, temp_path) is None:
+            logger.warning(
+                "Upload temp path has no matching file task; retaining staged file",
+                temp_path=temp_path,
+                task_id=upload_task.task_id,
+            )
+            return True
+        return False
 
     def _cleanup_upload_temp_files(
         self, upload_task: UploadTask, *, force: bool = False
@@ -1392,7 +1435,7 @@ class TaskService:
 
         retained: list[str] = []
         for temp_path in upload_task.temp_file_paths:
-            if not force and self._is_retryable_local_upload_temp(upload_task, temp_path):
+            if not force and self._should_retain_upload_temp(upload_task, temp_path):
                 retained.append(temp_path)
                 continue
             safe_unlink(temp_path)

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -1284,6 +1284,9 @@ class TaskService:
                     task.status in [TaskStatus.COMPLETED, TaskStatus.FAILED]
                     and current_time - task.updated_at > max_age_seconds
                 ):
+                    # Task is leaving memory; reclaim any retained upload temps
+                    # (including RETRYABLE locals kept for in-flight retry).
+                    self._cleanup_upload_temp_files(task, force=True)
                     del self.task_store[user_id][task_id]
                     # Clean up the associated lock
                     self._task_locks.pop(task_id, None)
@@ -1410,7 +1413,8 @@ class TaskService:
         1. Cancelling the periodic cleanup task
         2. Cancelling all running background tasks
         3. Waiting for cancellation to complete
-        4. Shutting down the process pool
+        4. Force-cleaning staged upload temps for all tracked tasks
+        5. Shutting down the process pool
         """
         logger.info("Shutting down TaskService", background_tasks_count=len(self.background_tasks))
 
@@ -1436,3 +1440,7 @@ class TaskService:
                     logger.warning(
                         "Background task raised exception during shutdown", error=str(result)
                     )
+
+        for user_tasks in self.task_store.values():
+            for upload_task in user_tasks.values():
+                self._cleanup_upload_temp_files(upload_task, force=True)

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -1374,9 +1374,7 @@ class TaskService:
 
         return True
 
-    def _file_task_for_temp_path(
-        self, upload_task: UploadTask, temp_path: str
-    ) -> FileTask | None:
+    def _file_task_for_temp_path(self, upload_task: UploadTask, temp_path: str) -> FileTask | None:
         """Resolve the FileTask for a staged upload temp path."""
         file_task = upload_task.file_tasks.get(temp_path)
         if file_task is not None:
@@ -1386,9 +1384,7 @@ class TaskService:
                 return candidate
         return None
 
-    def _is_retryable_local_upload_temp(
-        self, upload_task: UploadTask, temp_path: str
-    ) -> bool:
+    def _is_retryable_local_upload_temp(self, upload_task: UploadTask, temp_path: str) -> bool:
         """True when a staged temp belongs to a failed local RETRYABLE upload.
 
         Local uploads use the staged path as the file_tasks key and
@@ -1404,13 +1400,14 @@ class TaskService:
         metadata = self._infer_failure_metadata(file_task)
         return bool(metadata and metadata.get("actionable_by") == "RETRYABLE")
 
-    def _should_retain_upload_temp(
-        self, upload_task: UploadTask, temp_path: str
-    ) -> bool:
+    def _should_retain_upload_temp(self, upload_task: UploadTask, temp_path: str) -> bool:
         """Return True when an upload temp should be kept after processing."""
         if self._is_retryable_local_upload_temp(upload_task, temp_path):
             return True
-        if os.path.isabs(temp_path) and self._file_task_for_temp_path(upload_task, temp_path) is None:
+        if (
+            os.path.isabs(temp_path)
+            and self._file_task_for_temp_path(upload_task, temp_path) is None
+        ):
             logger.warning(
                 "Upload temp path has no matching file task; retaining staged file",
                 temp_path=temp_path,
@@ -1419,9 +1416,7 @@ class TaskService:
             return True
         return False
 
-    def _cleanup_upload_temp_files(
-        self, upload_task: UploadTask, *, force: bool = False
-    ) -> None:
+    def _cleanup_upload_temp_files(self, upload_task: UploadTask, *, force: bool = False) -> None:
         """Remove staged upload temp files that are not retryable.
 
         Keeps temps for failed local uploads classified as RETRYABLE so retry

--- a/tests/unit/test_task_service.py
+++ b/tests/unit/test_task_service.py
@@ -5,7 +5,7 @@ Tests timeout handling, cancellation, and cleanup functionality
 
 import asyncio
 import time
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -98,6 +98,45 @@ async def test_cleanup_old_tasks(task_service):
     # Verify lock was also cleaned up
     assert "old_task" not in task_service._task_locks
     assert "recent_task" in task_service._task_locks  # Recent task lock should remain
+
+
+@pytest.mark.asyncio
+async def test_cleanup_old_tasks_force_cleans_retained_temp_files(task_service):
+    """Evicted tasks must reclaim temps kept for retryable local failures."""
+    temp_path = "/var/folders/tmp/retryable.tmp"
+    old_task = UploadTask(
+        task_id="old_task",
+        total_files=1,
+        file_tasks={"file1": FileTask(file_path="file1")},
+        temp_file_paths=[temp_path],
+        status=TaskStatus.FAILED,
+    )
+    old_task.updated_at = time.time() - 7200
+
+    task_service.task_store["user1"] = {"old_task": old_task}
+
+    with patch.object(task_service, "_cleanup_upload_temp_files") as mock_cleanup:
+        cleaned = await task_service.cleanup_old_tasks(max_age_seconds=3600)
+
+    assert cleaned == 1
+    mock_cleanup.assert_called_once_with(old_task, force=True)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_force_cleans_upload_temp_files(task_service):
+    upload_task = UploadTask(
+        task_id="task1",
+        total_files=1,
+        file_tasks={},
+        temp_file_paths=["/var/folders/tmp/retryable.tmp"],
+        status=TaskStatus.FAILED,
+    )
+    task_service.task_store["user1"] = {"task1": upload_task}
+
+    with patch.object(task_service, "_cleanup_upload_temp_files") as mock_cleanup:
+        await task_service.shutdown()
+
+    mock_cleanup.assert_called_once_with(upload_task, force=True)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_task_service_retry_failed_files.py
+++ b/tests/unit/test_task_service_retry_failed_files.py
@@ -245,3 +245,108 @@ async def test_retry_connector_id_path_does_not_require_local_file(task_service)
     assert result["status"] == "accepted"
     assert ft.status == TaskStatus.PENDING
     mock_bg.assert_called_once()
+
+
+def test_is_retryable_local_upload_temp_true_for_failed_local_timeout(task_service):
+    temp_path = "/var/folders/tmp/retryable.tmp"
+    ft = _retryable_failed_file(temp_path)
+    task = UploadTask(
+        task_id="task-1",
+        total_files=1,
+        file_tasks={temp_path: ft},
+        temp_file_paths=[temp_path],
+    )
+
+    assert task_service._is_retryable_local_upload_temp(task, temp_path) is True
+
+
+def test_is_retryable_local_upload_temp_false_for_connector_id(task_service):
+    file_path = "google-drive-file-id"
+    ft = FileTask(file_path=file_path, filename="doc.pdf")
+    ft.status = TaskStatus.FAILED
+    ft.error = "All connection attempts failed"
+    task = UploadTask(
+        task_id="task-1",
+        total_files=1,
+        file_tasks={file_path: ft},
+        temp_file_paths=[],
+    )
+
+    assert task_service._is_retryable_local_upload_temp(task, file_path) is False
+
+
+def test_cleanup_upload_temp_files_keeps_retryable_local_failure(task_service):
+    retryable_path = "/var/folders/tmp/retryable.tmp"
+    other_path = "/var/folders/tmp/success.tmp"
+    ft_retryable = _retryable_failed_file(retryable_path)
+    ft_success = FileTask(file_path=other_path, filename="ok.pdf")
+    ft_success.status = TaskStatus.COMPLETED
+    task = UploadTask(
+        task_id="task-1",
+        total_files=2,
+        file_tasks={retryable_path: ft_retryable, other_path: ft_success},
+        temp_file_paths=[retryable_path, other_path],
+    )
+
+    with patch("utils.file_utils.safe_unlink") as mock_unlink:
+        task_service._cleanup_upload_temp_files(task)
+
+    mock_unlink.assert_called_once_with(other_path)
+    assert task.temp_file_paths == [retryable_path]
+
+
+def test_cleanup_upload_temp_files_removes_non_retryable_failure(task_service):
+    temp_path = "/var/folders/tmp/corrupt.tmp"
+    ft = FileTask(file_path=temp_path, filename="bad.pdf")
+    ft.status = TaskStatus.FAILED
+    ft.error = "The file appears corrupted or invalid"
+    task = UploadTask(
+        task_id="task-1",
+        total_files=1,
+        file_tasks={temp_path: ft},
+        temp_file_paths=[temp_path],
+    )
+
+    with patch("utils.file_utils.safe_unlink") as mock_unlink:
+        task_service._cleanup_upload_temp_files(task)
+
+    mock_unlink.assert_called_once_with(temp_path)
+    assert task.temp_file_paths == []
+
+
+def test_cleanup_upload_temp_files_retains_path_when_unlink_fails(task_service):
+    temp_path = "/var/folders/tmp/still-there.tmp"
+    ft = FileTask(file_path=temp_path, filename="ok.pdf")
+    ft.status = TaskStatus.COMPLETED
+    task = UploadTask(
+        task_id="task-1",
+        total_files=1,
+        file_tasks={temp_path: ft},
+        temp_file_paths=[temp_path],
+    )
+
+    with (
+        patch("utils.file_utils.safe_unlink") as mock_unlink,
+        patch("os.path.exists", return_value=True),
+    ):
+        task_service._cleanup_upload_temp_files(task)
+
+    mock_unlink.assert_called_once_with(temp_path)
+    assert task.temp_file_paths == [temp_path]
+
+
+def test_cleanup_upload_temp_files_does_not_unlink_retryable_local_failure(task_service):
+    retryable_path = "/var/folders/tmp/retryable.tmp"
+    ft = _retryable_failed_file(retryable_path)
+    task = UploadTask(
+        task_id="task-1",
+        total_files=1,
+        file_tasks={retryable_path: ft},
+        temp_file_paths=[retryable_path],
+    )
+
+    with patch("utils.file_utils.safe_unlink") as mock_unlink:
+        task_service._cleanup_upload_temp_files(task)
+
+    mock_unlink.assert_not_called()
+    assert task.temp_file_paths == [retryable_path]

--- a/tests/unit/test_task_service_retry_failed_files.py
+++ b/tests/unit/test_task_service_retry_failed_files.py
@@ -260,6 +260,19 @@ def test_is_retryable_local_upload_temp_true_for_failed_local_timeout(task_servi
     assert task_service._is_retryable_local_upload_temp(task, temp_path) is True
 
 
+def test_is_retryable_local_upload_temp_resolves_file_task_by_file_path(task_service):
+    temp_path = "/var/folders/tmp/retryable.tmp"
+    ft = _retryable_failed_file(temp_path)
+    task = UploadTask(
+        task_id="task-1",
+        total_files=1,
+        file_tasks={"different-key": ft},
+        temp_file_paths=[temp_path],
+    )
+
+    assert task_service._is_retryable_local_upload_temp(task, temp_path) is True
+
+
 def test_is_retryable_local_upload_temp_false_for_connector_id(task_service):
     file_path = "google-drive-file-id"
     ft = FileTask(file_path=file_path, filename="doc.pdf")
@@ -288,7 +301,10 @@ def test_cleanup_upload_temp_files_keeps_retryable_local_failure(task_service):
         temp_file_paths=[retryable_path, other_path],
     )
 
-    with patch("utils.file_utils.safe_unlink") as mock_unlink:
+    with (
+        patch("utils.file_utils.safe_unlink") as mock_unlink,
+        patch("os.path.exists", return_value=False),
+    ):
         task_service._cleanup_upload_temp_files(task)
 
     mock_unlink.assert_called_once_with(other_path)
@@ -307,7 +323,10 @@ def test_cleanup_upload_temp_files_removes_non_retryable_failure(task_service):
         temp_file_paths=[temp_path],
     )
 
-    with patch("utils.file_utils.safe_unlink") as mock_unlink:
+    with (
+        patch("utils.file_utils.safe_unlink") as mock_unlink,
+        patch("os.path.exists", return_value=False),
+    ):
         task_service._cleanup_upload_temp_files(task)
 
     mock_unlink.assert_called_once_with(temp_path)
@@ -350,3 +369,19 @@ def test_cleanup_upload_temp_files_does_not_unlink_retryable_local_failure(task_
 
     mock_unlink.assert_not_called()
     assert task.temp_file_paths == [retryable_path]
+
+
+def test_cleanup_upload_temp_files_retains_unmapped_absolute_temp(task_service):
+    temp_path = "/var/folders/tmp/unmapped.tmp"
+    task = UploadTask(
+        task_id="task-1",
+        total_files=0,
+        file_tasks={},
+        temp_file_paths=[temp_path],
+    )
+
+    with patch("utils.file_utils.safe_unlink") as mock_unlink:
+        task_service._cleanup_upload_temp_files(task)
+
+    mock_unlink.assert_not_called()
+    assert task.temp_file_paths == [temp_path]


### PR DESCRIPTION
upload retry broke after #1623 started deleting staged temp files
immediately after processing. The enhanced task API still marks those
failures as RETRYABLE, but retry then fails with source_file_missing
because the temp path no longer exists on disk.
Clean up upload temps per file only when they are not retryable:
- keep temps for failed local uploads classified as RETRYABLE
- delete temps for successes and non-retryable failures
- on cancel, force-delete all temps (no retry expected)
- if unlink fails, keep the path in temp_file_paths so cleanup can be
  retried later (safe_unlink swallows errors, so verify with exists)
Add unit tests for retryable retention, mixed success/failure cleanup,
failed unlink tracking, and ensuring retryable temps are never unlinked.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Retryable local upload failures now retain staged temp files for retry; non-retryable temps are removed. Cancelling tasks, evicting old tasks, or shutting down now force-remove staged temps to prevent leftovers. Temp path normalization now warns on mismatches to avoid broken retry retention.

* **Tests**
  * Added unit tests covering retry vs non-retry temp retention, unlink behavior, and forced cleanup on eviction/shutdown.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->