### PR TITLE
fix: sonarcube static sec findings / openrag operator token automounti…

### DIFF
--- a/kubernetes/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/kubernetes/operator/config/default/manager_auth_proxy_patch.yaml
@@ -15,3 +15,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi

--- a/kubernetes/operator/config/rbac/service_account.yaml
+++ b/kubernetes/operator/config/rbac/service_account.yaml
@@ -3,3 +3,4 @@ kind: ServiceAccount
 metadata:
   name: controller-manager
   namespace: system
+automountServiceAccountToken: false


### PR DESCRIPTION
**Description:**

* Fix sonarcube static sec findings / openrag operator token automounting and cpu/mem res limits

For static scan findings:
<img width="1031" height="112" alt="image" src="https://github.com/user-attachments/assets/d914406b-6312-4a0c-aa78-4710dcd73641" />

**Rationale**: 
- The operator uses RBAC (ClusterRoleBinding) for authorization, which is already properly configured
- The operator doesn't require the service account token to be mounted into the pod filesystem
- Disabling auto-mounting follows the principle of least privilege
- The operator can still function correctly because RBAC permissions are granted via the ClusterRoleBinding, not through mounted tokens

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Configured explicit CPU and memory resource limits and requests for container deployments to ensure stable and predictable resource allocation across infrastructure.
  * Enhanced security configuration by disabling automatic service account token mounting to enforce stricter access control and improve overall system security posture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->