### PR TITLE
fix: restore LLM model values in reapply_all_settings fallback (#1587)

### DIFF
--- a/src/api/settings/langflow_sync.py
+++ b/src/api/settings/langflow_sync.py
@@ -191,6 +191,26 @@ async def _update_langflow_model_values(
             )
 
         if not (embedding_model or embedding_provider or llm_model or llm_provider):
+            # 1. Update ALL configured LLM providers
+            llm_providers = []
+            if config.providers.openai.configured:
+                llm_providers.append("openai")
+            if config.providers.anthropic.configured:
+                llm_providers.append("anthropic")
+            if config.providers.watsonx.configured:
+                llm_providers.append("watsonx")
+            if config.providers.ollama.configured:
+                llm_providers.append("ollama")
+
+            current_llm_provider = (config.agent.llm_provider or "").lower()
+            for provider in llm_providers:
+                # Use configured model for current provider, or None (first available) for others
+                llm_model = config.agent.llm_model if provider == current_llm_provider else None
+                await flows_service.change_langflow_model_value(
+                    provider, llm_model=llm_model, force_llm_update=True
+                )
+                logger.info(f"Successfully updated Langflow flows for LLM provider {provider}")
+
             # 2. Update ALL configured embedding providers
             embedding_providers = []
             if config.providers.openai.configured:

--- a/tests/unit/api/test_langflow_sync_bug_1587.py
+++ b/tests/unit/api/test_langflow_sync_bug_1587.py
@@ -1,0 +1,109 @@
+"""Tests for bug #1587: LLM model values not restored by fallback branch."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.settings.langflow_sync import _update_langflow_model_values
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="Documents pre-fix behavior of #1587; fails by design on fixed code")
+async def test_bug_1587_unfixed_no_llm_updates_in_fallback():
+    """
+    Demonstrates the bug: when reapply_all_settings() calls _update_langflow_model_values()
+    with no explicit overrides, the fallback branch updates embedding providers but NOT
+    LLM providers, leaving flows in a reset state.
+
+    This test is skipped because it documents the UNFIXED behavior and will fail on fixed code.
+    """
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = True
+    mock_config.providers.watsonx.configured = True
+    mock_config.providers.ollama.configured = True
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = "anthropic"
+    mock_config.agent.llm_model = "claude-3-5-sonnet-20241022"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    # Call with no explicit overrides (the reapply_all_settings path)
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model=None,
+        llm_provider=None,
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    # On unfixed code: zero LLM calls, only embedding calls
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "llm_model" in call.kwargs or "force_llm_update" in call.kwargs
+    ]
+    assert len(llm_calls) == 0, "Bug #1587: fallback branch should update LLM providers but doesn't"
+
+
+@pytest.mark.asyncio
+async def test_bug_1587_fixed_llm_updates_in_fallback():
+    """
+    Validates the fix: when reapply_all_settings() calls _update_langflow_model_values()
+    with no explicit overrides, the fallback branch now updates BOTH LLM and embedding
+    providers across all configured providers.
+    """
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = True
+    mock_config.providers.watsonx.configured = True
+    mock_config.providers.ollama.configured = True
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = "anthropic"
+    mock_config.agent.llm_model = "claude-3-5-sonnet-20241022"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    # Call with no explicit overrides (the reapply_all_settings path)
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model=None,
+        llm_provider=None,
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    # Verify LLM calls
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_llm_update" in call.kwargs and call.kwargs["force_llm_update"] is True
+    ]
+    assert len(llm_calls) == 4, (
+        "Should update all 4 LLM providers (openai, anthropic, watsonx, ollama)"
+    )
+
+    # Verify current provider gets the configured model
+    anthropic_call = next((call for call in llm_calls if call.args[0] == "anthropic"), None)
+    assert anthropic_call is not None
+    assert anthropic_call.kwargs["llm_model"] == "claude-3-5-sonnet-20241022"
+
+    # Verify other providers get None
+    for provider in ["openai", "watsonx", "ollama"]:
+        provider_call = next((call for call in llm_calls if call.args[0] == provider), None)
+        assert provider_call is not None
+        assert provider_call.kwargs["llm_model"] is None
+
+    # Verify embedding calls unchanged (3 providers: openai, watsonx, ollama - no anthropic)
+    embedding_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_embedding_update" in call.kwargs and call.kwargs["force_embedding_update"] is True
+    ]
+    assert len(embedding_calls) == 3

--- a/tests/unit/api/test_langflow_sync_bug_1587.py
+++ b/tests/unit/api/test_langflow_sync_bug_1587.py
@@ -1,35 +1,48 @@
 """Tests for bug #1587: LLM model values not restored by fallback branch."""
-
+ 
 from unittest.mock import AsyncMock, MagicMock
-
+ 
 import pytest
-
+ 
 from api.settings.langflow_sync import _update_langflow_model_values
-
-
+ 
+ 
+@pytest.fixture
+def mock_config():
+    """Standard mock configuration for langflow sync tests.
+ 
+    All four providers configured; embedding via openai, LLM via anthropic.
+    """
+    config = MagicMock()
+    config.providers.openai.configured = True
+    config.providers.anthropic.configured = True
+    config.providers.watsonx.configured = True
+    config.providers.ollama.configured = True
+    config.knowledge.embedding_provider = "openai"
+    config.knowledge.embedding_model = "text-embedding-3-small"
+    config.agent.llm_provider = "anthropic"
+    config.agent.llm_model = "claude-3-5-sonnet-20241022"
+    return config
+ 
+ 
+@pytest.fixture
+def mock_flows_service():
+    """Flows service stub whose model-value calls report a successful update."""
+    service = AsyncMock()
+    service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+    return service
+ 
+ 
 @pytest.mark.asyncio
 @pytest.mark.skip(reason="Documents pre-fix behavior of #1587; fails by design on fixed code")
-async def test_bug_1587_unfixed_no_llm_updates_in_fallback():
+async def test_bug_1587_unfixed_no_llm_updates_in_fallback(mock_config, mock_flows_service):
     """
     Demonstrates the bug: when reapply_all_settings() calls _update_langflow_model_values()
     with no explicit overrides, the fallback branch updates embedding providers but NOT
     LLM providers, leaving flows in a reset state.
-
+ 
     This test is skipped because it documents the UNFIXED behavior and will fail on fixed code.
     """
-    mock_config = MagicMock()
-    mock_config.providers.openai.configured = True
-    mock_config.providers.anthropic.configured = True
-    mock_config.providers.watsonx.configured = True
-    mock_config.providers.ollama.configured = True
-    mock_config.knowledge.embedding_provider = "openai"
-    mock_config.knowledge.embedding_model = "text-embedding-3-small"
-    mock_config.agent.llm_provider = "anthropic"
-    mock_config.agent.llm_model = "claude-3-5-sonnet-20241022"
-
-    mock_flows_service = AsyncMock()
-    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
-
     # Call with no explicit overrides (the reapply_all_settings path)
     await _update_langflow_model_values(
         mock_config,
@@ -39,7 +52,7 @@ async def test_bug_1587_unfixed_no_llm_updates_in_fallback():
         embedding_model=None,
         embedding_provider=None,
     )
-
+ 
     # On unfixed code: zero LLM calls, only embedding calls
     llm_calls = [
         call
@@ -47,28 +60,15 @@ async def test_bug_1587_unfixed_no_llm_updates_in_fallback():
         if "llm_model" in call.kwargs or "force_llm_update" in call.kwargs
     ]
     assert len(llm_calls) == 0, "Bug #1587: fallback branch should update LLM providers but doesn't"
-
-
+ 
+ 
 @pytest.mark.asyncio
-async def test_bug_1587_fixed_llm_updates_in_fallback():
+async def test_bug_1587_fixed_llm_updates_in_fallback(mock_config, mock_flows_service):
     """
     Validates the fix: when reapply_all_settings() calls _update_langflow_model_values()
     with no explicit overrides, the fallback branch now updates BOTH LLM and embedding
     providers across all configured providers.
     """
-    mock_config = MagicMock()
-    mock_config.providers.openai.configured = True
-    mock_config.providers.anthropic.configured = True
-    mock_config.providers.watsonx.configured = True
-    mock_config.providers.ollama.configured = True
-    mock_config.knowledge.embedding_provider = "openai"
-    mock_config.knowledge.embedding_model = "text-embedding-3-small"
-    mock_config.agent.llm_provider = "anthropic"
-    mock_config.agent.llm_model = "claude-3-5-sonnet-20241022"
-
-    mock_flows_service = AsyncMock()
-    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
-
     # Call with no explicit overrides (the reapply_all_settings path)
     await _update_langflow_model_values(
         mock_config,
@@ -78,7 +78,7 @@ async def test_bug_1587_fixed_llm_updates_in_fallback():
         embedding_model=None,
         embedding_provider=None,
     )
-
+ 
     # Verify LLM calls
     llm_calls = [
         call
@@ -88,18 +88,18 @@ async def test_bug_1587_fixed_llm_updates_in_fallback():
     assert len(llm_calls) == 4, (
         "Should update all 4 LLM providers (openai, anthropic, watsonx, ollama)"
     )
-
+ 
     # Verify current provider gets the configured model
     anthropic_call = next((call for call in llm_calls if call.args[0] == "anthropic"), None)
     assert anthropic_call is not None
     assert anthropic_call.kwargs["llm_model"] == "claude-3-5-sonnet-20241022"
-
+ 
     # Verify other providers get None
     for provider in ["openai", "watsonx", "ollama"]:
         provider_call = next((call for call in llm_calls if call.args[0] == provider), None)
         assert provider_call is not None
         assert provider_call.kwargs["llm_model"] is None
-
+ 
     # Verify embedding calls unchanged (3 providers: openai, watsonx, ollama - no anthropic)
     embedding_calls = [
         call

--- a/tests/unit/api/test_langflow_sync_edge_cases.py
+++ b/tests/unit/api/test_langflow_sync_edge_cases.py
@@ -234,5 +234,3 @@ async def test_explicit_overrides_skip_fallback():
     assert llm_calls[0].args[0] == "openai"
     assert llm_calls[0].kwargs["llm_model"] == "gpt-4o"
 
-
-# Made with Bob

--- a/tests/unit/api/test_langflow_sync_edge_cases.py
+++ b/tests/unit/api/test_langflow_sync_edge_cases.py
@@ -1,0 +1,238 @@
+"""Edge case tests for LLM fallback update in langflow_sync."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.settings.langflow_sync import _update_langflow_model_values
+
+
+@pytest.mark.asyncio
+async def test_empty_string_llm_provider_no_crash():
+    """Empty string llm_provider should not crash and no provider receives the configured model."""
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = True
+    mock_config.providers.watsonx.configured = False
+    mock_config.providers.ollama.configured = False
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = ""  # Empty string
+    mock_config.agent.llm_model = "gpt-4o"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model=None,
+        llm_provider=None,
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    # Should not crash, and all LLM providers get None (no match for empty string)
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_llm_update" in call.kwargs
+    ]
+    assert len(llm_calls) == 2  # openai, anthropic
+    for call in llm_calls:
+        assert call.kwargs["llm_model"] is None
+
+
+@pytest.mark.asyncio
+async def test_llm_provider_not_in_configured_set():
+    """LLM provider names a provider not in the configured set."""
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = False
+    mock_config.providers.watsonx.configured = False
+    mock_config.providers.ollama.configured = False
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = "anthropic"  # Not configured
+    mock_config.agent.llm_model = "claude-3-5-sonnet-20241022"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model=None,
+        llm_provider=None,
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    # Only configured providers updated, all with None (no match)
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_llm_update" in call.kwargs
+    ]
+    assert len(llm_calls) == 1  # Only openai
+    assert llm_calls[0].args[0] == "openai"
+    assert llm_calls[0].kwargs["llm_model"] is None
+
+
+@pytest.mark.asyncio
+async def test_single_configured_provider():
+    """Single configured provider works correctly."""
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = False
+    mock_config.providers.anthropic.configured = False
+    mock_config.providers.watsonx.configured = True
+    mock_config.providers.ollama.configured = False
+    mock_config.knowledge.embedding_provider = "watsonx"
+    mock_config.knowledge.embedding_model = "ibm/granite-embedding-125m-english"
+    mock_config.agent.llm_provider = "watsonx"
+    mock_config.agent.llm_model = "ibm/granite-3-8b-instruct"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model=None,
+        llm_provider=None,
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_llm_update" in call.kwargs
+    ]
+    assert len(llm_calls) == 1
+    assert llm_calls[0].args[0] == "watsonx"
+    assert llm_calls[0].kwargs["llm_model"] == "ibm/granite-3-8b-instruct"
+
+
+@pytest.mark.asyncio
+async def test_provider_list_consistency():
+    """LLM set has 4 entries, embedding set has 3 (no anthropic)."""
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = True
+    mock_config.providers.watsonx.configured = True
+    mock_config.providers.ollama.configured = True
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = "openai"
+    mock_config.agent.llm_model = "gpt-4o"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model=None,
+        llm_provider=None,
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_llm_update" in call.kwargs
+    ]
+    embedding_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_embedding_update" in call.kwargs
+    ]
+
+    assert len(llm_calls) == 4  # openai, anthropic, watsonx, ollama
+    assert len(embedding_calls) == 3  # openai, watsonx, ollama (no anthropic)
+
+    llm_providers = {call.args[0] for call in llm_calls}
+    embedding_providers = {call.args[0] for call in embedding_calls}
+
+    assert llm_providers == {"openai", "anthropic", "watsonx", "ollama"}
+    assert embedding_providers == {"openai", "watsonx", "ollama"}
+    assert "anthropic" not in embedding_providers
+
+
+@pytest.mark.asyncio
+async def test_exception_mid_loop_propagates():
+    """Exception mid-loop propagates (matches embedding loop behavior)."""
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = True
+    mock_config.providers.watsonx.configured = True
+    mock_config.providers.ollama.configured = True
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = "openai"
+    mock_config.agent.llm_model = "gpt-4o"
+
+    mock_flows_service = AsyncMock()
+    # Fail on the second LLM call
+    call_count = [0]
+
+    async def side_effect(*args, **kwargs):
+        if "force_llm_update" in kwargs:
+            call_count[0] += 1
+            if call_count[0] == 2:
+                raise RuntimeError("Simulated failure")
+        return {"updated": True}
+
+    mock_flows_service.change_langflow_model_value = AsyncMock(side_effect=side_effect)
+
+    with pytest.raises(RuntimeError, match="Simulated failure"):
+        await _update_langflow_model_values(
+            mock_config,
+            mock_flows_service,
+            llm_model=None,
+            llm_provider=None,
+            embedding_model=None,
+            embedding_provider=None,
+        )
+
+
+@pytest.mark.asyncio
+async def test_explicit_overrides_skip_fallback():
+    """Explicit overrides passed means fallback branch NOT reached."""
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = True
+    mock_config.providers.watsonx.configured = True
+    mock_config.providers.ollama.configured = True
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = "anthropic"
+    mock_config.agent.llm_model = "claude-3-5-sonnet-20241022"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    # Pass explicit LLM override
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model="gpt-4o",
+        llm_provider="openai",
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    # Should only have 1 LLM call (the explicit override), not 4 from fallback
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_llm_update" in call.kwargs
+    ]
+    assert len(llm_calls) == 1
+    assert llm_calls[0].args[0] == "openai"
+    assert llm_calls[0].kwargs["llm_model"] == "gpt-4o"
+
+
+# Made with Bob

--- a/tests/unit/api/test_none_crash.py
+++ b/tests/unit/api/test_none_crash.py
@@ -47,6 +47,3 @@ async def test_none_llm_provider_handled_gracefully():
     assert len(llm_calls) == 2  # openai, anthropic
     for call in llm_calls:
         assert call.kwargs["llm_model"] is None
-
-
-# Made with Bob

--- a/tests/unit/api/test_none_crash.py
+++ b/tests/unit/api/test_none_crash.py
@@ -1,0 +1,52 @@
+"""Test that None llm_provider is handled gracefully without AttributeError."""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.settings.langflow_sync import _update_langflow_model_values
+
+
+@pytest.mark.asyncio
+async def test_none_llm_provider_handled_gracefully():
+    """
+    config.agent.llm_provider = None should not crash with AttributeError.
+
+    The schema types the field as str, but dataclasses don't enforce non-None at runtime.
+    The fix adds `or ""` guard before calling .lower() to prevent AttributeError.
+    """
+    mock_config = MagicMock()
+    mock_config.providers.openai.configured = True
+    mock_config.providers.anthropic.configured = True
+    mock_config.providers.watsonx.configured = False
+    mock_config.providers.ollama.configured = False
+    mock_config.knowledge.embedding_provider = "openai"
+    mock_config.knowledge.embedding_model = "text-embedding-3-small"
+    mock_config.agent.llm_provider = None  # None instead of string
+    mock_config.agent.llm_model = "gpt-4o"
+
+    mock_flows_service = AsyncMock()
+    mock_flows_service.change_langflow_model_value = AsyncMock(return_value={"updated": True})
+
+    # Should not raise AttributeError
+    await _update_langflow_model_values(
+        mock_config,
+        mock_flows_service,
+        llm_model=None,
+        llm_provider=None,
+        embedding_model=None,
+        embedding_provider=None,
+    )
+
+    # All providers should receive None model values (no match for empty string from None)
+    llm_calls = [
+        call
+        for call in mock_flows_service.change_langflow_model_value.call_args_list
+        if "force_llm_update" in call.kwargs
+    ]
+    assert len(llm_calls) == 2  # openai, anthropic
+    for call in llm_calls:
+        assert call.kwargs["llm_model"] is None
+
+
+# Made with Bob


### PR DESCRIPTION
Fixes #1587. The fallback branch of _update_langflow_model_values() only refreshed embedding providers, so LLM selections reverted to stale/default models after a flow reset. Add an LLM provider loop mirroring the embedding logic: current provider gets config.agent.llm_model, others get None (first available), all with force_llm_update=True. Guards config.agent.llm_provider against None before .lower().

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “reapply all settings” behavior so Langflow updates language model values for all configured LLM providers when no explicit overrides are provided.

* **Tests**
  * Added unit tests covering the fallback update path (including a regression for a previously failing scenario), edge cases around provider/config combinations, and graceful handling of null/empty provider inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->