### PR TITLE
fix: disable service account token automounting at pod spec level

### DIFF
--- a/kubernetes/operator/config/default/manager_auth_proxy_patch.yaml
+++ b/kubernetes/operator/config/default/manager_auth_proxy_patch.yaml
@@ -8,6 +8,7 @@ metadata:
 spec:
   template:
     spec:
+      automountServiceAccountToken: false
       containers:
       - name: manager
         env:

--- a/kubernetes/operator/config/manager/manager.yaml
+++ b/kubernetes/operator/config/manager/manager.yaml
@@ -18,6 +18,7 @@ spec:
         control-plane: controller-manager
     spec:
       serviceAccountName: controller-manager
+      automountServiceAccountToken: false
       securityContext:
         runAsNonRoot: true
       containers:


### PR DESCRIPTION
**Description:**
- Cherry Picked Fix from main
 
Addresses SonarQube security findings kubernetes:S6865 by explicitly disabling automountServiceAccountToken at the pod spec level in addition to the ServiceAccount level.

Changes:
- Added automountServiceAccountToken: false to manager.yaml pod spec
- Added automountServiceAccountToken: false to manager_auth_proxy_patch.yaml

This implements defense-in-depth by ensuring token automounting is disabled at both ServiceAccount and Pod levels, following Kubernetes security best practices.

Fixes: kubernetes:S6865 (2 findings)
Related: SonarQube static security analysis