### PR TITLE
fix: field indentation / enable-disable auto-mounting of service account K8S token

### DIFF
--- a/kubernetes/helm/openrag/templates/serviceaccount.yaml
+++ b/kubernetes/helm/openrag/templates/serviceaccount.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+  automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}

--- a/kubernetes/helm/openrag/templates/serviceaccount.yaml
+++ b/kubernetes/helm/openrag/templates/serviceaccount.yaml
@@ -10,5 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-  automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
+automountServiceAccountToken: {{ .Values.serviceAccount.automount }}
 {{- end }}


### PR DESCRIPTION
**Description:**
- Fix static scan issue / last PR had a templating issue, the automountServiceAccountToken field is now being defined (value from value.yaml) in the ServiceAccount, default this to 'false' when there are no RBAC roles associated with the SA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Helm value to control whether a ServiceAccount mounts its token (automountServiceAccountToken). When set, the rendered ServiceAccount includes this setting regardless of annotations, giving operators explicit control over token automounting in generated manifests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->