### PR TITLE
fix: Use bracket notation for document body keys

### DIFF
--- a/sdks/typescript/src/documents.ts
+++ b/sdks/typescript/src/documents.ts
@@ -166,8 +166,8 @@ export class DocumentsClient {
     }
 
     const body: Record<string, string> = {};
-    if (opts.filename) body.filename = opts.filename;
-    if (opts.filterId) body.filter_id = opts.filterId;
+    if (opts.filename) body['filename'] = opts.filename;
+    if (opts.filterId) body['filter_id'] = opts.filterId;
 
     try {
       const response = await this.client._request("DELETE", "/api/v1/documents", {


### PR DESCRIPTION
Change assignments to the request body to use bracket notation (body['filename'], body['filter_id']) instead of dot notation. This ensures the string keys are set explicitly on the Record<string, string> and avoids relying on declared property names.