### PR TITLE
fix: added visual loading spinner and success/error toast when restoring default langflow flows

### DIFF
--- a/frontend/app/settings/_components/agent-settings-section.tsx
+++ b/frontend/app/settings/_components/agent-settings-section.tsx
@@ -43,6 +43,7 @@ export function AgentSettingsSection() {
   const pathname = usePathname();
 
   const focusLlmModel = searchParams.get("focusLlmModel") === "true";
+  const [isRestoringFlow, setIsRestoringFlow] = useState<boolean>(false);
   const [openLlmSelector, setOpenLlmSelector] = useState(false);
   const [systemPrompt, setSystemPrompt] = useState<string>("");
 
@@ -183,6 +184,8 @@ export function AgentSettingsSection() {
   };
 
   const handleRestoreRetrievalFlow = (closeDialog: () => void) => {
+    setIsRestoringFlow(true);
+
     fetch("/api/reset-flow/retrieval", { method: "POST" })
       .then((res) => {
         if (res.ok) return res.json();
@@ -190,12 +193,15 @@ export function AgentSettingsSection() {
       })
       .then(() => {
         setSystemPrompt(DEFAULT_AGENT_SETTINGS.system_prompt);
+        toast.success("Default agent flow settings restored successfully");
         closeDialog();
       })
       .catch((err) => {
         console.error("Error restoring retrieval flow:", err);
+        toast.error("Failed to restore default agent flow settings");
         closeDialog();
-      });
+      })
+      .finally(() => setIsRestoringFlow(false));
   };
 
   return (
@@ -223,6 +229,7 @@ export function AgentSettingsSection() {
                 confirmText="Restore"
                 variant="destructive"
                 onConfirm={handleRestoreRetrievalFlow}
+                isLoading={isRestoringFlow}
               />
               <ConfirmationDialog
                 trigger={

--- a/frontend/app/settings/_components/ingest-settings-section.tsx
+++ b/frontend/app/settings/_components/ingest-settings-section.tsx
@@ -37,6 +37,8 @@ export function IngestSettingsSection() {
   const isCloudBrand = useIsCloudBrand();
   const { isAuthenticated, isNoAuthMode, isIbmAuthMode, runMode } = useAuth();
 
+  const [isRestoringFlow, setIsRestoringFlow] = useState<boolean>(false);
+
   const [chunkSize, setChunkSize] = useState<number>(1024);
   const [chunkOverlap, setChunkOverlap] = useState<number>(50);
   const [chunkValidationError, setChunkValidationError] = useState<
@@ -228,6 +230,8 @@ export function IngestSettingsSection() {
   };
 
   const handleRestoreIngestFlow = (closeDialog: () => void) => {
+    setIsRestoringFlow(true);
+
     fetch("/api/reset-flow/ingest", { method: "POST" })
       .then((res) => {
         if (res.ok) return res.json();
@@ -241,12 +245,15 @@ export function IngestSettingsSection() {
         setPictureDescriptions(DEFAULT_KNOWLEDGE_SETTINGS.picture_descriptions);
         setDisableIngestWithLangflow(false);
         setChunkValidationError(null);
+        toast.success("Default ingest flow settings restored successfully");
         closeDialog();
       })
       .catch((err) => {
         console.error("Error restoring ingest flow:", err);
+        toast.error("Failed to restore default ingest flow settings");
         closeDialog();
-      });
+      })
+      .finally(() => setIsRestoringFlow(false));
   };
 
   return (
@@ -274,6 +281,7 @@ export function IngestSettingsSection() {
                 confirmText="Restore"
                 variant="destructive"
                 onConfirm={handleRestoreIngestFlow}
+                isLoading={isRestoringFlow}
               />
               <ConfirmationDialog
                 trigger={

--- a/frontend/components/confirmation-dialog.tsx
+++ b/frontend/components/confirmation-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { Loader2 } from "lucide-react";
 import { ReactNode, useState } from "react";
 import { Button } from "@/components/ui/button";
 import {
@@ -22,6 +23,7 @@ interface ConfirmationDialogProps {
   onCancel?: () => void;
   variant?: "default" | "destructive" | "warning";
   confirmIcon?: ReactNode | null;
+  isLoading?: boolean;
 }
 
 export function ConfirmationDialog({
@@ -34,6 +36,7 @@ export function ConfirmationDialog({
   onCancel,
   variant = "default",
   confirmIcon = null,
+  isLoading = false,
 }: ConfirmationDialogProps) {
   const [open, setOpen] = useState(false);
 
@@ -61,7 +64,13 @@ export function ConfirmationDialog({
           <Button variant="ghost" onClick={handleCancel} size="sm">
             {cancelText}
           </Button>
-          <Button variant={variant} onClick={handleConfirm} size="sm">
+          <Button
+            variant={variant}
+            onClick={handleConfirm}
+            size="sm"
+            disabled={isLoading}
+          >
+            {isLoading && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
             {confirmText}
             {confirmIcon}
           </Button>


### PR DESCRIPTION
## Summary
Fixes https://github.com/langflow-ai/openrag/issues/1286, Adds loading state feedback for the restore retrieval flow functionality to improve user experience.

## Demo (Before) 
[screen-capture (4).webm](https://github.com/user-attachments/assets/cd2eee9a-b032-4007-8727-32917551b6b3)


## Demo (After)
[screen-capture (2).webm](https://github.com/user-attachments/assets/23be17d0-3154-407b-b251-552821984e0c)

## Changes
- Added loading state tracking to [`agent-settings-section.tsx`](frontend/app/settings/_components/agent-settings-section.tsx) and [`ingest-settings-section.tsx`](frontend/app/settings/_components/ingest-settings-section.tsx)
- Updated [`handleRestoreRetrieval()`](frontend/app/settings/_components/agent-settings-section.tsx) to display success/error toast notifications
- Updated [`confirmation-dialog.tsx`](frontend/components/confirmation-dialog.tsx) with optional `isLoading` prop
- Disabled restore button during loading to prevent duplicate requests
- Added spinner animation on the restore button to show processing state

## Testing
- Confirmed that button is disabled during loading by checking network requests when loading
- Confirmed that the spinner animation displays correctly
- Tested restore flow with successful completion
- Tested restore flow with error handling by disabling backend docker container before restoring

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **New Features**
  * Added loading indicators and toast notifications during settings restoration for both agent and ingest flows.
  * Updated the confirmation dialog to support an optional in-progress loading state (disabling confirmation and showing a spinner).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->