### PR TITLE
fix: use user JWT client for post-ingest index refresh under IBM auth

### DIFF
--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -602,9 +602,11 @@ class TaskService:
                         # using it here would silently fail; openrag_user_role grants
                         # indices:admin/refresh, so the user client can refresh.
                         session_manager = getattr(processor, "session_manager", None)
-                        if session_manager is not None:
+                        owner_user_id = getattr(processor, "owner_user_id", None)
+                        jwt_token = getattr(processor, "jwt_token", None)
+                        if session_manager is not None and owner_user_id and jwt_token:
                             opensearch_client = session_manager.get_user_opensearch_client(
-                                processor.owner_user_id, processor.jwt_token
+                                owner_user_id, jwt_token
                             )
                         else:
                             # Defensive fallback: works in non-IBM mode where the

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -595,9 +595,25 @@ class TaskService:
                 # the newly indexed chunks without hitting the near-real-time refresh window.
                 if upload_task.successful_files > 0:
                     try:
-                        from config.settings import clients, get_index_name
+                        from config.settings import get_index_name
 
-                        await clients.opensearch.indices.refresh(index=get_index_name())
+                        # Refresh with the user's JWT-scoped client. The global
+                        # client is unauthenticated when IBM_AUTH_ENABLED=true, so
+                        # using it here would silently fail; openrag_user_role grants
+                        # indices:admin/refresh, so the user client can refresh.
+                        session_manager = getattr(processor, "session_manager", None)
+                        if session_manager is not None:
+                            opensearch_client = session_manager.get_user_opensearch_client(
+                                processor.owner_user_id, processor.jwt_token
+                            )
+                        else:
+                            # Defensive fallback: works in non-IBM mode where the
+                            # global client is authenticated.
+                            from config.settings import clients
+
+                            opensearch_client = clients.opensearch
+
+                        await opensearch_client.indices.refresh(index=get_index_name())
                     except Exception as e:
                         logger.debug("Index refresh after ingest failed (non-fatal)", error=str(e))
 


### PR DESCRIPTION
@ -0,0 +1,74 @@
# fix: use user JWT client for post-ingest index refresh under IBM auth

## Description

After a custom-processor upload completes, `TaskService.background_custom_processor`
forces an OpenSearch index refresh **before** marking the task `COMPLETED`, so callers
polling for completion can immediately query or delete the freshly-indexed chunks
instead of waiting out the near-real-time refresh window.

That refresh used the **global** OpenSearch client:

```python
await clients.opensearch.indices.refresh(index=get_index_name())
```

But the global client is built in `AppClients.initialize()` as:

```python
http_auth = None if IBM_AUTH_ENABLED else (OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD)
```

So when `IBM_AUTH_ENABLED=true` (on-prem with IBM auth), the global client is
**unauthenticated**. The refresh request is rejected, the exception is swallowed as a
non-fatal `DEBUG` log, the refresh never happens, and pollers can observe **zero
chunks** right after a "completed" ingest.

## Fix

Refresh with the **user's JWT-scoped client** at this call site instead of the global
client, deriving it from the in-scope `processor`:

```python
session_manager = getattr(processor, "session_manager", None)
if session_manager is not None:
    opensearch_client = session_manager.get_user_opensearch_client(
        processor.owner_user_id, processor.jwt_token
    )
else:
    from config.settings import clients
    opensearch_client = clients.opensearch  # defensive fallback (non-IBM mode)

await opensearch_client.indices.refresh(index=get_index_name())
```

This mirrors the existing, working pattern already used by the other two
background-task refreshes in `src/models/processors.py`. The credential (Bearer JWT or
`Basic ...`) is passed verbatim by `create_opensearch_client_from_jwt`, so basic
credentials work too.

## Why this is safe

- `openrag_user_role` is explicitly granted `indices:admin/refresh` on `documents*`
  (`securityconfig/roles.yml`; identical in `cloud_securityconfig/roles.yml`), so a
  user-scoped client has permission to refresh.
- The JWT is reachable in the background task via the `processor`
  (`DocumentFileProcessor` / `LangflowFileProcessor` carry `session_manager`,
  `owner_user_id`, and `jwt_token`).
- No change to the global client's auth → **zero blast radius** on cloud / non-IBM
  deployments.

## Out of scope

- The other refresh sites already use the user client and need no change.
- The global client's `http_auth` in `AppClients.initialize()` is intentionally left
  unchanged.
