### PR TITLE
feat: crd supports multiple openrag instance in the same namespace

### DIFF
--- a/kubernetes/operator/api/v1alpha1/openrag_types.go
+++ b/kubernetes/operator/api/v1alpha1/openrag_types.go
@@ -674,6 +674,17 @@ type NetworkPolicySpec struct {
 
 // OpenRAGSpec defines the desired state of an OpenRAG instance.
 type OpenRAGSpec struct {
+	// MultiInstance enables per-CR resource naming (openrag-<crName>-<role>) so that
+	// multiple OpenRAG CRs can coexist in the same namespace. When false (default),
+	// resources use the legacy static names (openrag-fe, openrag-be, openrag-lf),
+	// which preserves backwards compatibility for existing deployments.
+	// Changing this field after initial deployment will rename all managed resources,
+	// which will break any external references (IngressRoutes, DNS, etc.).
+	// +optional
+	// +kubebuilder:default=false
+	// +kubebuilder:validation:XValidation:rule="self == oldSelf",message="multiInstance is immutable after creation"
+	MultiInstance bool `json:"multiInstance,omitempty"`
+
 	// TargetNamespace is the namespace where all OpenRAG resources are created.
 	// Defaults to the namespace of the CR itself. Cannot be "default".
 	// +optional

--- a/kubernetes/operator/config/crd/bases/openr.ag_openrags.yaml
+++ b/kubernetes/operator/config/crd/bases/openr.ag_openrags.yaml
@@ -13635,6 +13635,19 @@ spec:
                   provider:
                     type: string
                 type: object
+              multiInstance:
+                default: false
+                description: |-
+                  MultiInstance enables per-CR resource naming (openrag-<crName>-<role>) so that
+                  multiple OpenRAG CRs can coexist in the same namespace. When false (default),
+                  resources use the legacy static names (openrag-fe, openrag-be, openrag-lf),
+                  which preserves backwards compatibility for existing deployments.
+                  Changing this field after initial deployment will rename all managed resources,
+                  which will break any external references (IngressRoutes, DNS, etc.).
+                type: boolean
+                x-kubernetes-validations:
+                - message: multiInstance is immutable after creation
+                  rule: self == oldSelf
               networkPolicy:
                 description: NetworkPolicy controls creation of a NetworkPolicy for
                   the Langflow pod.

--- a/kubernetes/operator/config/samples/kind-cluster-openrag-cr.yaml
+++ b/kubernetes/operator/config/samples/kind-cluster-openrag-cr.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: my-tenant
 spec:
   targetNamespace: my-tenant
+  multiInstance: true   # Set to true to allow multiple OpenRAG CRs in the same namespace (namespaced resource names)
 
   frontend:
     image: edwinjosechittilappilly/orag-staging-frontend:release-saas-19a95c48

--- a/kubernetes/operator/internal/controller/deletion_handler.go
+++ b/kubernetes/operator/internal/controller/deletion_handler.go
@@ -34,7 +34,7 @@ func (r *OpenRAGReconciler) handleDeletion(ctx context.Context, o *openragv1alph
 	logger.Info("starting secret cleanup", "targetNamespace", targetNS)
 
 	// Remove finalizers from .env secrets and delete them
-	for _, envSecretName := range []string{resourceName("be-env"), resourceName("lf-env")} {
+	for _, envSecretName := range []string{instanceResourceName(o, "be-env"), instanceResourceName(o, "lf-env")} {
 		logger.Info("processing .env secret", "name", envSecretName, "namespace", targetNS)
 		envSecret := &corev1.Secret{}
 		err := r.Get(ctx, client.ObjectKey{Name: envSecretName, Namespace: targetNS}, envSecret)
@@ -176,7 +176,7 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 	logger := log.FromContext(ctx)
 
 	// Delete .env secrets with finalizers first
-	for _, envSecretName := range []string{resourceName("be-env"), resourceName("lf-env")} {
+	for _, envSecretName := range []string{instanceResourceName(o, "be-env"), instanceResourceName(o, "lf-env")} {
 		envSecret := &corev1.Secret{}
 		err := r.Get(ctx, client.ObjectKey{Name: envSecretName, Namespace: targetNS}, envSecret)
 		if err == nil {
@@ -245,7 +245,7 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 	}
 
 	// Delete deployments
-	for _, name := range []string{resourceName("fe"), resourceName("be"), resourceName("lf")} {
+	for _, name := range []string{instanceResourceName(o, "fe"), instanceResourceName(o, "be"), instanceResourceName(o, "lf")} {
 		deployment := &appsv1.Deployment{}
 		err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: targetNS}, deployment)
 		if err == nil {
@@ -289,35 +289,35 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 
 	if policy == openragv1alpha1.PVCReclaimDelete {
 		pvc := &corev1.PersistentVolumeClaim{}
-		err := r.Get(ctx, client.ObjectKey{Name: resourceName("lf-data"), Namespace: targetNS}, pvc)
+		err := r.Get(ctx, client.ObjectKey{Name: instanceResourceName(o, "lf-data"), Namespace: targetNS}, pvc)
 		if err == nil {
-			logger.Info("Deleting Langflow PVC per pvcReclaimPolicy", "pvc", resourceName("lf-data"), "policy", policy)
+			logger.Info("Deleting Langflow PVC per pvcReclaimPolicy", "pvc", instanceResourceName(o, "lf-data"), "policy", policy)
 			if err := r.Delete(ctx, pvc); err != nil && !errors.IsNotFound(err) {
-				logger.Error(err, "failed to delete PVC", "name", resourceName("lf-data"))
+				logger.Error(err, "failed to delete PVC", "name", instanceResourceName(o, "lf-data"))
 			}
 		}
 	} else {
-		logger.Info("Retaining Langflow PVC to preserve user data", "pvc", resourceName("lf-data"), "policy", policy)
+		logger.Info("Retaining Langflow PVC to preserve user data", "pvc", instanceResourceName(o, "lf-data"), "policy", policy)
 	}
 
 	// Delete network policy if enabled
 	if o.Spec.NetworkPolicy.Enabled {
 		np := &networkingv1.NetworkPolicy{}
-		err := r.Get(ctx, client.ObjectKey{Name: resourceName("lf-netpol"), Namespace: targetNS}, np)
+		err := r.Get(ctx, client.ObjectKey{Name: instanceResourceName(o, "lf-netpol"), Namespace: targetNS}, np)
 		if err == nil {
-			logger.Info("Deleting NetworkPolicy", "name", resourceName("lf-netpol"), "namespace", targetNS)
+			logger.Info("Deleting NetworkPolicy", "name", instanceResourceName(o, "lf-netpol"), "namespace", targetNS)
 			if err := r.Delete(ctx, np); err != nil && !errors.IsNotFound(err) {
-				logger.Error(err, "failed to delete network policy", "name", resourceName("lf-netpol"))
+				logger.Error(err, "failed to delete network policy", "name", instanceResourceName(o, "lf-netpol"))
 			}
 		} else if !errors.IsNotFound(err) {
-			logger.Error(err, "failed to get network policy for deletion", "name", resourceName("lf-netpol"))
+			logger.Error(err, "failed to get network policy for deletion", "name", instanceResourceName(o, "lf-netpol"))
 		}
 	}
 
 	// Delete Docling components if enabled
 	if o.Spec.DoclingComponents != nil && o.Spec.DoclingComponents.Enabled {
 		// Delete Docling deployments (ds and dw)
-		for _, name := range []string{resourceName("ds"), resourceName("dw")} {
+		for _, name := range []string{instanceResourceName(o, "ds"), instanceResourceName(o, "dw")} {
 			deployment := &appsv1.Deployment{}
 			err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: targetNS}, deployment)
 			if err == nil {
@@ -356,7 +356,7 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 		}
 
 		// Delete Docling HPAs if enabled
-		for _, name := range []string{resourceName("ds-hpa"), resourceName("dw-hpa")} {
+		for _, name := range []string{instanceResourceName(o, "ds-hpa"), instanceResourceName(o, "dw-hpa")} {
 			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: targetNS}, hpa)
 			if err == nil {
@@ -369,7 +369,7 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 
 		// Delete Docling PVCs if storage is enabled
 		// Note: Could add reclaim policy for Docling PVCs in future
-		for _, name := range []string{resourceName("ds-data"), resourceName("dw-data")} {
+		for _, name := range []string{instanceResourceName(o, "ds-data"), instanceResourceName(o, "dw-data")} {
 			pvc := &corev1.PersistentVolumeClaim{}
 			err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: targetNS}, pvc)
 			if err == nil {
@@ -384,16 +384,16 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 		if o.Spec.DoclingComponents.Valkey != nil {
 			// Delete Valkey StatefulSet
 			sts := &appsv1.StatefulSet{}
-			err := r.Get(ctx, client.ObjectKey{Name: resourceName("valkey"), Namespace: targetNS}, sts)
+			err := r.Get(ctx, client.ObjectKey{Name: instanceResourceName(o, "valkey"), Namespace: targetNS}, sts)
 			if err == nil {
-				logger.Info("Deleting Valkey StatefulSet", "name", resourceName("valkey"))
+				logger.Info("Deleting Valkey StatefulSet", "name", instanceResourceName(o, "valkey"))
 				if err := r.Delete(ctx, sts); err != nil && !errors.IsNotFound(err) {
 					logger.Error(err, "failed to delete Valkey StatefulSet")
 				}
 			}
 
 			// Delete Valkey services
-			for _, name := range []string{resourceName("valkey"), resourceName("valkey-headless")} {
+			for _, name := range []string{instanceResourceName(o, "valkey"), instanceResourceName(o, "valkey-headless")} {
 				service := &corev1.Service{}
 				err := r.Get(ctx, client.ObjectKey{Name: name, Namespace: targetNS}, service)
 				if err == nil {
@@ -406,9 +406,9 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 
 			// Delete Valkey ConfigMap
 			cm := &corev1.ConfigMap{}
-			err = r.Get(ctx, client.ObjectKey{Name: resourceName("valkey-config"), Namespace: targetNS}, cm)
+			err = r.Get(ctx, client.ObjectKey{Name: instanceResourceName(o, "valkey-config"), Namespace: targetNS}, cm)
 			if err == nil {
-				logger.Info("Deleting Valkey ConfigMap", "name", resourceName("valkey-config"))
+				logger.Info("Deleting Valkey ConfigMap", "name", instanceResourceName(o, "valkey-config"))
 				if err := r.Delete(ctx, cm); err != nil && !errors.IsNotFound(err) {
 					logger.Error(err, "failed to delete Valkey ConfigMap")
 				}
@@ -416,9 +416,9 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 
 			// Delete Valkey Secret
 			secret := &corev1.Secret{}
-			err = r.Get(ctx, client.ObjectKey{Name: resourceName("valkey-auth"), Namespace: targetNS}, secret)
+			err = r.Get(ctx, client.ObjectKey{Name: instanceResourceName(o, "valkey-auth"), Namespace: targetNS}, secret)
 			if err == nil {
-				logger.Info("Deleting Valkey Secret", "name", resourceName("valkey-auth"))
+				logger.Info("Deleting Valkey Secret", "name", instanceResourceName(o, "valkey-auth"))
 				if err := r.Delete(ctx, secret); err != nil && !errors.IsNotFound(err) {
 					logger.Error(err, "failed to delete Valkey Secret")
 				}
@@ -428,7 +428,7 @@ func (r *OpenRAGReconciler) deleteResources(ctx context.Context, o *openragv1alp
 			// Note: StatefulSet PVCs have format: data-<statefulset-name>-<ordinal>
 			// We should delete these to avoid orphaned PVCs
 			for i := 0; i < 1; i++ { // Default replicas is 1
-				pvcName := fmt.Sprintf("data-%s-%d", resourceName("valkey"), i)
+				pvcName := fmt.Sprintf("data-%s-%d", instanceResourceName(o, "valkey"), i)
 				pvc := &corev1.PersistentVolumeClaim{}
 				err := r.Get(ctx, client.ObjectKey{Name: pvcName, Namespace: targetNS}, pvc)
 				if err == nil {

--- a/kubernetes/operator/internal/controller/openrag_controller.go
+++ b/kubernetes/operator/internal/controller/openrag_controller.go
@@ -98,8 +98,8 @@ func (r *OpenRAGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, r.handleDeletion(ctx, instance)
 	}
 
-	if instance.Spec.MultiInstance && len(instance.Name) > 40 {
-		return ctrl.Result{}, fmt.Errorf("CR name %q exceeds maximum length of 40 characters (%d) required for multiInstance mode", instance.Name, len(instance.Name))
+	if instance.Spec.MultiInstance && len(instance.Name) > 38 {
+		return ctrl.Result{}, fmt.Errorf("CR name %q exceeds maximum length of 38 characters (%d) required for multiInstance mode", instance.Name, len(instance.Name))
 	}
 
 	targetNS := targetNamespace(instance)
@@ -2270,7 +2270,7 @@ func instanceSAName(o *openragv1alpha1.OpenRAG, role string) string {
 
 // resourceName generates a per-CR resource name with the openrag- prefix for DNS-1035
 // compliance (required when crName is a UUID starting with a digit).
-// Max length with a 40-char crName: "openrag-"(8) + 40 + "-docling-worker"(15) = 63 chars.
+// Max length with a 38-char crName: "openrag-"(8) + 38 + "-valkey-headless"(16) = 62 chars.
 func resourceName(crName, role string) string {
 	switch role {
 	case "ds":

--- a/kubernetes/operator/internal/controller/openrag_controller.go
+++ b/kubernetes/operator/internal/controller/openrag_controller.go
@@ -98,6 +98,10 @@ func (r *OpenRAGReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, r.handleDeletion(ctx, instance)
 	}
 
+	if instance.Spec.MultiInstance && len(instance.Name) > 40 {
+		return ctrl.Result{}, fmt.Errorf("CR name %q exceeds maximum length of 40 characters (%d) required for multiInstance mode", instance.Name, len(instance.Name))
+	}
+
 	targetNS := targetNamespace(instance)
 	logger.Info("target namespace determined", "targetNS", targetNS, "crNamespace", instance.Namespace)
 
@@ -258,8 +262,8 @@ func (r *OpenRAGReconciler) reconcileEnvSecrets(ctx context.Context, o *openragv
 		spec    openragv1alpha1.ComponentSpec
 	}
 	defs := []envDef{
-		{resourceName("be-env"), backendEnvContent, o.Spec.Backend.ComponentSpec},
-		{resourceName("lf-env"), langflowEnvContent, o.Spec.Langflow.ComponentSpec},
+		{instanceResourceName(o, "be-env"), backendEnvContent, o.Spec.Backend.ComponentSpec},
+		{instanceResourceName(o, "lf-env"), langflowEnvContent, o.Spec.Langflow.ComponentSpec},
 	}
 	for _, d := range defs {
 		baseLabels := map[string]string{"app.kubernetes.io/managed-by": "openrag-operator"}
@@ -300,14 +304,14 @@ func (r *OpenRAGReconciler) buildBackendEnv(ctx context.Context, o *openragv1alp
 
 	// Get or generate encryption key (AES-256)
 	// Priority: 1) User-provided secret in CR, 2) Existing value in .env, 3) Generate new
-	encryptionKey, err := r.getOrGenerateSecret(ctx, o, targetNS, o.Spec.Backend.EncryptionKeySecret, "OPENRAG_ENCRYPTION_KEY", resourceName("be-env"), GenerateAESKeyString32)
+	encryptionKey, err := r.getOrGenerateSecret(ctx, o, targetNS, o.Spec.Backend.EncryptionKeySecret, "OPENRAG_ENCRYPTION_KEY", instanceResourceName(o, "be-env"), GenerateAESKeyString32)
 	if err != nil {
 		return "", fmt.Errorf("failed to get encryption key: %w", err)
 	}
 	envVars["OPENRAG_ENCRYPTION_KEY"] = encryptionKey
 
 	// Get or generate JWT signing key (base64 secret)
-	jwtSigningKey, err := r.getOrGenerateSecret(ctx, o, targetNS, o.Spec.Backend.JWTSigningKeySecret, "JWT_SIGNING_KEY", resourceName("be-env"), generateBase64SecretKey)
+	jwtSigningKey, err := r.getOrGenerateSecret(ctx, o, targetNS, o.Spec.Backend.JWTSigningKeySecret, "JWT_SIGNING_KEY", instanceResourceName(o, "be-env"), generateBase64SecretKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to get JWT signing key: %w", err)
 	}
@@ -489,7 +493,7 @@ func (r *OpenRAGReconciler) buildLangflowEnv(ctx context.Context, o *openragv1al
 	}
 
 	// Get or generate Langflow secret key (Fernet key - base64, shared with backend)
-	langflowSecretKey, err := r.getOrGenerateSecret(ctx, o, targetNS, o.Spec.Langflow.SecretKeySecret, "LANGFLOW_SECRET_KEY", resourceName("lf-env"), generateBase64SecretKey)
+	langflowSecretKey, err := r.getOrGenerateSecret(ctx, o, targetNS, o.Spec.Langflow.SecretKeySecret, "LANGFLOW_SECRET_KEY", instanceResourceName(o, "lf-env"), generateBase64SecretKey)
 	if err != nil {
 		return "", fmt.Errorf("failed to get langflow secret key: %w", err)
 	}
@@ -584,8 +588,8 @@ func (r *OpenRAGReconciler) reconcilePVCs(ctx context.Context, o *openragv1alpha
 		storage *openragv1alpha1.PersistenceSpec
 	}
 	defs := []pvcDef{
-		{resourceName("lf-data"), o.Spec.Langflow.Storage},
-		{resourceName("be-data"), o.Spec.Backend.Storage},
+		{instanceResourceName(o, "lf-data"), o.Spec.Langflow.Storage},
+		{instanceResourceName(o, "be-data"), o.Spec.Backend.Storage},
 	}
 	for _, d := range defs {
 		if d.storage == nil || !d.storage.Enabled || d.storage.ExistingClaim != "" {
@@ -715,7 +719,7 @@ func (r *OpenRAGReconciler) frontendDeployment(o *openragv1alpha1.OpenRAG, targe
 	podAnnotations := mergePodAnnotations(spec.PodAnnotations)
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("fe"),
+			Name:        instanceResourceName(o, "fe"),
 			Namespace:   targetNS,
 			Labels:      deploymentLabels,
 			Annotations: deploymentAnnotations,
@@ -769,7 +773,7 @@ func (r *OpenRAGReconciler) backendDeployment(o *openragv1alpha1.OpenRAG, target
 		{
 			Name: "backend-env",
 			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: resourceName("be-env")},
+				Secret: &corev1.SecretVolumeSource{SecretName: instanceResourceName(o, "be-env")},
 			},
 		},
 	}
@@ -779,7 +783,7 @@ func (r *OpenRAGReconciler) backendDeployment(o *openragv1alpha1.OpenRAG, target
 	}
 
 	if spec.Storage != nil && spec.Storage.Enabled {
-		pvcName := resourceName("be-data")
+		pvcName := instanceResourceName(o, "be-data")
 		if spec.Storage.ExistingClaim != "" {
 			pvcName = spec.Storage.ExistingClaim
 		}
@@ -806,7 +810,7 @@ func (r *OpenRAGReconciler) backendDeployment(o *openragv1alpha1.OpenRAG, target
 	podAnnotations["openr.ag/backend-env-hash"] = envHash
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("be"),
+			Name:        instanceResourceName(o, "be"),
 			Namespace:   targetNS,
 			Labels:      deploymentLabels,
 			Annotations: deploymentAnnotations,
@@ -860,7 +864,7 @@ func (r *OpenRAGReconciler) langflowDeployment(o *openragv1alpha1.OpenRAG, targe
 		{
 			Name: "langflow-env",
 			VolumeSource: corev1.VolumeSource{
-				Secret: &corev1.SecretVolumeSource{SecretName: resourceName("lf-env")},
+				Secret: &corev1.SecretVolumeSource{SecretName: instanceResourceName(o, "lf-env")},
 			},
 		},
 	}
@@ -870,7 +874,7 @@ func (r *OpenRAGReconciler) langflowDeployment(o *openragv1alpha1.OpenRAG, targe
 	}
 
 	if spec.Storage != nil && spec.Storage.Enabled {
-		pvcName := resourceName("lf-data")
+		pvcName := instanceResourceName(o, "lf-data")
 		if spec.Storage.ExistingClaim != "" {
 			pvcName = spec.Storage.ExistingClaim
 		}
@@ -929,7 +933,7 @@ func (r *OpenRAGReconciler) langflowDeployment(o *openragv1alpha1.OpenRAG, targe
 	podAnnotations["openr.ag/langflow-env-hash"] = envHash
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("lf"),
+			Name:        instanceResourceName(o, "lf"),
 			Namespace:   targetNS,
 			Labels:      deploymentLabels,
 			Annotations: deploymentAnnotations,
@@ -1028,7 +1032,7 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 
 	// Reconcile PVCs for docling components
 	if dc.Serve != nil && dc.Serve.Storage != nil && dc.Serve.Storage.Enabled {
-		pvcName := resourceName("ds-data")
+		pvcName := instanceResourceName(o, "ds-data")
 		if dc.Serve.Storage.ExistingClaim == "" {
 			// Default to ReadWriteOnce if not specified
 			accessModes := dc.Serve.Storage.AccessModes
@@ -1064,7 +1068,7 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 	}
 
 	if dc.Worker != nil && dc.Worker.Storage != nil && dc.Worker.Storage.Enabled {
-		pvcName := resourceName("dw-data")
+		pvcName := instanceResourceName(o, "dw-data")
 		if dc.Worker.Storage.ExistingClaim == "" {
 			// Default to ReadWriteOnce if not specified
 			accessModes := dc.Worker.Storage.AccessModes
@@ -1170,7 +1174,7 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 		// Delete HPA if it exists but is now disabled
 		hpa := &autoscalingv2.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName("ds-hpa"),
+				Name:      instanceResourceName(o, "ds-hpa"),
 				Namespace: targetNS,
 			},
 		}
@@ -1192,7 +1196,7 @@ func (r *OpenRAGReconciler) reconcileDoclingComponents(ctx context.Context, o *o
 		// Delete HPA if it exists but is now disabled
 		hpa := &autoscalingv2.HorizontalPodAutoscaler{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      resourceName("dw-hpa"),
+				Name:      instanceResourceName(o, "dw-hpa"),
 				Namespace: targetNS,
 			},
 		}
@@ -1343,7 +1347,7 @@ func (r *OpenRAGReconciler) doclingServeDeployment(o *openragv1alpha1.OpenRAG, t
 	}
 
 	if spec.Storage != nil && spec.Storage.Enabled {
-		pvcName := resourceName("ds-data")
+		pvcName := instanceResourceName(o, "ds-data")
 		if spec.Storage.ExistingClaim != "" {
 			pvcName = spec.Storage.ExistingClaim
 		}
@@ -1416,7 +1420,7 @@ func (r *OpenRAGReconciler) doclingServeDeployment(o *openragv1alpha1.OpenRAG, t
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("ds"),
+			Name:        instanceResourceName(o, "ds"),
 			Namespace:   targetNS,
 			Labels:      deploymentLabels,
 			Annotations: deploymentAnnotations,
@@ -1440,7 +1444,7 @@ func (r *OpenRAGReconciler) doclingWorkerDeployment(o *openragv1alpha1.OpenRAG, 
 	}
 
 	if spec.Storage != nil && spec.Storage.Enabled {
-		pvcName := resourceName("dw-data")
+		pvcName := instanceResourceName(o, "dw-data")
 		if spec.Storage.ExistingClaim != "" {
 			pvcName = spec.Storage.ExistingClaim
 		}
@@ -1590,7 +1594,7 @@ func (r *OpenRAGReconciler) doclingWorkerDeployment(o *openragv1alpha1.OpenRAG, 
 
 	return &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("dw"),
+			Name:        instanceResourceName(o, "dw"),
 			Namespace:   targetNS,
 			Labels:      deploymentLabels,
 			Annotations: deploymentAnnotations,
@@ -1635,7 +1639,7 @@ func (r *OpenRAGReconciler) doclingServeHPA(o *openragv1alpha1.OpenRAG, targetNS
 	baseLabels := componentLabels(o.Name, "ds")
 	return &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName("ds-hpa"),
+			Name:      instanceResourceName(o, "ds-hpa"),
 			Namespace: targetNS,
 			Labels:    baseLabels,
 		},
@@ -1643,7 +1647,7 @@ func (r *OpenRAGReconciler) doclingServeHPA(o *openragv1alpha1.OpenRAG, targetNS
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
-				Name:       resourceName("ds"),
+				Name:       instanceResourceName(o, "ds"),
 			},
 			MinReplicas: minReplicas,
 			MaxReplicas: hpaSpec.MaxReplicas,
@@ -1689,7 +1693,7 @@ func (r *OpenRAGReconciler) doclingWorkerHPA(o *openragv1alpha1.OpenRAG, targetN
 	baseLabels := componentLabels(o.Name, "dw")
 	return &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName("dw-hpa"),
+			Name:      instanceResourceName(o, "dw-hpa"),
 			Namespace: targetNS,
 			Labels:    baseLabels,
 		},
@@ -1697,7 +1701,7 @@ func (r *OpenRAGReconciler) doclingWorkerHPA(o *openragv1alpha1.OpenRAG, targetN
 			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 				APIVersion: "apps/v1",
 				Kind:       "Deployment",
-				Name:       resourceName("dw"),
+				Name:       instanceResourceName(o, "dw"),
 			},
 			MinReplicas: minReplicas,
 			MaxReplicas: hpaSpec.MaxReplicas,
@@ -1798,7 +1802,7 @@ func (r *OpenRAGReconciler) valkeyStatefulSet(o *openragv1alpha1.OpenRAG, target
 			Name: "valkey-config",
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
-					LocalObjectReference: corev1.LocalObjectReference{Name: resourceName("valkey-config")},
+					LocalObjectReference: corev1.LocalObjectReference{Name: instanceResourceName(o, "valkey-config")},
 				},
 			},
 		},
@@ -1814,7 +1818,7 @@ func (r *OpenRAGReconciler) valkeyStatefulSet(o *openragv1alpha1.OpenRAG, target
 			Name: "valkey-auth",
 			VolumeSource: corev1.VolumeSource{
 				Secret: &corev1.SecretVolumeSource{
-					SecretName: resourceName("valkey-auth"),
+					SecretName: instanceResourceName(o, "valkey-auth"),
 				},
 			},
 		})
@@ -1839,13 +1843,13 @@ func (r *OpenRAGReconciler) valkeyStatefulSet(o *openragv1alpha1.OpenRAG, target
 
 	sts := &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("valkey"),
+			Name:        instanceResourceName(o, "valkey"),
 			Namespace:   targetNS,
 			Labels:      deploymentLabels,
 			Annotations: deploymentAnnotations,
 		},
 		Spec: appsv1.StatefulSetSpec{
-			ServiceName: resourceName("valkey-headless"),
+			ServiceName: instanceResourceName(o, "valkey-headless"),
 			Replicas:    &replicas,
 			Selector:    &metav1.LabelSelector{MatchLabels: baseLabels},
 			Template: corev1.PodTemplateSpec{
@@ -1980,7 +1984,7 @@ func (r *OpenRAGReconciler) valkeyHeadlessService(o *openragv1alpha1.OpenRAG, ta
 	baseLabels := componentLabels(o.Name, "valkey")
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("valkey-headless"),
+			Name:        instanceResourceName(o, "valkey-headless"),
 			Namespace:   targetNS,
 			Labels:      mergeServiceLabels(o, spec.ComponentSpec, baseLabels),
 			Annotations: mergeServiceAnnotations(o, spec.ComponentSpec),
@@ -2030,7 +2034,7 @@ appendfilename "appendonly.aof"
 	baseLabels := componentLabels(o.Name, "valkey")
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName("valkey-config"),
+			Name:      instanceResourceName(o, "valkey-config"),
 			Namespace: targetNS,
 			Labels:    baseLabels,
 		},
@@ -2057,7 +2061,7 @@ func (r *OpenRAGReconciler) valkeySecret(ctx context.Context, o *openragv1alpha1
 	baseLabels := componentLabels(o.Name, "valkey")
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        resourceName("valkey-auth"),
+			Name:        instanceResourceName(o, "valkey-auth"),
 			Namespace:   targetNS,
 			Labels:      mergeSecretLabels(o, spec.ComponentSpec, baseLabels),
 			Annotations: mergeSecretAnnotations(o, spec.ComponentSpec),
@@ -2088,7 +2092,7 @@ func (r *OpenRAGReconciler) reconcileNetworkPolicy(ctx context.Context, o *openr
 
 	np := &networkingv1.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      resourceName("lf-netpol"),
+			Name:      instanceResourceName(o, "lf-netpol"),
 			Namespace: targetNS,
 			Labels:    labels,
 		},
@@ -2246,10 +2250,52 @@ func targetNamespace(o *openragv1alpha1.OpenRAG) string {
 	return o.Namespace
 }
 
-// resourceName generates a DNS-1035 compliant name for Kubernetes resources.
-// Since each namespace is tenant-exclusive, we don't need to include the CR name.
-// This provides clean, predictable names: openrag-fe, openrag-be, openrag-lf, docling-serve, docling-worker.
-func resourceName(role string) string {
+// instanceResourceName returns the resource name for a role, respecting MultiInstance.
+// When MultiInstance is false (default), legacy static names are used for backwards
+// compatibility. When true, the CR name is embedded to allow multiple CRs per namespace.
+func instanceResourceName(o *openragv1alpha1.OpenRAG, role string) string {
+	if o.Spec.MultiInstance {
+		return resourceName(o.Name, role)
+	}
+	return legacyResourceName(role)
+}
+
+// instanceSAName returns the ServiceAccount name for a role, respecting MultiInstance.
+func instanceSAName(o *openragv1alpha1.OpenRAG, role string) string {
+	if o.Spec.MultiInstance {
+		return saName(o.Name, role)
+	}
+	return legacySAName(role)
+}
+
+// resourceName generates a per-CR resource name with the openrag- prefix for DNS-1035
+// compliance (required when crName is a UUID starting with a digit).
+// Max length with a 40-char crName: "openrag-"(8) + 40 + "-docling-worker"(15) = 63 chars.
+func resourceName(crName, role string) string {
+	switch role {
+	case "ds":
+		return "openrag-" + crName + "-docling-serve"
+	case "dw":
+		return "openrag-" + crName + "-docling-worker"
+	default:
+		return "openrag-" + crName + "-" + role
+	}
+}
+
+// saName generates per-CR ServiceAccount names.
+func saName(crName, role string) string {
+	switch role {
+	case "ds":
+		return "openrag-" + crName + "-docling-serve"
+	case "dw":
+		return "openrag-" + crName + "-docling-worker"
+	default:
+		return "openrag-" + crName + "-" + role
+	}
+}
+
+// legacyResourceName returns the static resource names used before MultiInstance was introduced.
+func legacyResourceName(role string) string {
 	switch role {
 	case "ds":
 		return "docling-serve"
@@ -2260,9 +2306,8 @@ func resourceName(role string) string {
 	}
 }
 
-// saName generates service account names.
-// Since each namespace is tenant-exclusive, we don't need to include the CR name.
-func saName(role string) string {
+// legacySAName returns the static ServiceAccount names used before MultiInstance was introduced.
+func legacySAName(role string) string {
 	switch role {
 	case "ds":
 		return "docling-serve"
@@ -2300,7 +2345,7 @@ func getServiceAccountName(o *openragv1alpha1.OpenRAG, role string) string {
 	if customName != "" {
 		return customName
 	}
-	return saName(role)
+	return instanceSAName(o, role)
 }
 
 // shouldCreateServiceAccount returns true if the operator should create the ServiceAccount.
@@ -2361,7 +2406,7 @@ func getServiceName(o *openragv1alpha1.OpenRAG, role string) string {
 	if customName != "" {
 		return customName
 	}
-	return resourceName(role)
+	return instanceResourceName(o, role)
 }
 
 // shouldCreateService returns true if the operator should create the Service.

--- a/kubernetes/operator/internal/controller/openrag_controller_test.go
+++ b/kubernetes/operator/internal/controller/openrag_controller_test.go
@@ -96,20 +96,21 @@ func TestTargetNamespace_UsesSpecField(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestResourceName(t *testing.T) {
-	// Test simple, namespace-scoped names (no CR name prefix needed)
-	assert.Equal(t, "openrag-fe", resourceName("fe"))
-	assert.Equal(t, "openrag-be", resourceName("be"))
-	assert.Equal(t, "openrag-lf", resourceName("lf"))
-	// Test DNS-1035 compliance (must start with letter)
-	assert.Regexp(t, `^[a-z]([-a-z0-9]*[a-z0-9])?$`, resourceName("fe"))
-	assert.Regexp(t, `^[a-z]([-a-z0-9]*[a-z0-9])?$`, resourceName("be"))
+	assert.Equal(t, "openrag-my-cr-fe", resourceName("my-cr", "fe"))
+	assert.Equal(t, "openrag-my-cr-be", resourceName("my-cr", "be"))
+	assert.Equal(t, "openrag-my-cr-lf", resourceName("my-cr", "lf"))
+	assert.Equal(t, "openrag-my-cr-docling-serve", resourceName("my-cr", "ds"))
+	assert.Equal(t, "openrag-my-cr-docling-worker", resourceName("my-cr", "dw"))
+	// DNS-1035 compliance: must start with letter even when crName starts with a digit
+	uuidLike := "9a826efa-112d-4e2d-9f8d-ce103880ab41"
+	assert.Regexp(t, `^[a-z]([-a-z0-9]*[a-z0-9])?$`, resourceName(uuidLike, "fe"))
+	assert.Regexp(t, `^[a-z]([-a-z0-9]*[a-z0-9])?$`, resourceName(uuidLike, "be"))
 }
 
 func TestSAName(t *testing.T) {
-	// Service accounts also use simple, namespace-scoped names
-	assert.Equal(t, "openrag-fe", saName("fe"))
-	assert.Equal(t, "openrag-be", saName("be"))
-	assert.Equal(t, "openrag-lf", saName("lf"))
+	assert.Equal(t, "openrag-my-cr-fe", saName("my-cr", "fe"))
+	assert.Equal(t, "openrag-my-cr-be", saName("my-cr", "be"))
+	assert.Equal(t, "openrag-my-cr-lf", saName("my-cr", "lf"))
 }
 
 // ---------------------------------------------------------------------------
@@ -126,7 +127,7 @@ func TestReconcile_CreatesDeployments(t *testing.T) {
 	for _, role := range []string{"fe", "be", "lf"} {
 		d := &appsv1.Deployment{}
 		require.NoError(t, c.Get(context.Background(),
-			types.NamespacedName{Name: resourceName(role), Namespace: "my-ns"}, d),
+			types.NamespacedName{Name: instanceResourceName(cr, role), Namespace: "my-ns"}, d),
 			"deployment for role %s should exist", role)
 	}
 }
@@ -142,7 +143,7 @@ func TestReconcile_CreatesServices(t *testing.T) {
 	for role, port := range ports {
 		svc := &corev1.Service{}
 		require.NoError(t, c.Get(context.Background(),
-			types.NamespacedName{Name: resourceName(role), Namespace: "my-ns"}, svc))
+			types.NamespacedName{Name: instanceResourceName(cr, role), Namespace: "my-ns"}, svc))
 		assert.Equal(t, port, svc.Spec.Ports[0].Port, "service port for role %s", role)
 	}
 }
@@ -157,7 +158,7 @@ func TestReconcile_CreatesServiceAccounts(t *testing.T) {
 	for _, role := range []string{"fe", "be", "lf"} {
 		sa := &corev1.ServiceAccount{}
 		require.NoError(t, c.Get(context.Background(),
-			types.NamespacedName{Name: saName(role), Namespace: "my-ns"}, sa),
+			types.NamespacedName{Name: instanceSAName(cr, role), Namespace: "my-ns"}, sa),
 			"service account for role %s should exist", role)
 	}
 }
@@ -171,7 +172,7 @@ func TestReconcile_SetsOwnerReferences_SameNamespace(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "my-ns"}, d))
 	require.Len(t, d.OwnerReferences, 1)
 	assert.Equal(t, cr.Name, d.OwnerReferences[0].Name)
 }
@@ -185,7 +186,7 @@ func TestReconcile_FrontendEnvContainsBackendHost(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "my-ns"}, d))
 
 	var backendHost string
 	for _, e := range d.Spec.Template.Spec.Containers[0].Env {
@@ -193,7 +194,7 @@ func TestReconcile_FrontendEnvContainsBackendHost(t *testing.T) {
 			backendHost = e.Value
 		}
 	}
-	assert.Equal(t, resourceName("be"), backendHost)
+	assert.Equal(t, instanceResourceName(cr, "be"), backendHost)
 }
 
 func TestReconcile_BackendMountsOperatorManagedEnvSecret(t *testing.T) {
@@ -205,9 +206,9 @@ func TestReconcile_BackendMountsOperatorManagedEnvSecret(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "my-ns"}, d))
 
-	expectedSecret := resourceName("be-env")
+	expectedSecret := instanceResourceName(cr, "be-env")
 	var found bool
 	for _, v := range d.Spec.Template.Spec.Volumes {
 		if v.Name == "backend-env" {
@@ -227,7 +228,7 @@ func TestReconcile_BackendEnvContainsLangflowURL(t *testing.T) {
 
 	sec := &corev1.Secret{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be-env"), Namespace: "my-ns"}, sec))
+		types.NamespacedName{Name: instanceResourceName(cr, "be-env"), Namespace: "my-ns"}, sec))
 
 	// In the test environment, StringData is not converted to Data
 	// Use StringData if Data is empty (test env), otherwise use Data (real cluster)
@@ -235,8 +236,8 @@ func TestReconcile_BackendEnvContainsLangflowURL(t *testing.T) {
 	if envContent == "" && sec.StringData != nil {
 		envContent = sec.StringData[".env"]
 	}
-	assert.Contains(t, envContent, `LANGFLOW_URL="http://`+resourceName("lf")+`:7860"`)
-	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://`+resourceName("be")+`:8000"`)
+	assert.Contains(t, envContent, `LANGFLOW_URL="http://`+instanceResourceName(cr, "lf")+`:7860"`)
+	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://`+instanceResourceName(cr, "be")+`:8000"`)
 }
 
 func TestReconcile_LangflowMountsPVC(t *testing.T) {
@@ -250,12 +251,12 @@ func TestReconcile_LangflowMountsPVC(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("lf"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "lf"), Namespace: "my-ns"}, d))
 
 	var found bool
 	for _, v := range d.Spec.Template.Spec.Volumes {
 		if v.Name == "langflow-data" {
-			assert.Equal(t, resourceName("lf-data"), v.PersistentVolumeClaim.ClaimName)
+			assert.Equal(t, instanceResourceName(cr, "lf-data"), v.PersistentVolumeClaim.ClaimName)
 			found = true
 		}
 	}
@@ -323,7 +324,7 @@ func TestReconcile_ResourcesInTargetNamespace(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "tenant-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "tenant-ns"}, d))
 	// Cross-namespace: no owner references, managed-by label instead.
 	assert.Empty(t, d.OwnerReferences)
 	assert.Equal(t, cr.Name, d.Labels[managedByLabel])
@@ -516,7 +517,7 @@ func TestReconcile_FrontendCustomPodLabels(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "my-ns"}, d))
 
 	podLabels := d.Spec.Template.Labels
 
@@ -545,7 +546,7 @@ func TestReconcile_BackendCustomPodAnnotations(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "my-ns"}, d))
 
 	podAnnotations := d.Spec.Template.Annotations
 
@@ -572,7 +573,7 @@ func TestReconcile_LangflowCustomPodLabelsAndAnnotations(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("lf"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "lf"), Namespace: "my-ns"}, d))
 
 	podLabels := d.Spec.Template.Labels
 	podAnnotations := d.Spec.Template.Annotations
@@ -603,7 +604,7 @@ func TestReconcile_SelectorLabelsAreNotAffectedByCustomPodLabels(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "my-ns"}, d))
 
 	// Selector should only have operator-managed labels
 	selectorLabels := d.Spec.Selector.MatchLabels
@@ -639,7 +640,7 @@ func TestReconcile_FrontendDeploymentLevelLabelsAndAnnotations(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "my-ns"}, d))
 
 	// Deployment-level labels should be present
 	assert.Equal(t, "deployment-value", d.Labels["deployment-label"])
@@ -669,7 +670,7 @@ func TestReconcile_DeploymentAndPodLabelsAreIndependent(t *testing.T) {
 
 	d := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "my-ns"}, d))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "my-ns"}, d))
 
 	// Deployment should have deployment-only label
 	assert.Equal(t, "on-deployment", d.Labels["deployment-only"])
@@ -729,83 +730,71 @@ func TestReconcile_AllThreeComponentsSupportBothLevels(t *testing.T) {
 	// Check Frontend
 	feDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "my-ns"}, feDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "my-ns"}, feDeploy))
 	assert.Equal(t, "fe-value", feDeploy.Annotations["frontend-deploy-annotation"])
 	assert.Equal(t, "fe-pod-value", feDeploy.Spec.Template.Annotations["frontend-pod-annotation"])
 
 	// Check Backend
 	beDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "my-ns"}, beDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "my-ns"}, beDeploy))
 	assert.Equal(t, "be-value", beDeploy.Labels["backend-deploy-label"])
 	assert.Equal(t, "be-pod-value", beDeploy.Spec.Template.Labels["backend-pod-label"])
 
 	// Check Langflow
 	lfDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("lf"), Namespace: "my-ns"}, lfDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "lf"), Namespace: "my-ns"}, lfDeploy))
 	assert.Equal(t, "lf-value", lfDeploy.Labels["langflow-deploy-label"])
 	assert.Equal(t, "lf-annotation", lfDeploy.Annotations["langflow-deploy-annotation"])
 	assert.Equal(t, "lf-pod-value", lfDeploy.Spec.Template.Labels["langflow-pod-label"])
 	assert.Equal(t, "lf-pod-annotation", lfDeploy.Spec.Template.Annotations["langflow-pod-annotation"])
 }
 
-// TestReconcile_UUIDNameDNS1035Compliance verifies that resources work correctly
-// even when CR names start with numbers (UUIDs). Since we use namespace-scoped
-// naming (openrag-fe, openrag-be, openrag-lf), the CR name doesn't affect resource names.
+// TestReconcile_UUIDNameDNS1035Compliance verifies that resource names are DNS-1035
+// compliant even when the CR name is a UUID starting with a digit.
+// The openrag- prefix ensures names always start with a letter.
 func TestReconcile_UUIDNameDNS1035Compliance(t *testing.T) {
 	s := newScheme(t)
-	// Use the exact UUID from the production error - this should work fine now
 	uuidName := "9a826efa-112d-4e2d-9f8d-ce103880ab41"
 	cr := minimalCR(uuidName, "test-ns")
+	cr.Spec.MultiInstance = true
 
 	r, c := reconciler(s, cr)
 	reconcileOnce(t, r, cr)
 
-	// Verify all created resources have DNS-1035 compliant names
-	// DNS-1035: must start with letter, end with alphanumeric, contain only lowercase alphanumeric and hyphens
 	dns1035Regex := `^[a-z]([-a-z0-9]*[a-z0-9])?$`
 
-	// Check frontend deployment
 	feDeploy := &appsv1.Deployment{}
-	feName := resourceName("fe")
+	feName := instanceResourceName(cr, "fe")
 	require.NoError(t, c.Get(context.Background(),
 		types.NamespacedName{Name: feName, Namespace: "test-ns"}, feDeploy))
 	assert.Regexp(t, dns1035Regex, feName, "Frontend deployment name must be DNS-1035 compliant")
 	assert.Regexp(t, dns1035Regex, feDeploy.Name, "Frontend deployment name must be DNS-1035 compliant")
 
-	// Check frontend service
 	feSvc := &corev1.Service{}
 	require.NoError(t, c.Get(context.Background(),
 		types.NamespacedName{Name: feName, Namespace: "test-ns"}, feSvc))
 	assert.Regexp(t, dns1035Regex, feSvc.Name, "Frontend service name must be DNS-1035 compliant")
 
-	// Check backend deployment
 	beDeploy := &appsv1.Deployment{}
-	beName := resourceName("be")
+	beName := instanceResourceName(cr, "be")
 	require.NoError(t, c.Get(context.Background(),
 		types.NamespacedName{Name: beName, Namespace: "test-ns"}, beDeploy))
 	assert.Regexp(t, dns1035Regex, beName, "Backend deployment name must be DNS-1035 compliant")
 
-	// Check backend service
-	beSvc := &corev1.Service{}
-	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: beName, Namespace: "test-ns"}, beSvc))
-	assert.Regexp(t, dns1035Regex, beSvc.Name, "Backend service name must be DNS-1035 compliant")
-
-	// Check langflow deployment
 	lfDeploy := &appsv1.Deployment{}
-	lfName := resourceName("lf")
+	lfName := instanceResourceName(cr, "lf")
 	require.NoError(t, c.Get(context.Background(),
 		types.NamespacedName{Name: lfName, Namespace: "test-ns"}, lfDeploy))
 	assert.Regexp(t, dns1035Regex, lfName, "Langflow deployment name must be DNS-1035 compliant")
 
-	// Verify the simple naming pattern: "openrag-{role}" (namespace-scoped)
-	assert.Equal(t, "openrag-fe", feName)
-	assert.Equal(t, "openrag-be", beName)
-	assert.Equal(t, "openrag-lf", lfName)
+	// Verify names follow the openrag-<crName>-<role> pattern
+	assert.Equal(t, "openrag-"+uuidName+"-fe", feName)
+	assert.Equal(t, "openrag-"+uuidName+"-be", beName)
+	assert.Equal(t, "openrag-"+uuidName+"-lf", lfName)
 
-	// Verify the CR UUID name is tracked in labels, not in resource names
+	// CR name is tracked in labels
 	assert.Equal(t, uuidName, feDeploy.Labels["app.kubernetes.io/instance"])
 	assert.Equal(t, uuidName, beDeploy.Labels["app.kubernetes.io/instance"])
 	assert.Equal(t, uuidName, lfDeploy.Labels["app.kubernetes.io/instance"])
@@ -882,7 +871,7 @@ func TestReconcile_ComponentImagePullSecrets_Frontend(t *testing.T) {
 
 	deploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, deploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, deploy))
 
 	assert.Equal(t, []corev1.LocalObjectReference{{Name: "frontend-secret"}},
 		deploy.Spec.Template.Spec.ImagePullSecrets)
@@ -900,7 +889,7 @@ func TestReconcile_ComponentImagePullSecrets_Backend(t *testing.T) {
 
 	deploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, deploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, deploy))
 
 	assert.Equal(t, []corev1.LocalObjectReference{{Name: "backend-secret"}},
 		deploy.Spec.Template.Spec.ImagePullSecrets)
@@ -918,7 +907,7 @@ func TestReconcile_ComponentImagePullSecrets_Langflow(t *testing.T) {
 
 	deploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("lf"), Namespace: "test-ns"}, deploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "lf"), Namespace: "test-ns"}, deploy))
 
 	assert.Equal(t, []corev1.LocalObjectReference{{Name: "langflow-secret"}},
 		deploy.Spec.Template.Spec.ImagePullSecrets)
@@ -948,7 +937,7 @@ func TestReconcile_GlobalAndComponentImagePullSecrets(t *testing.T) {
 	// Check frontend: should have both frontend-specific and global
 	feDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, feDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, feDeploy))
 	assert.Equal(t, []corev1.LocalObjectReference{
 		{Name: "frontend-secret"},
 		{Name: "global-secret"},
@@ -957,7 +946,7 @@ func TestReconcile_GlobalAndComponentImagePullSecrets(t *testing.T) {
 	// Check backend: should have both backend-specific and global
 	beDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, beDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, beDeploy))
 	assert.Equal(t, []corev1.LocalObjectReference{
 		{Name: "backend-secret"},
 		{Name: "global-secret"},
@@ -966,7 +955,7 @@ func TestReconcile_GlobalAndComponentImagePullSecrets(t *testing.T) {
 	// Check langflow: should have both langflow-specific and global
 	lfDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("lf"), Namespace: "test-ns"}, lfDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "lf"), Namespace: "test-ns"}, lfDeploy))
 	assert.Equal(t, []corev1.LocalObjectReference{
 		{Name: "langflow-secret"},
 		{Name: "global-secret"},
@@ -986,19 +975,19 @@ func TestReconcile_OnlyGlobalImagePullSecrets(t *testing.T) {
 	// All components should use the global secret
 	feDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, feDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, feDeploy))
 	assert.Equal(t, []corev1.LocalObjectReference{{Name: "global-secret"}},
 		feDeploy.Spec.Template.Spec.ImagePullSecrets)
 
 	beDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, beDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, beDeploy))
 	assert.Equal(t, []corev1.LocalObjectReference{{Name: "global-secret"}},
 		beDeploy.Spec.Template.Spec.ImagePullSecrets)
 
 	lfDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("lf"), Namespace: "test-ns"}, lfDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "lf"), Namespace: "test-ns"}, lfDeploy))
 	assert.Equal(t, []corev1.LocalObjectReference{{Name: "global-secret"}},
 		lfDeploy.Spec.Template.Spec.ImagePullSecrets)
 }
@@ -1024,13 +1013,13 @@ func TestReconcile_CustomServiceAccountName_OperatorCreates(t *testing.T) {
 	// Verify deployment uses the custom SA
 	deploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, deploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, deploy))
 	assert.Equal(t, "my-custom-sa", deploy.Spec.Template.Spec.ServiceAccountName)
 
 	// Verify operator did NOT create the default SA
 	defaultSA := &corev1.ServiceAccount{}
 	err := c.Get(context.Background(),
-		types.NamespacedName{Name: saName("fe"), Namespace: "test-ns"}, defaultSA)
+		types.NamespacedName{Name: instanceSAName(cr, "fe"), Namespace: "test-ns"}, defaultSA)
 	assert.True(t, errors.IsNotFound(err), "Default SA should not be created when custom name is specified")
 }
 
@@ -1055,7 +1044,7 @@ func TestReconcile_CustomServiceAccountName_UserManaged(t *testing.T) {
 	// Verify deployment uses the custom SA
 	deploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, deploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, deploy))
 	assert.Equal(t, "my-custom-sa", deploy.Spec.Template.Spec.ServiceAccountName)
 
 	// Verify the SA still exists and wasn't recreated (check it's the pre-created one)
@@ -1075,13 +1064,13 @@ func TestReconcile_DefaultServiceAccountName(t *testing.T) {
 	// Verify operator creates the default SA
 	defaultSA := &corev1.ServiceAccount{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: saName("fe"), Namespace: "test-ns"}, defaultSA))
+		types.NamespacedName{Name: instanceSAName(cr, "fe"), Namespace: "test-ns"}, defaultSA))
 
 	// Verify deployment uses the default SA
 	deploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, deploy))
-	assert.Equal(t, saName("fe"), deploy.Spec.Template.Spec.ServiceAccountName)
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, deploy))
+	assert.Equal(t, instanceSAName(cr, "fe"), deploy.Spec.Template.Spec.ServiceAccountName)
 }
 
 func TestReconcile_CustomServiceName_OperatorCreates(t *testing.T) {
@@ -1102,19 +1091,19 @@ func TestReconcile_CustomServiceName_OperatorCreates(t *testing.T) {
 	// Verify operator did NOT create the default Service
 	defaultSvc := &corev1.Service{}
 	err := c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, defaultSvc)
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, defaultSvc)
 	assert.True(t, errors.IsNotFound(err), "Default Service should not be created when custom name is specified")
 
 	// Verify backend env secret references the custom service name
 	secret := &corev1.Secret{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be-env"), Namespace: "test-ns"}, secret))
+		types.NamespacedName{Name: instanceResourceName(cr, "be-env"), Namespace: "test-ns"}, secret))
 
 	envContent := string(secret.Data[".env"])
 	if envContent == "" && secret.StringData != nil {
 		envContent = secret.StringData[".env"]
 	}
-	assert.Contains(t, envContent, `LANGFLOW_URL="http://`+resourceName("lf")+`:7860"`,
+	assert.Contains(t, envContent, `LANGFLOW_URL="http://`+instanceResourceName(cr, "lf")+`:7860"`,
 		"Backend env should reference default langflow service")
 	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://my-backend-svc:8000"`,
 		"Backend env should reference custom backend service name")
@@ -1151,7 +1140,7 @@ func TestReconcile_CustomServiceName_UserManaged(t *testing.T) {
 	// Verify operator did NOT create the default Service
 	defaultSvc := &corev1.Service{}
 	err := c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, defaultSvc)
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, defaultSvc)
 	assert.True(t, errors.IsNotFound(err), "Default Service should not be created when custom name is specified")
 }
 
@@ -1179,7 +1168,7 @@ func TestReconcile_CustomServiceName_UsedInFrontendEnv(t *testing.T) {
 	// Verify frontend deployment references the custom backend service name
 	deploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, deploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, deploy))
 
 	var backendHost string
 	for _, env := range deploy.Spec.Template.Spec.Containers[0].Env {
@@ -1216,7 +1205,7 @@ func TestReconcile_CustomServiceName_Langflow_UsedInBackendEnv(t *testing.T) {
 	// Verify backend env secret references the custom langflow service name
 	secret := &corev1.Secret{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be-env"), Namespace: "test-ns"}, secret))
+		types.NamespacedName{Name: instanceResourceName(cr, "be-env"), Namespace: "test-ns"}, secret))
 
 	envContent := string(secret.Data[".env"])
 	if envContent == "" && secret.StringData != nil {
@@ -1224,7 +1213,7 @@ func TestReconcile_CustomServiceName_Langflow_UsedInBackendEnv(t *testing.T) {
 	}
 	assert.Contains(t, envContent, `LANGFLOW_URL="http://custom-lf-svc:7860"`,
 		"Backend env should reference custom langflow service name")
-	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://`+resourceName("be")+`:8000"`,
+	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://`+instanceResourceName(cr, "be")+`:8000"`,
 		"Backend env should reference default backend service")
 }
 
@@ -1262,19 +1251,19 @@ func TestReconcile_AllComponentsWithCustomNames_OperatorCreates(t *testing.T) {
 	// Verify all deployments use custom names
 	feDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("fe"), Namespace: "test-ns"}, feDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "fe"), Namespace: "test-ns"}, feDeploy))
 	assert.Equal(t, "custom-fe-sa", feDeploy.Spec.Template.Spec.ServiceAccountName)
 
 	// Verify no default SAs or Services were created
 	for _, role := range []string{"fe", "be", "lf"} {
 		defaultSA := &corev1.ServiceAccount{}
 		err := c.Get(context.Background(),
-			types.NamespacedName{Name: saName(role), Namespace: "test-ns"}, defaultSA)
+			types.NamespacedName{Name: instanceSAName(cr, role), Namespace: "test-ns"}, defaultSA)
 		assert.True(t, errors.IsNotFound(err), "Default SA for %s should not be created", role)
 
 		defaultSvc := &corev1.Service{}
 		err = c.Get(context.Background(),
-			types.NamespacedName{Name: resourceName(role), Namespace: "test-ns"}, defaultSvc)
+			types.NamespacedName{Name: instanceResourceName(cr, role), Namespace: "test-ns"}, defaultSvc)
 		assert.True(t, errors.IsNotFound(err), "Default Service for %s should not be created", role)
 	}
 }
@@ -1370,7 +1359,7 @@ func TestDeployment_ContainsEnvHashAnnotation(t *testing.T) {
 	// Get backend deployment
 	backendDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, backendDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, backendDeploy))
 
 	// Check for hash annotation
 	annotations := backendDeploy.Spec.Template.Annotations
@@ -1382,7 +1371,7 @@ func TestDeployment_ContainsEnvHashAnnotation(t *testing.T) {
 	// Get langflow deployment
 	langflowDeploy := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("lf"), Namespace: "test-ns"}, langflowDeploy))
+		types.NamespacedName{Name: instanceResourceName(cr, "lf"), Namespace: "test-ns"}, langflowDeploy))
 
 	// Check for hash annotation
 	lfAnnotations := langflowDeploy.Spec.Template.Annotations
@@ -1407,7 +1396,7 @@ func TestDeployment_HashChangeTriggersUpdate(t *testing.T) {
 	// Get initial hash
 	backendDeploy1 := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, backendDeploy1))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, backendDeploy1))
 	hash1 := backendDeploy1.Spec.Template.Annotations["openr.ag/backend-env-hash"]
 	require.NotEmpty(t, hash1, "Initial hash should exist")
 
@@ -1426,7 +1415,7 @@ func TestDeployment_HashChangeTriggersUpdate(t *testing.T) {
 	// Get updated hash
 	backendDeploy2 := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, backendDeploy2))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, backendDeploy2))
 	hash2 := backendDeploy2.Spec.Template.Annotations["openr.ag/backend-env-hash"]
 	require.NotEmpty(t, hash2, "Updated hash should exist")
 
@@ -1449,7 +1438,7 @@ func TestDeployment_NoHashChangeWhenEnvUnchanged(t *testing.T) {
 	// Get initial hash
 	backendDeploy1 := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, backendDeploy1))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, backendDeploy1))
 	hash1 := backendDeploy1.Spec.Template.Annotations["openr.ag/backend-env-hash"]
 
 	// Reconcile again without changing env
@@ -1458,7 +1447,7 @@ func TestDeployment_NoHashChangeWhenEnvUnchanged(t *testing.T) {
 	// Get hash after second reconcile
 	backendDeploy2 := &appsv1.Deployment{}
 	require.NoError(t, c.Get(context.Background(),
-		types.NamespacedName{Name: resourceName("be"), Namespace: "test-ns"}, backendDeploy2))
+		types.NamespacedName{Name: instanceResourceName(cr, "be"), Namespace: "test-ns"}, backendDeploy2))
 	hash2 := backendDeploy2.Spec.Template.Annotations["openr.ag/backend-env-hash"]
 
 	// Hash should be identical (no unnecessary pod restart)

--- a/kubernetes/operator/internal/controller/status.go
+++ b/kubernetes/operator/internal/controller/status.go
@@ -73,7 +73,7 @@ func (r *OpenRAGReconciler) updateBackendCondition(ctx context.Context, instance
 
 	deployment := &appsv1.Deployment{}
 	err := r.Get(ctx, client.ObjectKey{
-		Name:      resourceName("be"),
+		Name:      instanceResourceName(instance, "be"),
 		Namespace: targetNS,
 	}, deployment)
 
@@ -87,7 +87,7 @@ func (r *OpenRAGReconciler) updateBackendCondition(ctx context.Context, instance
 				Message:            "Backend deployment not found",
 				ObservedGeneration: instance.Generation,
 			})
-			logger.Info("Backend deployment not found", "deployment", resourceName("be"))
+			logger.Info("Backend deployment not found", "deployment", instanceResourceName(instance, "be"))
 			return metav1.ConditionUnknown, nil
 		}
 		return metav1.ConditionUnknown, fmt.Errorf("failed to get backend deployment: %w", err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `multiInstance` option (default: false) to enable per-instance resource naming: `openrag-<instanceName>-<role>`.
  * Enforces a maximum CR name length when multi-instance is enabled.

* **Behavioral**
  * Multi-instance mode changes naming for deployments, services, secrets, PVCs, HPAs, ServiceAccounts, and policies.

* **Documentation**
  * Sample manifest updated to show `spec.multiInstance: true`.

* **Tests**
  * Controller tests updated to validate instance-scoped naming and DNS-1035 compliance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->