### PR TITLE
chore: release 0.4.0.dev0 of sdks

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openrag-sdk"
-version = "0.4.0"
+version = "0.4.1"
 description = "Official Python SDK for OpenRAG API"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openrag-sdk"
-version = "0.4.1"
+version = "0.4.0.dev0"
 description = "Official Python SDK for OpenRAG API"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "openrag-sdk"
-version = "0.4.0"
+version = "0.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "openrag-sdk"
-version = "0.4.1"
+version = "0.4.0.dev0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrag-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrag-sdk",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrag-sdk",
-  "version": "0.4.1",
+  "version": "0.4.0.dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrag-sdk",
-      "version": "0.4.1",
+      "version": "0.4.0.dev0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrag-sdk",
-  "version": "0.4.0.dev0",
+  "version": "0.4.0-dev0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrag-sdk",
-      "version": "0.4.0.dev0",
+      "version": "0.4.0-dev0",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^20.0.0",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrag-sdk",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Official TypeScript/JavaScript SDK for OpenRAG API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrag-sdk",
-  "version": "0.4.0.dev0",
+  "version": "0.4.0-dev0",
   "description": "Official TypeScript/JavaScript SDK for OpenRAG API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrag-sdk",
-  "version": "0.4.1",
+  "version": "0.4.0.dev0",
   "description": "Official TypeScript/JavaScript SDK for OpenRAG API",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped SDK package versions: Python and TypeScript SDKs updated to 0.4.0.dev0 (development prerelease).
  * Version-only updates; no other user-facing changes or metadata updates included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->