### PR TITLE
fix: enhance Google Drive OAuth error handling and re-authentication logic

### DIFF
--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -193,6 +193,18 @@ async def compute_orphans_for_connector_type(
                 )
                 return None
 
+            # Re-authenticate to refresh any stale cached credentials before
+            # making API calls. get_connector() may return a cached connector
+            # whose access token has since expired (Google tokens last 1 hour).
+            # This mirrors the pattern used in connector_sync.
+            if not await connector.authenticate():
+                logger.info(
+                    "Skipping orphan compute — re-authentication failed",
+                    connector_type=connector_type,
+                    connection_id=conn.connection_id,
+                )
+                return None
+
             # Drive the per-id existence check via cfg.file_ids when the
             # connector supports it (SharePoint / OneDrive / Google Drive).
             # The flat default of list_files() only returns the *root* listing
@@ -235,6 +247,7 @@ async def compute_orphans_for_connector_type(
                 connector_type=connector_type,
                 connection_id=conn.connection_id,
                 error=str(e),
+                error_type=type(e).__name__,
             )
             return None
 

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -185,7 +185,7 @@ async def compute_orphans_for_connector_type(
     for conn in active:
         try:
             connector = await connector_service.get_connector(conn.connection_id)
-            if not connector or not connector.is_authenticated:
+            if not connector:
                 logger.info(
                     "Skipping orphan compute — connection unauthenticated",
                     connector_type=connector_type,
@@ -193,9 +193,8 @@ async def compute_orphans_for_connector_type(
                 )
                 return None
 
-            # Re-authenticate to refresh any stale cached credentials before
-            # making API calls. get_connector() may return a cached connector
-            # whose access token has since expired (Google tokens last 1 hour).
+            # Always re-authenticate before making API calls so that stale
+            # cached access tokens (Google tokens last 1 hour) are refreshed.
             # This mirrors the pattern used in connector_sync.
             if not await connector.authenticate():
                 logger.info(

--- a/src/connectors/google_drive/oauth.py
+++ b/src/connectors/google_drive/oauth.py
@@ -134,8 +134,7 @@ class GoogleDriveOAuth:
                 # should not force the user through re-authentication.
                 error_str = str(e).lower()
                 is_permanent = any(
-                    k in error_str
-                    for k in ("invalid_grant", "revoked", "unauthorized_client")
+                    k in error_str for k in ("invalid_grant", "revoked", "unauthorized_client")
                 )
                 if is_permanent:
                     self._remove_token_file()

--- a/src/connectors/google_drive/oauth.py
+++ b/src/connectors/google_drive/oauth.py
@@ -129,7 +129,16 @@ class GoogleDriveOAuth:
             except Exception as e:
                 logger.debug("[GoogleDrive] load_credentials: token refresh failed: %s", e)
                 self.creds = None
-                self._remove_token_file()
+                # Only wipe the token file for permanent failures (revoked or
+                # invalid grant). Transient failures (network timeout, etc.)
+                # should not force the user through re-authentication.
+                error_str = str(e).lower()
+                is_permanent = any(
+                    k in error_str
+                    for k in ("invalid_grant", "revoked", "unauthorized_client")
+                )
+                if is_permanent:
+                    self._remove_token_file()
                 raise ValueError(
                     f"Failed to refresh Google Drive credentials. "
                     f"The refresh token may have expired or been revoked. "

--- a/tests/unit/api/test_reconcile_orphans_for_connector_type.py
+++ b/tests/unit/api/test_reconcile_orphans_for_connector_type.py
@@ -30,6 +30,7 @@ def _make_connection(connection_id: str, is_active: bool = True):
 def _make_connector(remote_file_ids, *, authenticated=True, raise_on_list=False):
     connector = MagicMock()
     connector.is_authenticated = authenticated
+    connector.authenticate = AsyncMock(return_value=authenticated)
     if raise_on_list:
         connector.list_files = AsyncMock(side_effect=RuntimeError("graph 503"))
     else:
@@ -315,6 +316,7 @@ async def test_paginated_listing_aggregates_all_pages():
     conn = _make_connection("c1")
     connector = MagicMock()
     connector.is_authenticated = True
+    connector.authenticate = AsyncMock(return_value=True)
     pages = [
         {"files": [{"id": "a"}], "nextPageToken": "tok-1"},
         {"files": [{"id": "b"}, {"id": "c"}]},


### PR DESCRIPTION
This pull request improves the reliability of connector authentication and error handling, particularly for Google Drive connectors, and enhances test coverage to reflect these changes. The updates ensure that expired credentials are refreshed before performing operations and that error reporting is more detailed. The most important changes are:

**Authentication and Credential Handling:**

* Added a step to re-authenticate connectors before making API calls in `compute_orphans_for_connector_type`, ensuring that any cached but expired credentials (e.g., Google tokens) are refreshed, and gracefully skipping processing if re-authentication fails.
* Improved logic in `GoogleDriveOAuth2.load_credentials` to only remove the token file on permanent authentication failures (like revoked or invalid grants), avoiding unnecessary user re-authentication on transient errors.

**Error Reporting:**

* Enhanced error logging in `compute_orphans_for_connector_type` to include the exception type, making debugging easier.

**Test Improvements:**

* Updated connector mocks in unit tests to include an `authenticate` method, aligning test behavior with the new authentication flow. [[1]](diffhunk://#diff-c4dff6bf9f486a173236622d57940f2d2fffb2a51ac86b7a001822df45e1615fR33) [[2]](diffhunk://#diff-c4dff6bf9f486a173236622d57940f2d2fffb2a51ac86b7a001822df45e1615fR319)l

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth credentials are now preserved during transient refresh failures; only removed for permanent authorization errors.
  * Connection authentication is validated before orphan detection to ensure current status.
  * Orphan detection error logs now include exception type information for clearer troubleshooting.

* **Tests**
  * Unit tests updated to consistently simulate asynchronous connection authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->