### PR TITLE
fix: add ephemeral storage limits to backend and langflow deployments

### DIFF
--- a/kubernetes/helm/openrag/values.yaml
+++ b/kubernetes/helm/openrag/values.yaml
@@ -73,9 +73,11 @@ langflow:
     requests:
       cpu: "500m"
       memory: "1Gi"
+      ephemeral-storage: "1Gi"
     limits:
       cpu: "4"
       memory: "8Gi"
+      ephemeral-storage: "2Gi"
 
   # Persistence for SQLite DB and flows
   persistence:
@@ -235,9 +237,11 @@ backend:
     requests:
       cpu: "500m"
       memory: "2Gi"
+      ephemeral-storage: "1Gi"
     limits:
       cpu: "4"
       memory: "16Gi"
+      ephemeral-storage: "2Gi"
   # Init container resource limits
   # Configure resource requests/limits for init containers that load default documents and flows
   # Adjust ephemeral-storage based on the size of documents/flows being downloaded


### PR DESCRIPTION
Description:
- Fix for remaining helm chart related static sec findings - https://github.ibm.com/lakehouse/tracker/issues/70873
- ephemeral storage limits for backend and langflow

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Kubernetes resource configuration for Langflow and backend services with ephemeral storage allocations (1Gi requests, 2Gi limits) to enhance infrastructure resource management and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->