### PR TITLE
fix: forward Authorization/IBM credentials headers in server-side fetchFromBackend 

### DIFF
--- a/frontend/lib/fetch-server.ts
+++ b/frontend/lib/fetch-server.ts
@@ -1,4 +1,4 @@
-import { cookies } from "next/headers";
+import { cookies, headers } from "next/headers";
 
 export async function fetchFromBackend(
   path: string,
@@ -11,12 +11,35 @@ export async function fetchFromBackend(
     : `http://${backendHost}:8000`;
 
   const cookieStore = await cookies();
+  const incoming = await headers();
+
+  // Forward the gateway-injected auth headers, not just the cookie. In RBAC
+  // mode (OPENRAG_RBAC_ENFORCE=true) the backend derives identity/permissions
+  // from the JWT in the Authorization header and ignores the session cookie
+  // (src/dependencies.py). The browser proxy (app/api/[...path]/route.ts)
+  // already forwards these; server components must too, or server-rendered
+  // permission checks (e.g. settings/[tab]/page.tsx) see no permissions and
+  // wrongly redirect. Header names honor the backend's env overrides.
+  const jwtAuthHeader = (
+    process.env.OPENRAG_JWT_AUTH_HEADER || "Authorization"
+  ).toLowerCase();
+  const ibmCredentialsHeader = (
+    process.env.IBM_CREDENTIALS_HEADER || "X-IBM-LH-Credentials"
+  ).toLowerCase();
+
+  const forwarded: Record<string, string> = {
+    Cookie: cookieStore.toString(),
+  };
+  const authValue = incoming.get(jwtAuthHeader);
+  if (authValue) forwarded[jwtAuthHeader] = authValue;
+  const credentialsValue = incoming.get(ibmCredentialsHeader);
+  if (credentialsValue) forwarded[ibmCredentialsHeader] = credentialsValue;
 
   return fetch(`${baseUrl}/${path}`, {
     ...init,
     headers: {
+      ...forwarded,
       ...init?.headers,
-      Cookie: cookieStore.toString(),
     },
     cache: "no-store",
   });


### PR DESCRIPTION

## What this fixes

On IBM Lakehouse deployments running with RBAC enforcement (`OPENRAG_RBAC_ENFORCE=true`), an authenticated **admin** could see and click the Settings **Providers** and **Langflow** tabs, but the page immediately bounced back to **Connectors**. Connectors and the rest of the app worked fine.

## Root cause

When RBAC enforcement is on, JWT-role sync is active and the backend derives user identity + permissions **only from the gateway-forwarded `Authorization` header**, deliberately ignoring the `ibm-openrag-session` cookie (`src/dependencies.py:546-561`). The role claim in that JWT maps to an OpenRAG role, and the role → permission access policy comes from the DB seed (`src/db/seed.py`), surfaced via `/api/users/me`.

Two paths reach the backend, and they forwarded different headers:

- **Browser → backend (worked):** Client calls `/api/users/me` through the Next proxy `frontend/app/api/[...path]/route.ts`, which copies *all* incoming headers — including the gateway-injected `Authorization`. So the client got the admin's permissions and rendered the gated tabs.

- **Server component → backend (broken):** Rendering `frontend/app/settings/[tab]/page.tsx` calls `getTabAuthContext()` → `fetchFromBackend("auth/me" | "users/me")`, and `frontend/lib/fetch-server.ts` forwarded **only the `Cookie`** header — not `Authorization`. In RBAC mode the cookie is ignored, so those calls came back unauthenticated → empty permission set → the guards at `page.tsx:61-71` ran `redirect("/settings/connectors")` for `providers` and `langflow`.

Connectors has no server-side gate, so it always rendered — which is why only those two tabs failed.

**Net effect:** the client believed the user was authorized (tabs visible), the server did not (redirect), so every navigation bounced back.

## The change

`frontend/lib/fetch-server.ts` now forwards the same gateway-injected auth headers the browser proxy already forwards, so server-rendered permission checks match what the client sees:

- Forward the `Authorization` header (the roles-bearing JWT) — **the actual fix**
- Forward the `X-IBM-LH-Credentials` header — so the `settings` / `keys` prefetches on the same page get data-plane access
- Keep forwarding `Cookie` (preserves the RBAC-off path and OAuth flows)

Header names default to `Authorization` / `X-IBM-LH-Credentials`, matching the backend defaults. No backend changes required.

`fetchFromBackend` is used in exactly one place, so the blast radius is limited to the four server-side calls in the settings tab page.

## Verification

- As an IBM admin, open **Settings → Providers** and **Settings → Langflow** — both now stay on the selected tab and render their content instead of redirecting to Connectors
- Direct full-page load of `/settings/providers` renders rather than redirects
- RBAC-off / no-auth environments are unchanged (cookie forwarding + full-catalog permissions still apply)

## Known limitation

The header-name env overrides (`OPENRAG_JWT_AUTH_HEADER`, `IBM_CREDENTIALS_HEADER`) are read from the frontend `process.env`, but those vars are not currently injected into the frontend pod (helm/operator set only `OPENRAG_BACKEND_HOST`). So the defaults always apply.

This is correct for the standard deployment; if a future deployment customizes those header names on the backend, the same values must also be plumbed into the frontend pod.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication headers are now properly forwarded with backend requests, ensuring secure credential handling through the API gateway.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->