### PR TITLE
fix: remove dangerouslySetInnerHtml

### DIFF
--- a/frontend/components/icons/animated-processing-icon.tsx
+++ b/frontend/components/icons/animated-processing-icon.tsx
@@ -60,8 +60,7 @@ const AnimatedProcessingIcon = ({
       {...props}
     >
       <title>Animated Processing Icon</title>
-      {/* Inject animation styles into the SVG's shadow */}
-      <style dangerouslySetInnerHTML={{ __html: animationCSS }} />
+      <style>{animationCSS}</style>
 
       {/* State 1 */}
       <g className="state-1">

--- a/frontend/components/icons/dog-icon.tsx
+++ b/frontend/components/icons/dog-icon.tsx
@@ -76,7 +76,7 @@ const DogIcon = ({ disabled = false, stroke, ...props }: DogIconProps) => {
     >
       <title>Dog Icon</title>
       <defs>
-        <style dangerouslySetInnerHTML={{ __html: animationCSS }} />
+        <style>{animationCSS}</style>
       </defs>
 
       {/* State 1 - Add 14px left padding to align with state 3 */}


### PR DESCRIPTION
removes two instances of `dangerouslySetInnerHTML` which bypasses Reacts XSS protection. No functional changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced code quality and maintainability of icon rendering mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->