### PR TITLE
fix: bump shell-quote to 1.8.4 for CVE-2026-9277

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -17329,9 +17329,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-      "integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"


### PR DESCRIPTION
Transitive dep of @docusaurus/core via webpack-dev-server/launch-editor. Fixes command injection in quote() (GHSA-w7jw-789q-3m8p, CVSS 9.2). launch-editor's ^1.8.3 range already admits 1.8.4, so only the lockfile entry changes.