### PR TITLE
refactor: streamline required scopes handling in GoogleDriveOAuth and add test for optional group scopes

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -1,5 +1,5 @@
 # syntax=docker/dockerfile:1.4
-FROM langflowai/langflow:1.9.0
+FROM langflowai/langflow:1.9.6.rc0
 
 # Install uv and pre-create the Langflow data directory.
 # The base image already runs as uid=1000 and owns /app, so no root or chown needed.

--- a/flows/ingestion_flow.json
+++ b/flows/ingestion_flow.json
@@ -184,238 +184,6 @@
         "className": "",
         "data": {
           "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-CTKlr",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_allowed_groups",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-CTKlr{œdataTypeœ:œTextInputœ,œidœ:œTextInput-CTKlrœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_allowed_groupsœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-CTKlr",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-CTKlrœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_allowed_groupsœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-hlgVv",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_allowed_users",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-hlgVv{œdataTypeœ:œTextInputœ,œidœ:œTextInput-hlgVvœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_allowed_usersœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-hlgVv",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-hlgVvœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_allowed_usersœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-OGCeZ",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_connector_type",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-OGCeZ{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OGCeZœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_connector_typeœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-OGCeZ",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OGCeZœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_connector_typeœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-PI6at",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_document_id",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-PI6at{œdataTypeœ:œTextInputœ,œidœ:œTextInput-PI6atœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_document_idœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-PI6at",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-PI6atœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_document_idœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-gRPNR",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_owner",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-gRPNR{œdataTypeœ:œTextInputœ,œidœ:œTextInput-gRPNRœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_ownerœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-gRPNR",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-gRPNRœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_ownerœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-lTHSx",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_owner_email",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-lTHSx{œdataTypeœ:œTextInputœ,œidœ:œTextInput-lTHSxœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_owner_emailœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-lTHSx",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-lTHSxœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_owner_emailœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-UZQ8v",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_source_url",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-UZQ8v{œdataTypeœ:œTextInputœ,œidœ:œTextInput-UZQ8vœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_source_urlœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-UZQ8v",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-UZQ8vœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_source_urlœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-68n9L",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "dynamic_owner_name",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-68n9L{œdataTypeœ:œTextInputœ,œidœ:œTextInput-68n9Lœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-AdvancedDynamicFormBuilder-81Exw{œfieldNameœ:œdynamic_owner_nameœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-68n9L",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-68n9Lœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "AdvancedDynamicFormBuilder-81Exw",
-        "targetHandle": "{œfieldNameœ:œdynamic_owner_nameœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
             "dataType": "EmbeddingModel",
             "id": "EmbeddingModel-UcgwY",
             "name": "embeddings",
@@ -472,35 +240,6 @@
         "className": "",
         "data": {
           "sourceHandle": {
-            "dataType": "AdvancedDynamicFormBuilder",
-            "id": "AdvancedDynamicFormBuilder-81Exw",
-            "name": "form_data",
-            "output_types": [
-              "JSON"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "docs_metadata",
-            "id": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-            "inputTypes": [
-              "Data",
-              "JSON"
-            ],
-            "type": "table"
-          }
-        },
-        "id": "xy-edge__AdvancedDynamicFormBuilder-81Exw{œdataTypeœ:œAdvancedDynamicFormBuilderœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œnameœ:œform_dataœ,œoutput_typesœ:[œJSONœ]}-OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4{œfieldNameœ:œdocs_metadataœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œDataœ,œJSONœ],œtypeœ:œtableœ}",
-        "selected": false,
-        "source": "AdvancedDynamicFormBuilder-81Exw",
-        "sourceHandle": "{œdataTypeœ:œAdvancedDynamicFormBuilderœ,œidœ:œAdvancedDynamicFormBuilder-81Exwœ,œnameœ:œform_dataœ,œoutput_typesœ:[œJSONœ]}",
-        "target": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-        "targetHandle": "{œfieldNameœ:œdocs_metadataœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œDataœ,œJSONœ],œtypeœ:œtableœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
             "dataType": "SplitText",
             "id": "SplitText-QIKhg",
             "name": "dataframe",
@@ -525,93 +264,6 @@
         "sourceHandle": "{œdataTypeœ:œSplitTextœ,œidœ:œSplitText-QIKhgœ,œnameœ:œdataframeœ,œoutput_typesœ:[œTableœ]}",
         "target": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
         "targetHandle": "{œfieldNameœ:œingest_dataœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œDataœ,œDataFrameœ,œTableœ],œtypeœ:œotherœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-OpenRAGIngest-url",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "openrag_ingest_url",
-            "id": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-OpenRAGIngest-url{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OpenRAGIngest-urlœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4{œfieldNameœ:œopenrag_ingest_urlœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-OpenRAGIngest-url",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OpenRAGIngest-urlœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-        "targetHandle": "{œfieldNameœ:œopenrag_ingest_urlœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-OpenRAGIngest-token",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "openrag_ingest_token",
-            "id": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-OpenRAGIngest-token{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OpenRAGIngest-tokenœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4{œfieldNameœ:œopenrag_ingest_tokenœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-OpenRAGIngest-token",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OpenRAGIngest-tokenœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-        "targetHandle": "{œfieldNameœ:œopenrag_ingest_tokenœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
-      },
-      {
-        "animated": false,
-        "className": "",
-        "data": {
-          "sourceHandle": {
-            "dataType": "TextInput",
-            "id": "TextInput-OpenRAGIngest-run_id",
-            "name": "text",
-            "output_types": [
-              "Message"
-            ]
-          },
-          "targetHandle": {
-            "fieldName": "openrag_ingest_run_id",
-            "id": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-            "inputTypes": [
-              "Text",
-              "Message"
-            ],
-            "type": "str"
-          }
-        },
-        "id": "xy-edge__TextInput-OpenRAGIngest-run_id{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OpenRAGIngest-run_idœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}-OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4{œfieldNameœ:œopenrag_ingest_run_idœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}",
-        "selected": false,
-        "source": "TextInput-OpenRAGIngest-run_id",
-        "sourceHandle": "{œdataTypeœ:œTextInputœ,œidœ:œTextInput-OpenRAGIngest-run_idœ,œnameœ:œtextœ,œoutput_typesœ:[œMessageœ]}",
-        "target": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
-        "targetHandle": "{œfieldNameœ:œopenrag_ingest_run_idœ,œidœ:œOpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4œ,œinputTypesœ:[œTextœ,œMessageœ],œtypeœ:œstrœ}"
       }
     ],
     "nodes": [
@@ -893,502 +545,6 @@
         "selected": false,
         "type": "genericNode",
         "width": 320
-      },
-      {
-        "data": {
-          "id": "AdvancedDynamicFormBuilder-81Exw",
-          "node": {
-            "base_classes": [
-              "Data",
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Creates dynamic input fields that can receive data from other components or manual input.",
-            "display_name": "Create Data",
-            "documentation": "",
-            "edited": true,
-            "field_order": [
-              "form_fields",
-              "include_metadata"
-            ],
-            "frozen": false,
-            "icon": "braces",
-            "last_updated": "2026-05-26T19:04:35.148Z",
-            "legacy": false,
-            "lf_version": "1.7.0.dev21",
-            "metadata": {},
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Data",
-                "group_outputs": false,
-                "hidden": null,
-                "loop_types": null,
-                "method": "process_form",
-                "name": "form_data",
-                "options": null,
-                "required_inputs": null,
-                "selected": "JSON",
-                "tool_mode": true,
-                "types": [
-                  "JSON"
-                ],
-                "value": "__UNDEFINED__"
-              },
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Message",
-                "group_outputs": false,
-                "hidden": null,
-                "loop_types": null,
-                "method": "get_message",
-                "name": "message",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "d61134a0-3f8e-4e89-9165-ce13f2a14ac6"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\r\n\r\nfrom langflow.custom import Component\r\nfrom langflow.io import (\r\n    BoolInput,\r\n    FloatInput,\r\n    HandleInput,\r\n    IntInput,\r\n    MultilineInput,\r\n    Output,\r\n    StrInput,\r\n    TableInput,\r\n)\r\nfrom langflow.schema.data import Data\r\nfrom langflow.schema.message import Message\r\n\r\n\r\nclass CrateData(Component):\r\n    \"\"\"Dynamic Form Component\r\n\r\n    This component creates dynamic inputs that can receive data from other components\r\n    or be filled manually. It demonstrates advanced dynamic input functionality with\r\n    component connectivity.\r\n\r\n    ## Features\r\n    - **Dynamic Input Generation**: Create inputs based on table configuration\r\n    - **Component Connectivity**: Inputs can receive data from other components\r\n    - **Multiple Input Types**: Support for text, number, boolean, and handle inputs\r\n    - **Flexible Data Sources**: Manual input OR component connections\r\n    - **Real-time Updates**: Form fields update immediately when table changes\r\n         - **Multiple Output Formats**: Data and formatted Message outputs\r\n    - **JSON Output**: Collects all dynamic inputs into a structured JSON response\r\n\r\n    ## Use Cases\r\n    - Dynamic API parameter collection from multiple sources\r\n    - Variable data aggregation from different components\r\n    - Flexible pipeline configuration\r\n    - Multi-source data processing\r\n\r\n    ## Field Types Available\r\n    - **text**: Single-line text input (can connect to Text/String outputs)\r\n    - **multiline**: Multi-line text input (can connect to Text outputs)\r\n    - **number**: Integer input (can connect to Number outputs)\r\n    - **float**: Decimal number input (can connect to Number outputs)\r\n    - **boolean**: True/false checkbox (can connect to Boolean outputs)\r\n    - **handle**: Generic data input (can connect to any component output)\r\n    - **data**: Structured data input (can connect to Data outputs)\r\n\r\n    ## Input Types for Connections\r\n    - **Text**: Text/String data from components\r\n    - **Data**: Structured data objects\r\n    - **Message**: Message objects with text content\r\n    - **Number**: Numeric values\r\n    - **Boolean**: True/false values\r\n    - **Any**: Accepts any type of connection\r\n    - **Combinations**: Text,Message | Data,Text | Text,Data,Message | etc.\r\n    \"\"\"\r\n\r\n    display_name = \"Create Data\"\r\n    description = \"Creates dynamic input fields that can receive data from other components or manual input.\"\r\n    icon = \"braces\"\r\n    name = \"AdvancedDynamicFormBuilder\"\r\n\r\n    def __init__(self, **kwargs):\r\n        super().__init__(**kwargs)\r\n        self._dynamic_inputs = {}\r\n\r\n    inputs = [\r\n        TableInput(\r\n            name=\"form_fields\",\r\n            display_name=\"Input Configuration\",\r\n            info=\"Define the dynamic form fields. Each row creates a new input field that can connect to other components.\",\r\n            table_schema=[\r\n                {\r\n                    \"name\": \"field_name\",\r\n                    \"display_name\": \"Field Name\",\r\n                    \"type\": \"str\",\r\n                    \"description\": \"Name for the field (used as both internal name and display label)\",\r\n                },\r\n                {\r\n                    \"name\": \"field_type\",\r\n                    \"display_name\": \"Field Type\",\r\n                    \"type\": \"str\",\r\n                    \"description\": \"Type of input field to create\",\r\n                    \"options\": [\"Text\", \"Data\", \"Number\", \"Handle\", \"Boolean\"],\r\n                    \"value\": \"Text\",\r\n                },\r\n            ],\r\n            value=[{\"field_name\": \"field_name\", \"field_type\": \"Text\"}],\r\n            real_time_refresh=True,\r\n        ),\r\n        BoolInput(\r\n            name=\"include_metadata\",\r\n            display_name=\"Include Metadata\",\r\n            info=\"Include form configuration metadata in the output.\",\r\n            value=False,\r\n            advanced=True,\r\n        ),\r\n    ]\r\n\r\n    outputs = [\r\n        Output(display_name=\"Data\", name=\"form_data\", method=\"process_form\"),\r\n        Output(display_name=\"Message\", name=\"message\", method=\"get_message\"),\r\n    ]\r\n\r\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str = None) -> dict:\r\n        \"\"\"Update build configuration to add dynamic inputs that can connect to other components.\"\"\"\r\n        if field_name == \"form_fields\":\r\n            # Store current values before clearing dynamic inputs\r\n            current_values = {}\r\n            keys_to_remove = [key for key in build_config if key.startswith(\"dynamic_\")]\r\n            for key in keys_to_remove:\r\n                # Preserve the current value before deletion\r\n                if hasattr(self, key):\r\n                    current_values[key] = getattr(self, key)\r\n                del build_config[key]\r\n\r\n            # Add dynamic inputs based on table configuration\r\n            # Safety check to ensure field_value is not None and is iterable\r\n            if field_value is None:\r\n                field_value = []\r\n\r\n            for i, field_config in enumerate(field_value):\r\n                # Safety check to ensure field_config is not None\r\n                if field_config is None:\r\n                    continue\r\n\r\n                field_name = field_config.get(\"field_name\", f\"field_{i}\")\r\n                display_name = field_name  # Use field_name as display_name\r\n                field_type_option = field_config.get(\"field_type\", \"Text\")\r\n                default_value = \"\"  # All fields have empty default value\r\n                required = False  # All fields are optional by default\r\n                help_text = \"\"  # All fields have empty help text\r\n\r\n                # Map field type options to actual field types and input types\r\n                field_type_mapping = {\r\n                    \"Text\": {\"field_type\": \"multiline\", \"input_types\": [\"Text\", \"Message\"]},\r\n                    \"Data\": {\"field_type\": \"data\", \"input_types\": [\"Data\"]},\r\n                    \"Number\": {\"field_type\": \"number\", \"input_types\": [\"Text\", \"Message\"]},\r\n                    \"Handle\": {\"field_type\": \"handle\", \"input_types\": [\"Text\", \"Data\", \"Message\"]},\r\n                    \"Boolean\": {\"field_type\": \"boolean\", \"input_types\": None},\r\n                }\r\n\r\n                field_config_mapped = field_type_mapping.get(\r\n                    field_type_option, {\"field_type\": \"text\", \"input_types\": []}\r\n                )\r\n                field_type = field_config_mapped[\"field_type\"]\r\n                input_types_list = field_config_mapped[\"input_types\"]\r\n\r\n                # Create the appropriate input type based on field_type\r\n                dynamic_input_name = f\"dynamic_{field_name}\"\r\n\r\n                if field_type == \"text\":\r\n                    # Use preserved value if available, otherwise use default\r\n                    current_value = current_values.get(dynamic_input_name, default_value)\r\n                    if current_value is None:\r\n                        current_value = default_value\r\n                    \r\n                    if input_types_list:\r\n                        build_config[dynamic_input_name] = StrInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=f\"{help_text} (Can connect to: {', '.join(input_types_list)})\",\r\n                            value=current_value,\r\n                            required=required,\r\n                            input_types=input_types_list,\r\n                        )\r\n                    else:\r\n                        build_config[dynamic_input_name] = StrInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=help_text,\r\n                            value=current_value,\r\n                            required=required,\r\n                        )\r\n\r\n                elif field_type == \"multiline\":\r\n                    # Use preserved value if available, otherwise use default\r\n                    current_value = current_values.get(dynamic_input_name, default_value)\r\n                    if current_value is None:\r\n                        current_value = default_value\r\n                    \r\n                    if input_types_list:\r\n                        build_config[dynamic_input_name] = MultilineInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=f\"{help_text} (Can connect to: {', '.join(input_types_list)})\",\r\n                            value=current_value,\r\n                            required=required,\r\n                            input_types=input_types_list,\r\n                        )\r\n                    else:\r\n                        build_config[dynamic_input_name] = MultilineInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=help_text,\r\n                            value=current_value,\r\n                            required=required,\r\n                        )\r\n\r\n                elif field_type == \"number\":\r\n                    # Use preserved value if available, otherwise use default\r\n                    current_value = current_values.get(dynamic_input_name, default_value)\r\n                    if current_value is None:\r\n                        current_value = default_value\r\n                    \r\n                    try:\r\n                        if current_value:\r\n                            current_int = int(current_value)\r\n                        else:\r\n                            current_int = 0\r\n                    except (ValueError, TypeError):\r\n                        try:\r\n                            current_int = int(default_value) if default_value else 0\r\n                        except ValueError:\r\n                            current_int = 0\r\n\r\n                    if input_types_list:\r\n                        build_config[dynamic_input_name] = IntInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=f\"{help_text} (Can connect to: {', '.join(input_types_list)})\",\r\n                            value=current_int,\r\n                            required=required,\r\n                            input_types=input_types_list,\r\n                        )\r\n                    else:\r\n                        build_config[dynamic_input_name] = IntInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=help_text,\r\n                            value=current_int,\r\n                            required=required,\r\n                        )\r\n\r\n                elif field_type == \"float\":\r\n                    # Use preserved value if available, otherwise use default\r\n                    current_value = current_values.get(dynamic_input_name, default_value)\r\n                    if current_value is None:\r\n                        current_value = default_value\r\n                    \r\n                    try:\r\n                        if current_value:\r\n                            current_float = float(current_value)\r\n                        else:\r\n                            current_float = 0.0\r\n                    except (ValueError, TypeError):\r\n                        try:\r\n                            current_float = float(default_value) if default_value else 0.0\r\n                        except ValueError:\r\n                            current_float = 0.0\r\n\r\n                    if input_types_list:\r\n                        build_config[dynamic_input_name] = FloatInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=f\"{help_text} (Can connect to: {', '.join(input_types_list)})\",\r\n                            value=current_float,\r\n                            required=required,\r\n                            input_types=input_types_list,\r\n                        )\r\n                    else:\r\n                        build_config[dynamic_input_name] = FloatInput(\r\n                            name=dynamic_input_name,\r\n                            display_name=display_name,\r\n                            info=help_text,\r\n                            value=current_float,\r\n                            required=required,\r\n                        )\r\n\r\n                elif field_type == \"boolean\":\r\n                    # Use preserved value if available, otherwise use default\r\n                    current_value = current_values.get(dynamic_input_name, default_value)\r\n                    if current_value is None:\r\n                        current_value = default_value\r\n                    \r\n                    # Convert current value to boolean\r\n                    if isinstance(current_value, bool):\r\n                        current_bool = current_value\r\n                    else:\r\n                        current_bool = str(current_value).lower() in [\"true\", \"1\", \"yes\"] if current_value else False\r\n\r\n                    # Boolean fields don't use input_types parameter to avoid errors\r\n                    build_config[dynamic_input_name] = BoolInput(\r\n                        name=dynamic_input_name,\r\n                        display_name=display_name,\r\n                        info=help_text,\r\n                        value=current_bool,\r\n                        input_types=[],\r\n                        required=required,\r\n                    )\r\n\r\n                elif field_type == \"handle\":\r\n                    # HandleInput for generic data connections\r\n                    build_config[dynamic_input_name] = HandleInput(\r\n                        name=dynamic_input_name,\r\n                        display_name=display_name,\r\n                        info=f\"{help_text} (Accepts: {', '.join(input_types_list) if input_types_list else 'Any'})\",\r\n                        input_types=input_types_list if input_types_list else [\"Data\", \"Text\", \"Message\"],\r\n                        required=required,\r\n                    )\r\n\r\n                elif field_type == \"data\":\r\n                    # Specialized for Data type connections\r\n                    build_config[dynamic_input_name] = HandleInput(\r\n                        name=dynamic_input_name,\r\n                        display_name=display_name,\r\n                        info=f\"{help_text} (Data input)\",\r\n                        input_types=[\"Data\"] if not input_types_list else input_types_list,\r\n                        required=required,\r\n                    )\r\n\r\n                else:\r\n                    # Default to text input for unknown types\r\n                    # Use preserved value if available, otherwise use default\r\n                    current_value = current_values.get(dynamic_input_name, default_value)\r\n                    if current_value is None:\r\n                        current_value = default_value\r\n                    \r\n                    build_config[dynamic_input_name] = StrInput(\r\n                        name=dynamic_input_name,\r\n                        display_name=display_name,\r\n                        info=f\"{help_text} (Unknown type '{field_type}', defaulting to text)\",\r\n                        value=current_value,\r\n                        required=required,\r\n                    )\r\n\r\n        return build_config\r\n\r\n    def get_dynamic_values(self) -> dict[str, Any]:\r\n        \"\"\"Extract simple values from all dynamic inputs, handling both manual and connected inputs.\"\"\"\r\n        dynamic_values = {}\r\n        connection_info = {}\r\n        form_fields = getattr(self, \"form_fields\", [])\r\n\r\n        for field_config in form_fields:\r\n            # Safety check to ensure field_config is not None\r\n            if field_config is None:\r\n                continue\r\n\r\n            field_name = field_config.get(\"field_name\", \"\")\r\n            if field_name:\r\n                dynamic_input_name = f\"dynamic_{field_name}\"\r\n                value = getattr(self, dynamic_input_name, None)\r\n\r\n                # Extract simple values from connections or manual input\r\n                if value is not None:\r\n                    try:\r\n                        extracted_value = self._extract_simple_value(value)\r\n                        dynamic_values[field_name] = extracted_value\r\n\r\n                        # Determine connection type for status\r\n                        if hasattr(value, \"text\") and hasattr(value, \"timestamp\"):\r\n                            connection_info[field_name] = \"Connected (Message)\"\r\n                        elif hasattr(value, \"data\"):\r\n                            connection_info[field_name] = \"Connected (Data)\"\r\n                        elif isinstance(value, (str, int, float, bool, list, dict)):\r\n                            connection_info[field_name] = \"Manual input\"\r\n                        else:\r\n                            connection_info[field_name] = \"Connected (Object)\"\r\n\r\n                    except Exception:\r\n                        # Fallback to string representation if all else fails\r\n                        dynamic_values[field_name] = str(value)\r\n                        connection_info[field_name] = \"Error\"\r\n                else:\r\n                    # Use empty default value if nothing connected\r\n                    dynamic_values[field_name] = \"\"\r\n                    connection_info[field_name] = \"Empty default\"\r\n\r\n        # Store connection info for status output\r\n        self._connection_info = connection_info\r\n        return dynamic_values\r\n\r\n    def _extract_simple_value(self, value: Any) -> Any:\r\n        \"\"\"Extract the simplest, most useful value from any input type.\"\"\"\r\n        # Handle None\r\n        if value is None:\r\n            return None\r\n\r\n        # Handle simple types directly\r\n        if isinstance(value, (str, int, float, bool)):\r\n            return value\r\n\r\n        # Handle lists and tuples - keep simple\r\n        if isinstance(value, (list, tuple)):\r\n            return [self._extract_simple_value(item) for item in value]\r\n\r\n        # Handle dictionaries - keep simple\r\n        if isinstance(value, dict):\r\n            return {str(k): self._extract_simple_value(v) for k, v in value.items()}\r\n\r\n        # Handle Message objects - extract only the text\r\n        if hasattr(value, \"text\"):\r\n            return str(value.text) if value.text is not None else \"\"\r\n\r\n        # Handle Data objects - extract the data content\r\n        if hasattr(value, \"data\") and value.data is not None:\r\n            return self._extract_simple_value(value.data)\r\n\r\n        # For any other object, convert to string\r\n        return str(value)\r\n\r\n    def process_form(self) -> Data:\r\n        \"\"\"Process all dynamic form inputs and return clean data with just field values.\"\"\"\r\n        # Get all dynamic values (just the key:value pairs)\r\n        dynamic_values = self.get_dynamic_values()\r\n\r\n        # Update status with connection info\r\n        connected_fields = len([v for v in getattr(self, \"_connection_info\", {}).values() if \"Connected\" in v])\r\n        total_fields = len(dynamic_values)\r\n\r\n        self.status = f\"Form processed successfully. {connected_fields}/{total_fields} fields connected to components.\"\r\n\r\n        # Return clean Data object with just the field values\r\n        return Data(data=dynamic_values)\r\n\r\n    def get_message(self) -> Message:\r\n        \"\"\"Return form data as a formatted text message.\"\"\"\r\n        # Get all dynamic values\r\n        dynamic_values = self.get_dynamic_values()\r\n\r\n        if not dynamic_values:\r\n            return Message(text=\"No form data available\")\r\n\r\n        # Format as text message\r\n        message_lines = [\"📋 Form Data:\"]\r\n        message_lines.append(\"=\" * 40)\r\n\r\n        for field_name, value in dynamic_values.items():\r\n            # Use field_name as display_name\r\n            display_name = field_name\r\n\r\n            message_lines.append(f\"• {display_name}: {value}\")\r\n\r\n        message_lines.append(\"=\" * 40)\r\n        message_lines.append(f\"Total fields: {len(dynamic_values)}\")\r\n\r\n        message_text = \"\\n\".join(message_lines)\r\n        self.status = f\"Message formatted with {len(dynamic_values)} fields\"\r\n\r\n        return Message(text=message_text)"
-              },
-              "dynamic_allowed_groups": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "allowed_groups",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_allowed_groups",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "dynamic_allowed_users": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "allowed_users",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_allowed_users",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "dynamic_connector_type": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "connector_type",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_connector_type",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "dynamic_document_id": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "document_id",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_document_id",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "dynamic_owner": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "owner",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_owner",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "dynamic_owner_email": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "owner_email",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_owner_email",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "dynamic_owner_name": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "owner_name",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_owner_name",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "dynamic_source_url": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "source_url",
-                "dynamic": false,
-                "helper_text": null,
-                "info": " (Can connect to: Text, Message)",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "multiline": true,
-                "name": "dynamic_source_url",
-                "override_skip": false,
-                "password": false,
-                "placeholder": "",
-                "real_time_refresh": null,
-                "refresh_button": null,
-                "refresh_button_text": null,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": ""
-              },
-              "form_fields": {
-                "_input_type": "TableInput",
-                "advanced": false,
-                "display_name": "Input Configuration",
-                "dynamic": false,
-                "info": "Define the dynamic form fields. Each row creates a new input field that can connect to other components.",
-                "is_list": true,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "name": "form_fields",
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "table_icon": "Table",
-                "table_schema": {
-                  "columns": [
-                    {
-                      "default": "None",
-                      "description": "Name for the field (used as both internal name and display label)",
-                      "disable_edit": false,
-                      "display_name": "Field Name",
-                      "edit_mode": "popover",
-                      "filterable": true,
-                      "formatter": "text",
-                      "hidden": false,
-                      "name": "field_name",
-                      "sortable": true,
-                      "type": "str"
-                    },
-                    {
-                      "default": "None",
-                      "description": "Type of input field to create",
-                      "disable_edit": false,
-                      "display_name": "Field Type",
-                      "edit_mode": "popover",
-                      "filterable": true,
-                      "formatter": "text",
-                      "hidden": false,
-                      "name": "field_type",
-                      "options": [
-                        "Text",
-                        "Data",
-                        "Number",
-                        "Handle",
-                        "Boolean"
-                      ],
-                      "sortable": true,
-                      "type": "str"
-                    }
-                  ]
-                },
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "trigger_icon": "Table",
-                "trigger_text": "Open table",
-                "type": "table",
-                "value": [
-                  {
-                    "field_name": "owner",
-                    "field_type": "Text"
-                  },
-                  {
-                    "field_name": "owner_name",
-                    "field_type": "Text"
-                  },
-                  {
-                    "field_name": "owner_email",
-                    "field_type": "Text"
-                  },
-                  {
-                    "field_name": "connector_type",
-                    "field_type": "Text"
-                  },
-                  {
-                    "field_name": "source_url",
-                    "field_type": "Text"
-                  },
-                  {
-                    "field_name": "document_id",
-                    "field_type": "Text"
-                  },
-                  {
-                    "field_name": "allowed_users",
-                    "field_type": "Text"
-                  },
-                  {
-                    "field_name": "allowed_groups",
-                    "field_type": "Text"
-                  }
-                ]
-              },
-              "include_metadata": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Include Metadata",
-                "dynamic": false,
-                "info": "Include form configuration metadata in the output.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "include_metadata",
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "type": "bool",
-                "value": false
-              },
-              "is_refresh": false
-            },
-            "tool_mode": false
-          },
-          "selected_output": "form_data",
-          "showNode": true,
-          "type": "AdvancedDynamicFormBuilder"
-        },
-        "dragging": false,
-        "id": "AdvancedDynamicFormBuilder-81Exw",
-        "measured": {
-          "height": 881,
-          "width": 320
-        },
-        "position": {
-          "x": 1331.3793686192853,
-          "y": 868.8499669098999
-        },
-        "selected": false,
-        "type": "genericNode"
       },
       {
         "data": {
@@ -3927,9 +3083,11 @@
             "description": "Store and search documents using OpenSearch with multi-model hybrid semantic and keyword search. To search use the tools search_documents and raw_search. Search documents takes a query for vector search, for example\n  {search_query: \"components in openrag\"}",
             "display_name": "OpenSearch (Multi-Model Multi-Embedding)",
             "documentation": "",
-            "edited": false,
+            "edited": true,
             "field_order": [
               "docs_metadata",
+              "openrag_ingest_token",
+              "openrag_ingest_run_id",
               "opensearch_url",
               "index_name",
               "engine",
@@ -3954,30 +3112,38 @@
               "use_ssl",
               "verify_certs",
               "request_timeout",
-              "max_retries"
+              "max_retries",
+              "openrag_ingest_url",
+              "openrag_ingest_token",
+              "openrag_ingest_run_id",
+              "openrag_ingest_batch_size"
             ],
             "frozen": false,
             "icon": "OpenSearch",
-            "last_updated": "2026-04-09T14:08:46.327Z",
+            "last_updated": "2026-06-01T15:10:00.684Z",
             "legacy": false,
             "metadata": {
-              "code_hash": "4a05432fb489",
+              "code_hash": "220fbf21a963",
               "dependencies": {
                 "dependencies": [
                   {
-                    "name": "opensearchpy",
-                    "version": "2.8.0"
+                    "name": "httpx",
+                    "version": "0.28.1"
                   },
                   {
                     "name": "lfx",
-                    "version": null
+                    "version": "0.4.0"
+                  },
+                  {
+                    "name": "opensearchpy",
+                    "version": "2.8.0"
                   },
                   {
                     "name": "tenacity",
                     "version": "8.5.0"
                   }
                 ],
-                "total_dependencies": 3
+                "total_dependencies": 4
               },
               "module": "custom_components.opensearch_multimodel_multiembedding"
             },
@@ -4045,7 +3211,7 @@
                 "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
               },
               "_frontend_node_folder_id": {
-                "value": "d89df57e-0640-47c5-973b-37849ac97186"
+                "value": "2be9efb3-6f08-4dee-9d08-1747bd9c33ee"
               },
               "_type": "Component",
               "auth_mode": {
@@ -4056,11 +3222,13 @@
                 "display_name": "Authentication Mode",
                 "dynamic": false,
                 "external_options": {},
-                "info": "Authentication method: 'basic' for username/password authentication, or 'jwt' for JSON Web Token (Bearer) authentication.",
+                "info": "Authentication method: 'basic' for username/password authentication, 'jwt' for JSON Web Token (Bearer) authentication, or 'openrag' to delegate writes to the OpenRAG backend ingest callback (no direct OpenSearch credentials required — only OPENRAG_* fields).",
+                "load_from_db": false,
                 "name": "auth_mode",
                 "options": [
                   "basic",
-                  "jwt"
+                  "jwt",
+                  "openrag"
                 ],
                 "options_metadata": [],
                 "override_skip": false,
@@ -4074,7 +3242,7 @@
                 "trace_as_metadata": true,
                 "track_in_telemetry": true,
                 "type": "str",
-                "value": "jwt"
+                "value": "openrag"
               },
               "bearer_prefix": {
                 "_input_type": "BoolInput",
@@ -4088,7 +3256,7 @@
                 "override_skip": false,
                 "placeholder": "",
                 "required": false,
-                "show": true,
+                "show": false,
                 "title_case": false,
                 "tool_mode": false,
                 "trace_as_metadata": true,
@@ -4336,8 +3504,8 @@
                 "name": "jwt_header",
                 "override_skip": false,
                 "placeholder": "",
-                "required": true,
-                "show": true,
+                "required": false,
+                "show": false,
                 "title_case": false,
                 "tool_mode": false,
                 "trace_as_metadata": true,
@@ -4352,17 +3520,17 @@
                 "dynamic": false,
                 "info": "Valid JSON Web Token for authentication. Will be sent in the Authorization header (with optional 'Bearer ' prefix).",
                 "input_types": [],
-                "load_from_db": true,
+                "load_from_db": false,
                 "name": "jwt_token",
                 "override_skip": false,
                 "password": true,
                 "placeholder": "",
-                "required": true,
-                "show": true,
+                "required": false,
+                "show": false,
                 "title_case": false,
                 "track_in_telemetry": false,
                 "type": "str",
-                "value": "JWT"
+                "value": ""
               },
               "m": {
                 "_input_type": "IntInput",
@@ -4444,6 +3612,101 @@
                 "track_in_telemetry": true,
                 "type": "int",
                 "value": 10
+              },
+              "openrag_ingest_batch_size": {
+                "_input_type": "IntInput",
+                "advanced": false,
+                "display_name": "OpenRAG Ingest Batch Size",
+                "dynamic": false,
+                "info": "",
+                "list": false,
+                "list_add_label": "Add More",
+                "name": "openrag_ingest_batch_size",
+                "override_skip": false,
+                "placeholder": "",
+                "required": false,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": true,
+                "type": "int",
+                "value": 100
+              },
+              "openrag_ingest_run_id": {
+                "_input_type": "StrInput",
+                "advanced": false,
+                "display_name": "OpenRAG Ingest Run ID",
+                "dynamic": false,
+                "info": "",
+                "input_types": [
+                  "Text",
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": true,
+                "name": "openrag_ingest_run_id",
+                "override_skip": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "OPENRAG_INGEST_RUN_ID"
+              },
+              "openrag_ingest_token": {
+                "_input_type": "StrInput",
+                "advanced": false,
+                "display_name": "OpenRAG Ingest Token",
+                "dynamic": false,
+                "info": "Short-lived token used only for OpenRAG ingest callbacks.",
+                "input_types": [
+                  "Text",
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": true,
+                "name": "openrag_ingest_token",
+                "override_skip": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "OPENRAG_INGEST_TOKEN"
+              },
+              "openrag_ingest_url": {
+                "_input_type": "StrInput",
+                "advanced": false,
+                "display_name": "OpenRAG Ingest URL",
+                "dynamic": false,
+                "info": "Internal OpenRAG callback URL for backend-owned document indexing.",
+                "input_types": [
+                  "Text",
+                  "Message"
+                ],
+                "list": false,
+                "list_add_label": "Add More",
+                "load_from_db": true,
+                "name": "openrag_ingest_url",
+                "override_skip": false,
+                "placeholder": "",
+                "required": true,
+                "show": true,
+                "title_case": false,
+                "tool_mode": false,
+                "trace_as_metadata": true,
+                "track_in_telemetry": false,
+                "type": "str",
+                "value": "OPENRAG_INGEST_URL"
               },
               "opensearch_url": {
                 "_input_type": "StrInput",
@@ -4662,99 +3925,6 @@
                 "track_in_telemetry": true,
                 "type": "bool",
                 "value": false
-              },
-              "openrag_ingest_url": {
-                "_input_type": "StrInput",
-                "advanced": true,
-                "display_name": "OpenRAG Ingest URL",
-                "dynamic": false,
-                "info": "Internal OpenRAG callback URL for backend-owned document indexing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "name": "openrag_ingest_url",
-                "override_skip": false,
-                "placeholder": "",
-                "required": false,
-                "show": false,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OPENRAG_INGEST_URL",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ]
-              },
-              "openrag_ingest_token": {
-                "_input_type": "StrInput",
-                "advanced": true,
-                "display_name": "OpenRAG Ingest Token",
-                "dynamic": false,
-                "info": "Short-lived token used only for OpenRAG ingest callbacks.",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ],
-                "load_from_db": true,
-                "name": "openrag_ingest_token",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": false,
-                "title_case": false,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OPENRAG_INGEST_TOKEN"
-              },
-              "openrag_ingest_run_id": {
-                "_input_type": "StrInput",
-                "advanced": true,
-                "display_name": "OpenRAG Ingest Run ID",
-                "dynamic": false,
-                "info": "",
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "name": "openrag_ingest_run_id",
-                "override_skip": false,
-                "placeholder": "",
-                "required": false,
-                "show": false,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OPENRAG_INGEST_RUN_ID",
-                "input_types": [
-                  "Text",
-                  "Message"
-                ]
-              },
-              "openrag_ingest_batch_size": {
-                "_input_type": "IntInput",
-                "advanced": true,
-                "display_name": "OpenRAG Ingest Batch Size",
-                "dynamic": false,
-                "info": "",
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": false,
-                "name": "openrag_ingest_batch_size",
-                "override_skip": false,
-                "placeholder": "",
-                "required": false,
-                "show": false,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "int",
-                "value": 100
               }
             },
             "tool_mode": false
@@ -4766,12 +3936,12 @@
         "dragging": false,
         "id": "OpenSearchVectorStoreComponentMultimodalMultiEmbedding-By9U4",
         "measured": {
-          "height": 967,
+          "height": 1213,
           "width": 320
         },
         "position": {
           "x": 1756.949537574781,
-          "y": 1525.6023642029047
+          "y": 1353.9990788264315
         },
         "selected": false,
         "type": "genericNode"
@@ -4852,7 +4022,7 @@
                 "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
               },
               "_frontend_node_folder_id": {
-                "value": "d61134a0-3f8e-4e89-9165-ce13f2a14ac6"
+                "value": "2be9efb3-6f08-4dee-9d08-1747bd9c33ee"
               },
               "_type": "Component",
               "api_base": {
@@ -5306,1230 +4476,6 @@
       },
       {
         "data": {
-          "id": "TextInput-CTKlr",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "ALLOWED_GROUPS"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-CTKlr",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1028.9084907232098,
-          "y": 1062.849997200131
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-hlgVv",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "ALLOWED_USERS"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-hlgVv",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1032.6873315933058,
-          "y": 1145.9844963422515
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-OGCeZ",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "CONNECTOR_TYPE"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-OGCeZ",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1034.5767520283541,
-          "y": 1227.2295750493238
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-PI6at",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "DOCUMENT_ID"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-PI6at",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1034.5767520283543,
-          "y": 1310.364074191445
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-gRPNR",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OWNER"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-gRPNR",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1034.5767520283541,
-          "y": 1393.498573333566
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-lTHSx",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OWNER_EMAIL"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-lTHSx",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1032.6873315933058,
-          "y": 1476.633072475687
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-68n9L",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OWNER_NAME"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-68n9L",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1032.687331593306,
-          "y": 1552.2098898776146
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-UZQ8v",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "SOURCE_URL"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-UZQ8v",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1034.5767520283541,
-          "y": 1639.123229889832
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
           "description": "Generate embeddings using a specified provider.",
           "display_name": "Embedding Model",
           "id": "EmbeddingModel-UcgwY",
@@ -6604,7 +4550,7 @@
                 "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
               },
               "_frontend_node_folder_id": {
-                "value": "d61134a0-3f8e-4e89-9165-ce13f2a14ac6"
+                "value": "2be9efb3-6f08-4dee-9d08-1747bd9c33ee"
               },
               "_type": "Component",
               "api_base": {
@@ -7132,7 +5078,7 @@
                 "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
               },
               "_frontend_node_folder_id": {
-                "value": "d61134a0-3f8e-4e89-9165-ce13f2a14ac6"
+                "value": "2be9efb3-6f08-4dee-9d08-1747bd9c33ee"
               },
               "_type": "Component",
               "api_base": {
@@ -7581,478 +5527,19 @@
         },
         "selected": false,
         "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-OpenRAGIngest-url",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OPENRAG_INGEST_URL"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-OpenRAGIngest-url",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1036.949537574781,
-          "y": 1280.6023642029047
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-OpenRAGIngest-token",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OPENRAG_INGEST_TOKEN"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-OpenRAGIngest-token",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1036.949537574781,
-          "y": 1362.6023642029047
-        },
-        "selected": false,
-        "type": "genericNode"
-      },
-      {
-        "data": {
-          "id": "TextInput-OpenRAGIngest-run_id",
-          "node": {
-            "base_classes": [
-              "Message"
-            ],
-            "beta": false,
-            "conditional_paths": [],
-            "custom_fields": {},
-            "description": "Get user text inputs.",
-            "display_name": "Text Input",
-            "documentation": "https://docs.langflow.org/text-input-and-output",
-            "edited": false,
-            "field_order": [
-              "input_value",
-              "use_global_variable"
-            ],
-            "frozen": false,
-            "icon": "type",
-            "last_updated": "2026-02-27T18:37:07.463Z",
-            "legacy": false,
-            "metadata": {
-              "code_hash": "518f16485886",
-              "dependencies": {
-                "dependencies": [
-                  {
-                    "name": "lfx",
-                    "version": null
-                  }
-                ],
-                "total_dependencies": 1
-              },
-              "module": "lfx.components.input_output.text.TextInputComponent"
-            },
-            "minimized": false,
-            "output_types": [],
-            "outputs": [
-              {
-                "allows_loop": false,
-                "cache": true,
-                "display_name": "Output Text",
-                "group_outputs": false,
-                "loop_types": null,
-                "method": "text_response",
-                "name": "text",
-                "options": null,
-                "required_inputs": null,
-                "selected": "Message",
-                "tool_mode": true,
-                "types": [
-                  "Message"
-                ],
-                "value": "__UNDEFINED__"
-              }
-            ],
-            "pinned": false,
-            "template": {
-              "_frontend_node_flow_id": {
-                "value": "5488df7c-b93f-4f87-a446-b67028bc0813"
-              },
-              "_frontend_node_folder_id": {
-                "value": "2bef1fdd-4d60-4bb6-8fd2-c0a3eae09d1e"
-              },
-              "_type": "Component",
-              "code": {
-                "advanced": true,
-                "dynamic": true,
-                "fileTypes": [],
-                "file_path": "",
-                "info": "",
-                "list": false,
-                "load_from_db": false,
-                "multiline": true,
-                "name": "code",
-                "password": false,
-                "placeholder": "",
-                "required": true,
-                "show": true,
-                "title_case": false,
-                "type": "code",
-                "value": "from typing import Any\n\nfrom lfx.base.io.text import TextComponent\nfrom lfx.io import BoolInput, MultilineInput, Output\nfrom lfx.schema.message import Message\n\n\nclass TextInputComponent(TextComponent):\n    display_name = \"Text Input\"\n    description = \"Get user text inputs.\"\n    documentation: str = \"https://docs.langflow.org/text-input-and-output\"\n    icon = \"type\"\n    name = \"TextInput\"\n\n    inputs = [\n        MultilineInput(\n            name=\"input_value\",\n            display_name=\"Text\",\n            info=\"Text to be passed as input.\",\n        ),\n        BoolInput(\n            name=\"use_global_variable\",\n            display_name=\"Use Global Variable\",\n            info=\"Enable to select from global variables (shows globe icon). Disables multiline editing.\",\n            value=False,\n            advanced=True,\n            real_time_refresh=True,\n        ),\n    ]\n    outputs = [\n        Output(display_name=\"Output Text\", name=\"text\", method=\"text_response\"),\n    ]\n\n    def update_build_config(self, build_config: dict, field_value: Any, field_name: str | None = None) -> dict:\n        if field_name == \"use_global_variable\":\n            if field_value:\n                # Enable global variable mode: single-line with password masking and globe dropdown\n                build_config[\"input_value\"][\"multiline\"] = False\n                build_config[\"input_value\"][\"password\"] = True\n            else:\n                # Default mode: multiline text editing\n                build_config[\"input_value\"][\"multiline\"] = True\n                build_config[\"input_value\"][\"password\"] = False\n        return build_config\n\n    def text_response(self) -> Message:\n        return Message(\n            text=self.input_value,\n        )\n"
-              },
-              "input_value": {
-                "_input_type": "MultilineInput",
-                "advanced": false,
-                "ai_enabled": false,
-                "copy_field": false,
-                "display_name": "Text",
-                "dynamic": false,
-                "info": "Text to be passed as input.",
-                "input_types": [
-                  "Message"
-                ],
-                "list": false,
-                "list_add_label": "Add More",
-                "load_from_db": true,
-                "multiline": false,
-                "name": "input_value",
-                "override_skip": false,
-                "password": true,
-                "placeholder": "",
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_input": true,
-                "trace_as_metadata": true,
-                "track_in_telemetry": false,
-                "type": "str",
-                "value": "OPENRAG_INGEST_RUN_ID"
-              },
-              "is_refresh": false,
-              "use_global_variable": {
-                "_input_type": "BoolInput",
-                "advanced": true,
-                "display_name": "Use Global Variable",
-                "dynamic": false,
-                "info": "Enable to select from global variables (shows globe icon). Disables multiline editing.",
-                "list": false,
-                "list_add_label": "Add More",
-                "name": "use_global_variable",
-                "override_skip": false,
-                "placeholder": "",
-                "real_time_refresh": true,
-                "required": false,
-                "show": true,
-                "title_case": false,
-                "tool_mode": false,
-                "trace_as_metadata": true,
-                "track_in_telemetry": true,
-                "type": "bool",
-                "value": true
-              }
-            },
-            "tool_mode": false
-          },
-          "showNode": false,
-          "type": "TextInput"
-        },
-        "dragging": false,
-        "id": "TextInput-OpenRAGIngest-run_id",
-        "measured": {
-          "height": 52,
-          "width": 192
-        },
-        "position": {
-          "x": 1036.949537574781,
-          "y": 1444.6023642029047
-        },
-        "selected": false,
-        "type": "genericNode"
       }
     ],
     "viewport": {
-      "x": 239.96894590419038,
-      "y": -373.3174538705754,
-      "zoom": 0.475706358533402
+      "x": 88.5162499041611,
+      "y": -383.79779651448473,
+      "zoom": 0.39626280960074645
     }
   },
   "description": "Load your data for chat context with Retrieval Augmented Generation.",
   "endpoint_name": null,
   "id": "5488df7c-b93f-4f87-a446-b67028bc0813",
   "is_component": false,
-  "last_tested_version": "1.9.3",
+  "last_tested_version": "1.9.0",
   "locked": true,
   "name": "OpenSearch Ingestion Flow",
   "tags": [

--- a/flows/openrag_agent.json
+++ b/flows/openrag_agent.json
@@ -286,6 +286,8 @@
         "targetHandle": "{œfieldNameœ:œtoolsœ,œidœ:œAgent-Nfw7uœ,œinputTypesœ:[œToolœ],œtypeœ:œotherœ}"
       },
       {
+        "animated": false,
+        "className": "",
         "data": {
           "sourceHandle": {
             "dataType": "MCPTools",
@@ -305,6 +307,7 @@
           }
         },
         "id": "xy-edge__MCPTools-uu7m3{œdataTypeœ:œMCPToolsœ,œidœ:œMCPTools-uu7m3œ,œnameœ:œcomponent_as_toolœ,œoutput_typesœ:[œToolœ]}-Agent-Nfw7u{œfieldNameœ:œtoolsœ,œidœ:œAgent-Nfw7uœ,œinputTypesœ:[œToolœ],œtypeœ:œotherœ}",
+        "selected": false,
         "source": "MCPTools-uu7m3",
         "sourceHandle": "{œdataTypeœ:œMCPToolsœ,œidœ:œMCPTools-uu7m3œ,œnameœ:œcomponent_as_toolœ,œoutput_typesœ:[œToolœ]}",
         "target": "Agent-Nfw7u",
@@ -1034,7 +1037,7 @@
               },
               "_frontend_node_folder_id": {
                 "input_types": [],
-                "value": "3b7ac23f-e74d-4fa3-ae00-a54b24a27f93"
+                "value": "ef261332-778a-4347-96bc-99b4207d86b1"
               },
               "_type": "Component",
               "add_current_date_tool": {
@@ -1428,109 +1431,6 @@
                     },
                     "name": "gpt-4o",
                     "provider": "OpenAI"
-                  },
-                  {
-                    "category": "Ollama",
-                    "icon": "Ollama",
-                    "metadata": {
-                      "api_key_param": "api_key",
-                      "base_url_param": "base_url",
-                      "context_length": 128000,
-                      "max_tokens_field_name": "max_tokens",
-                      "model_class": "ChatOllama",
-                      "model_name_param": "model"
-                    },
-                    "name": "gpt-oss:20b",
-                    "provider": "Ollama"
-                  },
-                  {
-                    "category": "Ollama",
-                    "icon": "Ollama",
-                    "metadata": {
-                      "api_key_param": "api_key",
-                      "base_url_param": "base_url",
-                      "context_length": 128000,
-                      "max_tokens_field_name": "max_tokens",
-                      "model_class": "ChatOllama",
-                      "model_name_param": "model"
-                    },
-                    "name": "qwen3:8b",
-                    "provider": "Ollama"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "api_key_param": "apikey",
-                      "context_length": 128000,
-                      "max_tokens_field_name": "max_tokens",
-                      "model_class": "ChatWatsonx",
-                      "model_name_param": "model_id",
-                      "project_id_param": "project_id",
-                      "url_param": "url"
-                    },
-                    "name": "ibm/granite-4-h-small",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "api_key_param": "apikey",
-                      "context_length": 128000,
-                      "max_tokens_field_name": "max_tokens",
-                      "model_class": "ChatWatsonx",
-                      "model_name_param": "model_id",
-                      "project_id_param": "project_id",
-                      "url_param": "url"
-                    },
-                    "name": "ibm/granite-8b-code-instruct",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "api_key_param": "apikey",
-                      "context_length": 128000,
-                      "max_tokens_field_name": "max_tokens",
-                      "model_class": "ChatWatsonx",
-                      "model_name_param": "model_id",
-                      "project_id_param": "project_id",
-                      "url_param": "url"
-                    },
-                    "name": "ibm/granite-guardian-3-8b",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "api_key_param": "apikey",
-                      "context_length": 128000,
-                      "max_tokens_field_name": "max_tokens",
-                      "model_class": "ChatWatsonx",
-                      "model_name_param": "model_id",
-                      "project_id_param": "project_id",
-                      "url_param": "url"
-                    },
-                    "name": "meta-llama/llama-3-2-11b-vision-instruct",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "api_key_param": "apikey",
-                      "context_length": 128000,
-                      "max_tokens_field_name": "max_tokens",
-                      "model_class": "ChatWatsonx",
-                      "model_name_param": "model_id",
-                      "project_id_param": "project_id",
-                      "url_param": "url"
-                    },
-                    "name": "meta-llama/llama-3-3-70b-instruct",
-                    "provider": "IBM WatsonX"
                   }
                 ],
                 "override_skip": false,
@@ -1783,16 +1683,14 @@
             ],
             "frozen": false,
             "icon": "calculator",
-            "last_updated": "2026-04-28T13:28:59.343Z",
             "legacy": false,
-            "lf_version": "1.9.0",
             "metadata": {
-              "code_hash": "37caa1aba62c",
+              "code_hash": "d0b2936e74fa",
               "dependencies": {
                 "dependencies": [
                   {
                     "name": "lfx",
-                    "version": null
+                    "version": "0.4.3"
                   }
                 ],
                 "total_dependencies": 1
@@ -1823,12 +1721,6 @@
             ],
             "pinned": false,
             "template": {
-              "_frontend_node_flow_id": {
-                "value": "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
-              },
-              "_frontend_node_folder_id": {
-                "value": "3b7ac23f-e74d-4fa3-ae00-a54b24a27f93"
-              },
               "_type": "Component",
               "code": {
                 "advanced": true,
@@ -1846,7 +1738,7 @@
                 "show": true,
                 "title_case": false,
                 "type": "code",
-                "value": "import ast\nimport operator\nfrom collections.abc import Callable\n\nfrom lfx.custom.custom_component.component import Component\nfrom lfx.inputs.inputs import MessageTextInput\nfrom lfx.io import Output\nfrom lfx.schema.data import Data\n\n\nclass CalculatorComponent(Component):\n    display_name = \"Calculator\"\n    description = \"Perform basic arithmetic operations on a given expression.\"\n    documentation: str = \"https://docs.langflow.org/calculator\"\n    icon = \"calculator\"\n\n    # Cache operators dictionary as a class variable\n    OPERATORS: dict[type[ast.operator], Callable] = {\n        ast.Add: operator.add,\n        ast.Sub: operator.sub,\n        ast.Mult: operator.mul,\n        ast.Div: operator.truediv,\n        ast.Pow: operator.pow,\n    }\n\n    inputs = [\n        MessageTextInput(\n            name=\"expression\",\n            display_name=\"Expression\",\n            info=\"The arithmetic expression to evaluate (e.g., '4*4*(33/22)+12-20').\",\n            tool_mode=True,\n        ),\n    ]\n\n    outputs = [\n        Output(display_name=\"JSON\", name=\"result\", type_=Data, method=\"evaluate_expression\"),\n    ]\n\n    def _eval_expr(self, node: ast.AST) -> float:\n        \"\"\"Evaluate an AST node recursively.\"\"\"\n        if isinstance(node, ast.Constant):\n            if isinstance(node.value, int | float):\n                return float(node.value)\n            error_msg = f\"Unsupported constant type: {type(node.value).__name__}\"\n            raise TypeError(error_msg)\n        if isinstance(node, ast.Num):  # For backwards compatibility\n            if isinstance(node.n, int | float):\n                return float(node.n)\n            error_msg = f\"Unsupported number type: {type(node.n).__name__}\"\n            raise TypeError(error_msg)\n\n        if isinstance(node, ast.BinOp):\n            op_type = type(node.op)\n            if op_type not in self.OPERATORS:\n                error_msg = f\"Unsupported binary operator: {op_type.__name__}\"\n                raise TypeError(error_msg)\n\n            left = self._eval_expr(node.left)\n            right = self._eval_expr(node.right)\n            return self.OPERATORS[op_type](left, right)\n\n        error_msg = f\"Unsupported operation or expression type: {type(node).__name__}\"\n        raise TypeError(error_msg)\n\n    def evaluate_expression(self) -> Data:\n        \"\"\"Evaluate the mathematical expression and return the result.\"\"\"\n        try:\n            tree = ast.parse(self.expression, mode=\"eval\")\n            result = self._eval_expr(tree.body)\n\n            formatted_result = f\"{float(result):.6f}\".rstrip(\"0\").rstrip(\".\")\n            self.log(f\"Calculation result: {formatted_result}\")\n\n            self.status = formatted_result\n            return Data(data={\"result\": formatted_result})\n\n        except ZeroDivisionError:\n            error_message = \"Error: Division by zero\"\n            self.status = error_message\n            return Data(data={\"error\": error_message, \"input\": self.expression})\n\n        except (SyntaxError, TypeError, KeyError, ValueError, AttributeError, OverflowError) as e:\n            error_message = f\"Invalid expression: {e!s}\"\n            self.status = error_message\n            return Data(data={\"error\": error_message, \"input\": self.expression})\n\n    def build(self):\n        \"\"\"Return the main evaluation function.\"\"\"\n        return self.evaluate_expression\n"
+                "value": "import ast\nimport operator\nfrom collections.abc import Callable\n\nfrom lfx.custom.custom_component.component import Component\nfrom lfx.inputs.inputs import MessageTextInput\nfrom lfx.io import Output\nfrom lfx.schema.data import Data\n\n\nclass CalculatorComponent(Component):\n    display_name = \"Calculator\"\n    description = \"Perform basic arithmetic operations on a given expression.\"\n    documentation: str = \"https://docs.langflow.org/calculator\"\n    icon = \"calculator\"\n\n    # Cache operators dictionary as a class variable\n    OPERATORS: dict[type[ast.operator], Callable] = {\n        ast.Add: operator.add,\n        ast.Sub: operator.sub,\n        ast.Mult: operator.mul,\n        ast.Div: operator.truediv,\n        ast.Pow: operator.pow,\n    }\n\n    inputs = [\n        MessageTextInput(\n            name=\"expression\",\n            display_name=\"Expression\",\n            info=\"The arithmetic expression to evaluate (e.g., '4*4*(33/22)+12-20').\",\n            tool_mode=True,\n        ),\n    ]\n\n    outputs = [\n        Output(display_name=\"JSON\", name=\"result\", type_=Data, method=\"evaluate_expression\"),\n    ]\n\n    def _eval_expr(self, node: ast.AST) -> float:\n        \"\"\"Evaluate an AST node recursively.\"\"\"\n        if isinstance(node, ast.Constant):\n            if isinstance(node.value, int | float):\n                return float(node.value)\n            error_msg = f\"Unsupported constant type: {type(node.value).__name__}\"\n            raise TypeError(error_msg)\n\n        if isinstance(node, ast.BinOp):\n            op_type = type(node.op)\n            if op_type not in self.OPERATORS:\n                error_msg = f\"Unsupported binary operator: {op_type.__name__}\"\n                raise TypeError(error_msg)\n\n            left = self._eval_expr(node.left)\n            right = self._eval_expr(node.right)\n            return self.OPERATORS[op_type](left, right)\n\n        error_msg = f\"Unsupported operation or expression type: {type(node).__name__}\"\n        raise TypeError(error_msg)\n\n    def evaluate_expression(self) -> Data:\n        \"\"\"Evaluate the mathematical expression and return the result.\"\"\"\n        try:\n            tree = ast.parse(self.expression, mode=\"eval\")\n            result = self._eval_expr(tree.body)\n\n            formatted_result = f\"{float(result):.6f}\".rstrip(\"0\").rstrip(\".\")\n            self.log(f\"Calculation result: {formatted_result}\")\n\n            self.status = formatted_result\n            return Data(data={\"result\": formatted_result})\n\n        except ZeroDivisionError:\n            error_message = \"Error: Division by zero\"\n            self.status = error_message\n            return Data(data={\"error\": error_message, \"input\": self.expression})\n\n        except (SyntaxError, TypeError, KeyError, ValueError, AttributeError, OverflowError) as e:\n            error_message = f\"Invalid expression: {e!s}\"\n            self.status = error_message\n            return Data(data={\"error\": error_message, \"input\": self.expression})\n\n    def build(self):\n        \"\"\"Return the main evaluation function.\"\"\"\n        return self.evaluate_expression\n"
               },
               "expression": {
                 "_input_type": "MessageTextInput",
@@ -1873,7 +1765,6 @@
                 "type": "str",
                 "value": ""
               },
-              "is_refresh": false,
               "tools_metadata": {
                 "_input_type": "ToolsInput",
                 "advanced": false,
@@ -2012,7 +1903,7 @@
                 "value": "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
               },
               "_frontend_node_folder_id": {
-                "value": "3b7ac23f-e74d-4fa3-ae00-a54b24a27f93"
+                "value": "ef261332-778a-4347-96bc-99b4207d86b1"
               },
               "_type": "Component",
               "api_base": {
@@ -2281,113 +2172,6 @@
                     },
                     "name": "text-embedding-ada-002",
                     "provider": "OpenAI"
-                  },
-                  {
-                    "category": "Ollama",
-                    "icon": "Ollama",
-                    "metadata": {
-                      "embedding_class": "OllamaEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "base_url": "base_url",
-                        "model": "model",
-                        "model_kwargs": "model_kwargs",
-                        "num_ctx": "num_ctx",
-                        "request_timeout": "request_timeout"
-                      }
-                    },
-                    "name": "nomic-embed-text:latest",
-                    "provider": "Ollama"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/granite-embedding-278m-multilingual",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/slate-125m-english-rtrvr-v2",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/slate-30m-english-rtrvr-v2",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "intfloat/multilingual-e5-large",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "sentence-transformers/all-minilm-l6-v2",
-                    "provider": "IBM WatsonX"
                   }
                 ],
                 "override_skip": false,
@@ -2619,7 +2403,7 @@
             ],
             "frozen": false,
             "icon": "OpenSearch",
-            "last_updated": "2026-04-28T13:28:59.343Z",
+            "last_updated": "2026-05-18T18:15:01.796Z",
             "legacy": false,
             "lf_version": "1.9.0",
             "metadata": {
@@ -2671,7 +2455,7 @@
                 "value": "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
               },
               "_frontend_node_folder_id": {
-                "value": "3b7ac23f-e74d-4fa3-ae00-a54b24a27f93"
+                "value": "ef261332-778a-4347-96bc-99b4207d86b1"
               },
               "_type": "Component",
               "auth_mode": {
@@ -3469,7 +3253,7 @@
                 "value": "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
               },
               "_frontend_node_folder_id": {
-                "value": "3b7ac23f-e74d-4fa3-ae00-a54b24a27f93"
+                "value": "ef261332-778a-4347-96bc-99b4207d86b1"
               },
               "_type": "Component",
               "api_base": {
@@ -3738,113 +3522,6 @@
                     },
                     "name": "text-embedding-ada-002",
                     "provider": "OpenAI"
-                  },
-                  {
-                    "category": "Ollama",
-                    "icon": "Ollama",
-                    "metadata": {
-                      "embedding_class": "OllamaEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "base_url": "base_url",
-                        "model": "model",
-                        "model_kwargs": "model_kwargs",
-                        "num_ctx": "num_ctx",
-                        "request_timeout": "request_timeout"
-                      }
-                    },
-                    "name": "nomic-embed-text:latest",
-                    "provider": "Ollama"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/granite-embedding-278m-multilingual",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/slate-125m-english-rtrvr-v2",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/slate-30m-english-rtrvr-v2",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "intfloat/multilingual-e5-large",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "sentence-transformers/all-minilm-l6-v2",
-                    "provider": "IBM WatsonX"
                   }
                 ],
                 "override_skip": false,
@@ -4106,7 +3783,7 @@
                 "value": "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
               },
               "_frontend_node_folder_id": {
-                "value": "3b7ac23f-e74d-4fa3-ae00-a54b24a27f93"
+                "value": "ef261332-778a-4347-96bc-99b4207d86b1"
               },
               "_type": "Component",
               "api_base": {
@@ -4375,113 +4052,6 @@
                     },
                     "name": "text-embedding-ada-002",
                     "provider": "OpenAI"
-                  },
-                  {
-                    "category": "Ollama",
-                    "icon": "Ollama",
-                    "metadata": {
-                      "embedding_class": "OllamaEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "base_url": "base_url",
-                        "model": "model",
-                        "model_kwargs": "model_kwargs",
-                        "num_ctx": "num_ctx",
-                        "request_timeout": "request_timeout"
-                      }
-                    },
-                    "name": "nomic-embed-text:latest",
-                    "provider": "Ollama"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/granite-embedding-278m-multilingual",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/slate-125m-english-rtrvr-v2",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "ibm/slate-30m-english-rtrvr-v2",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "intfloat/multilingual-e5-large",
-                    "provider": "IBM WatsonX"
-                  },
-                  {
-                    "category": "IBM WatsonX",
-                    "icon": "WatsonxAI",
-                    "metadata": {
-                      "embedding_class": "WatsonxEmbeddings",
-                      "model_type": "embeddings",
-                      "param_mapping": {
-                        "api_key": "apikey",
-                        "model_id": "model_id",
-                        "project_id": "project_id",
-                        "request_timeout": "request_timeout",
-                        "space_id": "space_id",
-                        "url": "url"
-                      }
-                    },
-                    "name": "sentence-transformers/all-minilm-l6-v2",
-                    "provider": "IBM WatsonX"
                   }
                 ],
                 "override_skip": false,
@@ -5058,7 +4628,7 @@
             ],
             "frozen": false,
             "icon": "Mcp",
-            "last_updated": "2026-04-28T13:55:00.662Z",
+            "last_updated": "2026-05-18T18:15:01.797Z",
             "legacy": false,
             "metadata": {
               "code_hash": "ccd98ac0a0fb",
@@ -5109,7 +4679,7 @@
                 "value": "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
               },
               "_frontend_node_folder_id": {
-                "value": "3b7ac23f-e74d-4fa3-ae00-a54b24a27f93"
+                "value": "ef261332-778a-4347-96bc-99b4207d86b1"
               },
               "_type": "Component",
               "code": {
@@ -5406,16 +4976,16 @@
       }
     ],
     "viewport": {
-      "x": -144.06609500883735,
-      "y": -221.7218791332906,
-      "zoom": 0.3639973872497736
+      "x": 44.66212804073905,
+      "y": -301.06294556867385,
+      "zoom": 0.47224912881136594
     }
   },
   "description": "OpenRAG OpenSearch Agent",
   "endpoint_name": null,
   "id": "1098eea1-6649-4e1d-aed1-b77249fb8dd0",
   "is_component": false,
-  "last_tested_version": "1.9.0",
+  "last_tested_version": "1.9.3",
   "locked": true,
   "name": "OpenRAG OpenSearch Agent Flow",
   "tags": [

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1043,16 +1043,80 @@ async def onboarding(
         # Initialize the OpenSearch index if embedding model is configured
         if body.embedding_model or body.embedding_provider:
             try:
-                from config.settings import IBM_AUTH_ENABLED
                 from config.settings import clients as app_clients
+                from config.settings import (
+                    get_openrag_service_token,
+                    get_opensearch_password,
+                    get_opensearch_username,
+                )
                 from main import init_index
+                from utils.run_mode_utils import (
+                    is_run_mode_on_prem,
+                    is_run_mode_oss,
+                    is_run_mode_saas,
+                )
 
+                # Choose the OpenSearch client + admin identity for index/security
+                # setup, by run mode:
+                #   saas    -> platform service token (JWT); admin from its claim
+                #   on_prem -> OpenSearch basic auth; OpenSearch username as admin
+                #   oss     -> OpenSearch basic auth; OpenSearch username as admin
                 opensearch_client = None
-                if IBM_AUTH_ENABLED and user and user.jwt_token:
-                    opensearch_client = app_clients.create_user_opensearch_client(user.jwt_token)
+                admin_username = None
+                if is_run_mode_saas():
+                    service_token = get_openrag_service_token()
+                    if service_token:
+                        # Prefer the platform service token so onboarding pins the
+                        # same admin identity as the startup security bootstrap
+                        # (see app/lifespan.py).
+                        from auth.ibm_auth import admin_username_from_service_jwt
+
+                        admin_username = admin_username_from_service_jwt(service_token)
+                        if not admin_username:
+                            raise RuntimeError(
+                                "OPENRAG_SERVICE_TOKEN has no 'username' or 'sub' claim; "
+                                "cannot determine OpenSearch admin during onboarding"
+                            )
+                        opensearch_client = app_clients.create_opensearch_client_from_jwt(
+                            service_token
+                        )
+                        logger.info(
+                            "Onboarding OpenSearch setup: saas mode, using platform service token",
+                            admin_username=admin_username,
+                        )
+                    elif user:
+                        # TODO: backward-compatibility fallback for saas deployments
+                        # without OPENRAG_SERVICE_TOKEN — pins the onboarding user as
+                        # admin instead of the platform service identity. Remove once
+                        # the service token is always provided.
+                        if user.jwt_token:
+                            opensearch_client = app_clients.create_user_opensearch_client(
+                                user.jwt_token
+                            )
+                        admin_username = user.user_id
+                        logger.warning(
+                            "Onboarding OpenSearch setup: saas mode without "
+                            "OPENRAG_SERVICE_TOKEN; falling back to the onboarding user "
+                            "as admin (backward-compatibility path, to be removed later)",
+                            admin_username=admin_username,
+                        )
+                    else:
+                        logger.info(
+                            "Onboarding OpenSearch setup: saas mode with no service "
+                            "token or user; using the unauthenticated global client"
+                        )
+                elif is_run_mode_on_prem() or is_run_mode_oss():
+                    admin_username = get_opensearch_username()
+                    opensearch_client = app_clients.create_basic_opensearch_client(
+                        admin_username, get_opensearch_password()
+                    )
+                    logger.info(
+                        "Onboarding OpenSearch setup: %s mode, using OpenSearch basic auth"
+                        % ("on_prem" if is_run_mode_on_prem() else "oss"),
+                        admin_username=admin_username,
+                    )
 
                 logger.info("Initializing OpenSearch index after onboarding configuration")
-                admin_username = user.user_id if IBM_AUTH_ENABLED and user else None
                 await init_index(opensearch_client, admin_username=admin_username)
                 logger.info("OpenSearch index initialization completed successfully")
             except Exception as e:
@@ -1069,6 +1133,7 @@ async def onboarding(
             if should_ingest_sample_data:
                 try:
                     # Import the function here to avoid circular imports
+                    from config.settings import IBM_AUTH_ENABLED
                     from main import ingest_default_documents_when_ready
 
                     if not config_manager.save_config_file(current_config):

--- a/src/app/lifespan.py
+++ b/src/app/lifespan.py
@@ -21,6 +21,8 @@ from config.settings import (
     clients,
     get_openrag_config,
     get_openrag_service_token,
+    get_opensearch_password,
+    get_opensearch_username,
 )
 from services.startup_orchestrator import startup_tasks
 from utils.logging_config import get_logger
@@ -207,23 +209,47 @@ async def run_startup(app: FastAPI):
     # talks to OpenSearch. The corresponding call inside startup_tasks
     # is suppressed when this flag is on.
     if OPENRAG_BOOTSTRAP_OS_SECURITY_ON_STARTUP:
-        service_token = get_openrag_service_token()
-        if not service_token:
-            raise RuntimeError(
-                "OPENRAG_BOOTSTRAP_OS_SECURITY_ON_STARTUP is enabled but "
-                "OPENRAG_SERVICE_TOKEN is not set"
-            )
-        from auth.ibm_auth import admin_username_from_service_jwt
         from utils.opensearch_init import wait_for_opensearch
         from utils.opensearch_utils import setup_opensearch_security
+        from utils.run_mode_utils import (
+            is_run_mode_on_prem,
+            is_run_mode_oss,
+        )
 
-        admin_username = admin_username_from_service_jwt(service_token)
-        if not admin_username:
-            raise RuntimeError(
-                "OPENRAG_SERVICE_TOKEN has no 'username' or 'sub' claim; "
-                "cannot bootstrap OpenSearch security"
+        # Choose the bootstrap OpenSearch client + admin identity, by run mode:
+        #   saas    -> platform service token (JWT); admin from its claim
+        #   on_prem -> OpenSearch basic auth; OpenSearch username as admin
+        #   oss     -> OpenSearch basic auth; OpenSearch username as admin
+        if is_run_mode_on_prem() or is_run_mode_oss():
+            admin_username = get_opensearch_username()
+            opensearch_client = clients.create_basic_opensearch_client(
+                admin_username, get_opensearch_password()
             )
-        opensearch_client = clients.create_opensearch_client_from_jwt(service_token)
+            logger.info(
+                "OpenSearch security bootstrap: %s mode, using OpenSearch basic auth"
+                % ("on_prem" if is_run_mode_on_prem() else "oss"),
+                admin_username=admin_username,
+            )
+        else:
+            service_token = get_openrag_service_token()
+            if not service_token:
+                raise RuntimeError(
+                    "OPENRAG_BOOTSTRAP_OS_SECURITY_ON_STARTUP is enabled but "
+                    "OPENRAG_SERVICE_TOKEN is not set"
+                )
+            from auth.ibm_auth import admin_username_from_service_jwt
+
+            admin_username = admin_username_from_service_jwt(service_token)
+            if not admin_username:
+                raise RuntimeError(
+                    "OPENRAG_SERVICE_TOKEN has no 'username' or 'sub' claim; "
+                    "cannot bootstrap OpenSearch security"
+                )
+            opensearch_client = clients.create_opensearch_client_from_jwt(service_token)
+            logger.info(
+                "OpenSearch security bootstrap: saas mode, using platform service token",
+                admin_username=admin_username,
+            )
         try:
             await wait_for_opensearch(opensearch_client)
             logger.info("Bootstrapping OpenSearch security", admin_username=admin_username)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -37,6 +37,21 @@ LANGFLOW_OPENSEARCH_PORT = get_env_int("LANGFLOW_OPENSEARCH_PORT", OPENSEARCH_PO
 
 OPENSEARCH_USERNAME = os.getenv("OPENSEARCH_USERNAME", "admin")
 OPENSEARCH_PASSWORD = os.getenv("OPENSEARCH_PASSWORD")
+
+
+def get_opensearch_username() -> str:
+    """OpenSearch admin/basic-auth username, read per-call so runtime/test
+    overrides (e.g. credentials supplied during onboarding) take effect without
+    a restart. Falls back to the value captured at import time, then "admin"."""
+    return os.getenv("OPENSEARCH_USERNAME") or OPENSEARCH_USERNAME or "admin"
+
+
+def get_opensearch_password() -> str | None:
+    """OpenSearch basic-auth password, read per-call so runtime/test overrides
+    take effect without a restart. Falls back to the import-time value."""
+    return os.getenv("OPENSEARCH_PASSWORD") or OPENSEARCH_PASSWORD
+
+
 OPENRAG_FQDN = os.getenv("OPENRAG_FQDN")
 LANGFLOW_URL = os.getenv("LANGFLOW_URL", "http://localhost:7860")
 # Optional: public URL for browser links (e.g., http://localhost:7860)
@@ -77,6 +92,7 @@ OPENRAG_TENANT_ID = os.getenv("OPENRAG_TENANT_ID", "openrag")
 IBM_JWT_PUBLIC_KEY_URL = os.getenv("IBM_JWT_PUBLIC_KEY_URL", "")
 IBM_SESSION_COOKIE_NAME = os.getenv("IBM_SESSION_COOKIE_NAME", "ibm-openrag-session")
 IBM_CREDENTIALS_HEADER = os.getenv("IBM_CREDENTIALS_HEADER", "X-IBM-LH-Credentials")
+
 
 # ── JWT roles claim ─────────────────────────────────────────────
 # These are exposed as functions (not module constants) so they are read
@@ -581,18 +597,47 @@ class AppClients:
         self._docling_service = None
 
     async def initialize(self):
-        os_auth = None if IBM_AUTH_ENABLED else (OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD)
-
-        self.opensearch = AsyncOpenSearch(
-            hosts=[{"host": OPENSEARCH_HOST, "port": OPENSEARCH_PORT}],
-            connection_class=AIOHttpConnection,
-            scheme="https",
-            use_ssl=True,
-            verify_certs=False,
-            ssl_assert_fingerprint=None,
-            http_auth=os_auth,
-            http_compress=True,
+        from utils.run_mode_utils import (
+            is_run_mode_on_prem,
+            is_run_mode_oss,
+            is_run_mode_saas,
         )
+
+        # Credentials for the global (backend-owned) writer client, by run mode:
+        #   saas    -> platform service token (JWT) when available, else unauthenticated
+        #   on_prem -> OpenSearch basic auth
+        #   oss     -> OpenSearch basic auth
+        service_token = get_openrag_service_token() if is_run_mode_saas() else None
+        if service_token:
+            logger.info(
+                "Initializing global OpenSearch writer client: saas mode, "
+                "using platform service token"
+            )
+            self.opensearch = self.create_opensearch_client_from_jwt(service_token)
+        else:
+            if is_run_mode_on_prem() or is_run_mode_oss():
+                os_auth = (get_opensearch_username(), get_opensearch_password())
+                logger.info(
+                    "Initializing global OpenSearch writer client: %s mode, "
+                    "using OpenSearch basic auth" % ("on_prem" if is_run_mode_on_prem() else "oss")
+                )
+            else:
+                os_auth = None
+                logger.info(
+                    "Initializing global OpenSearch writer client: saas mode without "
+                    "service token, using the unauthenticated client"
+                )
+
+            self.opensearch = AsyncOpenSearch(
+                hosts=[{"host": OPENSEARCH_HOST, "port": OPENSEARCH_PORT}],
+                connection_class=AIOHttpConnection,
+                scheme="https",
+                use_ssl=True,
+                verify_certs=False,
+                ssl_assert_fingerprint=None,
+                http_auth=os_auth,
+                http_compress=True,
+            )
 
         # Initialize patched OpenAI client if API key is available
         # This allows the app to start even if OPENAI_API_KEY is not set yet

--- a/src/connectors/google_drive/oauth.py
+++ b/src/connectors/google_drive/oauth.py
@@ -18,12 +18,16 @@ _REFRESH_TIMEOUT_SECONDS = 30
 class GoogleDriveOAuth:
     """Handles Google Drive OAuth authentication flow"""
 
+    REQUIRED_SCOPES = [
+        "https://www.googleapis.com/auth/drive.readonly",
+        "https://www.googleapis.com/auth/drive.metadata.readonly",
+    ]
+
     SCOPES = [
         "openid",
         "email",
         "profile",
-        "https://www.googleapis.com/auth/drive.readonly",
-        "https://www.googleapis.com/auth/drive.metadata.readonly",
+        *REQUIRED_SCOPES,
         "https://www.googleapis.com/auth/cloud-identity.groups.readonly",
         "https://www.googleapis.com/auth/admin.directory.group.readonly",
     ]
@@ -50,7 +54,7 @@ class GoogleDriveOAuth:
 
     def _missing_required_scopes(self, scopes: list[str] | None) -> list[str]:
         current_scopes = set(scopes or [])
-        return [scope for scope in self.SCOPES if scope not in current_scopes]
+        return [scope for scope in self.REQUIRED_SCOPES if scope not in current_scopes]
 
     def _remove_token_file(self) -> None:
         if os.path.exists(self.token_file):

--- a/src/services/langflow_ingest_token_service.py
+++ b/src/services/langflow_ingest_token_service.py
@@ -8,12 +8,48 @@ from typing import Any
 
 import jwt
 from cachetools import TTLCache
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ec, ed448, ed25519, rsa
 
-from config.settings import LANGFLOW_INGEST_CALLBACK_TTL_SECONDS, SESSION_SECRET
+from config.settings import LANGFLOW_INGEST_CALLBACK_TTL_SECONDS
 from services.document_index_writer import DocumentIndexContext
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+def _resolve_default_signing_config() -> tuple[Any, Any, str]:
+    """Prefer JWT_SIGNING_KEY when set; otherwise fall back to SESSION_SECRET."""
+    from config.settings import JWT_SIGNING_KEY, SESSION_SECRET
+
+    signing_key = JWT_SIGNING_KEY
+    if not signing_key:
+        return SESSION_SECRET, SESSION_SECRET, "HS256"
+
+    if signing_key.lstrip().startswith("-----BEGIN"):
+        key = serialization.load_pem_private_key(signing_key.encode(), password=None)
+        public_key = key.public_key()
+
+        if isinstance(key, rsa.RSAPrivateKey):
+            algorithm = "RS256"
+        elif isinstance(key, ec.EllipticCurvePrivateKey):
+            curve = key.curve
+            if isinstance(curve, ec.SECP256R1):
+                algorithm = "ES256"
+            elif isinstance(curve, ec.SECP384R1):
+                algorithm = "ES384"
+            elif isinstance(curve, ec.SECP521R1):
+                algorithm = "ES512"
+            else:
+                raise ValueError(f"Unsupported EC curve: {curve.name}")
+        elif isinstance(key, (ed25519.Ed25519PrivateKey, ed448.Ed448PrivateKey)):
+            algorithm = "EdDSA"
+        else:
+            raise ValueError(f"Unsupported private key type: {type(key)}")
+
+        return key, public_key, algorithm
+
+    return signing_key, signing_key, "HS256"
 
 
 class LangflowIngestTokenService:
@@ -25,10 +61,16 @@ class LangflowIngestTokenService:
     """
 
     audience = "openrag-langflow-ingest"
-    algorithm = "HS256"
 
     def __init__(self, secret: str | None = None, ttl_seconds: int | None = None):
-        self.secret = secret or SESSION_SECRET
+        if secret is not None:
+            self._signing_key = secret
+            self._verification_key = secret
+            self.algorithm = "HS256"
+        else:
+            self._signing_key, self._verification_key, self.algorithm = (
+                _resolve_default_signing_config()
+            )
         self.ttl_seconds = max(ttl_seconds or LANGFLOW_INGEST_CALLBACK_TTL_SECONDS, 1)
         self._finalized_jtis: TTLCache[str, bool] = TTLCache(
             maxsize=8192,
@@ -50,13 +92,13 @@ class LangflowIngestTokenService:
             "exp": now + self.ttl_seconds,
             "ctx": self._context_to_payload(context),
         }
-        return jwt.encode(payload, self.secret, algorithm=self.algorithm)
+        return jwt.encode(payload, self._signing_key, algorithm=self.algorithm)
 
     def validate_token(self, token: str) -> tuple[DocumentIndexContext, str]:
         try:
             payload = jwt.decode(
                 token,
-                self.secret,
+                self._verification_key,
                 algorithms=[self.algorithm],
                 audience=self.audience,
             )
@@ -91,7 +133,7 @@ class LangflowIngestTokenService:
         try:
             payload = jwt.decode(
                 token,
-                self.secret,
+                self._verification_key,
                 algorithms=[self.algorithm],
                 audience=self.audience,
                 options={"verify_exp": False},

--- a/tests/unit/test_langflow_ingest_callback.py
+++ b/tests/unit/test_langflow_ingest_callback.py
@@ -383,3 +383,28 @@ def test_langflow_callback_global_vars_have_runtime_placeholders(config_path):
 
     for variable_name in CALLBACK_GLOBAL_VARS:
         assert f"{variable_name}=" in config_text or f'"{variable_name}":' in config_text
+
+
+def test_ingest_token_prefers_jwt_signing_key_over_session_secret(monkeypatch):
+    jwt_secret = "jwt-signing-secret-with-32-bytes!!"
+    session_secret = "session-secret-should-not-be-used"
+
+    monkeypatch.setattr("config.settings.JWT_SIGNING_KEY", jwt_secret)
+    monkeypatch.setattr("config.settings.SESSION_SECRET", session_secret)
+
+    token_service = LangflowIngestTokenService(ttl_seconds=60)
+    context = DocumentIndexContext(
+        document_id="doc-jwt",
+        filename="source.pdf",
+        mimetype="application/pdf",
+        embedding_model="text-embedding-3-small",
+        owner="user-1",
+        ingest_run_id="run-jwt",
+    )
+    token = token_service.create_token(context)
+
+    token_service.validate_token(token)
+
+    session_service = LangflowIngestTokenService(secret=session_secret, ttl_seconds=60)
+    with pytest.raises(ValueError, match="Invalid Langflow ingest token"):
+        session_service.validate_token(token)

--- a/tests/unit/test_oauth_encryption.py
+++ b/tests/unit/test_oauth_encryption.py
@@ -67,6 +67,33 @@ async def test_google_drive_auth_missing_scopes_forces_reauth(tmp_path, monkeypa
 
 
 @pytest.mark.asyncio
+async def test_google_drive_auth_allows_missing_optional_group_scopes(tmp_path, monkeypatch):
+    import utils.encryption
+
+    utils.encryption._cached_master_secret = None
+    monkeypatch.setenv(
+        "OPENRAG_ENCRYPTION_KEY",
+        "dGVzdC1rZXktMzItYnl0ZXMtZm9yLXVuaXQtdGVzdGluZy1vbmx5",
+    )
+
+    g_token_path = tmp_path / "fake_gdrive_token.json"
+    g_plain = {
+        "token": "google-token",
+        "refresh_token": "refresh",
+        "scopes": GoogleDriveOAuth.REQUIRED_SCOPES,
+        "expiry": "2028-03-02T15:46:11.368083",
+    }
+    with open(g_token_path, "w") as f:
+        json.dump(g_plain, f)
+
+    g_oauth = GoogleDriveOAuth(client_id="abc", client_secret="def", token_file=str(g_token_path))
+
+    assert await g_oauth.load_credentials() is not None
+    assert g_oauth.creds is not None
+    assert g_token_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_msal_auth_upgrade(tmp_path, monkeypatch):
     """Test that MSAL credentials are encrypted on load if not already."""
     import utils.encryption


### PR DESCRIPTION
Google Drive OAuth was requesting Drive scopes plus optional Google Workspace group/admin scopes, then treating all of them as required. If Google withheld either optional scope, the OAuth callback could succeed, but the next connector status check would reject/delete the token and show Google Drive as not connected. That matches your symptom: consent flow completes, but ingestion/file selection never becomes enabled.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Google Drive auth now distinguishes required vs optional scopes to reduce unnecessary re-authentication.

* **New Features**
  * Updated flow: calculator now safely evaluates arithmetic expressions with clearer numeric results and structured error messages.
  * Flow UI: model selection options trimmed to a smaller, focused set.

* **Chores**
  * Updated base image for the Langflow-related container.

* **Tests**
  * Added tests for Google Drive credential handling and ingest token signing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->