### PR TITLE
feat: set Router enabled by default in Saas

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -83,10 +83,9 @@ INGEST_CALLBACK_PATH = "/internal/ingest/chunks"
 #   * anything else        -> "false" (today's behaviour preserved)
 # An explicit OPENRAG_BACKEND_ROUTER_ENABLE value always wins.
 def _resolve_backend_router_enable_default() -> str:
-    run_mode = os.getenv("OPENRAG_RUN_MODE", "").strip().lower()
-    if run_mode == "saas":
-        return "true"
-    return "false"
+    from utils.run_mode_utils import is_run_mode_saas
+
+    return "true" if is_run_mode_saas() else "false"
 
 
 OPENRAG_BACKEND_ROUTER_ENABLE = os.getenv(
@@ -319,10 +318,9 @@ DOCLING_SERVE_VERIFY_SSL = os.getenv("DOCLING_SERVE_VERIFY_SSL", "true").lower()
 # An explicit OPENRAG_SKIP_OS_SECURITY_SETUP value always wins, so an
 # operator can force-enable the setup in SaaS for a one-off bootstrap.
 def _resolve_skip_os_security_default() -> str:
-    run_mode = os.getenv("OPENRAG_RUN_MODE", "").strip().lower()
-    if run_mode in ("saas", "on_prem"):
-        return "true"
-    return "false"
+    from utils.run_mode_utils import is_run_mode_on_prem, is_run_mode_saas
+
+    return "true" if is_run_mode_saas() or is_run_mode_on_prem() else "false"
 
 
 OPENRAG_SKIP_OS_SECURITY_SETUP = os.getenv(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -76,7 +76,22 @@ OPENRAG_BACKEND_INTERNAL_URL = os.getenv(
 # pointed at the router instead of the backend internal URL, so Langflow's
 # reachable surface narrows to that single endpoint.
 INGEST_CALLBACK_PATH = "/internal/ingest/chunks"
-OPENRAG_BACKEND_ROUTER_ENABLE = os.getenv("OPENRAG_BACKEND_ROUTER_ENABLE", "false").lower() in (
+
+
+# Default depends on OPENRAG_RUN_MODE:
+#   * saas                 -> "true" (the platform requires the narrowed surface)
+#   * anything else        -> "false" (today's behaviour preserved)
+# An explicit OPENRAG_BACKEND_ROUTER_ENABLE value always wins.
+def _resolve_backend_router_enable_default() -> str:
+    run_mode = os.getenv("OPENRAG_RUN_MODE", "").strip().lower()
+    if run_mode == "saas":
+        return "true"
+    return "false"
+
+
+OPENRAG_BACKEND_ROUTER_ENABLE = os.getenv(
+    "OPENRAG_BACKEND_ROUTER_ENABLE", _resolve_backend_router_enable_default()
+).lower() in (
     "true",
     "1",
     "yes",

--- a/tests/unit/test_backend_router.py
+++ b/tests/unit/test_backend_router.py
@@ -1,10 +1,33 @@
 """Tests for the standalone ingestion-callback proxy router and the callback-URL
 selection helper that points Langflow at it."""
 
+import pytest
 from fastapi.testclient import TestClient
 
 from app import router_app
 from config import settings
+
+# --- run-mode-dependent enable default ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    "run_mode, expected",
+    [
+        ("", "false"),  # unset -> default oss path
+        ("oss", "false"),
+        ("saas", "true"),
+        ("SaaS", "true"),
+        ("on_prem", "false"),
+        ("unknown-mode", "false"),
+    ],
+)
+def test_enable_default_resolves_from_run_mode(monkeypatch, run_mode, expected):
+    if run_mode:
+        monkeypatch.setenv("OPENRAG_RUN_MODE", run_mode)
+    else:
+        monkeypatch.delenv("OPENRAG_RUN_MODE", raising=False)
+    assert settings._resolve_backend_router_enable_default() == expected
+
 
 # --- callback URL selection -------------------------------------------------
 


### PR DESCRIPTION
feat: set Router enabled by default in Saas

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Backend router now enables by default for SaaS deployments (dynamic default based on run mode).
  * Default for OS security setup remains enabled for SaaS/on‑prem but is now derived from run mode logic.
* **Tests**
  * Added unit tests covering the dynamic defaults for run-mode driven settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->