### PR TITLE
feat: add support for specifying labels and annotations on resources create…

### DIFF
--- a/kubernetes/operator/api/v1alpha1/openrag_types.go
+++ b/kubernetes/operator/api/v1alpha1/openrag_types.go
@@ -136,6 +136,41 @@ type ComponentSpec struct {
 	// +optional
 	ServiceAnnotations map[string]string `json:"serviceAnnotations,omitempty"`
 
+	// ServiceLabels are custom labels to add to the Service resource.
+	// Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+	// Useful for service discovery, monitoring, and network policies.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	ServiceLabels map[string]string `json:"serviceLabels,omitempty"`
+
+	// ServiceAccountLabels are custom labels to add to the ServiceAccount resource.
+	// Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+	// Useful for RBAC policies, auditing, and IAM integration.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	ServiceAccountLabels map[string]string `json:"serviceAccountLabels,omitempty"`
+
+	// ServiceAccountAnnotations are custom annotations to add to the ServiceAccount resource.
+	// Merged with CommonResourceAnnotations from OpenRAGSpec.
+	// Useful for IAM role binding (e.g., eks.amazonaws.com/role-arn, iam.gke.io/gcp-service-account).
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	ServiceAccountAnnotations map[string]string `json:"serviceAccountAnnotations,omitempty"`
+
+	// SecretLabels are custom labels to add to component-managed Secrets (e.g., .env secrets).
+	// Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+	// Useful for secret management tools, backup policies, and auditing.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	SecretLabels map[string]string `json:"secretLabels,omitempty"`
+
+	// SecretAnnotations are custom annotations to add to component-managed Secrets.
+	// Merged with CommonResourceAnnotations from OpenRAGSpec.
+	// Useful for secret injection tools (e.g., vault.hashicorp.com/agent-inject).
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	SecretAnnotations map[string]string `json:"secretAnnotations,omitempty"`
+
 	// Command overrides the container's entrypoint.
 	// +optional
 	Command []string `json:"command,omitempty"`
@@ -297,6 +332,20 @@ type PersistenceSpec struct {
 	// ExistingClaim reuses a pre-existing PVC instead of creating one.
 	// +optional
 	ExistingClaim string `json:"existingClaim,omitempty"`
+
+	// Labels are custom labels to add to the PersistentVolumeClaim.
+	// Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+	// Useful for storage policies, backup tools (e.g., Velero), and cost allocation.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	Labels map[string]string `json:"labels,omitempty"`
+
+	// Annotations are custom annotations to add to the PersistentVolumeClaim.
+	// Merged with CommonResourceAnnotations from OpenRAGSpec.
+	// Useful for volume provisioning hints and backup policies.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	Annotations map[string]string `json:"annotations,omitempty"`
 }
 
 // OpenSearchSpec points the operator at an external OpenSearch cluster.
@@ -639,6 +688,23 @@ type OpenRAGSpec struct {
 	// +optional
 	// +kubebuilder:validation:XValidation:rule="self.all(x, x.name != '')",message="imagePullSecret name cannot be empty"
 	ImagePullSecrets []corev1.LocalObjectReference `json:"imagePullSecrets,omitempty"`
+
+	// CommonResourceLabels are labels applied to all managed infrastructure resources
+	// (PVCs, Secrets, Services, ServiceAccounts). These labels are merged with
+	// resource-specific labels, with resource-specific labels taking precedence.
+	// Operator-managed labels (e.g., app.kubernetes.io/managed-by) cannot be overridden.
+	// Useful for organization-wide policies, cost allocation, and resource grouping.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	CommonResourceLabels map[string]string `json:"commonResourceLabels,omitempty"`
+
+	// CommonResourceAnnotations are annotations applied to all managed infrastructure resources
+	// (PVCs, Secrets, Services, ServiceAccounts). These annotations are merged with
+	// resource-specific annotations, with resource-specific annotations taking precedence.
+	// Useful for backup policies, monitoring configuration, and GitOps metadata.
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	CommonResourceAnnotations map[string]string `json:"commonResourceAnnotations,omitempty"`
 
 	// Frontend configures the OpenRAG Next.js frontend.
 	// +kubebuilder:validation:Required

--- a/kubernetes/operator/api/v1alpha1/zz_generated.deepcopy.go
+++ b/kubernetes/operator/api/v1alpha1/zz_generated.deepcopy.go
@@ -165,6 +165,41 @@ func (in *ComponentSpec) DeepCopyInto(out *ComponentSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.ServiceLabels != nil {
+		in, out := &in.ServiceLabels, &out.ServiceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ServiceAccountLabels != nil {
+		in, out := &in.ServiceAccountLabels, &out.ServiceAccountLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.ServiceAccountAnnotations != nil {
+		in, out := &in.ServiceAccountAnnotations, &out.ServiceAccountAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.SecretLabels != nil {
+		in, out := &in.SecretLabels, &out.SecretLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.SecretAnnotations != nil {
+		in, out := &in.SecretAnnotations, &out.SecretAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Command != nil {
 		in, out := &in.Command, &out.Command
 		*out = make([]string, len(*in))
@@ -725,6 +760,20 @@ func (in *OpenRAGSpec) DeepCopyInto(out *OpenRAGSpec) {
 		*out = make([]v1.LocalObjectReference, len(*in))
 		copy(*out, *in)
 	}
+	if in.CommonResourceLabels != nil {
+		in, out := &in.CommonResourceLabels, &out.CommonResourceLabels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.CommonResourceAnnotations != nil {
+		in, out := &in.CommonResourceAnnotations, &out.CommonResourceAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	in.Frontend.DeepCopyInto(&out.Frontend)
 	in.Backend.DeepCopyInto(&out.Backend)
 	in.Langflow.DeepCopyInto(&out.Langflow)
@@ -821,6 +870,20 @@ func (in *PersistenceSpec) DeepCopyInto(out *PersistenceSpec) {
 		in, out := &in.AccessModes, &out.AccessModes
 		*out = make([]v1.PersistentVolumeAccessMode, len(*in))
 		copy(*out, *in)
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
 	}
 }
 

--- a/kubernetes/operator/config/crd/bases/openr.ag_openrags.yaml
+++ b/kubernetes/operator/config/crd/bases/openr.ag_openrags.yaml
@@ -1624,6 +1624,24 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  secretAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      SecretAnnotations are custom annotations to add to component-managed Secrets.
+                      Merged with CommonResourceAnnotations from OpenRAGSpec.
+                      Useful for secret injection tools (e.g., vault.hashicorp.com/agent-inject).
+                    maxProperties: 64
+                    type: object
+                  secretLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      SecretLabels are custom labels to add to component-managed Secrets (e.g., .env secrets).
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for secret management tools, backup policies, and auditing.
+                    maxProperties: 64
+                    type: object
                   securityContext:
                     description: SecurityContext holds container-level security attributes.
                     properties:
@@ -1816,6 +1834,24 @@ spec:
                             type: string
                         type: object
                     type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are custom annotations to add to the ServiceAccount resource.
+                      Merged with CommonResourceAnnotations from OpenRAGSpec.
+                      Useful for IAM role binding (e.g., eks.amazonaws.com/role-arn, iam.gke.io/gcp-service-account).
+                    maxProperties: 64
+                    type: object
+                  serviceAccountLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountLabels are custom labels to add to the ServiceAccount resource.
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for RBAC policies, auditing, and IAM integration.
+                    maxProperties: 64
+                    type: object
                   serviceAccountName:
                     description: |-
                       ServiceAccountName is the name of the ServiceAccount to use for this component's pod.
@@ -1828,6 +1864,15 @@ spec:
                       type: string
                     description: ServiceAnnotations are annotations to add to the
                       Service resource.
+                    type: object
+                  serviceLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceLabels are custom labels to add to the Service resource.
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for service discovery, monitoring, and network policies.
+                    maxProperties: 64
                     type: object
                   serviceName:
                     description: |-
@@ -1849,6 +1894,15 @@ spec:
                         items:
                           type: string
                         type: array
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations are custom annotations to add to the PersistentVolumeClaim.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for volume provisioning hints and backup policies.
+                        maxProperties: 64
+                        type: object
                       enabled:
                         default: true
                         type: boolean
@@ -1856,6 +1910,15 @@ spec:
                         description: ExistingClaim reuses a pre-existing PVC instead
                           of creating one.
                         type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are custom labels to add to the PersistentVolumeClaim.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for storage policies, backup tools (e.g., Velero), and cost allocation.
+                        maxProperties: 64
+                        type: object
                       size:
                         anyOf:
                         - type: integer
@@ -2084,6 +2147,27 @@ spec:
                     type: array
                 required:
                 - image
+                type: object
+              commonResourceAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CommonResourceAnnotations are annotations applied to all managed infrastructure resources
+                  (PVCs, Secrets, Services, ServiceAccounts). These annotations are merged with
+                  resource-specific annotations, with resource-specific annotations taking precedence.
+                  Useful for backup policies, monitoring configuration, and GitOps metadata.
+                maxProperties: 64
+                type: object
+              commonResourceLabels:
+                additionalProperties:
+                  type: string
+                description: |-
+                  CommonResourceLabels are labels applied to all managed infrastructure resources
+                  (PVCs, Secrets, Services, ServiceAccounts). These labels are merged with
+                  resource-specific labels, with resource-specific labels taking precedence.
+                  Operator-managed labels (e.g., app.kubernetes.io/managed-by) cannot be overridden.
+                  Useful for organization-wide policies, cost allocation, and resource grouping.
+                maxProperties: 64
                 type: object
               docling:
                 description: |-
@@ -4292,6 +4376,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      secretAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          SecretAnnotations are custom annotations to add to component-managed Secrets.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for secret injection tools (e.g., vault.hashicorp.com/agent-inject).
+                        maxProperties: 64
+                        type: object
+                      secretLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          SecretLabels are custom labels to add to component-managed Secrets (e.g., .env secrets).
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for secret management tools, backup policies, and auditing.
+                        maxProperties: 64
+                        type: object
                       securityContext:
                         description: SecurityContext holds container-level security
                           attributes.
@@ -4485,6 +4587,24 @@ spec:
                                 type: string
                             type: object
                         type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountAnnotations are custom annotations to add to the ServiceAccount resource.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for IAM role binding (e.g., eks.amazonaws.com/role-arn, iam.gke.io/gcp-service-account).
+                        maxProperties: 64
+                        type: object
+                      serviceAccountLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountLabels are custom labels to add to the ServiceAccount resource.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for RBAC policies, auditing, and IAM integration.
+                        maxProperties: 64
+                        type: object
                       serviceAccountName:
                         description: |-
                           ServiceAccountName is the name of the ServiceAccount to use for this component's pod.
@@ -4497,6 +4617,15 @@ spec:
                           type: string
                         description: ServiceAnnotations are annotations to add to
                           the Service resource.
+                        type: object
+                      serviceLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceLabels are custom labels to add to the Service resource.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for service discovery, monitoring, and network policies.
+                        maxProperties: 64
                         type: object
                       serviceName:
                         description: |-
@@ -4519,6 +4648,15 @@ spec:
                             items:
                               type: string
                             type: array
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations are custom annotations to add to the PersistentVolumeClaim.
+                              Merged with CommonResourceAnnotations from OpenRAGSpec.
+                              Useful for volume provisioning hints and backup policies.
+                            maxProperties: 64
+                            type: object
                           enabled:
                             default: true
                             type: boolean
@@ -4526,6 +4664,15 @@ spec:
                             description: ExistingClaim reuses a pre-existing PVC instead
                               of creating one.
                             type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Labels are custom labels to add to the PersistentVolumeClaim.
+                              Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                              Useful for storage policies, backup tools (e.g., Velero), and cost allocation.
+                            maxProperties: 64
+                            type: object
                           size:
                             anyOf:
                             - type: integer
@@ -6250,6 +6397,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      secretAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          SecretAnnotations are custom annotations to add to component-managed Secrets.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for secret injection tools (e.g., vault.hashicorp.com/agent-inject).
+                        maxProperties: 64
+                        type: object
+                      secretLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          SecretLabels are custom labels to add to component-managed Secrets (e.g., .env secrets).
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for secret management tools, backup policies, and auditing.
+                        maxProperties: 64
+                        type: object
                       securityContext:
                         description: SecurityContext holds container-level security
                           attributes.
@@ -6443,6 +6608,24 @@ spec:
                                 type: string
                             type: object
                         type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountAnnotations are custom annotations to add to the ServiceAccount resource.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for IAM role binding (e.g., eks.amazonaws.com/role-arn, iam.gke.io/gcp-service-account).
+                        maxProperties: 64
+                        type: object
+                      serviceAccountLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountLabels are custom labels to add to the ServiceAccount resource.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for RBAC policies, auditing, and IAM integration.
+                        maxProperties: 64
+                        type: object
                       serviceAccountName:
                         description: |-
                           ServiceAccountName is the name of the ServiceAccount to use for this component's pod.
@@ -6455,6 +6638,15 @@ spec:
                           type: string
                         description: ServiceAnnotations are annotations to add to
                           the Service resource.
+                        type: object
+                      serviceLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceLabels are custom labels to add to the Service resource.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for service discovery, monitoring, and network policies.
+                        maxProperties: 64
                         type: object
                       serviceName:
                         description: |-
@@ -6476,6 +6668,15 @@ spec:
                             items:
                               type: string
                             type: array
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations are custom annotations to add to the PersistentVolumeClaim.
+                              Merged with CommonResourceAnnotations from OpenRAGSpec.
+                              Useful for volume provisioning hints and backup policies.
+                            maxProperties: 64
+                            type: object
                           enabled:
                             default: true
                             type: boolean
@@ -6483,6 +6684,15 @@ spec:
                             description: ExistingClaim reuses a pre-existing PVC instead
                               of creating one.
                             type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Labels are custom labels to add to the PersistentVolumeClaim.
+                              Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                              Useful for storage policies, backup tools (e.g., Velero), and cost allocation.
+                            maxProperties: 64
+                            type: object
                           size:
                             anyOf:
                             - type: integer
@@ -8925,6 +9135,24 @@ spec:
                               More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                             type: object
                         type: object
+                      secretAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          SecretAnnotations are custom annotations to add to component-managed Secrets.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for secret injection tools (e.g., vault.hashicorp.com/agent-inject).
+                        maxProperties: 64
+                        type: object
+                      secretLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          SecretLabels are custom labels to add to component-managed Secrets (e.g., .env secrets).
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for secret management tools, backup policies, and auditing.
+                        maxProperties: 64
+                        type: object
                       securityContext:
                         description: SecurityContext holds container-level security
                           attributes.
@@ -9118,6 +9346,24 @@ spec:
                                 type: string
                             type: object
                         type: object
+                      serviceAccountAnnotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountAnnotations are custom annotations to add to the ServiceAccount resource.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for IAM role binding (e.g., eks.amazonaws.com/role-arn, iam.gke.io/gcp-service-account).
+                        maxProperties: 64
+                        type: object
+                      serviceAccountLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceAccountLabels are custom labels to add to the ServiceAccount resource.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for RBAC policies, auditing, and IAM integration.
+                        maxProperties: 64
+                        type: object
                       serviceAccountName:
                         description: |-
                           ServiceAccountName is the name of the ServiceAccount to use for this component's pod.
@@ -9130,6 +9376,15 @@ spec:
                           type: string
                         description: ServiceAnnotations are annotations to add to
                           the Service resource.
+                        type: object
+                      serviceLabels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          ServiceLabels are custom labels to add to the Service resource.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for service discovery, monitoring, and network policies.
+                        maxProperties: 64
                         type: object
                       serviceName:
                         description: |-
@@ -9151,6 +9406,15 @@ spec:
                             items:
                               type: string
                             type: array
+                          annotations:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Annotations are custom annotations to add to the PersistentVolumeClaim.
+                              Merged with CommonResourceAnnotations from OpenRAGSpec.
+                              Useful for volume provisioning hints and backup policies.
+                            maxProperties: 64
+                            type: object
                           enabled:
                             default: true
                             type: boolean
@@ -9158,6 +9422,15 @@ spec:
                             description: ExistingClaim reuses a pre-existing PVC instead
                               of creating one.
                             type: string
+                          labels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              Labels are custom labels to add to the PersistentVolumeClaim.
+                              Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                              Useful for storage policies, backup tools (e.g., Velero), and cost allocation.
+                            maxProperties: 64
+                            type: object
                           size:
                             anyOf:
                             - type: integer
@@ -10835,6 +11108,24 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  secretAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      SecretAnnotations are custom annotations to add to component-managed Secrets.
+                      Merged with CommonResourceAnnotations from OpenRAGSpec.
+                      Useful for secret injection tools (e.g., vault.hashicorp.com/agent-inject).
+                    maxProperties: 64
+                    type: object
+                  secretLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      SecretLabels are custom labels to add to component-managed Secrets (e.g., .env secrets).
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for secret management tools, backup policies, and auditing.
+                    maxProperties: 64
+                    type: object
                   securityContext:
                     description: SecurityContext holds container-level security attributes.
                     properties:
@@ -11027,6 +11318,24 @@ spec:
                             type: string
                         type: object
                     type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are custom annotations to add to the ServiceAccount resource.
+                      Merged with CommonResourceAnnotations from OpenRAGSpec.
+                      Useful for IAM role binding (e.g., eks.amazonaws.com/role-arn, iam.gke.io/gcp-service-account).
+                    maxProperties: 64
+                    type: object
+                  serviceAccountLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountLabels are custom labels to add to the ServiceAccount resource.
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for RBAC policies, auditing, and IAM integration.
+                    maxProperties: 64
+                    type: object
                   serviceAccountName:
                     description: |-
                       ServiceAccountName is the name of the ServiceAccount to use for this component's pod.
@@ -11039,6 +11348,15 @@ spec:
                       type: string
                     description: ServiceAnnotations are annotations to add to the
                       Service resource.
+                    type: object
+                  serviceLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceLabels are custom labels to add to the Service resource.
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for service discovery, monitoring, and network policies.
+                    maxProperties: 64
                     type: object
                   serviceName:
                     description: |-
@@ -12756,6 +13074,15 @@ spec:
                           More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
                         type: object
                     type: object
+                  secretAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      SecretAnnotations are custom annotations to add to component-managed Secrets.
+                      Merged with CommonResourceAnnotations from OpenRAGSpec.
+                      Useful for secret injection tools (e.g., vault.hashicorp.com/agent-inject).
+                    maxProperties: 64
+                    type: object
                   secretKeySecret:
                     description: |-
                       SecretKeySecret references the Secret key for LANGFLOW_SECRET_KEY,
@@ -12784,6 +13111,15 @@ spec:
                     - key
                     type: object
                     x-kubernetes-map-type: atomic
+                  secretLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      SecretLabels are custom labels to add to component-managed Secrets (e.g., .env secrets).
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for secret management tools, backup policies, and auditing.
+                    maxProperties: 64
+                    type: object
                   securityContext:
                     description: SecurityContext holds container-level security attributes.
                     properties:
@@ -12976,6 +13312,24 @@ spec:
                             type: string
                         type: object
                     type: object
+                  serviceAccountAnnotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountAnnotations are custom annotations to add to the ServiceAccount resource.
+                      Merged with CommonResourceAnnotations from OpenRAGSpec.
+                      Useful for IAM role binding (e.g., eks.amazonaws.com/role-arn, iam.gke.io/gcp-service-account).
+                    maxProperties: 64
+                    type: object
+                  serviceAccountLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceAccountLabels are custom labels to add to the ServiceAccount resource.
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for RBAC policies, auditing, and IAM integration.
+                    maxProperties: 64
+                    type: object
                   serviceAccountName:
                     description: |-
                       ServiceAccountName is the name of the ServiceAccount to use for this component's pod.
@@ -12988,6 +13342,15 @@ spec:
                       type: string
                     description: ServiceAnnotations are annotations to add to the
                       Service resource.
+                    type: object
+                  serviceLabels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      ServiceLabels are custom labels to add to the Service resource.
+                      Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                      Useful for service discovery, monitoring, and network policies.
+                    maxProperties: 64
                     type: object
                   serviceName:
                     description: |-
@@ -13010,6 +13373,15 @@ spec:
                         items:
                           type: string
                         type: array
+                      annotations:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Annotations are custom annotations to add to the PersistentVolumeClaim.
+                          Merged with CommonResourceAnnotations from OpenRAGSpec.
+                          Useful for volume provisioning hints and backup policies.
+                        maxProperties: 64
+                        type: object
                       enabled:
                         default: true
                         type: boolean
@@ -13017,6 +13389,15 @@ spec:
                         description: ExistingClaim reuses a pre-existing PVC instead
                           of creating one.
                         type: string
+                      labels:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          Labels are custom labels to add to the PersistentVolumeClaim.
+                          Merged with operator-managed labels and CommonResourceLabels from OpenRAGSpec.
+                          Useful for storage policies, backup tools (e.g., Velero), and cost allocation.
+                        maxProperties: 64
+                        type: object
                       size:
                         anyOf:
                         - type: integer

--- a/kubernetes/operator/config/samples/openrag_v1alpha1_openrag-with-labels-annotations.yaml
+++ b/kubernetes/operator/config/samples/openrag_v1alpha1_openrag-with-labels-annotations.yaml
@@ -1,0 +1,173 @@
+apiVersion: openr.ag/v1alpha1
+kind: OpenRAG
+metadata:
+  name: openrag-with-custom-labels
+  namespace: openrag-system
+spec:
+  # Global labels and annotations applied to all infrastructure resources
+  # (PVCs, Secrets, Services, ServiceAccounts)
+  commonResourceLabels:
+    environment: production
+    team: ai-platform
+    cost-center: "12345"
+    managed-by: platform-team
+  
+  commonResourceAnnotations:
+    backup.velero.io/backup-volumes: "true"
+    monitoring.prometheus.io/scrape: "true"
+    contact: "platform-team@example.com"
+
+  frontend:
+    image: quay.io/langflow-ai/openrag-frontend:latest
+    replicas: 2
+    
+    # ServiceAccount-specific labels and annotations
+    serviceAccountLabels:
+      app-tier: frontend
+    serviceAccountAnnotations:
+      description: "Frontend service account for OpenRAG UI"
+    
+    # Service-specific labels and annotations
+    serviceLabels:
+      service-type: web-ui
+      expose: "true"
+    serviceAnnotations:
+      service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    
+    # Secret-specific labels and annotations
+    secretLabels:
+      secret-type: env-config
+    secretAnnotations:
+      vault.hashicorp.com/agent-inject: "false"
+
+  backend:
+    image: quay.io/langflow-ai/openrag-backend:latest
+    replicas: 3
+    
+    # ServiceAccount with IAM role binding (AWS EKS example)
+    serviceAccountAnnotations:
+      eks.amazonaws.com/role-arn: "arn:aws:iam::123456789012:role/openrag-backend"
+    
+    # Service labels for monitoring and network policies
+    serviceLabels:
+      app-tier: backend
+      api: "true"
+    
+    # Secret labels for backup policies
+    secretLabels:
+      backup-priority: high
+      encryption: required
+    
+    storage:
+      enabled: true
+      size: 20Gi
+      storageClassName: fast-ssd
+      
+      # PVC-specific labels and annotations
+      labels:
+        storage-tier: ssd
+        backup-policy: daily
+        data-classification: confidential
+      annotations:
+        volume.beta.kubernetes.io/storage-provisioner: ebs.csi.aws.com
+        backup.velero.io/backup-volumes-excludes: "false"
+
+  langflow:
+    image: quay.io/langflow-ai/openrag-langflow:latest
+    replicas: 2
+    
+    # ServiceAccount with GCP Workload Identity (GKE example)
+    serviceAccountAnnotations:
+      iam.gke.io/gcp-service-account: "openrag-langflow@project-id.iam.gserviceaccount.com"
+    
+    serviceLabels:
+      app-tier: workflow-engine
+    
+    storage:
+      enabled: true
+      size: 30Gi
+      
+      # PVC labels for cost allocation and backup
+      labels:
+        storage-type: workflow-data
+        retention-policy: long-term
+      annotations:
+        snapshot.storage.kubernetes.io/is-default-class: "true"
+
+  # Optional: Docling components with custom labels/annotations
+  doclingComponents:
+    enabled: true
+    
+    serve:
+      image: quay.io/langflow-ai/docling-serve:latest
+      replicas: 2
+      
+      serviceAccountLabels:
+        component: docling-serve
+      
+      serviceLabels:
+        api-type: document-processing
+      
+      storage:
+        enabled: true
+        size: 50Gi
+        labels:
+          storage-purpose: model-cache
+          performance-tier: high
+    
+    worker:
+      image: quay.io/langflow-ai/docling-worker:latest
+      replicas: 3
+      
+      serviceAccountLabels:
+        component: docling-worker
+      
+      storage:
+        enabled: true
+        size: 100Gi
+        labels:
+          storage-purpose: processing-workspace
+          io-intensive: "true"
+    
+    valkey:
+      image: valkey/valkey:7.2-alpine
+      
+      serviceAccountLabels:
+        component: valkey-queue
+      
+      serviceLabels:
+        database-type: redis-compatible
+      
+      secretLabels:
+        secret-type: database-credentials
+      
+      storage:
+        enabled: true
+        size: 10Gi
+        labels:
+          storage-purpose: queue-persistence
+          backup-frequency: hourly
+
+  opensearch:
+    host: opensearch.opensearch-system.svc.cluster.local
+    port: 9200
+    scheme: https
+    indexName: documents
+    credentialsSecret: opensearch-credentials
+
+  llm:
+    provider: watsonx
+    model: ibm/granite-13b-chat-v2
+
+  embedding:
+    provider: watsonx
+    model: ibm/slate-125m-english-rtrvr
+
+  watsonx:
+    endpoint: https://us-south.ml.cloud.ibm.com
+    projectId: your-project-id
+    apiKeySecret:
+      name: watsonx-credentials
+      key: apikey
+
+# Made with Bob

--- a/kubernetes/operator/internal/controller/label_merge_test.go
+++ b/kubernetes/operator/internal/controller/label_merge_test.go
@@ -1,0 +1,207 @@
+package controller
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	openragv1alpha1 "github.com/langflow-ai/openrag-operator/api/v1alpha1"
+)
+
+// TestMapOrderingDoesNotAffectHash verifies that map iteration order doesn't cause
+// unnecessary reconciliations. This test builds the same labels/annotations in different
+// orders and verifies they produce the same hash.
+func TestMapOrderingDoesNotAffectHash(t *testing.T) {
+	// Create two services with identical labels but built in different orders
+	labels1 := map[string]string{
+		"app.kubernetes.io/name":       "openrag",
+		"app.kubernetes.io/instance":   "test",
+		"app.kubernetes.io/component":  "backend",
+		"app.kubernetes.io/managed-by": "openrag-operator",
+		"environment":                  "production",
+		"team":                         "platform",
+		"cost-center":                  "12345",
+	}
+
+	labels2 := map[string]string{
+		"cost-center":                  "12345",
+		"team":                         "platform",
+		"environment":                  "production",
+		"app.kubernetes.io/managed-by": "openrag-operator",
+		"app.kubernetes.io/component":  "backend",
+		"app.kubernetes.io/instance":   "test",
+		"app.kubernetes.io/name":       "openrag",
+	}
+
+	svc1 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: "default",
+			Labels:    labels1,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 8000},
+			},
+		},
+	}
+
+	svc2 := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-service",
+			Namespace: "default",
+			Labels:    labels2,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{Name: "http", Port: 8000},
+			},
+		},
+	}
+
+	hash1, err := desiredHash(svc1)
+	if err != nil {
+		t.Fatalf("failed to compute hash1: %v", err)
+	}
+
+	hash2, err := desiredHash(svc2)
+	if err != nil {
+		t.Fatalf("failed to compute hash2: %v", err)
+	}
+
+	if hash1 != hash2 {
+		t.Errorf("hashes differ despite identical content:\nhash1: %s\nhash2: %s", hash1, hash2)
+	}
+}
+
+// TestMergeResourceLabelsIsDeterministic verifies that merging labels produces
+// consistent results regardless of the order in which source maps are iterated.
+func TestMergeResourceLabelsIsDeterministic(t *testing.T) {
+	o := &openragv1alpha1.OpenRAG{
+		Spec: openragv1alpha1.OpenRAGSpec{
+			CommonResourceLabels: map[string]string{
+				"environment": "production",
+				"team":        "platform",
+			},
+		},
+	}
+
+	baseLabels := map[string]string{
+		"app.kubernetes.io/name":       "openrag",
+		"app.kubernetes.io/managed-by": "openrag-operator",
+	}
+
+	componentLabels := map[string]string{
+		"component-tier": "backend",
+		"api":            "true",
+	}
+
+	resourceLabels := map[string]string{
+		"storage-tier": "ssd",
+		"backup":       "enabled",
+	}
+
+	// Merge multiple times to ensure consistency
+	results := make([]map[string]string, 10)
+	for i := 0; i < 10; i++ {
+		results[i] = mergeResourceLabels(o, baseLabels, componentLabels, resourceLabels)
+	}
+
+	// Verify all results have the same keys and values
+	for i := 1; i < len(results); i++ {
+		if len(results[0]) != len(results[i]) {
+			t.Errorf("result %d has different length: %d vs %d", i, len(results[0]), len(results[i]))
+		}
+		for k, v := range results[0] {
+			if results[i][k] != v {
+				t.Errorf("result %d differs at key %s: %s vs %s", i, k, v, results[i][k])
+			}
+		}
+	}
+}
+
+// TestMergeResourceAnnotationsIsDeterministic verifies that merging annotations
+// produces consistent results.
+func TestMergeResourceAnnotationsIsDeterministic(t *testing.T) {
+	o := &openragv1alpha1.OpenRAG{
+		Spec: openragv1alpha1.OpenRAGSpec{
+			CommonResourceAnnotations: map[string]string{
+				"backup.velero.io/backup-volumes": "true",
+				"monitoring.prometheus.io/scrape": "true",
+			},
+		},
+	}
+
+	componentAnnotations := map[string]string{
+		"eks.amazonaws.com/role-arn":                        "arn:aws:iam::123:role/backend",
+		"service.beta.kubernetes.io/aws-load-balancer-type": "nlb",
+	}
+
+	resourceAnnotations := map[string]string{
+		"volume.beta.kubernetes.io/storage-provisioner": "ebs.csi.aws.com",
+	}
+
+	// Merge multiple times to ensure consistency
+	results := make([]map[string]string, 10)
+	for i := 0; i < 10; i++ {
+		results[i] = mergeResourceAnnotations(o, componentAnnotations, resourceAnnotations)
+	}
+
+	// Verify all results have the same keys and values
+	for i := 1; i < len(results); i++ {
+		if len(results[0]) != len(results[i]) {
+			t.Errorf("result %d has different length: %d vs %d", i, len(results[0]), len(results[i]))
+		}
+		for k, v := range results[0] {
+			if results[i][k] != v {
+				t.Errorf("result %d differs at key %s: %s vs %s", i, k, v, results[i][k])
+			}
+		}
+	}
+}
+
+// TestLabelPrecedence verifies that labels are merged with the correct priority.
+func TestLabelPrecedence(t *testing.T) {
+	o := &openragv1alpha1.OpenRAG{
+		Spec: openragv1alpha1.OpenRAGSpec{
+			CommonResourceLabels: map[string]string{
+				"environment": "dev",
+				"team":        "platform",
+			},
+		},
+	}
+
+	baseLabels := map[string]string{
+		"app.kubernetes.io/name":       "openrag",
+		"app.kubernetes.io/managed-by": "openrag-operator",
+		"environment":                  "production", // Should override common
+	}
+
+	componentLabels := map[string]string{
+		"team": "backend-team", // Should override common
+	}
+
+	resourceLabels := map[string]string{
+		"team": "storage-team", // Should override component
+	}
+
+	result := mergeResourceLabels(o, baseLabels, componentLabels, resourceLabels)
+
+	// Base labels should win
+	if result["environment"] != "production" {
+		t.Errorf("expected environment=production (from base), got %s", result["environment"])
+	}
+
+	// Resource labels should override component labels
+	if result["team"] != "storage-team" {
+		t.Errorf("expected team=storage-team (from resource), got %s", result["team"])
+	}
+
+	// Base labels should always be present
+	if result["app.kubernetes.io/name"] != "openrag" {
+		t.Errorf("expected app.kubernetes.io/name=openrag, got %s", result["app.kubernetes.io/name"])
+	}
+}
+
+// Made with Bob

--- a/kubernetes/operator/internal/controller/openrag_controller.go
+++ b/kubernetes/operator/internal/controller/openrag_controller.go
@@ -174,17 +174,29 @@ func (r *OpenRAGReconciler) reconcileNamespace(ctx context.Context, o *openragv1
 }
 
 func (r *OpenRAGReconciler) reconcileServiceAccounts(ctx context.Context, o *openragv1alpha1.OpenRAG, targetNS string) error {
-	for _, role := range []string{"fe", "be", "lf"} {
+	type saDef struct {
+		role string
+		spec openragv1alpha1.ComponentSpec
+	}
+	defs := []saDef{
+		{"fe", o.Spec.Frontend.ComponentSpec},
+		{"be", o.Spec.Backend.ComponentSpec},
+		{"lf", o.Spec.Langflow.ComponentSpec},
+	}
+
+	for _, d := range defs {
 		// Only create ServiceAccount if flag is true
-		if !shouldCreateServiceAccount(o, role) {
+		if !shouldCreateServiceAccount(o, d.role) {
 			continue
 		}
 
+		baseLabels := componentLabels(o.Name, d.role)
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      getServiceAccountName(o, role), // Use custom name if specified
-				Namespace: targetNS,
-				Labels:    componentLabels(o.Name, role),
+				Name:        getServiceAccountName(o, d.role),
+				Namespace:   targetNS,
+				Labels:      mergeServiceAccountLabels(o, d.spec, baseLabels),
+				Annotations: mergeServiceAccountAnnotations(o, d.spec),
 			},
 		}
 		if err := r.setOwnerOrLabel(o, sa, targetNS); err != nil {
@@ -234,21 +246,28 @@ func (r *OpenRAGReconciler) reconcileEnvSecrets(ctx context.Context, o *openragv
 	type envDef struct {
 		name    string
 		content string
+		spec    openragv1alpha1.ComponentSpec
 	}
 	defs := []envDef{
-		{resourceName("be-env"), backendEnvContent},
-		{resourceName("lf-env"), langflowEnvContent},
+		{resourceName("be-env"), backendEnvContent, o.Spec.Backend.ComponentSpec},
+		{resourceName("lf-env"), langflowEnvContent, o.Spec.Langflow.ComponentSpec},
 	}
 	for _, d := range defs {
+		baseLabels := map[string]string{"app.kubernetes.io/managed-by": "openrag-operator"}
+
+		// Merge custom labels and annotations
+		mergedLabels := mergeSecretLabels(o, d.spec, baseLabels)
+		mergedAnnotations := mergeSecretAnnotations(o, d.spec)
+		// Ensure immutable annotation is always present
+		mergedAnnotations[immutableAnnotation] = "true"
+
 		secret := &corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      d.name,
-				Namespace: targetNS,
-				Labels:    map[string]string{"app.kubernetes.io/managed-by": "openrag-operator"},
-				Annotations: map[string]string{
-					immutableAnnotation: "true",
-				},
-				Finalizers: []string{envSecretFinalizer},
+				Name:        d.name,
+				Namespace:   targetNS,
+				Labels:      mergedLabels,
+				Annotations: mergedAnnotations,
+				Finalizers:  []string{envSecretFinalizer},
 			},
 			StringData: map[string]string{".env": d.content},
 		}
@@ -561,11 +580,15 @@ func (r *OpenRAGReconciler) reconcilePVCs(ctx context.Context, o *openragv1alpha
 			accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 		}
 
+		// Base labels that cannot be overridden
+		baseLabels := map[string]string{"app.kubernetes.io/managed-by": "openrag-operator"}
+
 		pvc := &corev1.PersistentVolumeClaim{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      d.name,
-				Namespace: targetNS,
-				Labels:    map[string]string{"app.kubernetes.io/managed-by": "openrag-operator"},
+				Name:        d.name,
+				Namespace:   targetNS,
+				Labels:      mergePVCLabels(o, d.storage, baseLabels),
+				Annotations: mergePVCAnnotations(o, d.storage),
 			},
 			Spec: corev1.PersistentVolumeClaimSpec{
 				AccessModes:      accessModes,
@@ -599,11 +622,12 @@ func (r *OpenRAGReconciler) reconcileServices(ctx context.Context, o *openragv1a
 	type svcDef struct {
 		role string
 		port int32
+		spec openragv1alpha1.ComponentSpec
 	}
 	defs := []svcDef{
-		{"fe", 3000},
-		{"be", 8000},
-		{"lf", 7860},
+		{"fe", 3000, o.Spec.Frontend.ComponentSpec},
+		{"be", 8000, o.Spec.Backend.ComponentSpec},
+		{"lf", 7860, o.Spec.Langflow.ComponentSpec},
 	}
 	for _, d := range defs {
 		// Only create Service if flag is true
@@ -623,11 +647,13 @@ func (r *OpenRAGReconciler) reconcileServices(ctx context.Context, o *openragv1a
 			})
 		}
 
+		baseLabels := componentLabels(o.Name, d.role)
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      getServiceName(o, d.role), // Use custom name if specified
-				Namespace: targetNS,
-				Labels:    componentLabels(o.Name, d.role),
+				Name:        getServiceName(o, d.role),
+				Namespace:   targetNS,
+				Labels:      mergeServiceLabels(o, d.spec, baseLabels),
+				Annotations: mergeServiceAnnotations(o, d.spec),
 			},
 			Spec: corev1.ServiceSpec{
 				Type:     corev1.ServiceTypeClusterIP,
@@ -946,11 +972,13 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 
 	// Reconcile service accounts for docling components
 	if dc.Serve != nil && shouldCreateServiceAccount(o, "ds") {
+		baseLabels := componentLabels(o.Name, "ds")
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      getServiceAccountName(o, "ds"),
-				Namespace: targetNS,
-				Labels:    componentLabels(o.Name, "ds"),
+				Name:        getServiceAccountName(o, "ds"),
+				Namespace:   targetNS,
+				Labels:      mergeServiceAccountLabels(o, dc.Serve.ComponentSpec, baseLabels),
+				Annotations: mergeServiceAccountAnnotations(o, dc.Serve.ComponentSpec),
 			},
 		}
 		if err := r.setOwnerOrLabel(o, sa, targetNS); err != nil {
@@ -962,11 +990,13 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 	}
 
 	if dc.Worker != nil && shouldCreateServiceAccount(o, "dw") {
+		baseLabels := componentLabels(o.Name, "dw")
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      getServiceAccountName(o, "dw"),
-				Namespace: targetNS,
-				Labels:    componentLabels(o.Name, "dw"),
+				Name:        getServiceAccountName(o, "dw"),
+				Namespace:   targetNS,
+				Labels:      mergeServiceAccountLabels(o, dc.Worker.ComponentSpec, baseLabels),
+				Annotations: mergeServiceAccountAnnotations(o, dc.Worker.ComponentSpec),
 			},
 		}
 		if err := r.setOwnerOrLabel(o, sa, targetNS); err != nil {
@@ -987,11 +1017,13 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 				accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 			}
 
+			baseLabels := componentLabels(o.Name, "ds")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      pvcName,
-					Namespace: targetNS,
-					Labels:    componentLabels(o.Name, "ds"),
+					Name:        pvcName,
+					Namespace:   targetNS,
+					Labels:      mergePVCLabels(o, dc.Serve.Storage, baseLabels),
+					Annotations: mergePVCAnnotations(o, dc.Serve.Storage),
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					AccessModes: accessModes,
@@ -1021,11 +1053,13 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 				accessModes = []corev1.PersistentVolumeAccessMode{corev1.ReadWriteOnce}
 			}
 
+			baseLabels := componentLabels(o.Name, "dw")
 			pvc := &corev1.PersistentVolumeClaim{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      pvcName,
-					Namespace: targetNS,
-					Labels:    componentLabels(o.Name, "dw"),
+					Name:        pvcName,
+					Namespace:   targetNS,
+					Labels:      mergePVCLabels(o, dc.Worker.Storage, baseLabels),
+					Annotations: mergePVCAnnotations(o, dc.Worker.Storage),
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					AccessModes: accessModes,
@@ -1059,12 +1093,13 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 			serviceType = corev1.ServiceTypeClusterIP
 		}
 
+		baseLabels := componentLabels(o.Name, "ds")
 		svc := &corev1.Service{
 			ObjectMeta: metav1.ObjectMeta{
 				Name:        getServiceName(o, "ds"),
 				Namespace:   targetNS,
-				Labels:      componentLabels(o.Name, "ds"),
-				Annotations: dc.Serve.ServiceAnnotations,
+				Labels:      mergeServiceLabels(o, dc.Serve.ComponentSpec, baseLabels),
+				Annotations: mergeServiceAnnotations(o, dc.Serve.ComponentSpec),
 			},
 			Spec: corev1.ServiceSpec{
 				Type:     serviceType,
@@ -1659,11 +1694,13 @@ func (r *OpenRAGReconciler) reconcileValkey(ctx context.Context, o *openragv1alp
 
 	// Reconcile ServiceAccount
 	if shouldCreateServiceAccount(o, "valkey") {
+		baseLabels := componentLabels(o.Name, "valkey")
 		sa := &corev1.ServiceAccount{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      getServiceAccountName(o, "valkey"),
-				Namespace: targetNS,
-				Labels:    componentLabels(o.Name, "valkey"),
+				Name:        getServiceAccountName(o, "valkey"),
+				Namespace:   targetNS,
+				Labels:      mergeServiceAccountLabels(o, valkeySpec.ComponentSpec, baseLabels),
+				Annotations: mergeServiceAccountAnnotations(o, valkeySpec.ComponentSpec),
 			},
 		}
 		if err := r.setOwnerOrLabel(o, sa, targetNS); err != nil {
@@ -1853,8 +1890,9 @@ func (r *OpenRAGReconciler) valkeyStatefulSet(o *openragv1alpha1.OpenRAG, target
 		sts.Spec.VolumeClaimTemplates = []corev1.PersistentVolumeClaim{
 			{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "valkey-data",
-					Labels: baseLabels,
+					Name:        "valkey-data",
+					Labels:      mergePVCLabels(o, spec.Storage, baseLabels),
+					Annotations: mergePVCAnnotations(o, spec.Storage),
 				},
 				Spec: corev1.PersistentVolumeClaimSpec{
 					AccessModes: accessModes,
@@ -1898,9 +1936,10 @@ func (r *OpenRAGReconciler) valkeyService(o *openragv1alpha1.OpenRAG, targetNS s
 	baseLabels := componentLabels(o.Name, "valkey")
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      getServiceName(o, "valkey"),
-			Namespace: targetNS,
-			Labels:    baseLabels,
+			Name:        getServiceName(o, "valkey"),
+			Namespace:   targetNS,
+			Labels:      mergeServiceLabels(o, spec.ComponentSpec, baseLabels),
+			Annotations: mergeServiceAnnotations(o, spec.ComponentSpec),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:     corev1.ServiceTypeClusterIP,
@@ -1922,9 +1961,10 @@ func (r *OpenRAGReconciler) valkeyHeadlessService(o *openragv1alpha1.OpenRAG, ta
 	baseLabels := componentLabels(o.Name, "valkey")
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName("valkey-headless"),
-			Namespace: targetNS,
-			Labels:    baseLabels,
+			Name:        resourceName("valkey-headless"),
+			Namespace:   targetNS,
+			Labels:      mergeServiceLabels(o, spec.ComponentSpec, baseLabels),
+			Annotations: mergeServiceAnnotations(o, spec.ComponentSpec),
 		},
 		Spec: corev1.ServiceSpec{
 			Type:      corev1.ServiceTypeClusterIP,
@@ -1998,9 +2038,10 @@ func (r *OpenRAGReconciler) valkeySecret(ctx context.Context, o *openragv1alpha1
 	baseLabels := componentLabels(o.Name, "valkey")
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName("valkey-auth"),
-			Namespace: targetNS,
-			Labels:    baseLabels,
+			Name:        resourceName("valkey-auth"),
+			Namespace:   targetNS,
+			Labels:      mergeSecretLabels(o, spec.ComponentSpec, baseLabels),
+			Annotations: mergeSecretAnnotations(o, spec.ComponentSpec),
 		},
 		StringData: map[string]string{
 			"password": password,
@@ -2413,6 +2454,118 @@ func mergeDeploymentLabels(baseLabels, customLabels map[string]string) map[strin
 // mergeDeploymentAnnotations merges custom annotations for Deployment/StatefulSet objects.
 func mergeDeploymentAnnotations(customAnnotations map[string]string) map[string]string {
 	return mergeAnnotations(customAnnotations)
+}
+
+// Note on map ordering: While Go maps have random iteration order, this doesn't cause
+// unnecessary reconciliations because:
+// 1. The createOrUpdate() function uses desiredHash() for change detection
+// 2. desiredHash() uses json.Marshal() which sorts map keys alphabetically
+// 3. Therefore, maps with the same content produce the same hash regardless of build order
+
+// mergeResourceLabels merges labels for infrastructure resources (PVCs, Secrets, Services, ServiceAccounts).
+// Priority (highest to lowest):
+// 1. Base labels (operator-managed, cannot be overridden)
+// 2. Resource-specific labels (e.g., from PersistenceSpec.Labels)
+// 3. Component-level labels (e.g., from ComponentSpec.ServiceAccountLabels)
+// 4. Common resource labels (from OpenRAGSpec.CommonResourceLabels)
+func mergeResourceLabels(o *openragv1alpha1.OpenRAG, baseLabels, componentLabels, resourceLabels map[string]string) map[string]string {
+	merged := make(map[string]string)
+
+	// Start with common resource labels (lowest priority)
+	for k, v := range o.Spec.CommonResourceLabels {
+		merged[k] = v
+	}
+
+	// Add component-level labels
+	for k, v := range componentLabels {
+		merged[k] = v
+	}
+
+	// Add resource-specific labels
+	for k, v := range resourceLabels {
+		merged[k] = v
+	}
+
+	// Base labels always override (highest priority)
+	for k, v := range baseLabels {
+		merged[k] = v
+	}
+
+	return merged
+}
+
+// mergeResourceAnnotations merges annotations for infrastructure resources.
+// Priority (highest to lowest):
+// 1. Resource-specific annotations (e.g., from PersistenceSpec.Annotations)
+// 2. Component-level annotations (e.g., from ComponentSpec.ServiceAccountAnnotations)
+// 3. Common resource annotations (from OpenRAGSpec.CommonResourceAnnotations)
+func mergeResourceAnnotations(o *openragv1alpha1.OpenRAG, componentAnnotations, resourceAnnotations map[string]string) map[string]string {
+	merged := make(map[string]string)
+
+	// Start with common resource annotations (lowest priority)
+	for k, v := range o.Spec.CommonResourceAnnotations {
+		merged[k] = v
+	}
+
+	// Add component-level annotations
+	for k, v := range componentAnnotations {
+		merged[k] = v
+	}
+
+	// Add resource-specific annotations (highest priority)
+	for k, v := range resourceAnnotations {
+		merged[k] = v
+	}
+
+	return merged
+}
+
+// mergePVCLabels merges labels for PersistentVolumeClaim resources.
+func mergePVCLabels(o *openragv1alpha1.OpenRAG, storage *openragv1alpha1.PersistenceSpec, baseLabels map[string]string) map[string]string {
+	var storageLabels map[string]string
+	if storage != nil {
+		storageLabels = storage.Labels
+	}
+	return mergeResourceLabels(o, baseLabels, nil, storageLabels)
+}
+
+// mergePVCAnnotations merges annotations for PersistentVolumeClaim resources.
+func mergePVCAnnotations(o *openragv1alpha1.OpenRAG, storage *openragv1alpha1.PersistenceSpec) map[string]string {
+	var storageAnnotations map[string]string
+	if storage != nil {
+		storageAnnotations = storage.Annotations
+	}
+	return mergeResourceAnnotations(o, nil, storageAnnotations)
+}
+
+// mergeServiceAccountLabels merges labels for ServiceAccount resources.
+func mergeServiceAccountLabels(o *openragv1alpha1.OpenRAG, spec openragv1alpha1.ComponentSpec, baseLabels map[string]string) map[string]string {
+	return mergeResourceLabels(o, baseLabels, spec.ServiceAccountLabels, nil)
+}
+
+// mergeServiceAccountAnnotations merges annotations for ServiceAccount resources.
+func mergeServiceAccountAnnotations(o *openragv1alpha1.OpenRAG, spec openragv1alpha1.ComponentSpec) map[string]string {
+	return mergeResourceAnnotations(o, spec.ServiceAccountAnnotations, nil)
+}
+
+// mergeServiceLabels merges labels for Service resources.
+func mergeServiceLabels(o *openragv1alpha1.OpenRAG, spec openragv1alpha1.ComponentSpec, baseLabels map[string]string) map[string]string {
+	return mergeResourceLabels(o, baseLabels, spec.ServiceLabels, nil)
+}
+
+// mergeServiceAnnotations merges annotations for Service resources (includes existing ServiceAnnotations).
+func mergeServiceAnnotations(o *openragv1alpha1.OpenRAG, spec openragv1alpha1.ComponentSpec) map[string]string {
+	return mergeResourceAnnotations(o, spec.ServiceAnnotations, nil)
+}
+
+// mergeSecretLabels merges labels for Secret resources.
+func mergeSecretLabels(o *openragv1alpha1.OpenRAG, spec openragv1alpha1.ComponentSpec, baseLabels map[string]string) map[string]string {
+	return mergeResourceLabels(o, baseLabels, spec.SecretLabels, nil)
+}
+
+// mergeSecretAnnotations merges annotations for Secret resources.
+func mergeSecretAnnotations(o *openragv1alpha1.OpenRAG, spec openragv1alpha1.ComponentSpec) map[string]string {
+	return mergeResourceAnnotations(o, spec.SecretAnnotations, nil)
 }
 
 func replicasOrDefault(r *int32) int32 {


### PR DESCRIPTION
**Description:**
* Add support for specifying labels and annotations on resources created by OSS operator - PVs , Secrets, STS, SA, etc.
* This enables backup / restore by external product like Velero

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for custom labels and annotations on Services, ServiceAccounts, Secrets, and PVCs.
  * Introduced global common labels/annotations that apply across managed infrastructure with per-component overrides.
  * Included a sample manifest showing global and per-component label/annotation usage.

* **Tests**
  * Added deterministic tests ensuring consistent label/annotation merging and stable resource hashing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->