### PR TITLE
fix: disable service account token automounting at pod spec level

### DIFF
--- a/kubernetes/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/kubernetes/operator/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: manager
         env:

--- a/kubernetes/operator/config/manager/manager.yaml
+++ b/kubernetes/operator/config/manager/manager.yaml
@@ -18,6 +18,7 @@ spec:
         control-plane: controller-manager
     spec:
       serviceAccountName: controller-manager
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
Addresses SonarQube security findings kubernetes:S6865 by explicitly disabling automountServiceAccountToken at the pod spec level in addition to the ServiceAccount level.

This implements defense-in-depth by ensuring token automounting is disabled at both ServiceAccount and Pod levels, following Kubernetes security best practices.

Fixes: kubernetes:S6865 (2 findings)
Related: SonarQube static security analysis

<img width="1858" height="92" alt="image" src="https://github.com/user-attachments/assets/e8ddd8cf-fb24-4f5e-9a71-e83eeeacd8ec" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated controller manager deployment configurations to disable automatic service account token mounting in pod specifications across multiple configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->