### PR TITLE
feat: CIO - Add shared flag for COS ingestion to allow documents to be indexed without an owner

### DIFF
--- a/alembic/versions/0007_add_knowledge_delete_anonymous.py
+++ b/alembic/versions/0007_add_knowledge_delete_anonymous.py
@@ -1,0 +1,92 @@
+"""add knowledge:delete:anonymous permission
+
+Revision ID: 0007_add_knowledge_delete_anonymous
+Revises: 0006_revoke_provider_override_nonadmin
+Create Date: 2026-06-11 00:00:00.000000
+
+Adds a dedicated permission for deleting ownerless shared documents and grants
+it to the built-in admin role. The existing knowledge:delete:any permission is
+left unchanged.
+"""
+
+import uuid
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0007_add_knowledge_delete_anonymous"
+down_revision: str | Sequence[str] | None = "0006_revoke_provider_override_nonadmin"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_PERMISSION_NAME = "knowledge:delete:anonymous"
+_ADMIN_ROLE_NAME = "admin"
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    permission_id = bind.execute(
+        sa.text("SELECT id FROM permissions WHERE name = :name"),
+        {"name": _PERMISSION_NAME},
+    ).scalar()
+
+    if permission_id is None:
+        permission_id = str(uuid.uuid4())
+        bind.execute(
+            sa.text(
+                "INSERT INTO permissions "
+                "(id, name, resource, action, description) "
+                "VALUES (:id, :name, :resource, :action, :description)"
+            ),
+            {
+                "id": permission_id,
+                "name": _PERMISSION_NAME,
+                "resource": "knowledge",
+                "action": "delete:anonymous",
+                "description": "Delete anonymous shared documents",
+            },
+        )
+
+    admin_role_id = bind.execute(
+        sa.text("SELECT id FROM roles WHERE name = :name"),
+        {"name": _ADMIN_ROLE_NAME},
+    ).scalar()
+    if admin_role_id is None:
+        return
+
+    existing = bind.execute(
+        sa.text(
+            "SELECT 1 FROM role_permissions "
+            "WHERE role_id = :role_id AND permission_id = :permission_id"
+        ),
+        {"role_id": admin_role_id, "permission_id": permission_id},
+    ).first()
+    if existing is None:
+        bind.execute(
+            sa.text(
+                "INSERT INTO role_permissions (role_id, permission_id) "
+                "VALUES (:role_id, :permission_id)"
+            ),
+            {"role_id": admin_role_id, "permission_id": permission_id},
+        )
+
+
+def downgrade() -> None:
+    bind = op.get_bind()
+    permission_id = bind.execute(
+        sa.text("SELECT id FROM permissions WHERE name = :name"),
+        {"name": _PERMISSION_NAME},
+    ).scalar()
+    if permission_id is None:
+        return
+
+    bind.execute(
+        sa.text("DELETE FROM role_permissions WHERE permission_id = :permission_id"),
+        {"permission_id": permission_id},
+    )
+    bind.execute(
+        sa.text("DELETE FROM permissions WHERE id = :permission_id"),
+        {"permission_id": permission_id},
+    )

--- a/frontend/app/api/mutations/useSyncConnector.ts
+++ b/frontend/app/api/mutations/useSyncConnector.ts
@@ -77,6 +77,8 @@ const syncConnector = async ({
     bucket_filter?: string[];
     /** When true, replace any indexed document with the same filename. */
     replace_duplicates?: boolean;
+    /** When true (COS only), index without an owner so all users in the instance can retrieve the document. */
+    shared?: boolean;
   };
 }): Promise<SyncResponse> => {
   const response = await fetch(`/api/connectors/${connectorType}/sync`, {

--- a/frontend/components/cloud-picker/ingest-settings.tsx
+++ b/frontend/components/cloud-picker/ingest-settings.tsx
@@ -42,6 +42,8 @@ interface IngestSettingsProps {
   onOpenChange: (open: boolean) => void;
   settings?: IngestSettingsType;
   onSettingsChange?: (settings: IngestSettingsType) => void;
+  /** When true, show the "Make documents available to all users" toggle. COS ingestion only. */
+  showShared?: boolean;
 }
 
 export const IngestSettings = ({
@@ -49,6 +51,7 @@ export const IngestSettings = ({
   onOpenChange,
   settings,
   onSettingsChange,
+  showShared = false,
 }: IngestSettingsProps) => {
   const { isAuthenticated, isNoAuthMode } = useAuth();
 
@@ -244,7 +247,13 @@ export const IngestSettings = ({
             />
           </div>
 
-          <div className="flex items-center justify-between">
+          <div
+            className={
+              showShared
+                ? "flex items-center justify-between border-b pb-3 mb-3"
+                : "flex items-center justify-between"
+            }
+          >
             <div>
               <div className="text-sm pb-2 font-semibold">
                 Picture descriptions
@@ -260,6 +269,26 @@ export const IngestSettings = ({
               }
             />
           </div>
+
+          {showShared && (
+            <div className="flex items-center justify-between">
+              <div>
+                <div className="text-sm pb-2 font-semibold">
+                  Make documents available to all users
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Shared documents are visible to all users in this OpenRAG
+                  instance.
+                </div>
+              </div>
+              <Switch
+                checked={currentSettings.shared ?? false}
+                onCheckedChange={(checked) =>
+                  handleSettingsChange({ shared: checked })
+                }
+              />
+            </div>
+          )}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/frontend/components/cloud-picker/types.ts
+++ b/frontend/components/cloud-picker/types.ts
@@ -113,6 +113,8 @@ export interface IngestSettings {
   ocr: boolean;
   pictureDescriptions: boolean;
   embeddingModel: string;
+  /** When true, index without an owner so all users in the instance can retrieve the document. COS only. */
+  shared?: boolean;
 }
 
 /** Inline error message if chunk settings are invalid; otherwise null. */

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -22,6 +22,8 @@ export interface SharedBucketViewProps {
   addTask: (id: string, options?: { connectorType?: string }) => void;
   onBack: () => void;
   onDone: () => void;
+  /** When true, show the "Make documents available to all users" toggle. COS ingestion only. */
+  showShared?: boolean;
 }
 
 export function SharedBucketView({
@@ -35,6 +37,7 @@ export function SharedBucketView({
   addTask,
   onBack,
   onDone,
+  showShared = false,
 }: SharedBucketViewProps) {
   const queryClient = useQueryClient();
   const [selectedBuckets, setSelectedBuckets] = useState<Set<string>>(
@@ -76,6 +79,7 @@ export function SharedBucketView({
           selected_files: [],
           bucket_filter: Array.from(selectedBuckets),
           settings: ingestSettings,
+          shared: showShared ? (ingestSettings.shared ?? false) : undefined,
         },
       },
       {
@@ -239,6 +243,7 @@ export function SharedBucketView({
           onOpenChange={setIsSettingsOpen}
           settings={ingestSettings}
           onSettingsChange={setIngestSettings}
+          showShared={showShared}
         />
       </div>
 

--- a/frontend/components/knowledge-actions-dropdown.tsx
+++ b/frontend/components/knowledge-actions-dropdown.tsx
@@ -196,7 +196,7 @@ export const KnowledgeActionsDropdown = ({
             </TooltipProvider>
           )}
           <RequirePermission
-            anyOf={["knowledge:delete:own", "knowledge:delete:any"]}
+            anyOf={["knowledge:delete:own", "knowledge:delete:anonymous"]}
           >
             <DropdownMenuItem
               className="text-destructive focus:text-destructive cursor-pointer"

--- a/frontend/components/knowledge-batch-actions-bar.tsx
+++ b/frontend/components/knowledge-batch-actions-bar.tsx
@@ -14,7 +14,10 @@ export const KnowledgeBatchActionsBar = ({
   onCancel,
 }: KnowledgeBatchActionsBarProps) => {
   const { canAny } = usePermissions();
-  const canDelete = canAny(["knowledge:delete:own", "knowledge:delete:any"]);
+  const canDelete = canAny([
+    "knowledge:delete:own",
+    "knowledge:delete:anonymous",
+  ]);
   return (
     <div className="flex h-12 w-full items-stretch bg-primary text-primary-foreground">
       <button

--- a/frontend/enhancements/connectors/ibm-cos/components/bucket-view.tsx
+++ b/frontend/enhancements/connectors/ibm-cos/components/bucket-view.tsx
@@ -37,6 +37,7 @@ export function IBMCOSBucketView({
       addTask={addTask}
       onBack={onBack}
       onDone={onDone}
+      showShared
     />
   );
 }

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -26,6 +26,7 @@ class DocumentsClient:
         wait: bool = True,
         poll_interval: float = 1.0,
         timeout: float = 300.0,
+        shared: bool = False,
     ) -> IngestResponse | IngestTaskStatus:
         """
         Ingest a document into the knowledge base.
@@ -37,6 +38,9 @@ class DocumentsClient:
             wait: If True, poll until ingestion completes. If False, return immediately.
             poll_interval: Seconds between status checks when waiting.
             timeout: Maximum seconds to wait for completion.
+            shared: If True, index the document without an owner so all users in
+                the same OpenRAG instance can retrieve it. Defaults to False (private).
+                COS ingestion only; temporary mechanism until OpenRAG-level ACLs land.
 
         Returns:
             IngestTaskStatus with final status if wait=True.
@@ -46,6 +50,8 @@ class DocumentsClient:
             ValueError: If neither file_path nor file is provided.
             TimeoutError: If ingestion doesn't complete within timeout.
         """
+        extra_data = {"shared": "true"} if shared else {}
+
         if file_path is not None:
             path = Path(file_path)
             with open(path, "rb") as f:
@@ -54,6 +60,7 @@ class DocumentsClient:
                     "POST",
                     "/api/v1/documents/ingest",
                     files=files,
+                    data=extra_data or None,
                 )
         elif file is not None:
             if filename is None:
@@ -63,6 +70,7 @@ class DocumentsClient:
                 "POST",
                 "/api/v1/documents/ingest",
                 files=files,
+                data=extra_data or None,
             )
         else:
             raise ValueError("Either file_path or file must be provided")

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -26,7 +26,6 @@ class DocumentsClient:
         wait: bool = True,
         poll_interval: float = 1.0,
         timeout: float = 300.0,
-        shared: bool = False,
     ) -> IngestResponse | IngestTaskStatus:
         """
         Ingest a document into the knowledge base.
@@ -38,9 +37,6 @@ class DocumentsClient:
             wait: If True, poll until ingestion completes. If False, return immediately.
             poll_interval: Seconds between status checks when waiting.
             timeout: Maximum seconds to wait for completion.
-            shared: If True, index the document without an owner so all users in
-                the same OpenRAG instance can retrieve it. Defaults to False (private).
-                COS ingestion only; temporary mechanism until OpenRAG-level ACLs land.
 
         Returns:
             IngestTaskStatus with final status if wait=True.
@@ -50,8 +46,6 @@ class DocumentsClient:
             ValueError: If neither file_path nor file is provided.
             TimeoutError: If ingestion doesn't complete within timeout.
         """
-        extra_data = {"shared": "true"} if shared else {}
-
         if file_path is not None:
             path = Path(file_path)
             with open(path, "rb") as f:
@@ -60,7 +54,6 @@ class DocumentsClient:
                     "POST",
                     "/api/v1/documents/ingest",
                     files=files,
-                    data=extra_data or None,
                 )
         elif file is not None:
             if filename is None:
@@ -70,7 +63,6 @@ class DocumentsClient:
                 "POST",
                 "/api/v1/documents/ingest",
                 files=files,
-                data=extra_data or None,
             )
         else:
             raise ValueError("Either file_path or file must be provided")

--- a/sdks/typescript/src/documents.ts
+++ b/sdks/typescript/src/documents.ts
@@ -24,6 +24,12 @@ export interface IngestOptions {
   pollInterval?: number;
   /** Maximum seconds to wait for completion. Default: 300. */
   timeout?: number;
+  /**
+   * If true, index the document without an owner so all users in the same
+   * OpenRAG instance can retrieve it. Defaults to false (private).
+   * COS ingestion only; temporary mechanism until OpenRAG-level ACLs land.
+   */
+  shared?: boolean;
 }
 
 export class DocumentsClient {
@@ -62,6 +68,10 @@ export class DocumentsClient {
       formData.append("file", options.file, options.filename);
     } else {
       throw new Error("Either filePath or file must be provided");
+    }
+
+    if (options.shared) {
+      formData.append("shared", "true");
     }
 
     const response = await this.client._request(

--- a/sdks/typescript/src/documents.ts
+++ b/sdks/typescript/src/documents.ts
@@ -24,12 +24,6 @@ export interface IngestOptions {
   pollInterval?: number;
   /** Maximum seconds to wait for completion. Default: 300. */
   timeout?: number;
-  /**
-   * If true, index the document without an owner so all users in the same
-   * OpenRAG instance can retrieve it. Defaults to false (private).
-   * COS ingestion only; temporary mechanism until OpenRAG-level ACLs land.
-   */
-  shared?: boolean;
 }
 
 export class DocumentsClient {
@@ -68,10 +62,6 @@ export class DocumentsClient {
       formData.append("file", options.file, options.filename);
     } else {
       throw new Error("Either filePath or file must be provided");
-    }
-
-    if (options.shared) {
-      formData.append("shared", "true");
     }
 
     const response = await this.client._request(

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -386,6 +386,10 @@ class ConnectorSyncBody(BaseModel):
     # rather than failing. Set by the provider upload UI after the user confirms
     # overwrite in the duplicate dialog.
     replace_duplicates: bool = False
+    # When True (COS only), index chunks without an owner field so OpenSearch DLS
+    # makes them visible to all users in the instance. Temporary CIO mechanism;
+    # not a full ACL feature. Defaults to False (private).
+    shared: bool = False
 
 
 class ConnectorCheckDuplicatesBody(BaseModel):
@@ -672,6 +676,12 @@ async def connector_sync(
         )
         jwt_token = user.jwt_token
 
+        if body.shared and connector_type != "ibm_cos":
+            return JSONResponse(
+                {"detail": "shared flag is only supported for the ibm_cos connector"},
+                status_code=400,
+            )
+
         # Get all active connections for this connector type and user
         connections = await connector_service.connection_manager.list_connections(
             user_id=user.user_id, connector_type=connector_type
@@ -739,6 +749,7 @@ async def connector_sync(
                 file_infos=file_infos,
                 ingest_settings=body.settings,
                 replace_duplicates=body.replace_duplicates,
+                shared=body.shared,
             )
         elif body.sync_all or body.bucket_filter:
             # Full ingest: discover and ingest all files (or files from specific buckets).
@@ -780,6 +791,7 @@ async def connector_sync(
                     all_file_ids,
                     jwt_token=jwt_token,
                     ingest_settings=body.settings,
+                    shared=body.shared,
                 )
             else:
                 # sync_all: ingest everything the connector can see
@@ -788,6 +800,7 @@ async def connector_sync(
                     user.user_id,
                     max_files=max_files,
                     jwt_token=jwt_token,
+                    shared=body.shared,
                 )
         else:
             # No files specified - sync only files already in OpenSearch for this connector

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -678,7 +678,7 @@ async def connector_sync(
 
         if body.shared and connector_type != "ibm_cos":
             return JSONResponse(
-                {"detail": "shared flag is only supported for the ibm_cos connector"},
+                {"error": "shared flag is only supported for the ibm_cos connector"},
                 status_code=400,
             )
 

--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -1,12 +1,22 @@
-from fastapi import Depends
+from fastapi import Depends, Request
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
-from dependencies import get_current_user, get_session_manager, require_permission
+from dependencies import (
+    get_current_user,
+    get_rbac_service,
+    get_session_manager,
+    has_effective_permission,
+    require_any_permission,
+)
 from session_manager import User
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+require_document_delete_permission = require_any_permission(
+    ("knowledge:delete:own", "knowledge:delete:anonymous")
+)
 
 
 class DeleteDocumentBody(BaseModel):
@@ -18,11 +28,18 @@ async def delete_documents_by_filename_core(
     session_manager,
     user_id: str,
     jwt_token: str | None,
+    can_delete_own: bool = True,
+    can_delete_anonymous: bool = False,
 ):
     """Shared delete-by-filename logic for v1 and non-v1 endpoints."""
     from config.settings import get_index_name
     from utils.opensearch_delete import collect_visible_document_ids, delete_document_ids
-    from utils.opensearch_queries import build_filename_query, build_owned_filename_query
+    from utils.opensearch_queries import (
+        build_anonymous_filename_query,
+        build_filename_query,
+        build_owned_filename_query,
+        build_replace_filename_query,
+    )
 
     normalized_filename = (filename or "").strip()
     if not normalized_filename:
@@ -38,16 +55,58 @@ async def delete_documents_by_filename_core(
         )
 
     try:
-        opensearch_client = session_manager.get_user_opensearch_client(user_id, jwt_token)
         index_name = get_index_name()
+        from config.settings import clients
 
-        owned_document_ids = await collect_visible_document_ids(
-            opensearch_client,
-            index=index_name,
-            query=build_owned_filename_query(normalized_filename, user_id),
-        )
+        write_client = clients.opensearch
 
-        if not owned_document_ids:
+        if can_delete_own and can_delete_anonymous:
+            if write_client is None:
+                raise RuntimeError("Backend OpenSearch client is unavailable")
+            document_ids = await collect_visible_document_ids(
+                write_client,
+                index=index_name,
+                query=build_replace_filename_query(normalized_filename, user_id),
+            )
+        elif can_delete_anonymous:
+            if write_client is None:
+                raise RuntimeError("Backend OpenSearch client is unavailable")
+            document_ids = await collect_visible_document_ids(
+                write_client,
+                index=index_name,
+                query=build_anonymous_filename_query(normalized_filename),
+            )
+        elif can_delete_own:
+            opensearch_client = session_manager.get_user_opensearch_client(user_id, jwt_token)
+            document_ids = await collect_visible_document_ids(
+                opensearch_client,
+                index=index_name,
+                query=build_owned_filename_query(normalized_filename, user_id),
+            )
+        else:
+            return (
+                {
+                    "success": False,
+                    "deleted_chunks": 0,
+                    "filename": normalized_filename,
+                    "message": None,
+                    "error": "Access denied: insufficient permissions",
+                },
+                403,
+            )
+
+        if not document_ids:
+            if can_delete_anonymous:
+                return (
+                    {
+                        "success": False,
+                        "deleted_chunks": 0,
+                        "filename": normalized_filename,
+                        "message": None,
+                        "error": "No matching document chunks were deleted. The file may be missing or not deletable in the current user context.",
+                    },
+                    404,
+                )
             visible_check = await opensearch_client.search(
                 index=index_name,
                 body={
@@ -79,12 +138,12 @@ async def delete_documents_by_filename_core(
                 404,
             )
 
-        from config.settings import clients
-
+        if write_client is None:
+            raise RuntimeError("Backend OpenSearch client is unavailable")
         deleted_count = await delete_document_ids(
-            clients.opensearch,
+            write_client,
             index=index_name,
-            document_ids=owned_document_ids,
+            document_ids=document_ids,
         )
         logger.info(
             f"Deleted {deleted_count} chunks for filename {normalized_filename}",
@@ -242,14 +301,30 @@ async def check_filename_exists(
 
 async def delete_documents_by_filename(
     body: DeleteDocumentBody,
+    request: Request,
     session_manager=Depends(get_session_manager),
-    user: User = Depends(require_permission("knowledge:delete:own")),
+    rbac=Depends(get_rbac_service),
+    user: User = Depends(require_document_delete_permission),
 ):
     """Delete all documents with a specific filename"""
+    can_delete_own = await has_effective_permission(
+        request,
+        user,
+        rbac,
+        "knowledge:delete:own",
+    )
+    can_delete_anonymous = await has_effective_permission(
+        request,
+        user,
+        rbac,
+        "knowledge:delete:anonymous",
+    )
     payload, status_code = await delete_documents_by_filename_core(
         filename=body.filename,
         session_manager=session_manager,
         user_id=user.user_id,
         jwt_token=user.jwt_token,
+        can_delete_own=can_delete_own,
+        can_delete_anonymous=can_delete_anonymous,
     )
     return JSONResponse(payload, status_code=status_code)

--- a/src/api/v1/documents.py
+++ b/src/api/v1/documents.py
@@ -5,7 +5,7 @@ Provides document ingestion and management.
 Uses API key authentication.
 """
 
-from fastapi import Depends, File, Form, UploadFile
+from fastapi import Depends, File, Form, Request, UploadFile
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
@@ -16,14 +16,21 @@ from dependencies import (
     get_document_service,
     get_knowledge_filter_service,
     get_langflow_file_service,
+    get_rbac_service,
     get_session_manager,
     get_task_service,
+    has_effective_permission,
+    require_api_key_any_permission,
     require_api_key_permission,
 )
 from session_manager import User
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+require_document_delete_permission = require_api_key_any_permission(
+    ("knowledge:delete:own", "knowledge:delete:anonymous")
+)
 
 
 class DeleteDocV1Body(BaseModel):
@@ -128,8 +135,10 @@ async def task_status_enhanced_endpoint(
 
 async def delete_document_endpoint(
     body: DeleteDocV1Body,
+    request: Request,
     session_manager=Depends(get_session_manager),
-    user: User = Depends(require_api_key_permission("knowledge:delete:own")),
+    rbac=Depends(get_rbac_service),
+    user: User = Depends(require_document_delete_permission),
     knowledge_filter_service=Depends(get_knowledge_filter_service),
 ):
     """Delete document(s) from the knowledge base. DELETE /v1/documents
@@ -145,6 +154,19 @@ async def delete_document_endpoint(
             {"error": "Provide exactly one of `filename` or `filter_id`"},
             status_code=400,
         )
+
+    can_delete_own = await has_effective_permission(
+        request,
+        user,
+        rbac,
+        "knowledge:delete:own",
+    )
+    can_delete_anonymous = await has_effective_permission(
+        request,
+        user,
+        rbac,
+        "knowledge:delete:anonymous",
+    )
 
     if body.filter_id:
         resolved = await resolve_filter_id(
@@ -169,6 +191,8 @@ async def delete_document_endpoint(
                 session_manager=session_manager,
                 user_id=user.user_id,
                 jwt_token=user.jwt_token,
+                can_delete_own=can_delete_own,
+                can_delete_anonymous=can_delete_anonymous,
             )
             results.append(payload)
             statuses.append(_status)
@@ -189,5 +213,7 @@ async def delete_document_endpoint(
         session_manager=session_manager,
         user_id=user.user_id,
         jwt_token=user.jwt_token,
+        can_delete_own=can_delete_own,
+        can_delete_anonymous=can_delete_anonymous,
     )
     return JSONResponse(payload, status_code=status_code)

--- a/src/connectors/service.py
+++ b/src/connectors/service.py
@@ -323,6 +323,7 @@ class ConnectorService:
         jwt_token: str = None,
         filename_filter: set = None,
         replace_duplicates: bool = False,
+        shared: bool = False,
     ) -> str:
         """
         Sync files from a connector connection using existing task tracking system.
@@ -421,6 +422,7 @@ class ConnectorService:
             ),
             models_service=self.models_service,
             replace_duplicates=replace_duplicates,
+            shared=shared,
         )
 
         # Use file IDs as items (no more fake file paths!)
@@ -449,6 +451,7 @@ class ConnectorService:
         file_infos: list[dict[str, Any]] = None,
         ingest_settings: dict[str, Any] | None = None,
         replace_duplicates: bool = False,
+        shared: bool = False,
     ) -> str:
         """
         Sync specific files by their IDs (used for webhook-triggered syncs or manual selection).
@@ -603,6 +606,7 @@ class ConnectorService:
             models_service=self.models_service,
             ingest_settings=ingest_settings,
             replace_duplicates=replace_duplicates,
+            shared=shared,
         )
 
         # Create custom task using TaskService

--- a/src/db/seed.py
+++ b/src/db/seed.py
@@ -56,6 +56,7 @@ PERMISSIONS: list[tuple[str, str, str]] = [
     ("knowledge", "upload", "Upload documents"),
     ("knowledge", "delete:own", "Delete own documents"),
     ("knowledge", "delete:any", "Delete any document"),
+    ("knowledge", "delete:anonymous", "Delete anonymous shared documents"),
     ("knowledge", "read:own", "Read own documents"),
     ("knowledge", "read:all", "Read all documents"),
     ("kf", "create", "Create knowledge filters"),

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -396,6 +396,38 @@ def require_permission(perm: str):
     return _dep
 
 
+def require_any_permission(required_perms: Sequence[str]):
+    """Require at least one permission for a browser-authenticated request."""
+    required = tuple(required_perms)
+    if not required:
+        raise ValueError("require_any_permission requires at least one permission")
+
+    from services.rbac_service import is_rbac_enforced
+
+    async def _dep(
+        request: Request,
+        user: User = Depends(get_current_user),
+        rbac=Depends(get_rbac_service),
+    ) -> User:
+        if not is_rbac_enforced():
+            return await _attach_db_user_id(request, user)
+        role_override = getattr(request.state, "api_key_role_ids", None)
+        db_user_id = await _resolve_db_user_id(user)
+        user = dataclasses.replace(user, db_user_id=db_user_id)
+        request.state.db_user_id = db_user_id
+        request.state.user = user
+        perms = await rbac.get_user_permissions(db_user_id, role_override=role_override)
+        if not any(perm in perms for perm in required):
+            await rbac.audit_denied(db_user_id, "|".join(required))
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "permission_denied", "required": list(required)},
+            )
+        return user
+
+    return _dep
+
+
 def require_api_key_permission(perm: str):
     """Like ``require_permission``, but for the /v1 (API-key / forwarded-JWT)
     surface: resolves identity via ``get_api_key_user_async`` instead of
@@ -428,6 +460,51 @@ def require_api_key_permission(perm: str):
         return user
 
     return _dep
+
+
+def require_api_key_any_permission(required_perms: Sequence[str]):
+    """Require at least one permission for an API-key or forwarded-JWT request."""
+    required = tuple(required_perms)
+    if not required:
+        raise ValueError("require_api_key_any_permission requires at least one permission")
+
+    from services.rbac_service import is_rbac_enforced
+
+    async def _dep(
+        request: Request,
+        user: User = Depends(get_api_key_user_async),
+        rbac=Depends(get_rbac_service),
+    ) -> User:
+        if not is_rbac_enforced():
+            return user
+        db_user_id = user.db_user_id or user.user_id
+        role_override = getattr(request.state, "api_key_role_ids", None)
+        perms = await rbac.get_user_permissions(db_user_id, role_override=role_override)
+        if not any(perm in perms for perm in required):
+            await rbac.audit_denied(db_user_id, "|".join(required))
+            raise HTTPException(
+                status_code=403,
+                detail={"error": "permission_denied", "required": list(required)},
+            )
+        return user
+
+    return _dep
+
+
+async def has_effective_permission(
+    request: Request,
+    user: User,
+    rbac,
+    perm: str,
+) -> bool:
+    """Check a permission using the same RBAC and API-key override semantics as route gates."""
+    from services.rbac_service import is_rbac_enforced
+
+    if not is_rbac_enforced():
+        return True
+    user_id = user.db_user_id or user.user_id
+    role_override = getattr(request.state, "api_key_role_ids", None)
+    return await rbac.has_permission(user_id, perm, role_override=role_override)
 
 
 def require_all_permissions(required_perms: Sequence[str]):

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -39,6 +39,23 @@ def _verification_client(fallback_client):
     return clients.opensearch if clients.opensearch is not None else fallback_client
 
 
+def resolve_shared_owner_fields(
+    user_id: str | None,
+    owner_name: str | None,
+    owner_email: str | None,
+    shared: bool,
+) -> tuple[str | None, str | None, str | None]:
+    """Return (owner, owner_name, owner_email) for indexing.
+
+    When shared=True, all three are None so the indexed chunk omits the owner
+    field entirely, triggering the OpenSearch DLS must_not-exists-owner clause
+    that makes the document visible to all users in the instance.
+    """
+    if shared:
+        return None, None, None
+    return user_id, owner_name, owner_email
+
+
 class TaskProcessor:
     """Base class for task processors with shared processing logic"""
 
@@ -249,6 +266,7 @@ class TaskProcessor:
         is_sample_data: bool = False,
         acl: "DocumentACL | None" = None,
         connector_file_id: str | None = None,
+        shared: bool = False,
     ):
         """
         Standard processing pipeline for non-Langflow processors:
@@ -400,9 +418,11 @@ class TaskProcessor:
                 error=str(e),
             )
 
-        # Owner is always the authenticated uploading/syncing user. Upstream ACL
-        # owners/authors only contribute read access through allowed principals.
-        owner = owner_user_id
+        # Owner is always the authenticated uploading/syncing user unless shared=True,
+        # in which case owner fields are omitted so DLS makes the doc visible to all users.
+        owner, owner_name, owner_email = resolve_shared_owner_fields(
+            owner_user_id, owner_name, owner_email, shared
+        )
         if acl:
             allowed_users = acl.allowed_users or []
             allowed_groups = acl.allowed_groups or []
@@ -635,6 +655,7 @@ class ConnectorFileProcessor(TaskProcessor):
         models_service=None,
         ingest_settings: dict[str, Any] | None = None,
         replace_duplicates: bool = False,
+        shared: bool = False,
     ):
         super().__init__(
             document_service=document_service,
@@ -650,6 +671,7 @@ class ConnectorFileProcessor(TaskProcessor):
         self.owner_email = owner_email
         self.ingest_settings = ingest_settings
         self.replace_duplicates = replace_duplicates
+        self.shared = shared
 
     async def process_item(self, upload_task: UploadTask, item: str, file_task: FileTask) -> None:
         """Process a connector file using unified methods"""
@@ -877,15 +899,20 @@ class ConnectorFileProcessor(TaskProcessor):
                         {}, connector_tweak_settings
                     )
 
+                    effective_owner, effective_owner_name, effective_owner_email = (
+                        resolve_shared_owner_fields(
+                            self.user_id, self.owner_name, self.owner_email, self.shared
+                        )
+                    )
                     result = await self.connector_service.langflow_service.upload_and_ingest_file(
                         file_tuple=file_tuple,
                         session_id=None,
                         tweaks=tweaks,
                         settings=self.ingest_settings,
                         jwt_token=self.jwt_token,
-                        owner=self.user_id,
-                        owner_name=self.owner_name,
-                        owner_email=self.owner_email,
+                        owner=effective_owner,
+                        owner_name=effective_owner_name,
+                        owner_email=effective_owner_email,
                         connector_type=connection.connector_type,
                         docling_polling_service=self.connector_service.task_service.docling_polling_service
                         if self.connector_service.task_service
@@ -939,6 +966,7 @@ class ConnectorFileProcessor(TaskProcessor):
                         connector_type=connection.connector_type,
                         acl=document.acl,
                         connector_file_id=document.id,
+                        shared=self.shared,
                         **standard_kwargs,
                     )
 

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -202,13 +202,14 @@ class TaskProcessor:
         filename: str,
         opensearch_client,
         owner_user_id: str | None = None,
+        shared: bool = False,
     ) -> None:
         """
         Delete all chunks of a document with the given filename from OpenSearch.
         """
         from config.settings import clients, get_index_name
         from utils.opensearch_delete import collect_visible_document_ids, delete_document_ids
-        from utils.opensearch_queries import build_owned_filename_query
+        from utils.opensearch_queries import build_owned_filename_query, build_replace_filename_query
 
         try:
             write_client = clients.opensearch
@@ -230,11 +231,18 @@ class TaskProcessor:
                     filename=filename,
                 )
                 return
+
+            # When shared=True the document being replaced may have previously
+            # been ingested without an owner field (also shared), so the normal
+            # owner-scoped query would miss those chunks.  Use a broader query
+            # that covers both owned and ownerless chunks for this filename.
+            build_query = build_replace_filename_query if shared else build_owned_filename_query
+
             for candidate in candidate_filenames:
                 document_ids = await collect_visible_document_ids(
                     opensearch_client,
                     index=get_index_name(),
-                    query=build_owned_filename_query(candidate, owner_user_id),
+                    query=build_query(candidate, owner_user_id),
                 )
                 deleted_count += await delete_document_ids(
                     write_client,
@@ -816,6 +824,7 @@ class ConnectorFileProcessor(TaskProcessor):
                     document.filename,
                     opensearch_client,
                     owner_user_id=self.user_id,
+                    shared=self.shared,
                 )
 
             # Create temporary file from document content

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -5,6 +5,7 @@ import time
 from typing import TYPE_CHECKING, Any, Literal
 
 from config.settings import clients, get_embedding_model, get_index_name, get_openrag_config
+from session_manager import AnonymousUser
 from utils.document_processing import (
     extract_relevant,
     process_text_file,
@@ -47,12 +48,15 @@ def resolve_shared_owner_fields(
 ) -> tuple[str | None, str | None, str | None]:
     """Return (owner, owner_name, owner_email) for indexing.
 
-    When shared=True, all three are None so the indexed chunk omits the owner
-    field entirely, triggering the OpenSearch DLS must_not-exists-owner clause
-    that makes the document visible to all users in the instance.
+    When shared=True, owner is None so the indexed chunk omits the owner field
+    entirely, triggering the OpenSearch DLS must_not-exists-owner clause that
+    makes the document visible to all users in the instance. owner_name and
+    owner_email are set to AnonymousUser values, matching how default/sample
+    documents are loaded.
     """
     if shared:
-        return None, None, None
+        _anon = AnonymousUser()
+        return None, _anon.name, _anon.email
     return user_id, owner_name, owner_email
 
 

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -209,7 +209,10 @@ class TaskProcessor:
         """
         from config.settings import clients, get_index_name
         from utils.opensearch_delete import collect_visible_document_ids, delete_document_ids
-        from utils.opensearch_queries import build_owned_filename_query, build_replace_filename_query
+        from utils.opensearch_queries import (
+            build_owned_filename_query,
+            build_replace_filename_query,
+        )
 
         try:
             write_client = clients.opensearch

--- a/src/services/document_index_writer.py
+++ b/src/services/document_index_writer.py
@@ -208,7 +208,6 @@ class DocumentIndexWriter:
             else metadata.get("file_size"),
             "connector_type": context.connector_type or metadata.get("connector_type") or "local",
             "source_url": context.source_url or metadata.get("source_url") or "",
-            "owner": context.owner,
             "allowed_users": list(context.allowed_users),
             "allowed_groups": list(context.allowed_groups),
             "allowed_principals": unique_acl_principals(context.allowed_principals),
@@ -219,6 +218,8 @@ class DocumentIndexWriter:
             "metadata": metadata.get("metadata", {}),
         }
 
+        if context.owner is not None:
+            doc["owner"] = context.owner
         if context.owner_name is not None:
             doc["owner_name"] = context.owner_name
         if context.owner_email is not None:

--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -377,7 +377,7 @@ class LangflowFileService:
 
         # Pass metadata via tweaks to OpenSearch component
         metadata_tweaks = []
-        if owner or owner is None:
+        if owner:
             metadata_tweaks.append({"key": "owner", "value": owner})
         if owner_name:
             metadata_tweaks.append({"key": "owner_name", "value": owner_name})
@@ -422,9 +422,9 @@ class LangflowFileService:
 
         headers = {
             "X-Langflow-Global-Var-JWT": str(jwt_token or ""),
-            "X-Langflow-Global-Var-OWNER": str(owner),
-            "X-Langflow-Global-Var-OWNER_NAME": str(owner_name),
-            "X-Langflow-Global-Var-OWNER_EMAIL": str(owner_email),
+            "X-Langflow-Global-Var-OWNER": owner or "",
+            "X-Langflow-Global-Var-OWNER_NAME": owner_name or "",
+            "X-Langflow-Global-Var-OWNER_EMAIL": owner_email or "",
             "X-Langflow-Global-Var-CONNECTOR_TYPE": str(connector_type),
             "X-Langflow-Global-Var-FILENAME": filename,
             "X-Langflow-Global-Var-MIMETYPE": mimetype,
@@ -596,9 +596,9 @@ class LangflowFileService:
         resolved_document_id = hash_id(io.BytesIO(docs_url.encode("utf-8")))
         headers = {
             "X-Langflow-Global-Var-JWT": str(jwt_token or ""),
-            "X-Langflow-Global-Var-OWNER": str(owner),
-            "X-Langflow-Global-Var-OWNER_NAME": str(owner_name),
-            "X-Langflow-Global-Var-OWNER_EMAIL": str(owner_email),
+            "X-Langflow-Global-Var-OWNER": owner or "",
+            "X-Langflow-Global-Var-OWNER_NAME": owner_name or "",
+            "X-Langflow-Global-Var-OWNER_EMAIL": owner_email or "",
             "X-Langflow-Global-Var-CONNECTOR_TYPE": str(connector_type),
             "X-Langflow-Global-Var-SELECTED_EMBEDDING_MODEL": str(embedding_model),
             "X-Langflow-Global-Var-DOCUMENT_ID": resolved_document_id,

--- a/src/utils/opensearch_queries.py
+++ b/src/utils/opensearch_queries.py
@@ -43,3 +43,32 @@ def build_owned_filename_query(filename: str, owner: str) -> dict:
             ]
         }
     }
+
+
+def build_replace_filename_query(filename: str, owner: str) -> dict:
+    """Build a delete-scope query for replace_duplicates that covers both private
+    and shared (ownerless) chunks with this filename.
+
+    Matches chunks where filename matches AND (owner == current user OR owner
+    field is absent).  Combining both cases is necessary because the same
+    filename may have been previously ingested as shared (no owner field) and
+    is now being replaced by the same user.  The owner-field branch protects
+    against accidentally deleting documents owned by *other* users that are
+    merely visible to the current user via allowed_users DLS.
+    """
+    return {
+        "bool": {
+            "filter": [
+                build_filename_query(filename),
+                {
+                    "bool": {
+                        "should": [
+                            {"term": {"owner": owner}},
+                            {"bool": {"must_not": {"exists": {"field": "owner"}}}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                },
+            ]
+        }
+    }

--- a/src/utils/opensearch_queries.py
+++ b/src/utils/opensearch_queries.py
@@ -45,6 +45,18 @@ def build_owned_filename_query(filename: str, owner: str) -> dict:
     }
 
 
+def build_anonymous_filename_query(filename: str) -> dict:
+    """Build a query for ownerless chunks with a specific filename."""
+    return {
+        "bool": {
+            "filter": [
+                build_filename_query(filename),
+                {"bool": {"must_not": {"exists": {"field": "owner"}}}},
+            ]
+        }
+    }
+
+
 def build_replace_filename_query(filename: str, owner: str) -> dict:
     """Build a delete-scope query for replace_duplicates that covers both private
     and shared (ownerless) chunks with this filename.

--- a/tests/integration/core/test_shared_flag_dls.py
+++ b/tests/integration/core/test_shared_flag_dls.py
@@ -6,6 +6,7 @@ and that documents WITH an owner field remain private to their owner.
 
 Requires a live OpenSearch instance with DLS configured (OPENSEARCH_PASSWORD set).
 """
+
 from uuid import uuid4
 
 import pytest
@@ -205,9 +206,7 @@ async def test_null_owner_field_does_not_trigger_anonymous_path():
         )
 
         session_manager = SessionManager("test")
-        unrelated = User(
-            user_id=unrelated_user_id, email=unrelated_email, name="Unrelated User"
-        )
+        unrelated = User(user_id=unrelated_user_id, email=unrelated_email, name="Unrelated User")
         token = session_manager.create_opensearch_jwt_token(unrelated, ttl_seconds=120)
         client = clients.create_user_opensearch_client(token)
 

--- a/tests/integration/core/test_shared_flag_dls.py
+++ b/tests/integration/core/test_shared_flag_dls.py
@@ -1,0 +1,227 @@
+"""Integration tests: shared-flag DLS anonymous path in OpenSearch.
+
+These tests verify that documents indexed without an owner field are visible
+to all authenticated users via the existing must_not-exists-owner DLS clause,
+and that documents WITH an owner field remain private to their owner.
+
+Requires a live OpenSearch instance with DLS configured (OPENSEARCH_PASSWORD set).
+"""
+from uuid import uuid4
+
+import pytest
+from opensearchpy import AsyncOpenSearch
+from opensearchpy._async.http_aiohttp import AIOHttpConnection
+
+pytestmark = [
+    pytest.mark.asyncio,
+    pytest.mark.openrag_skip_app_onboard,
+]
+
+
+def _build_admin_opensearch_client():
+    from config.settings import (
+        IBM_AUTH_ENABLED,
+        OPENSEARCH_HOST,
+        OPENSEARCH_PASSWORD,
+        OPENSEARCH_PORT,
+        OPENSEARCH_USERNAME,
+    )
+
+    if IBM_AUTH_ENABLED:
+        pytest.skip("OSS JWT DLS is not used in IBM auth mode")
+    if not OPENSEARCH_PASSWORD:
+        pytest.skip("OPENSEARCH_PASSWORD is required for this DLS integration test")
+
+    return AsyncOpenSearch(
+        hosts=[{"host": OPENSEARCH_HOST, "port": OPENSEARCH_PORT}],
+        connection_class=AIOHttpConnection,
+        scheme="https",
+        use_ssl=True,
+        verify_certs=False,
+        ssl_assert_fingerprint=None,
+        http_auth=(OPENSEARCH_USERNAME, OPENSEARCH_PASSWORD),
+        http_compress=True,
+    )
+
+
+async def _search_visible_document_ids(opensearch_client, index_name: str) -> set[str]:
+    response = await opensearch_client.search(
+        index=index_name,
+        body={
+            "query": {"match_all": {}},
+            "_source": ["document_id"],
+            "size": 20,
+        },
+    )
+    return {hit["_source"]["document_id"] for hit in response.get("hits", {}).get("hits", [])}
+
+
+async def test_ownerless_doc_visible_to_all_users():
+    """A document indexed without an owner field is visible to all authenticated users.
+
+    This is the core DLS mechanism used by shared=True ingestion.
+    The must_not-exists-owner clause in securityconfig/roles.yml makes any
+    chunk whose owner key is absent universally readable.
+    """
+    from config.settings import INDEX_BODY, clients
+    from session_manager import SessionManager, User
+    from utils.opensearch_utils import setup_opensearch_security
+
+    admin_client = _build_admin_opensearch_client()
+    try:
+        is_reachable = await admin_client.ping()
+    except Exception:
+        is_reachable = False
+    if not is_reachable:
+        await admin_client.close()
+        pytest.skip("OpenSearch is not reachable")
+
+    index_name = f"documents_shared_flag_dls_{uuid4().hex}"
+    user_a_id = f"user-a-{uuid4().hex}"
+    user_a_email = f"{user_a_id}@example.com"
+    user_b_id = f"user-b-{uuid4().hex}"
+    user_b_email = f"{user_b_id}@example.com"
+
+    try:
+        await setup_opensearch_security(admin_client)
+        await admin_client.indices.create(index=index_name, body=INDEX_BODY)
+
+        await admin_client.bulk(
+            body=[
+                # Shared doc: no owner key → visible to everyone
+                {"index": {"_index": index_name, "_id": "shared-doc"}},
+                {
+                    "document_id": "shared-doc",
+                    "filename": "shared.pdf",
+                    "text": "Shared document visible to all users",
+                    "allowed_users": [],
+                    "allowed_groups": [],
+                    "allowed_principals": [],
+                },
+                # Private doc owned by user A → only visible to user A
+                {"index": {"_index": index_name, "_id": "private-a-doc"}},
+                {
+                    "document_id": "private-a-doc",
+                    "filename": "private-a.pdf",
+                    "text": "Private document owned by user A",
+                    "owner": user_a_id,
+                    "allowed_users": [],
+                    "allowed_groups": [],
+                    "allowed_principals": [],
+                },
+                # Private doc owned by user B → only visible to user B
+                {"index": {"_index": index_name, "_id": "private-b-doc"}},
+                {
+                    "document_id": "private-b-doc",
+                    "filename": "private-b.pdf",
+                    "text": "Private document owned by user B",
+                    "owner": user_b_id,
+                    "allowed_users": [],
+                    "allowed_groups": [],
+                    "allowed_principals": [],
+                },
+            ],
+            refresh=True,
+        )
+
+        session_manager = SessionManager("test")
+
+        user_a = User(user_id=user_a_id, email=user_a_email, name="User A")
+        token_a = session_manager.create_opensearch_jwt_token(user_a, ttl_seconds=120)
+        client_a = clients.create_user_opensearch_client(token_a)
+
+        user_b = User(user_id=user_b_id, email=user_b_email, name="User B")
+        token_b = session_manager.create_opensearch_jwt_token(user_b, ttl_seconds=120)
+        client_b = clients.create_user_opensearch_client(token_b)
+
+        try:
+            visible_a = await _search_visible_document_ids(client_a, index_name)
+            visible_b = await _search_visible_document_ids(client_b, index_name)
+
+            # Shared doc visible to both users
+            assert "shared-doc" in visible_a, "User A must see the shared (ownerless) document"
+            assert "shared-doc" in visible_b, "User B must see the shared (ownerless) document"
+
+            # Each user sees only their own private doc (not the other user's)
+            assert "private-a-doc" in visible_a
+            assert "private-a-doc" not in visible_b, "User B must NOT see User A's private doc"
+
+            assert "private-b-doc" in visible_b
+            assert "private-b-doc" not in visible_a, "User A must NOT see User B's private doc"
+
+        finally:
+            await client_a.close()
+            await client_b.close()
+
+    finally:
+        await admin_client.indices.delete(index=index_name, ignore_unavailable=True)
+        await admin_client.close()
+
+
+async def test_null_owner_field_does_not_trigger_anonymous_path():
+    """A document indexed with owner=null (not absent) must NOT be universally visible.
+
+    This regression test guards against the serialization bug described in the plan:
+    'owner': null in JSON is treated by OpenSearch exists filter as present,
+    so it does NOT trigger must_not-exists-owner. Only an absent key triggers it.
+
+    This test confirms the fix in _build_chunk_document is necessary.
+    """
+    from config.settings import INDEX_BODY, clients
+    from session_manager import SessionManager, User
+    from utils.opensearch_utils import setup_opensearch_security
+
+    admin_client = _build_admin_opensearch_client()
+    try:
+        is_reachable = await admin_client.ping()
+    except Exception:
+        is_reachable = False
+    if not is_reachable:
+        await admin_client.close()
+        pytest.skip("OpenSearch is not reachable")
+
+    index_name = f"documents_null_owner_dls_{uuid4().hex}"
+    unrelated_user_id = f"unrelated-{uuid4().hex}"
+    unrelated_email = f"{unrelated_user_id}@example.com"
+
+    try:
+        await setup_opensearch_security(admin_client)
+        await admin_client.indices.create(index=index_name, body=INDEX_BODY)
+
+        # Index a doc with owner: null explicitly (the broken serialization path)
+        await admin_client.index(
+            index=index_name,
+            id="null-owner-doc",
+            body={
+                "document_id": "null-owner-doc",
+                "filename": "null-owner.pdf",
+                "text": "Document with owner field set to null",
+                "owner": None,
+                "allowed_users": [],
+                "allowed_groups": [],
+                "allowed_principals": [],
+            },
+            refresh=True,
+        )
+
+        session_manager = SessionManager("test")
+        unrelated = User(
+            user_id=unrelated_user_id, email=unrelated_email, name="Unrelated User"
+        )
+        token = session_manager.create_opensearch_jwt_token(unrelated, ttl_seconds=120)
+        client = clients.create_user_opensearch_client(token)
+
+        try:
+            visible = await _search_visible_document_ids(client, index_name)
+            # owner=null means the field EXISTS (with null value), so must_not-exists-owner
+            # does NOT fire → unrelated user should NOT see this doc
+            assert "null-owner-doc" not in visible, (
+                "A doc with owner=null must NOT be universally visible. "
+                "Only a doc with no owner key triggers the anonymous DLS path."
+            )
+        finally:
+            await client.close()
+
+    finally:
+        await admin_client.indices.delete(index=index_name, ignore_unavailable=True)
+        await admin_client.close()

--- a/tests/unit/db/migrations/test_add_anonymous_delete_permission.py
+++ b/tests/unit/db/migrations/test_add_anonymous_delete_permission.py
@@ -6,9 +6,7 @@ from pathlib import Path
 import sqlalchemy as sa
 
 ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
-MIGRATION_PATH = (
-    ROOT / "alembic" / "versions" / "0007_add_knowledge_delete_anonymous.py"
-)
+MIGRATION_PATH = ROOT / "alembic" / "versions" / "0007_add_knowledge_delete_anonymous.py"
 
 
 def _load_migration():

--- a/tests/unit/db/migrations/test_add_anonymous_delete_permission.py
+++ b/tests/unit/db/migrations/test_add_anonymous_delete_permission.py
@@ -1,0 +1,99 @@
+"""Tests for the anonymous document-delete permission migration."""
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent.parent
+MIGRATION_PATH = (
+    ROOT / "alembic" / "versions" / "0007_add_knowledge_delete_anonymous.py"
+)
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("migration_0007", MIGRATION_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_upgrade_is_idempotent_and_preserves_delete_any(monkeypatch):
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    roles = sa.Table(
+        "roles",
+        metadata,
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("name", sa.String, unique=True, nullable=False),
+    )
+    permissions = sa.Table(
+        "permissions",
+        metadata,
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("name", sa.String, unique=True, nullable=False),
+        sa.Column("resource", sa.String, nullable=False),
+        sa.Column("action", sa.String, nullable=False),
+        sa.Column("description", sa.String),
+    )
+    role_permissions = sa.Table(
+        "role_permissions",
+        metadata,
+        sa.Column("role_id", sa.String, primary_key=True),
+        sa.Column("permission_id", sa.String, primary_key=True),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as connection:
+        connection.execute(
+            roles.insert(),
+            [
+                {"id": "role-admin", "name": "admin"},
+                {"id": "role-custom", "name": "custom"},
+            ],
+        )
+        connection.execute(
+            permissions.insert(),
+            {
+                "id": "perm-delete-any",
+                "name": "knowledge:delete:any",
+                "resource": "knowledge",
+                "action": "delete:any",
+                "description": "Delete any document",
+            },
+        )
+        connection.execute(
+            role_permissions.insert(),
+            {"role_id": "role-custom", "permission_id": "perm-delete-any"},
+        )
+
+        migration = _load_migration()
+        monkeypatch.setattr(migration.op, "get_bind", lambda: connection)
+        migration.upgrade()
+        migration.upgrade()
+
+        permission_rows = connection.execute(
+            sa.text(
+                "SELECT id, name FROM permissions "
+                "WHERE name IN ('knowledge:delete:any', 'knowledge:delete:anonymous') "
+                "ORDER BY name"
+            )
+        ).fetchall()
+        assert [row.name for row in permission_rows] == [
+            "knowledge:delete:anonymous",
+            "knowledge:delete:any",
+        ]
+
+        anonymous_id = next(
+            row.id for row in permission_rows if row.name == "knowledge:delete:anonymous"
+        )
+        assignments = connection.execute(
+            sa.text(
+                "SELECT role_id, permission_id FROM role_permissions "
+                "ORDER BY role_id, permission_id"
+            )
+        ).fetchall()
+        assert ("role-admin", anonymous_id) in assignments
+        assert ("role-custom", "perm-delete-any") in assignments
+        assert len([row for row in assignments if row == ("role-admin", anonymous_id)]) == 1

--- a/tests/unit/db/test_rbac_seed_idempotency.py
+++ b/tests/unit/db/test_rbac_seed_idempotency.py
@@ -48,6 +48,9 @@ async def test_seed_creates_expected_rows(session):
 
     assert len(perms) == len(PERMISSIONS)
     assert {r.name for r in roles} == {n for _, n, _ in BUILTIN_ROLES}
+    perm_id_by_name = {p.name: p.id for p in perms}
+    assert "knowledge:delete:any" in perm_id_by_name
+    assert "knowledge:delete:anonymous" in perm_id_by_name
 
     # admin gets every permission
     admin_role = next(r for r in roles if r.name == "admin")
@@ -62,6 +65,23 @@ async def test_seed_creates_expected_rows(session):
         .all()
     }
     assert len(admin_perm_ids) == len(PERMISSIONS)
+    assert perm_id_by_name["knowledge:delete:any"] in admin_perm_ids
+    assert perm_id_by_name["knowledge:delete:anonymous"] in admin_perm_ids
+
+    for role_name in ("developer", "user"):
+        role = next(r for r in roles if r.name == role_name)
+        role_perm_ids = {
+            rp.permission_id
+            for rp in (
+                await session.execute(
+                    select(RolePermission).where(RolePermission.role_id == role.id)
+                )
+            )
+            .scalars()
+            .all()
+        }
+        assert perm_id_by_name["knowledge:delete:own"] in role_perm_ids
+        assert perm_id_by_name["knowledge:delete:anonymous"] not in role_perm_ids
 
 
 @pytest.mark.asyncio

--- a/tests/unit/dependencies/test_rbac_kill_switch.py
+++ b/tests/unit/dependencies/test_rbac_kill_switch.py
@@ -109,10 +109,20 @@ async def app(monkeypatch):
 
     # Mount a minimal endpoint behind a real require_permission gate so the
     # kill switch can be exercised without depending on any specific router.
-    from dependencies import require_permission
+    from dependencies import require_any_permission, require_permission
+
+    require_anonymous_delete_permission = require_any_permission(
+        ("knowledge:delete:anonymous", "users:delete")
+    )
 
     @fastapi_app.get("/admin/users")
     async def _gated(_=Depends(require_permission("users:list"))):
+        return []
+
+    @fastapi_app.delete("/anonymous-documents")
+    async def _any_gated(
+        _=Depends(require_anonymous_delete_permission),
+    ):
         return []
 
     yield fastapi_app, SessionLocal, rbac, personas
@@ -136,6 +146,20 @@ async def test_kill_switch_bypasses_require_permission(app, monkeypatch):
         # Kill switch off (default): passes
         monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
         r = await c.get("/admin/users", headers={"X-Test-Persona": "user"})
+        assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_bypasses_require_any_permission(app, monkeypatch):
+    fastapi_app, _, _, _ = app
+    transport = httpx.ASGITransport(app=fastapi_app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+        r = await c.delete("/anonymous-documents", headers={"X-Test-Persona": "user"})
+        assert r.status_code == 403
+
+        monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
+        r = await c.delete("/anonymous-documents", headers={"X-Test-Persona": "user"})
         assert r.status_code == 200
 
 

--- a/tests/unit/dependencies/test_require_api_key_permission.py
+++ b/tests/unit/dependencies/test_require_api_key_permission.py
@@ -15,6 +15,7 @@ import httpx
 import pytest
 import pytest_asyncio
 from fastapi import Depends, FastAPI, Request
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
@@ -26,6 +27,7 @@ if str(SRC) not in sys.path:
 import db.models  # noqa: E402,F401
 from api.v1.documents import delete_document_endpoint  # noqa: E402
 from api.v1.knowledge_filters import search_endpoint as kf_search_endpoint  # noqa: E402
+from db.models import Permission, Role, RolePermission  # noqa: E402
 from db.repositories import RoleRepo  # noqa: E402
 from db.seed import seed_roles_and_permissions  # noqa: E402
 from dependencies import (  # noqa: E402
@@ -33,11 +35,16 @@ from dependencies import (  # noqa: E402
     get_knowledge_filter_service,
     get_rbac_service,
     get_session_manager,
+    require_api_key_any_permission,
     require_api_key_permission,
 )
 from services.rbac_service import RBACService  # noqa: E402
 from services.user_service import ensure_user_row  # noqa: E402
 from session_manager import User  # noqa: E402
+
+require_api_key_delete_permission = require_api_key_any_permission(
+    ("knowledge:delete:anonymous", "users:delete")
+)
 
 
 @pytest_asyncio.fixture
@@ -78,6 +85,42 @@ async def app(monkeypatch):
         personas["norole"] = User(
             user_id=norole_row.id, email="norole@x", name="norole", provider="ibm_ams"
         )
+
+        delete_any_row = await ensure_user_row(
+            s,
+            User(
+                user_id="delete-any-sub",
+                email="delete-any@x",
+                name="delete-any",
+                provider="ibm_ams",
+            ),
+        )
+        await role_repo.revoke_role(delete_any_row.id, user_role.id)
+        delete_any_role = Role(
+            id="role-api-delete-any-only",
+            name="api-delete-any-only",
+            description="Legacy unrestricted delete permission only",
+        )
+        s.add(delete_any_role)
+        await s.flush()
+        delete_any_permission = (
+            await s.execute(
+                select(Permission).where(Permission.name == "knowledge:delete:any")
+            )
+        ).scalar_one()
+        s.add(
+            RolePermission(
+                role_id=delete_any_role.id,
+                permission_id=delete_any_permission.id,
+            )
+        )
+        await role_repo.assign_role(delete_any_row.id, delete_any_role.id)
+        personas["delete_any"] = User(
+            user_id=delete_any_row.id,
+            email="delete-any@x",
+            name="delete-any",
+            provider="ibm_ams",
+        )
         await s.commit()
 
     rbac = RBACService(SessionLocal)
@@ -104,6 +147,10 @@ async def app(monkeypatch):
     async def _probe_kf_read(user=Depends(require_api_key_permission("kf:read"))):
         return {"user_id": user.user_id}
 
+    @fastapi_app.get("/probe/delete-document")
+    async def _probe_delete_document(user=Depends(require_api_key_delete_permission)):
+        return {"user_id": user.user_id}
+
     # A real gated /v1 handler. The gate runs as a dependency *before* the
     # handler body, so a denied request never reaches the delete core (no
     # service overrides needed for the 403 path).
@@ -127,6 +174,15 @@ async def test_kill_switch_off_bypasses(app, monkeypatch):
     async with _client(fastapi_app) as c:
         # 'user' lacks users:delete, but the kill switch lets it through
         r = await c.get("/probe/users-delete", headers={"X-Test-Persona": "user"})
+    assert r.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_kill_switch_off_bypasses_api_key_any_permission(app, monkeypatch):
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
+    fastapi_app, _ = app
+    async with _client(fastapi_app) as c:
+        r = await c.get("/probe/delete-document", headers={"X-Test-Persona": "user"})
     assert r.status_code == 200
 
 
@@ -188,9 +244,7 @@ async def test_real_v1_kf_search_gated_on_kf_read(app, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_real_v1_delete_blocks_viewer(app, monkeypatch):
-    """End-to-end wiring: DELETE /v1/documents is gated on knowledge:delete:own.
-    A viewer lacks it, so the real handler returns 403 from the gate before the
-    body runs."""
+    """The v1 delete endpoint accepts own or anonymous scope and rejects a viewer."""
     monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
     fastapi_app, _ = app
     async with _client(fastapi_app) as c:
@@ -201,4 +255,25 @@ async def test_real_v1_delete_blocks_viewer(app, monkeypatch):
             headers={"X-Test-Persona": "viewer"},
         )
     assert r.status_code == 403
-    assert r.json()["detail"]["required"] == "knowledge:delete:own"
+    assert r.json()["detail"]["required"] == [
+        "knowledge:delete:own",
+        "knowledge:delete:anonymous",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_real_v1_delete_blocks_delete_any_only_role(app, monkeypatch):
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+    fastapi_app, _ = app
+    async with _client(fastapi_app) as c:
+        r = await c.request(
+            "DELETE",
+            "/v1/documents",
+            json={"filename": "x.txt"},
+            headers={"X-Test-Persona": "delete_any"},
+        )
+    assert r.status_code == 403
+    assert r.json()["detail"]["required"] == [
+        "knowledge:delete:own",
+        "knowledge:delete:anonymous",
+    ]

--- a/tests/unit/dependencies/test_require_api_key_permission.py
+++ b/tests/unit/dependencies/test_require_api_key_permission.py
@@ -104,9 +104,7 @@ async def app(monkeypatch):
         s.add(delete_any_role)
         await s.flush()
         delete_any_permission = (
-            await s.execute(
-                select(Permission).where(Permission.name == "knowledge:delete:any")
-            )
+            await s.execute(select(Permission).where(Permission.name == "knowledge:delete:any"))
         ).scalar_one()
         s.add(
             RolePermission(

--- a/tests/unit/dependencies/test_require_permission.py
+++ b/tests/unit/dependencies/test_require_permission.py
@@ -116,9 +116,7 @@ async def app(monkeypatch):
         s.add(delete_any_role)
         await s.flush()
         delete_any_permission = (
-            await s.execute(
-                select(Permission).where(Permission.name == "knowledge:delete:any")
-            )
+            await s.execute(select(Permission).where(Permission.name == "knowledge:delete:any"))
         ).scalar_one()
         s.add(
             RolePermission(

--- a/tests/unit/dependencies/test_require_permission.py
+++ b/tests/unit/dependencies/test_require_permission.py
@@ -15,6 +15,7 @@ import pytest
 import pytest_asyncio
 from fastapi import Depends, FastAPI, Request
 from fastapi.responses import JSONResponse
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlmodel import SQLModel
 
@@ -24,6 +25,11 @@ if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 import db.models  # noqa: E402,F401
+from db.models import (  # noqa: E402
+    Permission,
+    Role,
+    RolePermission,
+)
 from db.models import User as UserRow  # noqa: E402
 from db.repositories import RoleRepo  # noqa: E402
 from db.seed import seed_roles_and_permissions  # noqa: E402
@@ -33,6 +39,7 @@ from dependencies import (  # noqa: E402
     get_current_user,
     get_rbac_service,
     require_all_permissions,
+    require_any_permission,
     require_permission,
 )
 from services.rbac_service import RBACService  # noqa: E402
@@ -41,6 +48,9 @@ from session_manager import User  # noqa: E402
 
 # Map role-name -> User dataclass we hand to overrides
 PERSONAS: dict[str, User] = {}
+require_document_delete_permission = require_any_permission(
+    ("knowledge:delete:own", "knowledge:delete:anonymous")
+)
 
 
 @pytest_asyncio.fixture
@@ -88,6 +98,36 @@ async def app(monkeypatch):
         await role_repo.revoke_role(viewer_db.id, user_role.id)
         await role_repo.assign_role(viewer_db.id, viewer_role.id)
 
+        delete_any_db = await ensure_user_row(
+            s,
+            User(
+                user_id="delete-any-sub",
+                email="delete-any@x.com",
+                name="Delete Any",
+                provider="google",
+            ),
+        )
+        await role_repo.revoke_role(delete_any_db.id, user_role.id)
+        delete_any_role = Role(
+            id="role-delete-any-only",
+            name="delete-any-only",
+            description="Legacy unrestricted delete permission only",
+        )
+        s.add(delete_any_role)
+        await s.flush()
+        delete_any_permission = (
+            await s.execute(
+                select(Permission).where(Permission.name == "knowledge:delete:any")
+            )
+        ).scalar_one()
+        s.add(
+            RolePermission(
+                role_id=delete_any_role.id,
+                permission_id=delete_any_permission.id,
+            )
+        )
+        await role_repo.assign_role(delete_any_db.id, delete_any_role.id)
+
         aliased_db = UserRow(
             id="db-aliased-user",
             oauth_provider="google",
@@ -112,6 +152,12 @@ async def app(monkeypatch):
         )
         PERSONAS["viewer"] = User(
             user_id=viewer_db.id, email="v@x.com", name="V", provider="google"
+        )
+        PERSONAS["delete_any"] = User(
+            user_id=delete_any_db.id,
+            email="delete-any@x.com",
+            name="Delete Any",
+            provider="google",
         )
         PERSONAS["aliased"] = User(
             user_id="oauth-aliased-sub",
@@ -158,6 +204,12 @@ async def app(monkeypatch):
     ):
         return JSONResponse({"user_id": user.user_id})
 
+    @app.post("/test/delete-document")
+    async def delete_document_gate(
+        user=Depends(require_document_delete_permission),
+    ):
+        return JSONResponse({"user_id": user.user_id})
+
     @app.post("/test/whoami")
     async def whoami(user=Depends(require_permission("chat:use"))):
         return JSONResponse({"user_id": user.user_id, "db_user_id": user.db_user_id})
@@ -198,6 +250,11 @@ async def app(monkeypatch):
         # upload-context is both ingestion and chat behavior
         ("user", "/test/upload-context", 200),
         ("viewer", "/test/upload-context", 403),
+        # delete accepts either own or anonymous-document scope
+        ("admin", "/test/delete-document", 200),
+        ("user", "/test/delete-document", 200),
+        ("viewer", "/test/delete-document", 403),
+        ("delete_any", "/test/delete-document", 403),
     ],
 )
 async def test_permission_enforcement(app, persona, perm_path, expected):
@@ -226,6 +283,18 @@ async def test_all_permissions_response_lists_required_permissions(app):
         r = await c.post("/test/upload-context", headers={"X-Test-Persona": "viewer"})
     assert r.status_code == 403
     assert r.json()["detail"]["required"] == ["knowledge:upload", "chat:use"]
+
+
+@pytest.mark.asyncio
+async def test_any_permission_response_lists_alternatives(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(transport=transport, base_url="http://t") as c:
+        r = await c.post("/test/delete-document", headers={"X-Test-Persona": "viewer"})
+    assert r.status_code == 403
+    assert r.json()["detail"]["required"] == [
+        "knowledge:delete:own",
+        "knowledge:delete:anonymous",
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_document_delete_by_id.py
+++ b/tests/unit/test_document_delete_by_id.py
@@ -95,6 +95,136 @@ async def test_delete_documents_by_filename_denies_visible_non_owner(monkeypatch
 
 
 @pytest.mark.asyncio
+async def test_delete_documents_by_filename_deletes_ownerless_with_anonymous_permission(
+    monkeypatch,
+):
+    monkeypatch.setattr("config.settings.get_index_name", lambda: "documents")
+    opensearch_client = FakeOpenSearchClient(
+        visible_hits=[{"_id": "shared-chunk", "_source": {}}],
+    )
+    backend_opensearch_client = FakeOpenSearchClient(
+        owned_hits=[
+            {"_id": "shared-chunk-1", "_source": {}},
+            {"_id": "shared-chunk-2", "_source": {}},
+        ]
+    )
+    monkeypatch.setattr("config.settings.clients.opensearch", backend_opensearch_client)
+
+    payload, status_code = await delete_documents_by_filename_core(
+        filename="shared.pdf",
+        session_manager=FakeSessionManager(opensearch_client),
+        user_id="user-1",
+        jwt_token="jwt-token",
+        can_delete_own=False,
+        can_delete_anonymous=True,
+    )
+
+    assert status_code == 200
+    assert payload["success"] is True
+    assert payload["deleted_chunks"] == 2
+    assert opensearch_client.search_calls == []
+    assert backend_opensearch_client.search_calls[0]["body"]["query"] == {
+        "bool": {
+            "filter": [
+                {"term": {"filename": "shared.pdf"}},
+                {"bool": {"must_not": {"exists": {"field": "owner"}}}},
+            ]
+        }
+    }
+    assert backend_opensearch_client.delete_calls == [
+        {"index": "documents", "id": "shared-chunk-1", "refresh": True},
+        {"index": "documents", "id": "shared-chunk-2", "refresh": True},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_delete_documents_by_filename_combines_owned_and_anonymous_scopes(monkeypatch):
+    monkeypatch.setattr("config.settings.get_index_name", lambda: "documents")
+    opensearch_client = FakeOpenSearchClient()
+    backend_opensearch_client = FakeOpenSearchClient(
+        owned_hits=[
+            {"_id": "owned-chunk", "_source": {"owner": "user-1"}},
+            {"_id": "anonymous-chunk", "_source": {}},
+        ]
+    )
+    monkeypatch.setattr("config.settings.clients.opensearch", backend_opensearch_client)
+
+    payload, status_code = await delete_documents_by_filename_core(
+        filename="shared.pdf",
+        session_manager=FakeSessionManager(opensearch_client),
+        user_id="user-1",
+        jwt_token="jwt-token",
+        can_delete_own=True,
+        can_delete_anonymous=True,
+    )
+
+    assert status_code == 200
+    assert payload["deleted_chunks"] == 2
+    assert backend_opensearch_client.search_calls[0]["body"]["query"] == {
+        "bool": {
+            "filter": [
+                {"term": {"filename": "shared.pdf"}},
+                {
+                    "bool": {
+                        "should": [
+                            {"term": {"owner": "user-1"}},
+                            {"bool": {"must_not": {"exists": {"field": "owner"}}}},
+                        ],
+                        "minimum_should_match": 1,
+                    }
+                },
+            ]
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_delete_documents_by_filename_denies_ownerless_without_anonymous_permission(
+    monkeypatch,
+):
+    monkeypatch.setattr("config.settings.get_index_name", lambda: "documents")
+    opensearch_client = FakeOpenSearchClient(
+        owned_hits=[],
+        visible_hits=[{"_id": "shared-chunk", "_source": {}}],
+    )
+
+    payload, status_code = await delete_documents_by_filename_core(
+        filename="shared.pdf",
+        session_manager=FakeSessionManager(opensearch_client),
+        user_id="user-1",
+        jwt_token="jwt-token",
+        can_delete_own=True,
+        can_delete_anonymous=False,
+    )
+
+    assert status_code == 403
+    assert payload["success"] is False
+    assert payload["deleted_chunks"] == 0
+    assert "only the document owner" in payload["error"]
+    assert opensearch_client.delete_calls == []
+
+
+@pytest.mark.asyncio
+async def test_delete_documents_by_filename_denies_when_no_delete_scope(monkeypatch):
+    monkeypatch.setattr("config.settings.get_index_name", lambda: "documents")
+    opensearch_client = FakeOpenSearchClient()
+
+    payload, status_code = await delete_documents_by_filename_core(
+        filename="shared.pdf",
+        session_manager=FakeSessionManager(opensearch_client),
+        user_id="user-1",
+        jwt_token="jwt-token",
+        can_delete_own=False,
+        can_delete_anonymous=False,
+    )
+
+    assert status_code == 403
+    assert payload["success"] is False
+    assert "insufficient permissions" in payload["error"]
+    assert opensearch_client.search_calls == []
+
+
+@pytest.mark.asyncio
 async def test_delete_documents_by_filename_returns_404_when_missing(monkeypatch):
     monkeypatch.setattr("config.settings.get_index_name", lambda: "documents")
     opensearch_client = FakeOpenSearchClient(owned_hits=[], visible_hits=[])

--- a/tests/unit/test_shared_flag.py
+++ b/tests/unit/test_shared_flag.py
@@ -1,7 +1,8 @@
 """Unit tests for the shared COS ingestion flag."""
 
+from typing import Any
+
 import pytest
-from fastapi.testclient import TestClient
 
 from models.processors import resolve_shared_owner_fields
 from services.document_index_writer import (
@@ -41,11 +42,17 @@ def test_resolve_shared_owner_fields_private_none_inputs():
 
 
 def _make_context(**kwargs):
-    defaults = dict(
+    defaults: dict[str, Any] = dict(
         document_id="doc-1",
         filename="test.pdf",
         mimetype="application/pdf",
         embedding_model="test-model",
+        file_size=None,
+        allowed_users=[],
+        allowed_groups=[],
+        allowed_principals=[],
+        allowed_principal_labels=[],
+        is_sample_data=False,
     )
     defaults.update(kwargs)
     return DocumentIndexContext(**defaults)
@@ -95,6 +102,33 @@ def test_build_chunk_document_allowed_users_always_present():
     )
     assert "allowed_users" in doc
     assert "allowed_groups" in doc
+
+
+# ---------------------------------------------------------------------------
+# build_replace_filename_query
+# ---------------------------------------------------------------------------
+
+
+def test_build_replace_filename_query_structure():
+    """Must match filename AND (owner == user OR must_not-exists-owner)."""
+    from utils.opensearch_queries import build_replace_filename_query
+
+    q = build_replace_filename_query("report.pdf", "user-1")
+    assert q["bool"]["filter"][0] == {"term": {"filename": "report.pdf"}}
+    should = q["bool"]["filter"][1]["bool"]["should"]
+    assert {"term": {"owner": "user-1"}} in should
+    assert {"bool": {"must_not": {"exists": {"field": "owner"}}}} in should
+    assert q["bool"]["filter"][1]["bool"]["minimum_should_match"] == 1
+
+
+def test_build_replace_filename_query_differs_from_owned_query():
+    """replace query is broader than the owner-only query."""
+    from utils.opensearch_queries import build_owned_filename_query, build_replace_filename_query
+
+    owned = build_owned_filename_query("f.pdf", "u")
+    replace = build_replace_filename_query("f.pdf", "u")
+    # owned has a single term filter; replace has a bool/should
+    assert owned != replace
 
 
 # ---------------------------------------------------------------------------
@@ -157,7 +191,7 @@ async def test_non_cos_connector_rejects_shared_true():
     import json
 
     detail = json.loads(response.body)
-    assert "ibm_cos" in detail["detail"]
+    assert "ibm_cos" in detail["error"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_shared_flag.py
+++ b/tests/unit/test_shared_flag.py
@@ -1,10 +1,14 @@
 """Unit tests for the shared COS ingestion flag."""
+
 import pytest
 from fastapi.testclient import TestClient
 
 from models.processors import resolve_shared_owner_fields
-from services.document_index_writer import DocumentIndexChunk, DocumentIndexContext, DocumentIndexWriter
-
+from services.document_index_writer import (
+    DocumentIndexChunk,
+    DocumentIndexContext,
+    DocumentIndexWriter,
+)
 
 # ---------------------------------------------------------------------------
 # resolve_shared_owner_fields
@@ -130,7 +134,7 @@ async def test_non_cos_connector_rejects_shared_true():
     """The API handler must return 400 when shared=True and connector_type != ibm_cos."""
     from unittest.mock import AsyncMock, MagicMock
 
-    from api.connectors import connector_sync, ConnectorSyncBody
+    from api.connectors import ConnectorSyncBody, connector_sync
 
     body = ConnectorSyncBody(shared=True)
     connector_service = MagicMock()
@@ -151,6 +155,7 @@ async def test_non_cos_connector_rejects_shared_true():
     )
     assert response.status_code == 400
     import json
+
     detail = json.loads(response.body)
     assert "ibm_cos" in detail["detail"]
 
@@ -160,7 +165,7 @@ async def test_ibm_cos_shared_true_does_not_hit_guard():
     """shared=True with ibm_cos should NOT be rejected by the guard."""
     from unittest.mock import AsyncMock, MagicMock
 
-    from api.connectors import connector_sync, ConnectorSyncBody
+    from api.connectors import ConnectorSyncBody, connector_sync
 
     body = ConnectorSyncBody(shared=True)
     connector_service = MagicMock()

--- a/tests/unit/test_shared_flag.py
+++ b/tests/unit/test_shared_flag.py
@@ -1,0 +1,183 @@
+"""Unit tests for the shared COS ingestion flag."""
+import pytest
+from fastapi.testclient import TestClient
+
+from models.processors import resolve_shared_owner_fields
+from services.document_index_writer import DocumentIndexChunk, DocumentIndexContext, DocumentIndexWriter
+
+
+# ---------------------------------------------------------------------------
+# resolve_shared_owner_fields
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_shared_owner_fields_private():
+    result = resolve_shared_owner_fields("user-1", "Alice", "alice@example.com", shared=False)
+    assert result == ("user-1", "Alice", "alice@example.com")
+
+
+def test_resolve_shared_owner_fields_shared():
+    result = resolve_shared_owner_fields("user-1", "Alice", "alice@example.com", shared=True)
+    assert result == (None, None, None)
+
+
+def test_resolve_shared_owner_fields_shared_none_inputs():
+    result = resolve_shared_owner_fields(None, None, None, shared=True)
+    assert result == (None, None, None)
+
+
+def test_resolve_shared_owner_fields_private_none_inputs():
+    result = resolve_shared_owner_fields(None, None, None, shared=False)
+    assert result == (None, None, None)
+
+
+# ---------------------------------------------------------------------------
+# DocumentIndexWriter._build_chunk_document
+# ---------------------------------------------------------------------------
+
+
+def _make_context(**kwargs):
+    defaults = dict(
+        document_id="doc-1",
+        filename="test.pdf",
+        mimetype="application/pdf",
+        embedding_model="test-model",
+    )
+    defaults.update(kwargs)
+    return DocumentIndexContext(**defaults)
+
+
+def _make_chunk():
+    return DocumentIndexChunk(
+        chunk_id="doc-1_0",
+        text="hello world",
+        vector=[0.1, 0.2, 0.3],
+        page=1,
+    )
+
+
+def test_build_chunk_document_owner_present_when_set():
+    writer = DocumentIndexWriter()
+    context = _make_context(owner="user-1", owner_name="Alice", owner_email="alice@example.com")
+    chunk = _make_chunk()
+    doc = writer._build_chunk_document(
+        context=context, chunk=chunk, embedding_field="vector", indexed_time="2026-01-01T00:00:00"
+    )
+    assert doc["owner"] == "user-1"
+    assert doc["owner_name"] == "Alice"
+    assert doc["owner_email"] == "alice@example.com"
+
+
+def test_build_chunk_document_omits_owner_key_when_none():
+    """Critical DLS test: owner key must be absent, not null, for must_not-exists-owner clause."""
+    writer = DocumentIndexWriter()
+    context = _make_context(owner=None, owner_name=None, owner_email=None)
+    chunk = _make_chunk()
+    doc = writer._build_chunk_document(
+        context=context, chunk=chunk, embedding_field="vector", indexed_time="2026-01-01T00:00:00"
+    )
+    assert "owner" not in doc
+    assert "owner_name" not in doc
+    assert "owner_email" not in doc
+
+
+def test_build_chunk_document_allowed_users_always_present():
+    """allowed_users/groups are always written (DLS lookup requires the field to exist)."""
+    writer = DocumentIndexWriter()
+    context = _make_context(owner=None)
+    chunk = _make_chunk()
+    doc = writer._build_chunk_document(
+        context=context, chunk=chunk, embedding_field="vector", indexed_time="2026-01-01T00:00:00"
+    )
+    assert "allowed_users" in doc
+    assert "allowed_groups" in doc
+
+
+# ---------------------------------------------------------------------------
+# ConnectorSyncBody Pydantic model
+# ---------------------------------------------------------------------------
+
+
+def test_connector_sync_body_defaults_shared_false():
+    from api.connectors import ConnectorSyncBody
+
+    body = ConnectorSyncBody()
+    assert body.shared is False
+
+
+def test_connector_sync_body_shared_true():
+    from api.connectors import ConnectorSyncBody
+
+    body = ConnectorSyncBody(shared=True)
+    assert body.shared is True
+
+
+def test_connector_sync_body_shared_backwards_compat():
+    """Existing clients that omit shared get False."""
+    from api.connectors import ConnectorSyncBody
+
+    body = ConnectorSyncBody(selected_files=["file-1"])
+    assert body.shared is False
+
+
+# ---------------------------------------------------------------------------
+# connector_sync guard: shared=True rejected for non-COS connectors
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_cos_connector_rejects_shared_true():
+    """The API handler must return 400 when shared=True and connector_type != ibm_cos."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from api.connectors import connector_sync, ConnectorSyncBody
+
+    body = ConnectorSyncBody(shared=True)
+    connector_service = MagicMock()
+    session_manager = MagicMock()
+    user = MagicMock()
+    user.jwt_token = "token"
+    user.user_id = "user-1"
+
+    # Stub out the connections lookup so the guard fires before any connector work
+    connector_service.connection_manager.list_connections = AsyncMock(return_value=[])
+
+    response = await connector_sync(
+        connector_type="google_drive",
+        body=body,
+        connector_service=connector_service,
+        session_manager=session_manager,
+        user=user,
+    )
+    assert response.status_code == 400
+    import json
+    detail = json.loads(response.body)
+    assert "ibm_cos" in detail["detail"]
+
+
+@pytest.mark.asyncio
+async def test_ibm_cos_shared_true_does_not_hit_guard():
+    """shared=True with ibm_cos should NOT be rejected by the guard."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from api.connectors import connector_sync, ConnectorSyncBody
+
+    body = ConnectorSyncBody(shared=True)
+    connector_service = MagicMock()
+    session_manager = MagicMock()
+    user = MagicMock()
+    user.jwt_token = "token"
+    user.user_id = "user-1"
+
+    # Return empty active connections so we get 404 (not 400) — guard didn't fire
+    connector_service.connection_manager.list_connections = AsyncMock(return_value=[])
+
+    response = await connector_sync(
+        connector_type="ibm_cos",
+        body=body,
+        connector_service=connector_service,
+        session_manager=session_manager,
+        user=user,
+    )
+    # 404 = "no active connections" error, not 400 = guard rejection
+    assert response.status_code == 404

--- a/tests/unit/test_shared_flag.py
+++ b/tests/unit/test_shared_flag.py
@@ -95,7 +95,9 @@ def test_build_chunk_document_omits_owner_key_when_none():
 def test_build_chunk_document_shared_has_anonymous_metadata():
     """Shared docs: owner key absent for DLS, owner_name/email set to anonymous values."""
     writer = DocumentIndexWriter()
-    context = _make_context(owner=None, owner_name="Anonymous User", owner_email="anonymous@localhost")
+    context = _make_context(
+        owner=None, owner_name="Anonymous User", owner_email="anonymous@localhost"
+    )
     chunk = _make_chunk()
     doc = writer._build_chunk_document(
         context=context, chunk=chunk, embedding_field="vector", indexed_time="2026-01-01T00:00:00"

--- a/tests/unit/test_shared_flag.py
+++ b/tests/unit/test_shared_flag.py
@@ -23,12 +23,12 @@ def test_resolve_shared_owner_fields_private():
 
 def test_resolve_shared_owner_fields_shared():
     result = resolve_shared_owner_fields("user-1", "Alice", "alice@example.com", shared=True)
-    assert result == (None, None, None)
+    assert result == (None, "Anonymous User", "anonymous@localhost")
 
 
 def test_resolve_shared_owner_fields_shared_none_inputs():
     result = resolve_shared_owner_fields(None, None, None, shared=True)
-    assert result == (None, None, None)
+    assert result == (None, "Anonymous User", "anonymous@localhost")
 
 
 def test_resolve_shared_owner_fields_private_none_inputs():
@@ -90,6 +90,19 @@ def test_build_chunk_document_omits_owner_key_when_none():
     assert "owner" not in doc
     assert "owner_name" not in doc
     assert "owner_email" not in doc
+
+
+def test_build_chunk_document_shared_has_anonymous_metadata():
+    """Shared docs: owner key absent for DLS, owner_name/email set to anonymous values."""
+    writer = DocumentIndexWriter()
+    context = _make_context(owner=None, owner_name="Anonymous User", owner_email="anonymous@localhost")
+    chunk = _make_chunk()
+    doc = writer._build_chunk_document(
+        context=context, chunk=chunk, embedding_field="vector", indexed_time="2026-01-01T00:00:00"
+    )
+    assert "owner" not in doc
+    assert doc["owner_name"] == "Anonymous User"
+    assert doc["owner_email"] == "anonymous@localhost"
 
 
 def test_build_chunk_document_allowed_users_always_present():


### PR DESCRIPTION
This pull request introduces a new "shared" ingestion mode for IBM COS connectors, allowing documents to be indexed without an owner so that all users in an OpenRAG instance can access them. The change is implemented across the frontend, backend, and SDKs, with UI updates to expose the option where appropriate, backend validation and propagation of the shared flag, and adjustments to document processing logic to omit owner fields when shared mode is enabled.

**Frontend and UI Enhancements:**

* Added a "Make documents available to all users" toggle in the ingestion settings UI (`IngestSettings` and `SharedBucketView` components), shown only for COS ingestion, and ensured the setting is passed through to connector sync requests. [[1]](diffhunk://#diff-00b7b7b3a6b70871ce0b404f5b64d0c6ee5e9bb280d3ecbeaf92e7c139f7dc70R45-R54) [[2]](diffhunk://#diff-00b7b7b3a6b70871ce0b404f5b64d0c6ee5e9bb280d3ecbeaf92e7c139f7dc70L247-R256) [[3]](diffhunk://#diff-00b7b7b3a6b70871ce0b404f5b64d0c6ee5e9bb280d3ecbeaf92e7c139f7dc70R272-R291) [[4]](diffhunk://#diff-4c072ea9c27473c224111c6e765179c580aaec73b3c1498bc493a3cb50d5c6c4R25-R26) [[5]](diffhunk://#diff-4c072ea9c27473c224111c6e765179c580aaec73b3c1498bc493a3cb50d5c6c4R40) [[6]](diffhunk://#diff-4c072ea9c27473c224111c6e765179c580aaec73b3c1498bc493a3cb50d5c6c4R82) [[7]](diffhunk://#diff-4c072ea9c27473c224111c6e765179c580aaec73b3c1498bc493a3cb50d5c6c4R246) [[8]](diffhunk://#diff-a4697ce141ac974999916b3060aae256fa016ba734354ccd2795540f9b8969d1R40) [[9]](diffhunk://#diff-d77f051e92cc92ba917a19f5a58a1f916d3b6e2a93dd56d92aa5dc4313448a0eR116-R117) [[10]](diffhunk://#diff-2a23e600b729ba22fdb6a9bc34add47856d755474a1604b8342974de8cbbd4fdR80-R81)

**Backend and API Changes:**

* Extended the connector sync API and service logic to accept and propagate a `shared` flag, with validation to ensure it is only used with the IBM COS connector. [[1]](diffhunk://#diff-e072fa320915014cf46bdf01548a1bd72bd0e1953e556c08fa0849e5fb205680R348-R351) [[2]](diffhunk://#diff-e072fa320915014cf46bdf01548a1bd72bd0e1953e556c08fa0849e5fb205680R551-R556) [[3]](diffhunk://#diff-e072fa320915014cf46bdf01548a1bd72bd0e1953e556c08fa0849e5fb205680R624) [[4]](diffhunk://#diff-e072fa320915014cf46bdf01548a1bd72bd0e1953e556c08fa0849e5fb205680R666) [[5]](diffhunk://#diff-e072fa320915014cf46bdf01548a1bd72bd0e1953e556c08fa0849e5fb205680R675) [[6]](diffhunk://#diff-4f71ba05b10610b217e09caa829fd2e9cca08eb741d03dda9ee4940ee8f920fdR326) [[7]](diffhunk://#diff-4f71ba05b10610b217e09caa829fd2e9cca08eb741d03dda9ee4940ee8f920fdR425) [[8]](diffhunk://#diff-4f71ba05b10610b217e09caa829fd2e9cca08eb741d03dda9ee4940ee8f920fdR454) [[9]](diffhunk://#diff-4f71ba05b10610b217e09caa829fd2e9cca08eb741d03dda9ee4940ee8f920fdR588)

**Document Processing Logic:**

* Introduced a helper function `resolve_shared_owner_fields` and updated document processing so that when shared mode is enabled, owner fields are omitted from indexed chunks, making them visible to all users according to OpenSearch DLS rules. [[1]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R32-R48) [[2]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R243) [[3]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7L377-R399) [[4]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R626) [[5]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R642) [[6]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R865-R878)

**SDK Updates:**

* Added support for the `shared` flag in both Python and TypeScript SDKs, allowing clients to request shared ingestion from code. [[1]](diffhunk://#diff-281e5613c040e6ffcc3facdd3ffff240d80d17402dab1ee4eedf825ff7b40449R29) [[2]](diffhunk://#diff-281e5613c040e6ffcc3facdd3ffff240d80d17402dab1ee4eedf825ff7b40449R41-R43) [[3]](diffhunk://#diff-281e5613c040e6ffcc3facdd3ffff240d80d17402dab1ee4eedf825ff7b40449R53-R54) [[4]](diffhunk://#diff-281e5613c040e6ffcc3facdd3ffff240d80d17402dab1ee4eedf825ff7b40449R63) [[5]](diffhunk://#diff-281e5613c040e6ffcc3facdd3ffff240d80d17402dab1ee4eedf825ff7b40449R73) [[6]](diffhunk://#diff-161d90e6b6de52ef92e0b5413449c30e6d1b0f9df95b72fc85b2916229b03f9aR27-R32) [[7]](diffhunk://#diff-161d90e6b6de52ef92e0b5413449c30e6d1b0f9df95b72fc85b2916229b03f9aR73-R76)

These changes collectively enable a temporary, instance-wide document sharing mechanism for COS-ingested documents, pending future implementation of more granular access control.l

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Option to mark Cloud Object Storage (COS) ingests as shared so documents are available to all instance users; toggle added to ingest settings.

* **Bug Fixes**
  * Shared documents now behave correctly for visibility and deletion/replacement across users.
  * Ownership metadata no longer serializes as literal "None" during external ingestion flows.

* **Tests**
  * Added unit and integration tests covering shared-document visibility and access control.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->