### PR TITLE
fix: honor langflow command and args from CR spec

### DIFF
--- a/kubernetes/operator/internal/controller/openrag_controller.go
+++ b/kubernetes/operator/internal/controller/openrag_controller.go
@@ -938,8 +938,8 @@ func (r *OpenRAGReconciler) langflowDeployment(o *openragv1alpha1.OpenRAG, targe
 							Name:            "langflow",
 							Image:           spec.Image,
 							ImagePullPolicy: spec.ImagePullPolicy,
-							Args:            []string{"run", "--env-file", "/app/.env"},
-							Command:         []string{"langflow"},
+							Command:         commandOrDefault(spec.Command, []string{"langflow"}),
+							Args:            argsOrDefault(spec.Args, []string{"run", "--env-file", "/app/.env"}),
 							Ports:           []corev1.ContainerPort{{Name: "http", ContainerPort: 7860}},
 							Env:             envVars,
 							Resources:       spec.Resources,
@@ -2598,6 +2598,22 @@ func probeOrDefault(custom, defaultProbe *corev1.Probe) *corev1.Probe {
 		return custom
 	}
 	return defaultProbe
+}
+
+// commandOrDefault returns the custom command if provided, otherwise returns the default command.
+func commandOrDefault(custom, defaultCommand []string) []string {
+	if len(custom) > 0 {
+		return custom
+	}
+	return defaultCommand
+}
+
+// argsOrDefault returns the custom args if provided, otherwise returns the default args.
+func argsOrDefault(custom, defaultArgs []string) []string {
+	if len(custom) > 0 {
+		return custom
+	}
+	return defaultArgs
 }
 
 func tcpPort(p int32) networkingv1.NetworkPolicyPort {


### PR DESCRIPTION
The langflow deployment was ignoring the command and args fields from the OpenRAG CR spec, always using hardcoded values instead. This prevented users from customizing the langflow startup command.

Changes:
- Add commandOrDefault() and argsOrDefault() helper functions
- Update langflowDeployment() to use spec.Command and spec.Args with fallback to default values
- Aligns with existing pattern used by docling-serve and docling-worker

Fixes issue where langflow spec with custom command/args was not applied to the deployment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Langflow container deployment now supports custom startup commands and arguments via configuration, with sensible default values applied when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->