### PR TITLE
fix: script injection vulnerability in operator-release workflow

### DIFF
--- a/.github/workflows/operator-release.yml
+++ b/.github/workflows/operator-release.yml
@@ -36,9 +36,11 @@ jobs:
 
       - name: Resolve image tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "value=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "value=${INPUT_TAG}" >> $GITHUB_OUTPUT
           else
             # Strip the "operator/" prefix from the git tag
             echo "value=${GITHUB_REF_NAME#operator/}" >> $GITHUB_OUTPUT
@@ -78,9 +80,11 @@ jobs:
 
       - name: Resolve image tag
         id: tag
+        env:
+          INPUT_TAG: ${{ inputs.tag }}
         run: |
           if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
-            echo "value=${{ inputs.tag }}" >> $GITHUB_OUTPUT
+            echo "value=${INPUT_TAG}" >> $GITHUB_OUTPUT
           else
             echo "value=${GITHUB_REF_NAME#operator/}" >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
Fixes SonarCube finding 412037-1954951 by preventing command injection in workflow_dispatch inputs.

Changes:
- Use environment variables to sanitize user-controlled inputs.tag
- Replace direct interpolation with INPUT_TAG environment variable
- Applied to both build and manifest jobs

This prevents malicious tag inputs from executing arbitrary commands while maintaining identical functionality for legitimate inputs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the release workflow to reliably handle manually-provided image tags during manual release triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->