### PR TITLE
fix: Verify IBM JWT in _get_ibm_user

### DIFF
--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -485,7 +485,7 @@ async def _get_ibm_user(request: Request, required: bool) -> Optional["User"]:
         ibm_token = (
             raw_jwt[7:].strip() if raw_jwt.startswith("Bearer ") else raw_jwt.strip()
         ) or None
-        claims = verify_jwt_from_issuer(ibm_token, verify_tls=False)
+        claims = verify_jwt_from_issuer(ibm_token, verify_tls=True)
     else:
         ibm_token = request.cookies.get(IBM_SESSION_COOKIE_NAME)
     user_id = None
@@ -745,7 +745,7 @@ async def get_api_key_user_async(
     raw_jwt = request.headers.get(get_jwt_auth_header(), "")
     if raw_jwt and raw_jwt.strip():
         token = raw_jwt[7:].strip() if raw_jwt.startswith("Bearer ") else raw_jwt.strip()
-        claims = verify_jwt_from_issuer(token, verify_tls=False)
+        claims = verify_jwt_from_issuer(token, verify_tls=True)
         sub = claims.get("sub") if claims else None
         if sub:
             user = User(

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -451,6 +451,7 @@ async def _get_ibm_user(request: Request, required: bool) -> Optional["User"]:
         PLATFORM_USERNAME,
         get_jwt_auth_header,
     )
+    from config.utils import verify_jwt_from_issuer
 
     # ── Option -1: Environment variable override (local dev/calls) ───────
 
@@ -484,6 +485,7 @@ async def _get_ibm_user(request: Request, required: bool) -> Optional["User"]:
         ibm_token = (
             raw_jwt[7:].strip() if raw_jwt.startswith("Bearer ") else raw_jwt.strip()
         ) or None
+        claims = verify_jwt_from_issuer(ibm_token, verify_tls=False)
     else:
         ibm_token = request.cookies.get(IBM_SESSION_COOKIE_NAME)
     user_id = None


### PR DESCRIPTION
Import verify_jwt_from_issuer and call it when an Authorization header token is parsed in _get_ibm_user. This adds server-side verification of the IBM JWT (using verify_tls=False) and extracts claims for downstream user resolution.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JWT verification for IBM AMS authentication: forwarded JWTs are now verified against their issuer and validated with TLS enabled when JWT-role synchronization is active, ensuring stronger token authenticity and more reliable authentication behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/langflow-ai/openrag/pull/1711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->