### PR TITLE
fix: put correct file type in langflow-less ingestion

### DIFF
--- a/src/api/router.py
+++ b/src/api/router.py
@@ -1,6 +1,7 @@
 """Router endpoints that automatically route based on configuration settings."""
 
 import json
+import os
 import tempfile
 
 from fastapi import Depends, File, Form, UploadFile
@@ -105,8 +106,11 @@ async def _traditional_upload_ingest_task(
             for upload_file in upload_files:
                 content = await upload_file.read()
                 original_filenames.append(upload_file.filename)
-                # Generate unique temp file to avoid collisions
-                temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".tmp")
+                # Generate unique temp file with the original extension to assist docling/format detection
+                suffix = os.path.splitext(upload_file.filename)[1] if upload_file.filename else ""
+                if not suffix:
+                    suffix = ".tmp"
+                temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
                 temp_path = temp_file.name
                 temp_file.close()
                 with open(temp_path, "wb") as f:
@@ -206,8 +210,11 @@ async def _langflow_upload_ingest_task(
             for upload_file in upload_files:
                 content = await upload_file.read()
                 original_filenames.append(upload_file.filename)
-                # Generate unique temp file to avoid collisions
-                temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=".tmp")
+                # Generate unique temp file with the original extension to assist docling/format detection
+                suffix = os.path.splitext(upload_file.filename)[1] if upload_file.filename else ""
+                if not suffix:
+                    suffix = ".tmp"
+                temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
                 temp_path = temp_file.name
                 temp_file.close()
                 with open(temp_path, "wb") as f:

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -111,6 +111,7 @@ async def _traditional_upload_ingest_task(
                 suffix = os.path.splitext(upload_file.filename)[1] if upload_file.filename else ""
                 if not suffix and upload_file.content_type:
                     from utils.file_utils import get_file_extension
+
                     suffix = get_file_extension(upload_file.content_type)
                     if not suffix:
                         suffix = mimetypes.guess_extension(upload_file.content_type)
@@ -220,6 +221,7 @@ async def _langflow_upload_ingest_task(
                 suffix = os.path.splitext(upload_file.filename)[1] if upload_file.filename else ""
                 if not suffix and upload_file.content_type:
                     from utils.file_utils import get_file_extension
+
                     suffix = get_file_extension(upload_file.content_type)
                     if not suffix:
                         suffix = mimetypes.guess_extension(upload_file.content_type)

--- a/src/api/router.py
+++ b/src/api/router.py
@@ -1,6 +1,7 @@
 """Router endpoints that automatically route based on configuration settings."""
 
 import json
+import mimetypes
 import os
 import tempfile
 
@@ -108,6 +109,11 @@ async def _traditional_upload_ingest_task(
                 original_filenames.append(upload_file.filename)
                 # Generate unique temp file with the original extension to assist docling/format detection
                 suffix = os.path.splitext(upload_file.filename)[1] if upload_file.filename else ""
+                if not suffix and upload_file.content_type:
+                    from utils.file_utils import get_file_extension
+                    suffix = get_file_extension(upload_file.content_type)
+                    if not suffix:
+                        suffix = mimetypes.guess_extension(upload_file.content_type)
                 if not suffix:
                     suffix = ".tmp"
                 temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)
@@ -212,6 +218,11 @@ async def _langflow_upload_ingest_task(
                 original_filenames.append(upload_file.filename)
                 # Generate unique temp file with the original extension to assist docling/format detection
                 suffix = os.path.splitext(upload_file.filename)[1] if upload_file.filename else ""
+                if not suffix and upload_file.content_type:
+                    from utils.file_utils import get_file_extension
+                    suffix = get_file_extension(upload_file.content_type)
+                    if not suffix:
+                        suffix = mimetypes.guess_extension(upload_file.content_type)
                 if not suffix:
                     suffix = ".tmp"
                 temp_file = tempfile.NamedTemporaryFile(delete=False, suffix=suffix)

--- a/tests/unit/config/test_disable_ingest_setting.py
+++ b/tests/unit/config/test_disable_ingest_setting.py
@@ -123,6 +123,7 @@ async def test_traditional_upload_ingest_task(monkeypatch):
     assert len(file_paths) == 1
     assert file_paths[0].endswith(".txt")
     import os
+
     for path in file_paths:
         if os.path.exists(path):
             os.unlink(path)
@@ -184,6 +185,7 @@ async def test_langflow_upload_ingest_task(monkeypatch):
     assert len(file_paths) == 1
     assert file_paths[0].endswith(".pptx")
     import os
+
     for path in file_paths:
         if os.path.exists(path):
             os.unlink(path)

--- a/tests/unit/config/test_disable_ingest_setting.py
+++ b/tests/unit/config/test_disable_ingest_setting.py
@@ -189,3 +189,55 @@ async def test_langflow_upload_ingest_task(monkeypatch):
     for path in file_paths:
         if os.path.exists(path):
             os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_traditional_upload_ingest_mime_fallback(monkeypatch):
+    """Verify that if the filename has no extension, the temporary file suffix is resolved from content_type."""
+    from unittest.mock import AsyncMock, MagicMock
+    from fastapi import UploadFile
+    from api.router import _traditional_upload_ingest_task
+    from session_manager import User
+
+    mock_file = MagicMock(spec=UploadFile)
+    mock_file.filename = "no_extension_file"
+    mock_file.content_type = "application/pdf"
+    mock_file.read = AsyncMock(return_value=b"Dummy content")
+
+    mock_task_service = MagicMock()
+    mock_task_service.create_upload_task = AsyncMock(return_value="task-mime-123")
+
+    mock_session_manager = MagicMock()
+    mock_user = MagicMock(spec=User)
+    mock_user.user_id = "test-user-id"
+    mock_user.name = "Test User"
+    mock_user.email = "test@example.com"
+    mock_user.jwt_token = "mock-jwt-token"
+
+    # Mock _ensure_index_exists to avoid calling opensearch
+    mock_ensure_index = AsyncMock()
+    monkeypatch.setattr("api.documents._ensure_index_exists", mock_ensure_index)
+
+    response = await _traditional_upload_ingest_task(
+        upload_files=[mock_file],
+        replace_duplicates=True,
+        create_filter=False,
+        session_manager=mock_session_manager,
+        task_service=mock_task_service,
+        user=mock_user,
+    )
+
+    assert response.status_code == 202
+    mock_task_service.create_upload_task.assert_called_once()
+
+    # Extract file_paths and verify the extension was resolved to .pdf from content_type
+    call_kwargs = mock_task_service.create_upload_task.call_args[1]
+    file_paths = call_kwargs.get("file_paths")
+    assert file_paths is not None
+    assert len(file_paths) == 1
+    assert file_paths[0].endswith(".pdf")
+
+    import os
+    for path in file_paths:
+        if os.path.exists(path):
+            os.unlink(path)

--- a/tests/unit/config/test_disable_ingest_setting.py
+++ b/tests/unit/config/test_disable_ingest_setting.py
@@ -195,7 +195,9 @@ async def test_langflow_upload_ingest_task(monkeypatch):
 async def test_traditional_upload_ingest_mime_fallback(monkeypatch):
     """Verify that if the filename has no extension, the temporary file suffix is resolved from content_type."""
     from unittest.mock import AsyncMock, MagicMock
+
     from fastapi import UploadFile
+
     from api.router import _traditional_upload_ingest_task
     from session_manager import User
 
@@ -238,6 +240,7 @@ async def test_traditional_upload_ingest_mime_fallback(monkeypatch):
     assert file_paths[0].endswith(".pdf")
 
     import os
+
     for path in file_paths:
         if os.path.exists(path):
             os.unlink(path)

--- a/tests/unit/config/test_disable_ingest_setting.py
+++ b/tests/unit/config/test_disable_ingest_setting.py
@@ -115,3 +115,75 @@ async def test_traditional_upload_ingest_task(monkeypatch):
 
     mock_task_service.create_upload_task.assert_called_once()
     mock_ensure_index.assert_called_once_with("mock-jwt-token")
+
+    # Extract file_paths, assert extension is preserved, and clean them up
+    call_kwargs = mock_task_service.create_upload_task.call_args[1]
+    file_paths = call_kwargs.get("file_paths")
+    assert file_paths is not None
+    assert len(file_paths) == 1
+    assert file_paths[0].endswith(".txt")
+    import os
+    for path in file_paths:
+        if os.path.exists(path):
+            os.unlink(path)
+
+
+@pytest.mark.asyncio
+async def test_langflow_upload_ingest_task(monkeypatch):
+    """Verify that langflow ingestion invokes task_service.create_langflow_upload_task and preserves extension."""
+    from unittest.mock import AsyncMock, MagicMock
+
+    from fastapi import UploadFile
+
+    from api.router import _langflow_upload_ingest_task
+    from session_manager import User
+
+    mock_file = MagicMock(spec=UploadFile)
+    mock_file.filename = "presentation.pptx"
+    mock_file.read = AsyncMock(return_value=b"Dummy pptx content")
+
+    mock_task_service = MagicMock()
+    mock_task_service.create_langflow_upload_task = AsyncMock(return_value="langflow-task-123")
+
+    mock_langflow_file_service = MagicMock()
+    mock_session_manager = MagicMock()
+
+    mock_user = MagicMock(spec=User)
+    mock_user.user_id = "test-user-id"
+    mock_user.name = "Test User"
+    mock_user.email = "test@example.com"
+    mock_user.jwt_token = "mock-jwt-token"
+
+    response = await _langflow_upload_ingest_task(
+        upload_files=[mock_file],
+        session_id="session-456",
+        settings_json=None,
+        tweaks_json=None,
+        replace_duplicates=True,
+        create_filter=False,
+        langflow_file_service=mock_langflow_file_service,
+        session_manager=mock_session_manager,
+        task_service=mock_task_service,
+        user=mock_user,
+    )
+
+    assert response.status_code == 202
+    import json
+
+    data = json.loads(response.body.decode())
+    assert data["task_id"] == "langflow-task-123"
+    assert data["file_count"] == 1
+    assert data["filename"] == "presentation.pptx"
+
+    mock_task_service.create_langflow_upload_task.assert_called_once()
+
+    # Extract file_paths, assert extension is preserved, and clean them up
+    call_kwargs = mock_task_service.create_langflow_upload_task.call_args[1]
+    file_paths = call_kwargs.get("file_paths")
+    assert file_paths is not None
+    assert len(file_paths) == 1
+    assert file_paths[0].endswith(".pptx")
+    import os
+    for path in file_paths:
+        if os.path.exists(path):
+            os.unlink(path)


### PR DESCRIPTION
This pull request improves how temporary files are handled during file uploads by preserving the original file extensions, which helps with format detection. It also adds unit tests to ensure this behavior for both traditional and langflow upload ingestion tasks.

**File Upload Improvements:**
- Temporary files are now created with the original file extension (if available) instead of always using `.tmp`, improving compatibility with downstream format detection [[1]](diffhunk://#diff-585a2e9d897ffbd47df61ed9efb432c1c7193e4d88cb147cd5e84e5b4ca3a9faL108-R113) [[2]](diffhunk://#diff-585a2e9d897ffbd47df61ed9efb432c1c7193e4d88cb147cd5e84e5b4ca3a9faL209-R217).

**Testing Enhancements:**
- Added and updated unit tests in `test_disable_ingest_setting.py` to verify that the file extension is preserved for both traditional and langflow upload ingestion tasks, and to clean up temporary files after tests.

**Dependency Updates:**
- Added `os` import to `router.py` to support file extension extraction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * File uploads now preserve original file extensions during processing, with automatic fallback for files that lack an extension.

* **Tests**
  * Added/updated unit tests to verify preserved extensions and fallback behavior for both traditional and Langflow-style uploads.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->