### PR TITLE
Fix: Podman compatibility by adding environment configurable repository prefix to Docker Compose image references

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   opensearch:
-    image: langflowai/openrag-opensearch:${OPENRAG_VERSION:-latest}
+    image: ${CONTAINER_REGISTRY:-docker.io}/langflowai/openrag-opensearch:${OPENRAG_VERSION:-latest}
     # build:
     #   context: .
     #   dockerfile: Dockerfile
@@ -26,7 +26,7 @@ services:
     restart: unless-stopped
 
   dashboards:
-    image: opensearchproject/opensearch-dashboards:3.0.0
+    image: ${CONTAINER_REGISTRY:-docker.io}/opensearchproject/opensearch-dashboards:3.0.0
     container_name: osdash
     depends_on:
       - opensearch
@@ -38,7 +38,7 @@ services:
       - "5601:5601"
 
   openrag-backend:
-    image: langflowai/openrag-backend:${OPENRAG_VERSION:-latest}
+    image: ${CONTAINER_REGISTRY:-docker.io}/langflowai/openrag-backend:${OPENRAG_VERSION:-latest}
     build:
       context: .
       dockerfile: Dockerfile.backend
@@ -116,7 +116,7 @@ services:
       - "host.docker.internal:host-gateway"
 
   openrag-frontend:
-    image: langflowai/openrag-frontend:${OPENRAG_VERSION:-latest}
+    image: ${CONTAINER_REGISTRY:-docker.io}/langflowai/openrag-frontend:${OPENRAG_VERSION:-latest}
     build:
       context: .
       dockerfile: Dockerfile.frontend
@@ -129,7 +129,7 @@ services:
       - "${FRONTEND_PORT:-3000}:3000"
 
   langflow:
-    image: langflowai/openrag-langflow:${OPENRAG_VERSION:-latest}
+    image: ${CONTAINER_REGISTRY:-docker.io}/langflowai/openrag-langflow:${OPENRAG_VERSION:-latest}
     build:
       context: .
       dockerfile: Dockerfile.langflow


### PR DESCRIPTION
## Summary
Fixes #1206. Podman fails to resolve unqualified image names (no registry prefix) by default, causing `podman pull`/`podman compose up` to fail with: `Error: short-name "langflowai/openrag-backend:latest" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"`

  ## Changes
  - Prefix all image references in `docker-compose.yml` with Added environment variable prefix that defaults to `docker.io/` (5 images total: opensearch, opensearch-dashboards, backend, frontend, langflow) if none provided

  ## Testing
  - Verified on Windows 10 + WSL2 + Ubuntu 24.04 + Podman 4.9.3,  image pulls and `podman compose up` now succeed
  - Confirmed `docker compose` still works identically (fully-qualified `docker.io/...` and unqualified `...` resolve to the same image on Docker Hub)
  - Ran unit test suite


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container image references to include an environment variable registry prefixes across services that defaults to docker.io, ensuring consistent image resolution across environments while preserving existing version tag behavior. No functional changes to runtime versions; deployment behavior remains the same.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->