### PR TITLE
fix: use run-mode-aware admin client for init_index instead of the end-user JWT client

### DIFF
--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -178,14 +178,14 @@ async def delete_chunks_by_document_ids(
 
 async def _ensure_index_exists(jwt_token: str = None):
     """Create the OpenSearch index if it doesn't exist yet."""
-    from config.settings import IBM_AUTH_ENABLED
     from config.settings import clients as app_clients
     from main import init_index
 
-    opensearch_client = None
-    if IBM_AUTH_ENABLED and jwt_token:
-        opensearch_client = app_clients.create_user_opensearch_client(jwt_token)
-
+    # Index administration needs more privileges than the per-user client has
+    # in SaaS (the end-user JWT can search/write documents but not run admin
+    # calls like HEAD /<index> or index creation) — pick the admin-capable
+    # client for the run mode.
+    opensearch_client = app_clients.create_index_admin_opensearch_client(jwt_token)
     await init_index(opensearch_client)
 
 

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1073,7 +1073,6 @@ async def onboarding(
                 from config.settings import clients as app_clients
                 from config.settings import (
                     get_openrag_service_token,
-                    get_opensearch_password,
                     get_opensearch_username,
                 )
                 from main import init_index
@@ -1083,12 +1082,11 @@ async def onboarding(
                     is_run_mode_saas,
                 )
 
-                # Choose the OpenSearch client + admin identity for index/security
-                # setup, by run mode:
+                # Choose the admin identity for index/security setup, by run mode:
                 #   saas    -> platform service token (JWT); admin from its claim
                 #   on_prem -> OpenSearch basic auth; OpenSearch username as admin
                 #   oss     -> OpenSearch basic auth; OpenSearch username as admin
-                opensearch_client = None
+                # The matching client comes from the shared run-mode-aware helper.
                 admin_username = None
                 if is_run_mode_saas():
                     service_token = get_openrag_service_token()
@@ -1104,44 +1102,22 @@ async def onboarding(
                                 "OPENRAG_SERVICE_TOKEN has no 'username' or 'sub' claim; "
                                 "cannot determine OpenSearch admin during onboarding"
                             )
-                        opensearch_client = app_clients.create_opensearch_client_from_jwt(
-                            service_token
-                        )
-                        logger.info(
-                            "Onboarding OpenSearch setup: saas mode, using platform service token",
-                            admin_username=admin_username,
-                        )
                     elif user:
                         # TODO: backward-compatibility fallback for saas deployments
                         # without OPENRAG_SERVICE_TOKEN — pins the onboarding user as
                         # admin instead of the platform service identity. Remove once
                         # the service token is always provided.
-                        if user.jwt_token:
-                            opensearch_client = app_clients.create_user_opensearch_client(
-                                user.jwt_token
-                            )
                         admin_username = user.user_id
-                        logger.warning(
-                            "Onboarding OpenSearch setup: saas mode without "
-                            "OPENRAG_SERVICE_TOKEN; falling back to the onboarding user "
-                            "as admin (backward-compatibility path, to be removed later)",
-                            admin_username=admin_username,
-                        )
-                    else:
-                        logger.info(
-                            "Onboarding OpenSearch setup: saas mode with no service "
-                            "token or user; using the unauthenticated global client"
-                        )
                 elif is_run_mode_on_prem() or is_run_mode_oss():
                     admin_username = get_opensearch_username()
-                    opensearch_client = app_clients.create_basic_opensearch_client(
-                        admin_username, get_opensearch_password()
-                    )
-                    logger.info(
-                        "Onboarding OpenSearch setup: %s mode, using OpenSearch basic auth"
-                        % ("on_prem" if is_run_mode_on_prem() else "oss"),
-                        admin_username=admin_username,
-                    )
+
+                opensearch_client = app_clients.create_index_admin_opensearch_client(
+                    user.jwt_token if user else None
+                )
+                logger.info(
+                    "Onboarding OpenSearch setup",
+                    admin_username=admin_username,
+                )
 
                 logger.info("Initializing OpenSearch index after onboarding configuration")
                 await init_index(opensearch_client, admin_username=admin_username)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1416,8 +1416,7 @@ class AppClients:
             service_token = get_openrag_service_token()
             if service_token:
                 logger.info(
-                    "Index admin OpenSearch client: saas mode, "
-                    "using platform service token"
+                    "Index admin OpenSearch client: saas mode, using platform service token"
                 )
                 return self.create_opensearch_client_from_jwt(service_token)
             if user_jwt_token:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1391,6 +1391,55 @@ class AppClients:
         """Create OpenSearch client with user's auth token."""
         return self.create_opensearch_client_from_jwt(jwt_token)
 
+    def create_index_admin_opensearch_client(self, user_jwt_token: str = None):
+        """Create the OpenSearch client used for index administration
+        (init_index: index creation, mapping/settings updates), by run mode:
+
+          saas    -> platform service token — the end-user JWT identity can
+                     search/write documents but lacks index-admin privileges on
+                     managed OpenSearch, so admin calls (e.g. HEAD /<index>)
+                     fail. Falls back to the user's token for legacy
+                     deployments without OPENRAG_SERVICE_TOKEN.
+          on_prem -> OpenSearch basic auth
+          oss     -> OpenSearch basic auth
+
+        Returns None when no suitable credentials exist; callers should then
+        use the global writer client (clients.opensearch).
+        """
+        from utils.run_mode_utils import (
+            is_run_mode_on_prem,
+            is_run_mode_oss,
+            is_run_mode_saas,
+        )
+
+        if is_run_mode_saas():
+            service_token = get_openrag_service_token()
+            if service_token:
+                logger.info(
+                    "Index admin OpenSearch client: saas mode, "
+                    "using platform service token"
+                )
+                return self.create_opensearch_client_from_jwt(service_token)
+            if user_jwt_token:
+                logger.warning(
+                    "Index admin OpenSearch client: saas mode without "
+                    "OPENRAG_SERVICE_TOKEN; falling back to the requesting "
+                    "user's token (backward-compatibility path)"
+                )
+                return self.create_opensearch_client_from_jwt(user_jwt_token)
+            logger.info(
+                "Index admin OpenSearch client: saas mode with no service or "
+                "user token; using the global writer client"
+            )
+            return None
+        if is_run_mode_on_prem() or is_run_mode_oss():
+            # Build a fresh basic-auth client so credentials updated after
+            # startup (e.g. during onboarding) take effect immediately.
+            return self.create_basic_opensearch_client(
+                get_opensearch_username(), get_opensearch_password()
+            )
+        return None
+
 
 # Component template paths — derived from the centralized flows directory
 def _component_path(env_var: str, filename: str) -> str:

--- a/tests/unit/config/test_index_admin_client_selection.py
+++ b/tests/unit/config/test_index_admin_client_selection.py
@@ -1,0 +1,100 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+def test_saas_prefers_service_token_over_user_jwt(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    sentinel = object()
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: True)
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: "svc-jwt-token")
+    captured = {}
+
+    def fake_from_jwt(token):
+        captured["token"] = token
+        return sentinel
+
+    monkeypatch.setattr(settings.clients, "create_opensearch_client_from_jwt", fake_from_jwt)
+
+    client = settings.clients.create_index_admin_opensearch_client("Bearer user-jwt")
+
+    assert client is sentinel
+    assert captured["token"] == "svc-jwt-token"
+
+
+def test_saas_without_service_token_falls_back_to_user_jwt(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    sentinel = object()
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: True)
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
+    captured = {}
+
+    def fake_from_jwt(token):
+        captured["token"] = token
+        return sentinel
+
+    monkeypatch.setattr(settings.clients, "create_opensearch_client_from_jwt", fake_from_jwt)
+
+    client = settings.clients.create_index_admin_opensearch_client("Bearer user-jwt")
+
+    assert client is sentinel
+    assert captured["token"] == "Bearer user-jwt"
+
+
+def test_saas_without_any_token_returns_none(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: True)
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
+
+    assert settings.clients.create_index_admin_opensearch_client(None) is None
+
+
+def test_on_prem_uses_basic_auth(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    sentinel = object()
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: False)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: True)
+    monkeypatch.setattr(settings, "get_opensearch_username", lambda: "admin")
+    monkeypatch.setattr(settings, "get_opensearch_password", lambda: "secret")
+    captured = {}
+
+    def fake_basic(username, password):
+        captured["creds"] = (username, password)
+        return sentinel
+
+    monkeypatch.setattr(settings.clients, "create_basic_opensearch_client", fake_basic)
+
+    client = settings.clients.create_index_admin_opensearch_client("Bearer user-jwt")
+
+    assert client is sentinel
+    assert captured["creds"] == ("admin", "secret")
+
+
+def test_oss_uses_basic_auth(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    sentinel = object()
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: False)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: False)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_oss", lambda: True)
+    monkeypatch.setattr(settings, "get_opensearch_username", lambda: "admin")
+    monkeypatch.setattr(settings, "get_opensearch_password", lambda: "secret")
+
+    monkeypatch.setattr(
+        settings.clients, "create_basic_opensearch_client", lambda u, p: sentinel
+    )
+
+    assert settings.clients.create_index_admin_opensearch_client(None) is sentinel

--- a/tests/unit/config/test_index_admin_client_selection.py
+++ b/tests/unit/config/test_index_admin_client_selection.py
@@ -93,8 +93,6 @@ def test_oss_uses_basic_auth(monkeypatch):
     monkeypatch.setattr(settings, "get_opensearch_username", lambda: "admin")
     monkeypatch.setattr(settings, "get_opensearch_password", lambda: "secret")
 
-    monkeypatch.setattr(
-        settings.clients, "create_basic_opensearch_client", lambda u, p: sentinel
-    )
+    monkeypatch.setattr(settings.clients, "create_basic_opensearch_client", lambda u, p: sentinel)
 
     assert settings.clients.create_index_admin_opensearch_client(None) is sentinel


### PR DESCRIPTION
In SaaS with IBM auth, _ensure_index_exists built the OpenSearch client from the end-user's JWT. That identity can search/write documents but lacks index-admin privileges on managed OpenSearch, so the first admin call in init_index (HEAD /<index> via indices.exists) failed with TransportError(500, '') and connector sync returned 500.

Add Clients.create_index_admin_opensearch_client, mirroring the onboarding client selection: saas -> platform service token (user-JWT fallback for legacy deployments without OPENRAG_SERVICE_TOKEN), on_prem/oss -> OpenSearch basic auth. Use it in _ensure_index_exists (fixes connector sync, traditional uploads, and router ingest in one place) and fold the onboarding block in settings/endpoints.py onto the shared helper.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved OpenSearch client initialization and authentication handling across deployment modes to streamline index setup operations and enhance credential management consistency.

* **Tests**
  * Added comprehensive unit tests for client selection logic across different deployment configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->