### PR TITLE
fix: stubs fix for `Dockerfile.frontend`

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -9,6 +9,9 @@ USER node
 
 # Copy frontend dependencies
 COPY --chown=node:node frontend/package*.json ./
+# Copy local stub packages referenced via file: in package.json (e.g. sharp stub
+# that keeps LGPL libvips binaries out of the tree). npm ci needs these present.
+COPY --chown=node:node frontend/stubs ./stubs
 RUN npm ci
 
 # Copy frontend source


### PR DESCRIPTION
Copys the stubs before running `npm ci`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the build process to ensure local stub packages are properly included during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->