### PR TITLE
docs: Add langflow_opensearch environment variables

### DIFF
--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -152,6 +152,8 @@ Configure OpenSearch database authentication.
 | `OPENSEARCH_HOST` | `localhost` | OpenSearch service host. |
 | `OPENSEARCH_PORT` | `9200` | OpenSearch service port. |
 | `OPENSEARCH_USERNAME` | `admin` | OpenSearch administrator username. |
+| `LANGFLOW_OPENSEARCH_HOST` | `opensearch` | Not explicitly set in OpenRAG by default; inherits the default value from Langflow. Set this variable in your OpenRAG `.env` to use a different OpenSearch endpoint for Langflow. |
+| `LANGFLOW_OPENSEARCH_PORT` | `9200` | Not explicitly set in OpenRAG by default; inherits the default value from Langflow. Set this variable in your OpenRAG `.env` to use a different OpenSearch endpoint for Langflow. |
 
 ## System settings
 

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -152,8 +152,8 @@ Configure OpenSearch database authentication.
 | `OPENSEARCH_HOST` | `localhost` | OpenSearch service host. |
 | `OPENSEARCH_PORT` | `9200` | OpenSearch service port. |
 | `OPENSEARCH_USERNAME` | `admin` | OpenSearch administrator username. |
-| `LANGFLOW_OPENSEARCH_HOST` | `opensearch` | Not explicitly set in OpenRAG by default; inherits the default value from Langflow. Set this variable in your OpenRAG `.env` to use a different OpenSearch endpoint for Langflow. |
-| `LANGFLOW_OPENSEARCH_PORT` | `9200` | Not explicitly set in OpenRAG by default; inherits the default value from Langflow. Set this variable in your OpenRAG `.env` to use a different OpenSearch endpoint for Langflow. |
+| `LANGFLOW_OPENSEARCH_HOST` | Not set | By default, OpenRAG passes the `OPENSEARCH_HOST` value to Langflow. Use the `LANGFLOW_OPENSEARCH_*` variables to set a different OpenSearch endpoint for Langflow specifically. OpenRAG itself still uses the `OPENSEARCH_HOST` value. |
+| `LANGFLOW_OPENSEARCH_PORT` | Not set | By default, OpenRAG passes the `OPENSEARCH_PORT` value to Langflow. Use the `LANGFLOW_OPENSEARCH_*` variables to set a different OpenSearch endpoint for Langflow specifically. OpenRAG itself still uses the `OPENSEARCH_PORT` value. |
 
 ## System settings
 


### PR DESCRIPTION
Add the descriptions of the langflow_opensearch environment variables to the env var table.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Configuration reference updated to document LANGFLOW_OPENSEARCH_HOST and LANGFLOW_OPENSEARCH_PORT environment variables, enabling Langflow to use a separate OpenSearch endpoint while OpenRAG continues to use OPENSEARCH_HOST/OPENSEARCH_PORT.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->