### PR TITLE
fix: change browsers fetch to get 401s and redirect

### DIFF
--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -3,6 +3,32 @@ import { QueryClientProvider } from "@tanstack/react-query";
 import type * as React from "react";
 import { getQueryClient } from "@/app/api/get-query-client";
 
+if (typeof window !== "undefined") {
+  const originalFetch = window.fetch;
+  window.fetch = async (...args) => {
+    const response = await originalFetch(...args);
+    if (response.status === 401) {
+      try {
+        const clone = response.clone();
+        const data = await clone.json();
+        if (data && typeof data === "object") {
+          const redirectUrl =
+            data.redirect_url || data.redirectUrl || data.redirect;
+          if (redirectUrl && typeof redirectUrl === "string") {
+            window.location.href = redirectUrl;
+          }
+        }
+      } catch (e) {
+        console.error(
+          "Failed to parse 401 response payload for redirect url:",
+          e,
+        );
+      }
+    }
+    return response;
+  };
+}
+
 export default function Providers({ children }: { children: React.ReactNode }) {
   const queryClient = getQueryClient();
 

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -4,29 +4,50 @@ import type * as React from "react";
 import { getQueryClient } from "@/app/api/get-query-client";
 
 if (typeof window !== "undefined") {
-  const originalFetch = window.fetch;
-  window.fetch = async (...args) => {
-    const response = await originalFetch(...args);
-    if (response.status === 401) {
-      try {
-        const clone = response.clone();
-        const data = await clone.json();
-        if (data && typeof data === "object") {
-          const redirectUrl =
-            data.redirect_url || data.redirectUrl || data.redirect;
-          if (redirectUrl && typeof redirectUrl === "string") {
-            window.location.href = redirectUrl;
+  const FETCH_PATCHED = Symbol.for("__fetch_patched__");
+  if (!(window.fetch as any)[FETCH_PATCHED]) {
+    const originalFetch = window.fetch;
+    const patchedFetch = async (...args: Parameters<typeof fetch>) => {
+      const response = await originalFetch(...args);
+      if (response.status === 401) {
+        try {
+          const clone = response.clone();
+          const data = await clone.json();
+          if (data && typeof data === "object") {
+            const redirectUrl =
+              data.redirect_url || data.redirectUrl || data.redirect;
+            if (redirectUrl && typeof redirectUrl === "string") {
+              // Validate redirectUrl to prevent open redirect
+              let validatedUrl = "/login";
+              if (redirectUrl.startsWith("/") && !redirectUrl.startsWith("//")) {
+                // Relative path - safe to use
+                validatedUrl = redirectUrl;
+              } else {
+                try {
+                  const url = new URL(redirectUrl, location.origin);
+                  if (url.origin === location.origin) {
+                    // Same-origin absolute URL - safe to use
+                    validatedUrl = redirectUrl;
+                  }
+                } catch (e) {
+                  // Invalid URL, use default
+                }
+              }
+              window.location.href = validatedUrl;
+            }
           }
+        } catch (e) {
+          console.error(
+            "Failed to parse 401 response payload for redirect url:",
+            e,
+          );
         }
-      } catch (e) {
-        console.error(
-          "Failed to parse 401 response payload for redirect url:",
-          e,
-        );
       }
-    }
-    return response;
-  };
+      return response;
+    };
+    (patchedFetch as any)[FETCH_PATCHED] = true;
+    window.fetch = patchedFetch as typeof fetch;
+  }
 }
 
 export default function Providers({ children }: { children: React.ReactNode }) {

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -19,7 +19,10 @@ if (typeof window !== "undefined") {
             if (redirectUrl && typeof redirectUrl === "string") {
               // Validate redirectUrl to prevent open redirect
               let validatedUrl = "/login";
-              if (redirectUrl.startsWith("/") && !redirectUrl.startsWith("//")) {
+              if (
+                redirectUrl.startsWith("/") &&
+                !redirectUrl.startsWith("//")
+              ) {
                 // Relative path - safe to use
                 validatedUrl = redirectUrl;
               } else {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1137,7 +1137,6 @@
       "integrity": "sha512-6TyEnHgd6SArQO8UO2OMTxshln3QMWBtPGrOCgs3wVEmQmwyuNtB10IZMfmYDE0riwNR1cu4q+pPcxMVtaG3TA==",
       "devOptional": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "playwright": "1.57.0"
       },
@@ -3085,7 +3084,6 @@
       "integrity": "sha512-yCAeZl7a0DxgNVteXFHt9+uyFbqXGy/ShC4BlcHkoE0AfGXYv/BUiplV72DjMYXHDBXFjhvr6DD1NiRVfB4j8g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -3101,7 +3099,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.12.tgz",
       "integrity": "sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3112,7 +3109,6 @@
       "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.0.0"
       }
@@ -3177,7 +3173,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -3773,7 +3768,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4276,7 +4270,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001737",
         "electron-to-chromium": "^1.5.211",
@@ -5108,7 +5101,6 @@
       "integrity": "sha512-VmQ+sifHUbI/IcSopBCF/HO3YiHQx/AVd3UVyYL6weuwW+HvON9VYn5l6Zl1WZzPWXPNZrSQpxwkkZ/VuvJZzg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5313,7 +5305,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7168,7 +7159,6 @@
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -9334,7 +9324,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -9409,7 +9398,6 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
       "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -9449,7 +9437,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -9744,7 +9731,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
       "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9754,7 +9740,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
       "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10936,7 +10921,6 @@
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-3.4.17.tgz",
       "integrity": "sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "arg": "^5.0.2",
@@ -11281,7 +11265,6 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
This pull request introduces a global override for `window.fetch` in the browser to handle authentication errors more gracefully. Now, if a fetch request receives a 401 Unauthorized response with a redirect URL in the response payload, the client will automatically redirect the user to that URL.

**Authentication and error handling improvements:**

* Added a global wrapper around `window.fetch` in `providers.tsx` to detect 401 responses, parse the response body for possible redirect URLs (`redirect_url`, `redirectUrl`, or `redirect`), and redirect the browser if a URL is found. Errors during parsing are logged to the console.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of authentication failures (401 responses) with automatic browser redirection when a valid redirect URL is provided by the server.
  * Added validation to ensure redirects are safe and prevent open-redirect scenarios.
  * Robust error handling and logging for redirect parsing issues while preserving original responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->