### PR TITLE
fix: redirect 401 to redirect url in payload

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -3,6 +3,32 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import type * as React from "react";
 import { getQueryClient } from "@/app/api/get-query-client";
 
+if (typeof window !== "undefined") {
+  const originalFetch = window.fetch;
+  window.fetch = async (...args) => {
+    const response = await originalFetch(...args);
+    if (response.status === 401) {
+      try {
+        const clone = response.clone();
+        const data = await clone.json();
+        if (data && typeof data === "object") {
+          const redirectUrl =
+            data.redirect_url || data.redirectUrl || data.redirect;
+          if (redirectUrl && typeof redirectUrl === "string") {
+            window.location.href = redirectUrl;
+          }
+        }
+      } catch (e) {
+        console.error(
+          "Failed to parse 401 response payload for redirect url:",
+          e,
+        );
+      }
+    }
+    return response;
+  };
+}
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
 


### PR DESCRIPTION
This pull request adds a global override for the `window.fetch` method in the frontend to automatically handle HTTP 401 (Unauthorized) responses. When a 401 is encountered, the code attempts to extract a redirect URL from the response payload and, if found, navigates the browser to that URL.

**Authentication and Redirect Handling:**

* Overrides `window.fetch` in the browser to check for HTTP 401 responses, and if present, parses the response for a redirect URL (`redirect_url`, `redirectUrl`, or `redirect`). If a valid URL is found, the browser is redirected to it. Errors during parsing are logged to the console.