### PR TITLE
fix: pass jwt to docling polling calls

### DIFF
--- a/src/services/docling_polling_service.py
+++ b/src/services/docling_polling_service.py
@@ -53,6 +53,8 @@ class DoclingPollingService:
         backoff_factor: float = 1.5,
         transient_retry_budget: int = 5,
         result_fetch_retry_budget: int = 3,
+        user_id: str | None = None,
+        auth_header: str | None = None,
     ) -> DoclingPollResult:
         """Loop on Docling status until terminal or until max_seconds elapses.
 
@@ -82,7 +84,9 @@ class DoclingPollingService:
 
         while True:
             logger.debug("Docling polling", task_id=task_id)
-            snapshot = await self.docling_service.check_task_status(task_id)
+            snapshot = await self.docling_service.check_task_status(
+                task_id, user_id=user_id, auth_header=auth_header
+            )
             last_snapshot = snapshot
             logger.debug("Snapshot received", task_id=task_id, snapshot=last_snapshot)
             elapsed = time.monotonic() - start
@@ -112,7 +116,9 @@ class DoclingPollingService:
                             elapsed_seconds=elapsed,
                         )
                     try:
-                        await self.docling_service.fetch_task_result(task_id)
+                        await self.docling_service.fetch_task_result(
+                            task_id, user_id=user_id, auth_header=auth_header
+                        )
                         break
                     except DoclingTransientError as e:
                         result_fetch_errors += 1

--- a/src/services/docling_service.py
+++ b/src/services/docling_service.py
@@ -214,7 +214,12 @@ class DoclingService:
             logger.error("Docling result retrieval failed", task_id=task_id, error=str(e))
             raise
 
-    async def check_task_status(self, task_id: str) -> DoclingStatusSnapshot:
+    async def check_task_status(
+        self,
+        task_id: str,
+        user_id: str | None = None,
+        auth_header: str | None = None,
+    ) -> DoclingStatusSnapshot:
         """
         Single (non-blocking) status check against Docling Serve.
 
@@ -224,8 +229,9 @@ class DoclingService:
         """
         client = self._get_client()
         url = f"{self.docling_url}/v1/status/poll/{task_id}"
+        headers = self._get_auth_headers(user_id, auth_header)
         try:
-            response = await client.get(url)
+            response = await client.get(url, headers=headers)
         except httpx.RequestError as e:
             # Transient network error — surface as PROCESSING so caller can
             # retry without prematurely failing the file.
@@ -261,7 +267,7 @@ class DoclingService:
         status = payload.get("task_status")
         if status == "success":
             return DoclingStatusSnapshot(state=DoclingTaskState.SUCCESS, raw=payload)
-        if status == "failure" or payload.get("errors"):
+        if status == "failure" or payload.get("errors") or payload.get("error"):
             errors = payload.get("errors", [])
             err_msg_list = []
             for err in errors:
@@ -269,6 +275,11 @@ class DoclingService:
                     err_msg_list.append(err["error_message"])
                 elif isinstance(err, str):
                     err_msg_list.append(err)
+            
+            single_err = payload.get("error")
+            if isinstance(single_err, str):
+                err_msg_list.append(single_err)
+
             err_details = (
                 "; ".join(err_msg_list) if err_msg_list else "Unknown Docling processing error"
             )
@@ -281,7 +292,12 @@ class DoclingService:
             return DoclingStatusSnapshot(state=DoclingTaskState.PROCESSING, raw=payload)
         return DoclingStatusSnapshot(state=DoclingTaskState.PENDING, raw=payload)
 
-    async def fetch_task_result(self, task_id: str) -> dict[str, Any]:
+    async def fetch_task_result(
+        self,
+        task_id: str,
+        user_id: str | None = None,
+        auth_header: str | None = None,
+    ) -> dict[str, Any]:
         """
         Fetch the converted document for a Docling task that is already SUCCESS.
 
@@ -292,8 +308,9 @@ class DoclingService:
         """
         client = self._get_client()
         url = f"{self.docling_url}/v1/result/{task_id}"
+        headers = self._get_auth_headers(user_id, auth_header)
         try:
-            response = await client.get(url)
+            response = await client.get(url, headers=headers)
         except httpx.RequestError as e:
             raise DoclingTransientError(f"Network error fetching docling result: {str(e)}") from e
 

--- a/src/services/docling_service.py
+++ b/src/services/docling_service.py
@@ -275,7 +275,7 @@ class DoclingService:
                     err_msg_list.append(err["error_message"])
                 elif isinstance(err, str):
                     err_msg_list.append(err)
-            
+
             single_err = payload.get("error")
             if isinstance(single_err, str):
                 err_msg_list.append(single_err)

--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -920,6 +920,8 @@ class LangflowFileService:
                 max_interval=DOCLING_POLL_MAX_INTERVAL_SECONDS,
                 backoff_factor=DOCLING_POLL_BACKOFF_FACTOR,
                 transient_retry_budget=DOCLING_POLL_TRANSIENT_RETRIES,
+                user_id=owner,
+                auth_header=jwt_token,
             )
 
             if poll_result.outcome != PollOutcome.SUCCESS:

--- a/src/tui/managers/docling_manager.py
+++ b/src/tui/managers/docling_manager.py
@@ -302,9 +302,11 @@ class DoclingManager:
                 "--with",
                 "easyocr",
                 "--with",
-                f"docling[{docling_extras}]",
+                f"docling[{docling_extras}]==2.95.0",
                 "--with",
                 "docling-core==2.77.1",
+                "--with",
+                "docling-jobkit==1.20.0",
                 "--with",
                 "transformers>=5.8.1,<5.9.0",
             ]

--- a/tests/unit/test_docling_polling_service.py
+++ b/tests/unit/test_docling_polling_service.py
@@ -56,7 +56,9 @@ async def test_returns_success_immediately_when_already_done(polling_service, mo
 
     assert result.outcome == PollOutcome.SUCCESS
     assert mock_docling_service.check_task_status.call_count == 1
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
+    mock_docling_service.fetch_task_result.assert_awaited_once_with(
+        "t1", user_id=None, auth_header=None
+    )
 
 
 @pytest.mark.asyncio
@@ -79,7 +81,9 @@ async def test_loops_through_processing_then_success(
     assert result.outcome == PollOutcome.SUCCESS
     assert mock_docling_service.check_task_status.call_count == 4
     assert no_sleep.call_count == 3
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
+    mock_docling_service.fetch_task_result.assert_awaited_once_with(
+        "t1", user_id=None, auth_header=None
+    )
 
 
 @pytest.mark.asyncio
@@ -95,7 +99,9 @@ async def test_success_status_requires_fetchable_result(polling_service, mock_do
 
     assert result.outcome == PollOutcome.FAILED
     assert "missing document.json_content" in (result.detail or "")
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
+    mock_docling_service.fetch_task_result.assert_awaited_once_with(
+        "t1", user_id=None, auth_header=None
+    )
 
 
 @pytest.mark.asyncio
@@ -133,7 +139,9 @@ async def test_tolerates_brief_not_found_then_succeeds(
     )
 
     assert result.outcome == PollOutcome.SUCCESS
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
+    mock_docling_service.fetch_task_result.assert_awaited_once_with(
+        "t1", user_id=None, auth_header=None
+    )
 
 
 @pytest.mark.asyncio
@@ -214,7 +222,9 @@ async def test_backoff_grows_interval_up_to_cap(polling_service, mock_docling_se
     # see the raw progression.
     sleeps = [call.args[0] for call in no_sleep.call_args_list]
     assert sleeps == [1.0, 2.0, 4.0, 4.0]
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
+    mock_docling_service.fetch_task_result.assert_awaited_once_with(
+        "t1", user_id=None, auth_header=None
+    )
 
 
 @pytest.mark.asyncio
@@ -277,4 +287,6 @@ async def test_permanent_result_fetch_error_fails_immediately(
 
     assert result.outcome == PollOutcome.FAILED
     assert "task expired" in (result.detail or "")
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
+    mock_docling_service.fetch_task_result.assert_awaited_once_with(
+        "t1", user_id=None, auth_header=None
+    )

--- a/tests/unit/test_docling_polling_service.py
+++ b/tests/unit/test_docling_polling_service.py
@@ -56,7 +56,7 @@ async def test_returns_success_immediately_when_already_done(polling_service, mo
 
     assert result.outcome == PollOutcome.SUCCESS
     assert mock_docling_service.check_task_status.call_count == 1
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1")
+    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
 
 
 @pytest.mark.asyncio
@@ -79,7 +79,7 @@ async def test_loops_through_processing_then_success(
     assert result.outcome == PollOutcome.SUCCESS
     assert mock_docling_service.check_task_status.call_count == 4
     assert no_sleep.call_count == 3
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1")
+    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
 
 
 @pytest.mark.asyncio
@@ -95,7 +95,7 @@ async def test_success_status_requires_fetchable_result(polling_service, mock_do
 
     assert result.outcome == PollOutcome.FAILED
     assert "missing document.json_content" in (result.detail or "")
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1")
+    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
 
 
 @pytest.mark.asyncio
@@ -133,7 +133,7 @@ async def test_tolerates_brief_not_found_then_succeeds(
     )
 
     assert result.outcome == PollOutcome.SUCCESS
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1")
+    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
 
 
 @pytest.mark.asyncio
@@ -214,7 +214,7 @@ async def test_backoff_grows_interval_up_to_cap(polling_service, mock_docling_se
     # see the raw progression.
     sleeps = [call.args[0] for call in no_sleep.call_args_list]
     assert sleeps == [1.0, 2.0, 4.0, 4.0]
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1")
+    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)
 
 
 @pytest.mark.asyncio
@@ -277,4 +277,4 @@ async def test_permanent_result_fetch_error_fails_immediately(
 
     assert result.outcome == PollOutcome.FAILED
     assert "task expired" in (result.detail or "")
-    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1")
+    mock_docling_service.fetch_task_result.assert_awaited_once_with("t1", user_id=None, auth_header=None)


### PR DESCRIPTION
This pull request enhances the Docling polling and result-fetching services to support optional user authentication, improves error handling, and updates related tests. The main changes include propagating `user_id` and `auth_header` through service and polling layers, handling additional error fields in responses, and ensuring all tests reflect the updated method signatures.

**Authentication propagation and API updates:**

* Added optional `user_id` and `auth_header` parameters to `poll_until_ready`, `check_task_status`, and `fetch_task_result` methods in `docling_polling_service.py` and `docling_service.py`, ensuring authentication information can be passed through all relevant service calls. [[1]](diffhunk://#diff-4f1804e65cbd6e028ade63f12e0ae73de3499fbd1af8419c95ae1e10b2f7d6aeR56-R57) [[2]](diffhunk://#diff-732675f677994bc2bd488b70a6884c8713d268c0ec5141128657d36e18bf7c41L217-R222) [[3]](diffhunk://#diff-732675f677994bc2bd488b70a6884c8713d268c0ec5141128657d36e18bf7c41L284-R300)
* Updated all internal calls and HTTP requests to include authentication headers when provided, using the `_get_auth_headers` helper. [[1]](diffhunk://#diff-4f1804e65cbd6e028ade63f12e0ae73de3499fbd1af8419c95ae1e10b2f7d6aeL85-R89) [[2]](diffhunk://#diff-732675f677994bc2bd488b70a6884c8713d268c0ec5141128657d36e18bf7c41R232-R234) [[3]](diffhunk://#diff-732675f677994bc2bd488b70a6884c8713d268c0ec5141128657d36e18bf7c41R311-R313) [[4]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958R923-R924)

**Error handling improvements:**

* Improved error extraction in `check_task_status` to handle both `errors` (list) and `error` (single string) fields from Docling API responses, ensuring more comprehensive error reporting.

**Test updates:**

* Updated all relevant unit tests in `test_docling_polling_service.py` to expect the new `user_id` and `auth_header` parameters in mock calls to `fetch_task_result`. [[1]](diffhunk://#diff-d0ab958b95442fdf50a7c555a2afcebcd29c522bd1a2e10e9f73541edd0736c4L59-R59) [[2]](diffhunk://#diff-d0ab958b95442fdf50a7c555a2afcebcd29c522bd1a2e10e9f73541edd0736c4L82-R82) [[3]](diffhunk://#diff-d0ab958b95442fdf50a7c555a2afcebcd29c522bd1a2e10e9f73541edd0736c4L98-R98) [[4]](diffhunk://#diff-d0ab958b95442fdf50a7c555a2afcebcd29c522bd1a2e10e9f73541edd0736c4L136-R136) [[5]](diffhunk://#diff-d0ab958b95442fdf50a7c555a2afcebcd29c522bd1a2e10e9f73541edd0736c4L217-R217) [[6]](diffhunk://#diff-d0ab958b95442fdf50a7c555a2afcebcd29c522bd1a2e10e9f73541edd0736c4L280-R280)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Document processing now preserves user context and authentication during polling and status/result retrieval, improving authenticated workflows.

* **Chores**
  * Startup/install behavior for the local docling service was made more deterministic by pinning the docling extras version.

* **Tests**
  * Unit tests updated to validate authentication parameters across polling, retry and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->