### PR TITLE
fix: remove clickhouse connect from langflow image

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -55,7 +55,8 @@ RUN pip install --no-cache-dir \
     torch \
     torchvision \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
-    uv
+    uv \
+    && pip uninstall -y clickhouse-connect
 
 # Create a symlink for backwards compatibility with the 'langflow' command
 RUN ln -s /opt/app-root/bin/langflow-base /usr/local/bin/langflow


### PR DESCRIPTION
This pull request makes a minor change to the `Dockerfile.langflow` to address package management. The main update is the removal of the `clickhouse-connect` package after installation.

- Dependency management:
  * Uninstalls the `clickhouse-connect` package after all dependencies are installed to ensure it is not present in the final Docker image.