### PR TITLE
fix: make sure feedback state doesn't remain accross chats

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -920,7 +920,7 @@ function ChatPage() {
                   ? (messages[index]?.content.match(FILES_REGEX)?.[0] ??
                       null) === null && (
                       <div
-                        key={`${
+                        key={`${currentConversationId ?? "new"}-${
                           message.role
                         }-${index}-${message.timestamp?.getTime()}`}
                         className="space-y-6 group"
@@ -956,7 +956,7 @@ function ChatPage() {
                       (messages[index - 1]?.content.match(FILES_REGEX)?.[0] ??
                         null) === null) && (
                       <div
-                        key={`${
+                        key={`${currentConversationId ?? "new"}-${
                           message.role
                         }-${index}-${message.timestamp?.getTime()}`}
                         className="space-y-6 group"


### PR DESCRIPTION
To test:

Create chat and get a response.
React to the response using the thumbs up or down
Go look at another chat and ensure that a feedback response doesn't carry over to the other chat

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved message rendering reliability and consistency when switching between different conversations in the chat interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->