### PR TITLE
fix: hide OneDrive if not OSS

### DIFF
--- a/frontend/app/api/queries/useGetConnectorsQuery.ts
+++ b/frontend/app/api/queries/useGetConnectorsQuery.ts
@@ -260,6 +260,22 @@ export interface ConnectorAccessItem {
 
 export const CONNECTOR_USER_ACCESS_KEY = ["connector-user-access"] as const;
 
+export function connectorUserAccessQueryKey(
+  isCloudBrand: boolean,
+  isIbmAuthMode: boolean,
+) {
+  return [...CONNECTOR_USER_ACCESS_KEY, isCloudBrand, isIbmAuthMode] as const;
+}
+
+function filterConnectorAccessItems(
+  connectors: ConnectorAccessItem[],
+  deploymentCtx: { isCloudBrand: boolean; isIbmAuthMode: boolean },
+): ConnectorAccessItem[] {
+  return connectors.filter((c) =>
+    isConnectorTypeVisible(c.type, deploymentCtx),
+  );
+}
+
 export const useGetConnectorAccessQuery = (
   options?: Omit<
     UseQueryOptions<ConnectorAccessItem[]>,
@@ -279,13 +295,11 @@ export const useGetConnectorAccessQuery = (
     const data = await response.json();
     const connectors = Array.isArray(data.connectors) ? data.connectors : [];
     const deploymentCtx = { isCloudBrand, isIbmAuthMode };
-    return connectors.filter((c: ConnectorAccessItem) =>
-      isConnectorTypeVisible(c.type, deploymentCtx),
-    );
+    return filterConnectorAccessItems(connectors, deploymentCtx);
   }
 
   return useQuery({
-    queryKey: [...CONNECTOR_USER_ACCESS_KEY, isCloudBrand, isIbmAuthMode],
+    queryKey: connectorUserAccessQueryKey(isCloudBrand, isIbmAuthMode),
     queryFn: fetchConnectorAccess,
     refetchOnWindowFocus: false,
     ...options,
@@ -294,6 +308,13 @@ export const useGetConnectorAccessQuery = (
 
 export const useUpdateConnectorAccessMutation = () => {
   const queryClient = useQueryClient();
+  const isCloudBrand = useIsCloudBrand();
+  const { isIbmAuthMode } = useAuth();
+  const deploymentCtx = { isCloudBrand, isIbmAuthMode };
+  const accessQueryKey = connectorUserAccessQueryKey(
+    isCloudBrand,
+    isIbmAuthMode,
+  );
 
   return useMutation({
     mutationFn: async (
@@ -311,10 +332,11 @@ export const useUpdateConnectorAccessMutation = () => {
         );
       }
       const data = await response.json();
-      return Array.isArray(data.connectors) ? data.connectors : [];
+      const connectors = Array.isArray(data.connectors) ? data.connectors : [];
+      return filterConnectorAccessItems(connectors, deploymentCtx);
     },
     onSuccess: (connectors) => {
-      queryClient.setQueryData(CONNECTOR_USER_ACCESS_KEY, connectors);
+      queryClient.setQueryData(accessQueryKey, connectors);
       queryClient.invalidateQueries(connectorsQueryFilter);
       toast.success("Connectors permission saved");
     },

--- a/frontend/app/api/queries/useGetConnectorsQuery.ts
+++ b/frontend/app/api/queries/useGetConnectorsQuery.ts
@@ -266,6 +266,9 @@ export const useGetConnectorAccessQuery = (
     "queryKey" | "queryFn"
   >,
 ) => {
+  const isCloudBrand = useIsCloudBrand();
+  const { isIbmAuthMode } = useAuth();
+
   async function fetchConnectorAccess(): Promise<ConnectorAccessItem[]> {
     const response = await fetch("/api/connectors/user-access");
     if (!response.ok) {
@@ -274,11 +277,15 @@ export const useGetConnectorAccessQuery = (
       );
     }
     const data = await response.json();
-    return Array.isArray(data.connectors) ? data.connectors : [];
+    const connectors = Array.isArray(data.connectors) ? data.connectors : [];
+    const deploymentCtx = { isCloudBrand, isIbmAuthMode };
+    return connectors.filter((c: ConnectorAccessItem) =>
+      isConnectorTypeVisible(c.type, deploymentCtx),
+    );
   }
 
   return useQuery({
-    queryKey: CONNECTOR_USER_ACCESS_KEY,
+    queryKey: [...CONNECTOR_USER_ACCESS_KEY, isCloudBrand, isIbmAuthMode],
     queryFn: fetchConnectorAccess,
     refetchOnWindowFocus: false,
     ...options,

--- a/frontend/lib/brand.ts
+++ b/frontend/lib/brand.ts
@@ -53,8 +53,8 @@ export function isConnectorAllowedByWorkspace(
 
 /**
  * Connectors tab visibility: workspace policy first, then deployment rules.
- * Explicit `storedAccess[type] === true` (saved in Connectors Permission) overrides
- * deployment filters so admins can re-enable types like OneDrive on cloud brand.
+ * Explicit `storedAccess[type] === true` overrides deployment filters except
+ * OneDrive outside OSS brand (hidden in SaaS/cloud UI).
  */
 export function isConnectorShownInWorkspace(
   type: string,
@@ -65,7 +65,9 @@ export function isConnectorShownInWorkspace(
   }: { isCloudBrand: boolean; isIbmAuthMode: boolean },
 ): boolean {
   if (!isConnectorAllowedByWorkspace(type, storedAccess)) return false;
-  if (storedAccess[type] === true) return true;
+  if (storedAccess[type] === true && !(type === "onedrive" && cloudBrand)) {
+    return true;
+  }
   return isConnectorTypeVisible(type, {
     isCloudBrand: cloudBrand,
     isIbmAuthMode,


### PR DESCRIPTION
Hide OneDrive in the frontend if not in OSS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector visibility so available connectors reflect the current deployment and authentication context.
  * Fixed OneDrive visibility so it remains hidden in cloud deployments even when workspace access is present.
  * Made access state updates more consistent across different deployment modes so connector lists stay accurate.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->