### PR TITLE
fix: make /api/connectors the source of truth for which connectors and get only those connectors for Saas (IBM COS, Sharepoint, Google Drive, S3)

### DIFF
--- a/enhancements/connectors/ibm_cos/connector.py
+++ b/enhancements/connectors/ibm_cos/connector.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from posixpath import basename
 from typing import Any
 
-from config.settings import IBM_AUTH_ENABLED
 from connectors.base import BaseConnector, ConnectorDocument, DocumentACL
 from utils.logging_config import get_logger
 
@@ -64,7 +63,20 @@ class IBMCOSConnector(BaseConnector):
 
     @classmethod
     def is_available(cls, manager, user_id=None) -> bool:
-        return IBM_AUTH_ENABLED
+        from config.settings import is_bucket_connector_deployed
+        from utils.run_mode_utils import is_run_mode_saas
+
+        if not is_bucket_connector_deployed():
+            return False
+        if is_run_mode_saas():
+            return True
+        try:
+            instance = cls({})
+            instance.get_client_id()
+            instance.get_client_secret()
+            return True
+        except (ValueError, NotImplementedError, RuntimeError):
+            return manager._has_saved_credentials_for_user(cls.CONNECTOR_TYPE, user_id)
 
     @classmethod
     def register_routes(cls, app) -> None:

--- a/frontend/app/api/mutations/useS3ConfigureMutation.ts
+++ b/frontend/app/api/mutations/useS3ConfigureMutation.ts
@@ -1,4 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  bucketConnectorsConfiguredQueryFilter,
+  connectorsQueryFilter,
+} from "@/app/api/queries/useGetConnectorsQuery";
 
 export interface S3ConfigurePayload {
   access_key?: string;
@@ -26,8 +30,9 @@ export function useS3ConfigureMutation() {
   return useMutation({
     mutationFn: configureS3,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["connectors"] });
+      queryClient.invalidateQueries(connectorsQueryFilter);
       queryClient.invalidateQueries({ queryKey: ["s3-defaults"] });
+      queryClient.invalidateQueries(bucketConnectorsConfiguredQueryFilter);
     },
   });
 }

--- a/frontend/app/api/queries/useGetConnectorsQuery.ts
+++ b/frontend/app/api/queries/useGetConnectorsQuery.ts
@@ -8,20 +8,25 @@ import {
 import { toast } from "sonner";
 import { useAuth } from "@/contexts/auth-context";
 import { useBrand, useIsCloudBrand } from "@/contexts/brand-context";
-import {
-  isConnectorShownInWorkspace,
-  isConnectorTypeVisible,
-  isSaasPolicyContext,
-} from "@/lib/brand";
+import { isSaasPolicyContext } from "@/lib/brand";
 
 /** Prefix for all connector list queries (see `connectorsQueryKey`). */
 export const CONNECTORS_QUERY_KEY_ROOT = ["connectors"] as const;
 
+/** Knowledge dropdown bucket menu — invalidate after S3/COS configure. */
+export const BUCKET_CONNECTORS_CONFIGURED_QUERY_KEY = [
+  "bucket-connectors-configured",
+] as const;
+
+/** Match every `["bucket-connectors-configured", …]` query (listed bucket types suffix). */
+export const bucketConnectorsConfiguredQueryFilter = {
+  queryKey: BUCKET_CONNECTORS_CONFIGURED_QUERY_KEY,
+  exact: false,
+} as const;
+
 /**
- * Cache key from policy + deployment filter context (inputs to `getConnectors`).
- * `cloudContext`: backend `/api/connectors` filtering (server policy).
- * `applyWorkspacePolicy`: SaaS workspace policy path in the query fn.
- * `isCloudBrand` / `isIbmAuthMode`: client deployment visibility (`isConnectorTypeVisible`).
+ * Cache key from policy context (inputs to `getConnectors` workspace filter).
+ * Deployment visibility comes from GET /api/connectors on the server.
  */
 export function connectorsQueryKey(
   cloudContext: boolean,
@@ -157,20 +162,10 @@ export interface GetConnectorsResponse {
   connectors: Connector[];
 }
 
-async function fetchWorkspaceConnectorAccess(): Promise<
-  Record<string, boolean>
-> {
-  const response = await fetch("/api/connectors/workspace-policy");
-  if (!response.ok) return {};
-  const data = await response.json();
-  return data?.access && typeof data.access === "object" ? data.access : {};
-}
-
 export const useGetConnectorsQuery = (
   options?: Omit<UseQueryOptions<Connector[]>, "queryKey" | "queryFn">,
 ) => {
-  const { applyWorkspacePolicy, isCloudBrand, isIbmAuthMode, queryKey } =
-    useConnectorsQueryKey();
+  const { queryKey } = useConnectorsQueryKey();
 
   async function getConnectors(): Promise<Connector[]> {
     const connectorsResponse = await fetch("/api/connectors");
@@ -181,7 +176,7 @@ export const useGetConnectorsQuery = (
     const { connectors: connectorsMap } = await connectorsResponse.json();
     const connectorTypes = Object.keys(connectorsMap);
 
-    const connectorsWithStatus = await Promise.all(
+    return Promise.all(
       connectorTypes.map(async (type) => {
         const connectorData = connectorsMap[type];
         const statusResponse = await fetch(`/api/connectors/${type}/status`);
@@ -226,22 +221,6 @@ export const useGetConnectorsQuery = (
         } as Connector;
       }),
     );
-
-    let result = connectorsWithStatus;
-    const deploymentCtx = { isCloudBrand, isIbmAuthMode };
-
-    if (applyWorkspacePolicy) {
-      const storedAccess = await fetchWorkspaceConnectorAccess();
-      result = result.filter((c) =>
-        isConnectorShownInWorkspace(c.type, storedAccess, deploymentCtx),
-      );
-    } else {
-      result = result.filter((c) =>
-        isConnectorTypeVisible(c.type, deploymentCtx),
-      );
-    }
-
-    return result;
   }
 
   return useQuery({

--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -607,7 +607,6 @@ export function KnowledgeDropdown() {
                 router.push("/settings");
               }
             },
-            ariaDisabled: !isConnected,
             className: !isConnected ? "opacity-50" : undefined,
           };
         }),
@@ -746,7 +745,6 @@ export function KnowledgeDropdown() {
           {menuItems.map((item, index) => {
             const entry = item as typeof item & {
               disabled?: boolean;
-              ariaDisabled?: boolean;
               className?: string;
             };
             return (
@@ -754,7 +752,6 @@ export function KnowledgeDropdown() {
                 key={`${entry.label}-${index}`}
                 onClick={entry.onClick}
                 disabled={entry.disabled ?? false}
-                aria-disabled={entry.ariaDisabled ? true : undefined}
                 className={entry.className}
               >
                 <entry.icon className="mr-2 h-4 w-4" />

--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useQueryClient } from "@tanstack/react-query";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   ChevronDown,
   File as FileIcon,
@@ -10,8 +10,13 @@ import {
   PlugZap,
 } from "lucide-react";
 import { useRouter } from "next/navigation";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
+import {
+  BUCKET_CONNECTORS_CONFIGURED_QUERY_KEY,
+  type Connector,
+  useGetConnectorsQuery,
+} from "@/app/api/queries/useGetConnectorsQuery";
 import type { File as SearchFile } from "@/app/api/queries/useGetSearchQuery";
 import { useGetTasksQuery } from "@/app/api/queries/useGetTasksQuery";
 import { DuplicateHandlingDialog } from "@/components/duplicate-handling-dialog";
@@ -36,8 +41,8 @@ import { useIsCloudBrand } from "@/contexts/brand-context";
 import { useTask } from "@/contexts/task-context";
 import { usePermissions } from "@/hooks/use-permissions";
 import {
+  BUCKET_CONNECTOR_TYPES,
   getConnectorDescriptor,
-  getConnectorDescriptors,
 } from "@/lib/connectors/registry";
 import {
   duplicateCheck,
@@ -116,8 +121,55 @@ const FolderIconWithColor = ({ className }: { className?: string }) => (
   <Folder className={cn(className, "text-muted-foreground")} />
 );
 
+/** Stable cache key for listed bucket types (at most two: aws_s3, ibm_cos). */
+function bucketTypesCacheKey(connectors: Connector[]): string {
+  const types: string[] = [];
+  for (const c of connectors) {
+    if (BUCKET_CONNECTOR_TYPES.has(c.type)) {
+      types.push(c.type);
+    }
+  }
+  if (types.length < 2) {
+    return types[0] ?? "";
+  }
+  types.sort();
+  return types.join(",");
+}
+
+async function fetchBucketConnectorConfigured(
+  bucketTypes: string[],
+): Promise<Record<string, boolean>> {
+  if (bucketTypes.length === 0) {
+    return {};
+  }
+
+  const entries = await Promise.all(
+    bucketTypes.map(async (connectorType) => {
+      try {
+        const res = await fetch(`/api/connectors/${connectorType}/defaults`);
+        if (!res.ok) {
+          return [connectorType, false] as const;
+        }
+        const data = (await res.json()) as Record<string, unknown> & {
+          connection_id?: string;
+        };
+        const hasCredentialSetFlag = Object.entries(data).some(
+          ([key, value]) => key.endsWith("_set") && value === true,
+        );
+        return [
+          connectorType,
+          Boolean(data.connection_id || hasCredentialSetFlag),
+        ] as const;
+      } catch {
+        return [connectorType, false] as const;
+      }
+    }),
+  );
+  return Object.fromEntries(entries);
+}
+
 export function KnowledgeDropdown() {
-  const { isIbmAuthMode } = useAuth();
+  const { cloudContext } = useAuth();
   const { can } = usePermissions();
   const canUpload = can("knowledge:upload");
   const isCloudBrand = useIsCloudBrand();
@@ -134,9 +186,6 @@ export function KnowledgeDropdown() {
   const [folderLoading, setFolderLoading] = useState(false);
   const [fileUploading, setFileUploading] = useState(false);
   const [isNavigatingToCloud, setIsNavigatingToCloud] = useState(false);
-  const [bucketConnectorConfigured, setBucketConnectorConfigured] = useState<
-    Record<string, boolean>
-  >({});
   const [pendingFile, setPendingFile] = useState<File | null>(null);
   const [duplicateFilename, setDuplicateFilename] = useState<string>("");
   const [pendingFolderUpload, setPendingFolderUpload] = useState<{
@@ -146,14 +195,6 @@ export function KnowledgeDropdown() {
     unsupportedCount: number;
   } | null>(null);
   const isFolderOverwriteConfirmedRef = useRef(false);
-  const [cloudConnectors, setCloudConnectors] = useState<{
-    [key: string]: {
-      name: string;
-      available: boolean;
-      connected: boolean;
-      hasToken: boolean;
-    };
-  }>({});
   const fileInputRef = useRef<HTMLInputElement>(null);
   const folderInputRef = useRef<HTMLInputElement>(null);
 
@@ -163,124 +204,39 @@ export function KnowledgeDropdown() {
     setDuplicateFilename("");
   };
 
-  // Check AWS availability and cloud connectors on mount
-  useEffect(() => {
-    const checkAvailability = async () => {
-      try {
-        const bucketDescriptors = getConnectorDescriptors().filter(
-          (d) => d.kind === "bucket",
-        );
+  const { data: connectors = [] } = useGetConnectorsQuery();
 
-        // Check upload batch size and bucket connector availability in parallel
-        const [uploadOptionsRes, ...bucketResponses] = await Promise.all([
-          fetch("/api/upload_options"),
-          ...bucketDescriptors.map((d) =>
-            fetch(`/api/connectors/${d.connectorType}/defaults`),
-          ),
-        ]);
+  const listedBucketTypesKey = useMemo(
+    () => bucketTypesCacheKey(connectors),
+    [connectors],
+  );
 
-        if (uploadOptionsRes.ok) {
-          const uploadOptionsData = await uploadOptionsRes.json();
-          if (
-            typeof uploadOptionsData.upload_batch_size === "number" &&
-            uploadOptionsData.upload_batch_size > 0
-          ) {
-            setUploadBatchSize(uploadOptionsData.upload_batch_size);
-          }
-        }
-
-        const configured: Record<string, boolean> = {};
-        await Promise.all(
-          bucketResponses.map(async (res, i) => {
-            const descriptor = bucketDescriptors[i];
-            if (!res.ok) return;
-            const data = await res.json();
-            // Generic predicate: connection_id set OR any *_set boolean is true.
-            const anySetFlag = Object.entries(data).some(
-              ([k, v]) => k.endsWith("_set") && v === true,
-            );
-            configured[descriptor.connectorType] = Boolean(
-              data.connection_id || anySetFlag,
-            );
-          }),
-        );
-        setBucketConnectorConfigured(configured);
-
-        // Check cloud connectors
-        const connectorsRes = await fetch("/api/connectors");
-        if (connectorsRes.ok) {
-          const connectorsResult = await connectorsRes.json();
-          const cloudConnectorTypes = [
-            "google_drive",
-            "onedrive",
-            "sharepoint",
-          ];
-          const connectorInfo: {
-            [key: string]: {
-              name: string;
-              available: boolean;
-              connected: boolean;
-              hasToken: boolean;
-            };
-          } = {};
-
-          for (const type of cloudConnectorTypes) {
-            if (connectorsResult.connectors[type]) {
-              connectorInfo[type] = {
-                name: connectorsResult.connectors[type].name,
-                available: connectorsResult.connectors[type].available,
-                connected: false,
-                hasToken: false,
-              };
-
-              // Check connection status
-              try {
-                const statusRes = await fetch(`/api/connectors/${type}/status`);
-                if (statusRes.ok) {
-                  const statusData = await statusRes.json();
-                  const connections = statusData.connections || [];
-                  const activeConnection = connections.find(
-                    (conn: { is_active: boolean; connection_id: string }) =>
-                      conn.is_active,
-                  );
-                  const isConnected = activeConnection !== undefined;
-
-                  if (isConnected && activeConnection) {
-                    connectorInfo[type].connected = true;
-
-                    // Check token availability
-                    try {
-                      const tokenRes = await fetch(
-                        `/api/connectors/${type}/token?connection_id=${activeConnection.connection_id}`,
-                      );
-                      if (tokenRes.ok) {
-                        const tokenData = await tokenRes.json();
-                        if (tokenData.access_token) {
-                          connectorInfo[type].hasToken = true;
-                        }
-                      }
-                    } catch {
-                      // Token check failed
-                    }
-                  }
-                }
-              } catch {
-                // Status check failed
-              }
-            }
-          }
-
-          setCloudConnectors(connectorInfo);
-        }
-      } catch (err) {
-        console.error("Failed to check availability", err);
-      }
-    };
-    checkAvailability();
-  }, []);
+  const { data: bucketConnectorConfigured = {} } = useQuery({
+    queryKey: [...BUCKET_CONNECTORS_CONFIGURED_QUERY_KEY, listedBucketTypesKey],
+    queryFn: () =>
+      fetchBucketConnectorConfigured(
+        listedBucketTypesKey ? listedBucketTypesKey.split(",") : [],
+      ),
+    enabled: listedBucketTypesKey.length > 0,
+    staleTime: 60_000,
+  });
 
   useEffect(() => {
     setMounted(true);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/upload_options")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (
+          typeof data?.upload_batch_size === "number" &&
+          data.upload_batch_size > 0
+        ) {
+          setUploadBatchSize(data.upload_batch_size);
+        }
+      })
+      .catch(() => {});
   }, []);
 
   const handleFileUpload = () => {
@@ -619,48 +575,56 @@ export function KnowledgeDropdown() {
     }
   };
 
-  const cloudConnectorItems = Object.entries(cloudConnectors)
-    .filter(([type, info]) => {
-      if (!info.available) return false;
-      if (isCloudBrand && type === "onedrive") return false;
-      return true;
-    })
-    .map(([type, info]) => {
-      const descriptor = getConnectorDescriptor(type);
-      return {
-        label: info.name,
-        icon: descriptor?.Icon ?? PlugZap,
-        onClick: async () => {
-          if (info.connected && info.hasToken) {
-            setIsNavigatingToCloud(true);
-            try {
-              router.push(`/upload/${type}`);
-              setTimeout(() => setIsNavigatingToCloud(false), 1000);
-            } catch {
-              setIsNavigatingToCloud(false);
-            }
-          } else {
-            router.push("/settings");
-          }
-        },
-        disabled: !info.connected || !info.hasToken,
-      };
-    });
-
-  const bucketConnectorItems = isIbmAuthMode
-    ? getConnectorDescriptors()
+  const cloudConnectorItems = useMemo(
+    () =>
+      connectors
+        .filter((c) => !BUCKET_CONNECTOR_TYPES.has(c.type))
+        .filter((c) => c.available !== false)
         .filter(
-          (d) =>
-            d.kind === "bucket" &&
-            d.menuItem &&
-            bucketConnectorConfigured[d.connectorType],
+          (c) => !((isCloudBrand || cloudContext) && c.type === "onedrive"),
         )
-        .map((d) => ({
-          label: d.menuItem!.label,
-          icon: d.Icon,
-          onClick: () => router.push(d.menuItem!.route),
-        }))
-    : [];
+        .map((c) => {
+          const descriptor = getConnectorDescriptor(c.type);
+          const isConnected = c.status === "connected";
+          return {
+            label: c.name,
+            icon: descriptor?.Icon ?? PlugZap,
+            onClick: async () => {
+              if (isConnected) {
+                setIsNavigatingToCloud(true);
+                try {
+                  router.push(`/upload/${c.type}`);
+                  setTimeout(() => setIsNavigatingToCloud(false), 1000);
+                } catch {
+                  setIsNavigatingToCloud(false);
+                }
+              } else {
+                router.push("/settings");
+              }
+            },
+            disabled: !isConnected,
+          };
+        }),
+    [cloudContext, connectors, isCloudBrand, router],
+  );
+
+  const bucketConnectorItems = useMemo(() => {
+    const items = [];
+
+    for (const c of connectors) {
+      if (!BUCKET_CONNECTOR_TYPES.has(c.type)) continue;
+      if (!bucketConnectorConfigured[c.type]) continue;
+      const descriptor = getConnectorDescriptor(c.type);
+      if (!descriptor?.menuItem) continue;
+      items.push({
+        label: descriptor.menuItem.label,
+        icon: descriptor.Icon,
+        onClick: () => router.push(descriptor.menuItem!.route),
+      });
+    }
+
+    return items;
+  }, [bucketConnectorConfigured, connectors, router]);
 
   const menuItems = [
     {

--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -36,7 +36,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
-import { useAuth } from "@/contexts/auth-context";
 import { useIsCloudBrand } from "@/contexts/brand-context";
 import { useTask } from "@/contexts/task-context";
 import { usePermissions } from "@/hooks/use-permissions";
@@ -180,7 +179,6 @@ async function fetchUploadOptions(): Promise<{ upload_batch_size?: number }> {
 }
 
 export function KnowledgeDropdown() {
-  const { cloudContext, isIbmAuthMode } = useAuth();
   const { can } = usePermissions();
   const canUpload = can("knowledge:upload");
   const isCloudBrand = useIsCloudBrand();
@@ -590,13 +588,6 @@ export function KnowledgeDropdown() {
       connectors
         .filter((c) => !BUCKET_CONNECTOR_TYPES.has(c.type))
         .filter((c) => c.available !== false)
-        .filter(
-          (c) =>
-            !(
-              (isCloudBrand || cloudContext || isIbmAuthMode) &&
-              c.type === "onedrive"
-            ),
-        )
         .map((c) => {
           const descriptor = getConnectorDescriptor(c.type);
           const isConnected = c.status === "connected";
@@ -620,7 +611,7 @@ export function KnowledgeDropdown() {
             className: !isConnected ? "opacity-50" : undefined,
           };
         }),
-    [cloudContext, connectors, isCloudBrand, isIbmAuthMode, router],
+    [connectors, router],
   );
 
   const bucketConnectorItems = useMemo(() => {

--- a/frontend/components/knowledge-dropdown.tsx
+++ b/frontend/components/knowledge-dropdown.tsx
@@ -168,8 +168,19 @@ async function fetchBucketConnectorConfigured(
   return Object.fromEntries(entries);
 }
 
+const UPLOAD_OPTIONS_QUERY_KEY = ["upload-options"] as const;
+const DEFAULT_UPLOAD_BATCH_SIZE = 25;
+
+async function fetchUploadOptions(): Promise<{ upload_batch_size?: number }> {
+  const res = await fetch("/api/upload_options");
+  if (!res.ok) {
+    throw new Error("Failed to fetch upload options");
+  }
+  return res.json();
+}
+
 export function KnowledgeDropdown() {
-  const { cloudContext } = useAuth();
+  const { cloudContext, isIbmAuthMode } = useAuth();
   const { can } = usePermissions();
   const canUpload = can("knowledge:upload");
   const isCloudBrand = useIsCloudBrand();
@@ -181,7 +192,6 @@ export function KnowledgeDropdown() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
   const [showFolderDialog, setShowFolderDialog] = useState(false);
   const [showDuplicateDialog, setShowDuplicateDialog] = useState(false);
-  const [uploadBatchSize, setUploadBatchSize] = useState(25);
   const [folderPath, setFolderPath] = useState("");
   const [folderLoading, setFolderLoading] = useState(false);
   const [fileUploading, setFileUploading] = useState(false);
@@ -221,22 +231,22 @@ export function KnowledgeDropdown() {
     staleTime: 60_000,
   });
 
-  useEffect(() => {
-    setMounted(true);
-  }, []);
+  const { data: uploadOptions } = useQuery({
+    queryKey: UPLOAD_OPTIONS_QUERY_KEY,
+    queryFn: fetchUploadOptions,
+    staleTime: 60_000,
+  });
+
+  const uploadBatchSize = useMemo(() => {
+    const size = uploadOptions?.upload_batch_size;
+    if (typeof size === "number" && size > 0) {
+      return size;
+    }
+    return DEFAULT_UPLOAD_BATCH_SIZE;
+  }, [uploadOptions?.upload_batch_size]);
 
   useEffect(() => {
-    fetch("/api/upload_options")
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (
-          typeof data?.upload_batch_size === "number" &&
-          data.upload_batch_size > 0
-        ) {
-          setUploadBatchSize(data.upload_batch_size);
-        }
-      })
-      .catch(() => {});
+    setMounted(true);
   }, []);
 
   const handleFileUpload = () => {
@@ -581,7 +591,11 @@ export function KnowledgeDropdown() {
         .filter((c) => !BUCKET_CONNECTOR_TYPES.has(c.type))
         .filter((c) => c.available !== false)
         .filter(
-          (c) => !((isCloudBrand || cloudContext) && c.type === "onedrive"),
+          (c) =>
+            !(
+              (isCloudBrand || cloudContext || isIbmAuthMode) &&
+              c.type === "onedrive"
+            ),
         )
         .map((c) => {
           const descriptor = getConnectorDescriptor(c.type);
@@ -602,10 +616,11 @@ export function KnowledgeDropdown() {
                 router.push("/settings");
               }
             },
-            disabled: !isConnected,
+            ariaDisabled: !isConnected,
+            className: !isConnected ? "opacity-50" : undefined,
           };
         }),
-    [cloudContext, connectors, isCloudBrand, router],
+    [cloudContext, connectors, isCloudBrand, isIbmAuthMode, router],
   );
 
   const bucketConnectorItems = useMemo(() => {
@@ -737,16 +752,25 @@ export function KnowledgeDropdown() {
           )}
         </DropdownMenuTrigger>
         <DropdownMenuContent align="end" className="w-56">
-          {menuItems.map((item, index) => (
-            <DropdownMenuItem
-              key={`${item.label}-${index}`}
-              onClick={item.onClick}
-              disabled={"disabled" in item ? item.disabled : false}
-            >
-              <item.icon className="mr-2 h-4 w-4" />
-              {item.label}
-            </DropdownMenuItem>
-          ))}
+          {menuItems.map((item, index) => {
+            const entry = item as typeof item & {
+              disabled?: boolean;
+              ariaDisabled?: boolean;
+              className?: string;
+            };
+            return (
+              <DropdownMenuItem
+                key={`${entry.label}-${index}`}
+                onClick={entry.onClick}
+                disabled={entry.disabled ?? false}
+                aria-disabled={entry.ariaDisabled ? true : undefined}
+                className={entry.className}
+              >
+                <entry.icon className="mr-2 h-4 w-4" />
+                {entry.label}
+              </DropdownMenuItem>
+            );
+          })}
         </DropdownMenuContent>
       </DropdownMenu>
 

--- a/frontend/enhancements/connectors/ibm-cos/useIBMCOSConfigureMutation.ts
+++ b/frontend/enhancements/connectors/ibm-cos/useIBMCOSConfigureMutation.ts
@@ -1,4 +1,8 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  bucketConnectorsConfiguredQueryFilter,
+  connectorsQueryFilter,
+} from "@/app/api/queries/useGetConnectorsQuery";
 
 export interface IBMCOSConfigurePayload {
   auth_mode: "iam" | "hmac";
@@ -33,8 +37,9 @@ export function useIBMCOSConfigureMutation() {
   return useMutation({
     mutationFn: configureIBMCOS,
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["connectors"] });
+      queryClient.invalidateQueries(connectorsQueryFilter);
       queryClient.invalidateQueries({ queryKey: ["ibm-cos-defaults"] });
+      queryClient.invalidateQueries(bucketConnectorsConfiguredQueryFilter);
     },
   });
 }

--- a/frontend/lib/brand.ts
+++ b/frontend/lib/brand.ts
@@ -75,7 +75,8 @@ export function isConnectorTypeVisible(
   if (type === "ibm_cos" || type === "aws_s3") {
     return isIbmAuthMode || cloudContext;
   }
-  if ((cloudContext || cloudBrand) && type === "onedrive") return false;
+  if ((cloudContext || cloudBrand || isIbmAuthMode) && type === "onedrive")
+    return false;
   return true;
 }
 

--- a/frontend/lib/brand.ts
+++ b/frontend/lib/brand.ts
@@ -52,24 +52,15 @@ export function isConnectorAllowedByWorkspace(
 }
 
 /**
- * Connectors tab visibility: workspace policy first, then deployment rules.
- * Explicit `storedAccess[type] === true` (saved in Connectors Permission) overrides
- * deployment filters so admins can re-enable types like OneDrive on cloud brand.
+ * Connectors tab visibility: workspace policy (admin disable) only.
+ * Deployment rules (OneDrive in SaaS, buckets in OSS, etc.) are enforced by
+ * GET /api/connectors — do not re-apply client-side or admin saves can bypass them.
  */
 export function isConnectorShownInWorkspace(
   type: string,
   storedAccess: Record<string, boolean>,
-  {
-    isCloudBrand: cloudBrand,
-    isIbmAuthMode,
-  }: { isCloudBrand: boolean; isIbmAuthMode: boolean },
 ): boolean {
-  if (!isConnectorAllowedByWorkspace(type, storedAccess)) return false;
-  if (storedAccess[type] === true) return true;
-  return isConnectorTypeVisible(type, {
-    isCloudBrand: cloudBrand,
-    isIbmAuthMode,
-  });
+  return isConnectorAllowedByWorkspace(type, storedAccess);
 }
 
 /** Deployment filter shared by Connectors tab, permission admin, and upload menus. */
@@ -78,10 +69,13 @@ export function isConnectorTypeVisible(
   {
     isCloudBrand: cloudBrand,
     isIbmAuthMode,
-  }: { isCloudBrand: boolean; isIbmAuthMode: boolean },
+    cloudContext = false,
+  }: { isCloudBrand: boolean; isIbmAuthMode: boolean; cloudContext?: boolean },
 ): boolean {
-  if (type === "ibm_cos" || type === "aws_s3") return isIbmAuthMode;
-  if (cloudBrand && type === "onedrive") return false;
+  if (type === "ibm_cos" || type === "aws_s3") {
+    return isIbmAuthMode || cloudContext;
+  }
+  if ((cloudContext || cloudBrand) && type === "onedrive") return false;
   return true;
 }
 

--- a/frontend/lib/connectors/registry.ts
+++ b/frontend/lib/connectors/registry.ts
@@ -47,6 +47,19 @@ const ALL_CONNECTORS: ConnectorUIDescriptor[] = [
   ...ADDITIONAL_CONNECTORS,
 ];
 
+function buildBucketConnectorTypes(): Set<string> {
+  const types = new Set<string>();
+  for (const descriptor of ALL_CONNECTORS) {
+    if (descriptor.kind === "bucket") {
+      types.add(descriptor.connectorType);
+    }
+  }
+  return types;
+}
+
+export const BUCKET_CONNECTOR_TYPES: ReadonlySet<string> =
+  buildBucketConnectorTypes();
+
 export function getConnectorDescriptors(): ConnectorUIDescriptor[] {
   return ALL_CONNECTORS;
 }

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -16,10 +16,11 @@ from dependencies import (
 )
 from services.connector_access_service import (
     CONNECTOR_TYPES,
-    filter_connectors_for_user,
+    filter_connectors_for_list,
     get_access_map,
     is_connector_access_policy_enforced,
     is_connector_allowed_for_request,
+    is_connector_listed_in_deployment,
     list_access_for_admin,
     set_connector_access_bulk,
 )
@@ -35,10 +36,8 @@ async def _connector_access_denied(
     session: AsyncSession,
     connector_type: str,
 ) -> JSONResponse | None:
-    """Return 403 when workspace policy blocks this connector type."""
+    """Return 403 when deployment rules or workspace policy block this connector type."""
     if connector_type not in CONNECTOR_TYPES:
-        return None
-    if not is_connector_access_policy_enforced():
         return None
     if await is_connector_allowed_for_request(session, connector_type):
         return None
@@ -53,11 +52,12 @@ async def _allowed_connector_types_for_request(
     session: AsyncSession,
     connector_types: list[str],
 ) -> list[str]:
-    """Drop connector types blocked by workspace policy (sync-all style endpoints)."""
+    """Drop connector types blocked by deployment rules and workspace policy."""
+    allowed = [t for t in connector_types if is_connector_listed_in_deployment(t)]
     if not is_connector_access_policy_enforced():
-        return connector_types
+        return allowed
     access_map = await get_access_map(session)
-    return [t for t in connector_types if access_map.get(t, True)]
+    return [t for t in allowed if access_map.get(t, True)]
 
 
 def _connector_sync_should_replace(connector_type: str) -> bool:
@@ -554,9 +554,7 @@ async def list_connectors(
         connector_types = connector_service.connection_manager.get_available_connector_types(
             user_id=user.user_id
         )
-        if is_connector_access_policy_enforced():
-            access_map = await get_access_map(session)
-            connector_types = filter_connectors_for_user(connector_types, access_map)
+        connector_types = await filter_connectors_for_list(session, connector_types)
         return JSONResponse({"connectors": connector_types})
     except Exception as e:
         logger.error("[CONNECTOR] Error listing connectors", error=str(e))

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -219,6 +219,14 @@ def is_cloud_context() -> bool:
     return IBM_AUTH_ENABLED or is_run_mode_saas() or is_dev_connector_policy_enabled()
 
 
+def is_bucket_connector_deployed() -> bool:
+    """Whether bucket connectors (S3, IBM COS) are offered in this deployment.
+
+    Kept in sync with ``is_cloud_context()`` / frontend ``cloudContext``.
+    """
+    return is_cloud_context()
+
+
 def get_default_user_role() -> str:
     """Built-in role assigned to new users when JWT role sync is off."""
     return os.getenv("OPENRAG_DEFAULT_ROLE", "user")

--- a/src/connectors/aws_s3/connector.py
+++ b/src/connectors/aws_s3/connector.py
@@ -6,7 +6,6 @@ from datetime import UTC, datetime
 from posixpath import basename
 from typing import Any
 
-from config.settings import IBM_AUTH_ENABLED
 from connectors.base import BaseConnector, ConnectorDocument, DocumentACL
 from utils.logging_config import get_logger
 
@@ -57,8 +56,20 @@ class S3Connector(BaseConnector):
 
     @classmethod
     def is_available(cls, manager, user_id=None) -> bool:
-        # Gated by feature flag in OSS; SaaS / enterprise can flip it on.
-        return IBM_AUTH_ENABLED
+        from config.settings import is_bucket_connector_deployed
+        from utils.run_mode_utils import is_run_mode_saas
+
+        if not is_bucket_connector_deployed():
+            return False
+        if is_run_mode_saas():
+            return True
+        try:
+            instance = cls({})
+            instance.get_client_id()
+            instance.get_client_secret()
+            return True
+        except (ValueError, NotImplementedError, RuntimeError):
+            return manager._has_saved_credentials_for_user(cls.CONNECTOR_TYPE, user_id)
 
     @classmethod
     def register_routes(cls, app) -> None:

--- a/src/services/connector_access_service.py
+++ b/src/services/connector_access_service.py
@@ -16,13 +16,27 @@ CONNECTOR_TYPES: tuple[str, ...] = tuple(cls.CONNECTOR_TYPE for cls in get_conne
 _BUCKET_CONNECTOR_TYPES = frozenset({"aws_s3", "ibm_cos"})
 
 
+def is_connector_listed_in_deployment(connector_type: str) -> bool:
+    """Deployment-level listing rules (independent of admin workspace policy)."""
+    from config.settings import is_bucket_connector_deployed, is_cloud_context
+
+    if connector_type in _BUCKET_CONNECTOR_TYPES:
+        return is_bucket_connector_deployed()
+    if connector_type == "onedrive" and is_cloud_context():
+        return False
+    return True
+
+
 def governable_connector_types() -> tuple[str, ...]:
     """Types shown in admin Connectors Permission — independent of the live connectors list."""
-    from config.settings import IBM_AUTH_ENABLED, is_cloud_context
+    from config.settings import is_bucket_connector_deployed, is_cloud_context
 
-    if is_cloud_context() and not IBM_AUTH_ENABLED:
-        return tuple(t for t in CONNECTOR_TYPES if t not in _BUCKET_CONNECTOR_TYPES)
-    return CONNECTOR_TYPES
+    types: tuple[str, ...] = CONNECTOR_TYPES
+    if not is_bucket_connector_deployed():
+        types = tuple(t for t in types if t not in _BUCKET_CONNECTOR_TYPES)
+    if is_cloud_context():
+        types = tuple(t for t in types if t != "onedrive")
+    return types
 
 
 async def get_access_map(session: AsyncSession) -> dict[str, bool]:
@@ -63,21 +77,46 @@ async def is_connector_allowed_for_request(
     session: AsyncSession,
     connector_type: str,
 ) -> bool:
+    if not is_connector_listed_in_deployment(connector_type):
+        return False
     if not is_connector_access_policy_enforced():
         return True
     return await is_connector_allowed(session, connector_type)
+
+
+def filter_connectors_for_deployment(
+    connector_metadata: dict[str, dict],
+) -> dict[str, dict]:
+    """Drop connector types excluded by deployment rules."""
+    return {
+        connector_type: meta
+        for connector_type, meta in connector_metadata.items()
+        if is_connector_listed_in_deployment(connector_type)
+    }
 
 
 def filter_connectors_for_user(
     connector_metadata: dict[str, dict],
     access_map: dict[str, bool],
 ) -> dict[str, dict]:
-    """Apply workspace policy to the connector list for every role."""
+    """Apply workspace admin policy to the connector list."""
     return {
         connector_type: meta
         for connector_type, meta in connector_metadata.items()
         if access_map.get(connector_type, True)
     }
+
+
+async def filter_connectors_for_list(
+    session: AsyncSession,
+    connector_metadata: dict[str, dict],
+) -> dict[str, dict]:
+    """Deployment rules plus workspace policy when enforced (used by GET /api/connectors)."""
+    filtered = filter_connectors_for_deployment(connector_metadata)
+    if not is_connector_access_policy_enforced():
+        return filtered
+    access_map = await get_access_map(session)
+    return filter_connectors_for_user(filtered, access_map)
 
 
 async def list_access_for_admin(

--- a/tests/unit/services/test_connector_access_service.py
+++ b/tests/unit/services/test_connector_access_service.py
@@ -22,6 +22,7 @@ from services.connector_access_service import (  # noqa: E402
     governable_connector_types,
     is_connector_access_policy_enforced,
     is_connector_allowed,
+    is_connector_allowed_for_request,
     list_access_for_admin,
     set_connector_access_bulk,
 )
@@ -137,7 +138,7 @@ def test_connector_access_policy_enforced_with_dev_connector_policy(monkeypatch)
     assert is_connector_access_policy_enforced() is True
 
 
-def test_governable_connector_types_excludes_buckets_in_saas(monkeypatch):
+def test_governable_connector_types_includes_buckets_in_saas(monkeypatch):
     monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
     monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
 
@@ -145,8 +146,114 @@ def test_governable_connector_types_excludes_buckets_in_saas(monkeypatch):
 
     assert "google_drive" in governable
     assert "sharepoint" in governable
+    assert "aws_s3" in governable
+    assert "ibm_cos" in governable
+
+
+def test_governable_connector_types_excludes_buckets_in_oss(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+    monkeypatch.delenv("OPENRAG_DEV_CONNECTOR_POLICY", raising=False)
+
+    governable = governable_connector_types()
+
     assert "aws_s3" not in governable
     assert "ibm_cos" not in governable
+
+
+def test_governable_connector_types_excludes_onedrive_in_saas(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+
+    governable = governable_connector_types()
+
+    assert "onedrive" not in governable
+    assert "sharepoint" in governable
+
+
+def test_filter_connectors_for_deployment_saas_connector_set(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+
+    from services.connector_access_service import filter_connectors_for_deployment
+
+    metadata = {
+        "google_drive": {"name": "Google Drive"},
+        "sharepoint": {"name": "SharePoint"},
+        "onedrive": {"name": "OneDrive"},
+        "aws_s3": {"name": "Amazon S3"},
+        "ibm_cos": {"name": "IBM COS"},
+    }
+    filtered = filter_connectors_for_deployment(metadata)
+    assert set(filtered.keys()) == {
+        "google_drive",
+        "sharepoint",
+        "aws_s3",
+        "ibm_cos",
+    }
+
+
+def test_filter_connectors_for_deployment_excludes_buckets_in_oss(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+    monkeypatch.delenv("OPENRAG_DEV_CONNECTOR_POLICY", raising=False)
+
+    from services.connector_access_service import filter_connectors_for_deployment
+
+    metadata = {
+        "google_drive": {"name": "Google Drive"},
+        "aws_s3": {"name": "Amazon S3"},
+        "ibm_cos": {"name": "IBM COS"},
+    }
+    filtered = filter_connectors_for_deployment(metadata)
+    assert set(filtered.keys()) == {"google_drive"}
+
+
+def test_filter_connectors_for_deployment_includes_buckets_with_dev_policy(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+    monkeypatch.setenv("OPENRAG_DEV_CONNECTOR_POLICY", "true")
+
+    from services.connector_access_service import filter_connectors_for_deployment
+
+    metadata = {
+        "google_drive": {"name": "Google Drive"},
+        "onedrive": {"name": "OneDrive"},
+        "aws_s3": {"name": "Amazon S3"},
+        "ibm_cos": {"name": "IBM COS"},
+    }
+    filtered = filter_connectors_for_deployment(metadata)
+    assert set(filtered.keys()) == {"google_drive", "aws_s3", "ibm_cos"}
+
+
+def test_governable_connector_types_includes_buckets_with_dev_policy(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+    monkeypatch.setenv("OPENRAG_DEV_CONNECTOR_POLICY", "true")
+
+    governable = governable_connector_types()
+
+    assert "aws_s3" in governable
+    assert "ibm_cos" in governable
+
+
+@pytest.mark.asyncio
+async def test_is_connector_allowed_for_request_blocks_buckets_in_oss(session, monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+    monkeypatch.delenv("OPENRAG_DEV_CONNECTOR_POLICY", raising=False)
+
+    assert await is_connector_allowed_for_request(session, "aws_s3") is False
+    assert await is_connector_allowed_for_request(session, "google_drive") is True
+
+
+@pytest.mark.asyncio
+async def test_is_connector_allowed_for_request_blocks_onedrive_in_saas(session, monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    monkeypatch.setattr("config.settings.IBM_AUTH_ENABLED", False)
+
+    assert await is_connector_allowed_for_request(session, "onedrive") is False
+    assert await is_connector_allowed_for_request(session, "sharepoint") is True
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
in each deployment: bucket connectors only in cloud/SaaS context, OneDrive hidden in SaaS, OAuth connectors in pure OSS. Apply the same rules to sync and access checks so workspace admin toggles cannot bypass deployment policy. Frontend: drop client-side deployment filtering from useGetConnectorsQuery, simplify knowledge-dropdown to use connector queries, and refresh bucket configure cache after S3/COS setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connector availability now respects deployment/run-mode and cloud context, with improved credential checks and bucket support in SaaS.

* **Bug Fixes**
  * More targeted cache invalidation so connector and bucket configuration updates refresh UI state reliably; listing and access filtering moved to deployment-aware logic.

* **Style / UX**
  * Simplified connector menus: unavailable items show disabled styling and route to settings when not connectable.

* **Tests**
  * Expanded unit tests covering deployment/run-mode visibility and request-time access rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->