### PR TITLE
fix: to respect value from cr env

### DIFF
--- a/kubernetes/operator/internal/controller/env.go
+++ b/kubernetes/operator/internal/controller/env.go
@@ -210,22 +210,21 @@ func (m *EnvVarManager) mergeEnvVars(ctx context.Context, c client.Client, names
 	}
 
 	// Level 3: Override with CR spec env vars (highest priority)
-	// Resolve ALL types of env vars (direct values, secrets, configmaps)
+	// CR values are always respected as-is, including empty string.
 	for _, envVar := range crEnvVars {
-		if envVar.Value != "" {
-			// Direct value assignment
-			result[envVar.Name] = envVar.Value
-		} else if envVar.ValueFrom != nil {
-			// Resolve valueFrom references
+		if envVar.ValueFrom != nil {
 			value, found, err := resolveEnvVarValue(ctx, c, namespace, &envVar)
 			if err != nil {
 				return nil, fmt.Errorf("failed to resolve env var %s: %w", envVar.Name, err)
 			}
 			if !found {
-				// If the reference was optional and not found, skip it without error
+				// Optional reference not found — leave any existing value in place
 				continue
 			}
 			result[envVar.Name] = value
+		} else {
+			// Direct value: always set, even if empty. CR is authoritative.
+			result[envVar.Name] = envVar.Value
 		}
 	}
 
@@ -305,9 +304,9 @@ func resolveEnvVarValue(ctx context.Context, c client.Client, namespace string, 
 }
 
 // BuildEnvFileContent converts a map of env vars to .env file format.
-// Values are always double-quoted with special characters escaped so that
-// arbitrary secret/configmap content cannot corrupt the file.
-// python-dotenv (>=1.0.0) interprets these escape sequences correctly.
+// Values are written raw unless they contain characters that would break dotenv
+// parsing without quoting: newlines, carriage returns, or '#' (comment marker).
+// Those values are double-quoted via strconv.Quote so the content is preserved.
 func (m *EnvVarManager) BuildEnvFileContent(envVars map[string]string) string {
 	// Sort keys to ensure deterministic output
 	keys := make([]string, 0, len(envVars))
@@ -318,9 +317,14 @@ func (m *EnvVarManager) BuildEnvFileContent(envVars map[string]string) string {
 
 	var b strings.Builder
 	for _, k := range keys {
+		v := envVars[k]
 		b.WriteString(k)
 		b.WriteString("=")
-		b.WriteString(strconv.Quote(envVars[k]))
+		if strings.ContainsAny(v, "\n\r#") {
+			b.WriteString(strconv.Quote(v))
+		} else {
+			b.WriteString(v)
+		}
 		b.WriteString("\n")
 	}
 	return b.String()

--- a/kubernetes/operator/internal/controller/env_test.go
+++ b/kubernetes/operator/internal/controller/env_test.go
@@ -123,7 +123,10 @@ func TestEnvVarManager_CREmptyValueOverridesDefault(t *testing.T) {
 	}
 
 	_ = os.Setenv("OPTLF_LANGFLOW_KEY", "operator-key")
-	defer os.Unsetenv("OPTLF_LANGFLOW_KEY")
+	defer func() {
+		err := os.Unsetenv("OPTLF_LANGFLOW_KEY")
+		require.NoError(t, err)
+	}()
 
 	crEnvVars := []corev1.EnvVar{
 		{Name: "LANGFLOW_KEY", Value: ""},   // explicit empty — must win

--- a/kubernetes/operator/internal/controller/env_test.go
+++ b/kubernetes/operator/internal/controller/env_test.go
@@ -112,6 +112,56 @@ func TestEnvVarManager_CREnvVarOverride(t *testing.T) {
 	assert.Equal(t, "DEBUG", result["LOG_LEVEL"], "CR should override defaults")
 }
 
+// TestEnvVarManager_CREmptyValueOverridesDefault verifies that an explicit empty string
+// in the CR is respected as-is and overrides any default or operator-set value.
+func TestEnvVarManager_CREmptyValueOverridesDefault(t *testing.T) {
+	manager := &EnvVarManager{
+		DefaultLangflowEnvVars: map[string]string{
+			"LANGFLOW_KEY":   "some-default-key",
+			"SEGMENT_WRITES": "default-segment-key",
+		},
+	}
+
+	_ = os.Setenv("OPTLF_LANGFLOW_KEY", "operator-key")
+	defer os.Unsetenv("OPTLF_LANGFLOW_KEY")
+
+	crEnvVars := []corev1.EnvVar{
+		{Name: "LANGFLOW_KEY", Value: ""},   // explicit empty — must win
+		{Name: "SEGMENT_WRITES", Value: ""}, // overrides default
+	}
+
+	result, err := manager.GetLangflowEnvVars(context.Background(), nil, "test-ns", crEnvVars)
+	require.NoError(t, err)
+
+	assert.Equal(t, "", result["LANGFLOW_KEY"], "CR empty string must override operator env value")
+	assert.Equal(t, "", result["SEGMENT_WRITES"], "CR empty string must override default value")
+}
+
+// TestEnvVarManager_CRValueIsLiterallyRespected verifies that CR values containing
+// special characters (spaces, quotes, hashes, URLs) are passed through without modification.
+func TestEnvVarManager_CRValueIsLiterallyRespected(t *testing.T) {
+	manager := &EnvVarManager{
+		DefaultOpenRagBEEnvVars: map[string]string{
+			"DATABASE_URL": "default-url",
+			"DESCRIPTION":  "default-desc",
+			"API_KEY":      "default-key",
+		},
+	}
+
+	crEnvVars := []corev1.EnvVar{
+		{Name: "DATABASE_URL", Value: "postgresql://user:p@ss#word@host:5432/db"},
+		{Name: "DESCRIPTION", Value: "hello world with spaces"},
+		{Name: "API_KEY", Value: "key with \"quotes\" inside"},
+	}
+
+	result, err := manager.GetBackendEnvVars(context.Background(), nil, "test-ns", crEnvVars)
+	require.NoError(t, err)
+
+	assert.Equal(t, "postgresql://user:p@ss#word@host:5432/db", result["DATABASE_URL"])
+	assert.Equal(t, "hello world with spaces", result["DESCRIPTION"])
+	assert.Equal(t, `key with "quotes" inside`, result["API_KEY"])
+}
+
 func TestEnvVarManager_EmptyCREnvVars(t *testing.T) {
 	manager := &EnvVarManager{
 		DefaultLangflowEnvVars: map[string]string{
@@ -181,22 +231,23 @@ func TestEnvVarManager_BuildEnvFileContent(t *testing.T) {
 
 	content := manager.BuildEnvFileContent(envVars)
 
-	// Should contain all three vars in quoted key=value format
-	assert.Contains(t, content, `VAR1="value1"`)
-	assert.Contains(t, content, `VAR2="value2"`)
-	assert.Contains(t, content, `VAR3="value3"`)
+	// Should contain all three vars in raw key=value format (no quotes for simple values)
+	assert.Contains(t, content, "VAR1=value1")
+	assert.Contains(t, content, "VAR2=value2")
+	assert.Contains(t, content, "VAR3=value3")
 
 	// Should have newlines
 	assert.Contains(t, content, "\n")
 
 	// Should be deterministic (alphabetically sorted)
-	expected := "VAR1=\"value1\"\nVAR2=\"value2\"\nVAR3=\"value3\"\n"
+	expected := "VAR1=value1\nVAR2=value2\nVAR3=value3\n"
 	assert.Equal(t, expected, content, "Output should be deterministic and sorted")
 
 	// Verify determinism by calling multiple times
 	for i := 0; i < 10; i++ {
 		result := manager.BuildEnvFileContent(envVars)
 		assert.Equal(t, expected, result, "Output should be identical on iteration %d", i)
+
 	}
 }
 

--- a/kubernetes/operator/internal/controller/env_test.go
+++ b/kubernetes/operator/internal/controller/env_test.go
@@ -246,6 +246,19 @@ func TestEnvVarManager_BuildEnvFileContent(t *testing.T) {
 	expected := "VAR1=value1\nVAR2=value2\nVAR3=value3\n"
 	assert.Equal(t, expected, content, "Output should be deterministic and sorted")
 
+	t.Run("quotes values that need dotenv protection", func(t *testing.T) {
+		protected := map[string]string{
+			"HASH_VALUE": "postgresql://user:p@ss#word@host/db",
+			"MULTILINE":  "line1\nline2",
+			"CR_VALUE":   "line1\rline2",
+		}
+
+		protectedContent := manager.BuildEnvFileContent(protected)
+		assert.Contains(t, protectedContent, `HASH_VALUE="postgresql://user:p@ss#word@host/db"`)
+		assert.Contains(t, protectedContent, `MULTILINE="line1\nline2"`)
+		assert.Contains(t, protectedContent, `CR_VALUE="line1\rline2"`)
+	})
+
 	// Verify determinism by calling multiple times
 	for i := 0; i < 10; i++ {
 		result := manager.BuildEnvFileContent(envVars)

--- a/kubernetes/operator/internal/controller/openrag_controller_env_behavior_test.go
+++ b/kubernetes/operator/internal/controller/openrag_controller_env_behavior_test.go
@@ -25,9 +25,9 @@ func TestComponentSpec_Env_DirectValues_GoToEnvFileOnly(t *testing.T) {
 	// Check .env file content contains direct values
 	backendEnvContent, err := r.buildBackendEnv(context.Background(), cr, "test-ns")
 	require.NoError(t, err)
-	assert.Contains(t, backendEnvContent, `CUSTOM_VAR="custom_value"`,
+	assert.Contains(t, backendEnvContent, `CUSTOM_VAR=custom_value`,
 		"Direct value should be in .env file")
-	assert.Contains(t, backendEnvContent, `ANOTHER_VAR="another_value"`,
+	assert.Contains(t, backendEnvContent, `ANOTHER_VAR=another_value`,
 		"Direct value should be in .env file")
 
 	// Check container env is EMPTY (no spec.Env)
@@ -79,9 +79,9 @@ func TestComponentSpec_Env_SecretRefs_ResolvedToEnvFile(t *testing.T) {
 	// Check .env file content - should contain RESOLVED secret value
 	backendEnvContent, err := r.buildBackendEnv(context.Background(), cr, "test-ns")
 	require.NoError(t, err)
-	assert.Contains(t, backendEnvContent, `DATABASE_PASSWORD="super-secret-password"`,
+	assert.Contains(t, backendEnvContent, `DATABASE_PASSWORD=super-secret-password`,
 		".env file should contain RESOLVED secret value")
-	assert.Contains(t, backendEnvContent, `REGULAR_VAR="regular_value"`,
+	assert.Contains(t, backendEnvContent, `REGULAR_VAR=regular_value`,
 		".env file should contain direct values")
 
 	// Check container env - should be EMPTY (no spec.Env)
@@ -129,7 +129,7 @@ func TestComponentSpec_Env_ConfigMapRefs_ResolvedToEnvFile(t *testing.T) {
 	// Check .env file - should contain resolved value
 	backendEnvContent, err := r.buildBackendEnv(context.Background(), cr, "test-ns")
 	require.NoError(t, err)
-	assert.Contains(t, backendEnvContent, `API_ENDPOINT="https://api.example.com"`,
+	assert.Contains(t, backendEnvContent, `API_ENDPOINT=https://api.example.com`,
 		".env file should contain resolved configmap value")
 
 	// Check container env - should be empty
@@ -175,9 +175,9 @@ func TestComponentSpec_Env_Langflow_SameBehavior(t *testing.T) {
 	// Check .env file
 	langflowEnvContent, err := r.buildLangflowEnv(context.Background(), cr, "test-ns")
 	require.NoError(t, err)
-	assert.Contains(t, langflowEnvContent, `DIRECT_VAR="direct_value"`,
+	assert.Contains(t, langflowEnvContent, `DIRECT_VAR=direct_value`,
 		"Direct value should be in Langflow .env file")
-	assert.Contains(t, langflowEnvContent, `SECRET_VAR="secret-value"`,
+	assert.Contains(t, langflowEnvContent, `SECRET_VAR=secret-value`,
 		"Resolved secret value should be in Langflow .env file")
 
 	// Check container env is empty
@@ -270,11 +270,11 @@ func TestComponentSpec_Env_MixedTypes_AllResolvedToEnvFile(t *testing.T) {
 	// Check .env file - should contain ALL 5 resolved values
 	backendEnvContent, err := r.buildBackendEnv(context.Background(), cr, "test-ns")
 	require.NoError(t, err)
-	assert.Contains(t, backendEnvContent, `LITERAL_1="value1"`)
-	assert.Contains(t, backendEnvContent, `SECRET_REF="secret-value-1"`)
-	assert.Contains(t, backendEnvContent, `LITERAL_2="value2"`)
-	assert.Contains(t, backendEnvContent, `CONFIGMAP_REF="config-value-2"`)
-	assert.Contains(t, backendEnvContent, `LITERAL_3="value3"`)
+	assert.Contains(t, backendEnvContent, `LITERAL_1=value1`)
+	assert.Contains(t, backendEnvContent, `SECRET_REF=secret-value-1`)
+	assert.Contains(t, backendEnvContent, `LITERAL_2=value2`)
+	assert.Contains(t, backendEnvContent, `CONFIGMAP_REF=config-value-2`)
+	assert.Contains(t, backendEnvContent, `LITERAL_3=value3`)
 
 	// Check container env - should be empty (no spec.Env vars)
 	deploy := r.backendDeployment(cr, "test-ns", "hash123")

--- a/kubernetes/operator/internal/controller/openrag_controller_test.go
+++ b/kubernetes/operator/internal/controller/openrag_controller_test.go
@@ -236,8 +236,8 @@ func TestReconcile_BackendEnvContainsLangflowURL(t *testing.T) {
 	if envContent == "" && sec.StringData != nil {
 		envContent = sec.StringData[".env"]
 	}
-	assert.Contains(t, envContent, `LANGFLOW_URL="http://`+instanceResourceName(cr, "lf")+`:7860"`)
-	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://`+instanceResourceName(cr, "be")+`:8000"`)
+	assert.Contains(t, envContent, `LANGFLOW_URL=http://`+instanceResourceName(cr, "lf")+`:7860`)
+	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL=http://`+instanceResourceName(cr, "be")+`:8000`)
 }
 
 func TestReconcile_LangflowMountsPVC(t *testing.T) {
@@ -1103,9 +1103,9 @@ func TestReconcile_CustomServiceName_OperatorCreates(t *testing.T) {
 	if envContent == "" && secret.StringData != nil {
 		envContent = secret.StringData[".env"]
 	}
-	assert.Contains(t, envContent, `LANGFLOW_URL="http://`+instanceResourceName(cr, "lf")+`:7860"`,
+	assert.Contains(t, envContent, `LANGFLOW_URL=http://`+instanceResourceName(cr, "lf")+`:7860`,
 		"Backend env should reference default langflow service")
-	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://my-backend-svc:8000"`,
+	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL=http://my-backend-svc:8000`,
 		"Backend env should reference custom backend service name")
 }
 
@@ -1211,9 +1211,9 @@ func TestReconcile_CustomServiceName_Langflow_UsedInBackendEnv(t *testing.T) {
 	if envContent == "" && secret.StringData != nil {
 		envContent = secret.StringData[".env"]
 	}
-	assert.Contains(t, envContent, `LANGFLOW_URL="http://custom-lf-svc:7860"`,
+	assert.Contains(t, envContent, `LANGFLOW_URL=http://custom-lf-svc:7860`,
 		"Backend env should reference custom langflow service name")
-	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL="http://`+instanceResourceName(cr, "be")+`:8000"`,
+	assert.Contains(t, envContent, `OPENRAG_BACKEND_INTERNAL_URL=http://`+instanceResourceName(cr, "be")+`:8000`,
 		"Backend env should reference default backend service")
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Merge logic now respects explicitly set empty environment values when overriding defaults.
  * .env output is only quoted when values contain newlines, carriage returns, or hash symbols for cleaner files.

* **Tests**
  * Added and updated tests to assert unquoted simple KEY=value entries, ensure empty-string overrides, preserve deterministic ordering, and verify correct quoting/escaping for special-character values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->