### PR TITLE
Add TypeScript SDK client for listing provider models

### DIFF
--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -216,6 +216,14 @@ await client.settings.update({
 });
 ```
 
+## Models
+
+```typescript
+const models = await client.models.list("openai");
+console.log(models.language_models);
+console.log(models.embedding_models);
+```
+
 ## Knowledge Filters
 
 Knowledge filters are reusable, named filter configurations that can be applied to chat and search operations.

--- a/sdks/typescript/src/client.ts
+++ b/sdks/typescript/src/client.ts
@@ -6,6 +6,7 @@ import { ChatClient } from "./chat";
 import { DocumentsClient } from "./documents";
 import { SearchClient } from "./search";
 import { KnowledgeFiltersClient } from "./knowledge-filters";
+import { ModelsClient } from "./models";
 import {
   AuthenticationError,
   NotFoundError,
@@ -106,6 +107,8 @@ export class OpenRAGClient {
   readonly settings: SettingsClient;
   /** Knowledge filters client for managing filters. */
   readonly knowledgeFilters: KnowledgeFiltersClient;
+  /** Models client for listing provider models. */
+  readonly models: ModelsClient;
 
   constructor(options: OpenRAGClientOptions = {}) {
     // Resolve API key from argument or environment
@@ -127,6 +130,7 @@ export class OpenRAGClient {
     this.documents = new DocumentsClient(this);
     this.settings = new SettingsClient(this);
     this.knowledgeFilters = new KnowledgeFiltersClient(this);
+    this.models = new ModelsClient(this);
   }
 
   /** @internal Get request headers with authentication. */

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -38,6 +38,7 @@ export { ChatClient, ChatStream } from "./chat";
 export { SearchClient } from "./search";
 export { DocumentsClient } from "./documents";
 export { KnowledgeFiltersClient } from "./knowledge-filters";
+export { ModelsClient } from "./models";
 
 export {
   // Error types
@@ -76,6 +77,9 @@ export {
   SettingsUpdateResponse,
   AgentSettings,
   KnowledgeSettings,
+  // Models types
+  ModelOption,
+  ModelsResponse,
   // Knowledge filter types
   KnowledgeFilter,
   KnowledgeFilterQueryData,

--- a/sdks/typescript/src/models.ts
+++ b/sdks/typescript/src/models.ts
@@ -1,0 +1,24 @@
+/**
+ * OpenRAG SDK models client.
+ */
+
+import type { OpenRAGClient } from "./client";
+import type { ModelsResponse } from "./types";
+
+export class ModelsClient {
+  constructor(private client: OpenRAGClient) {}
+
+  /**
+   * List available language and embedding models for a provider.
+   *
+   * @param provider - One of openai, anthropic, ollama, watsonx.
+   */
+  async list(provider: string): Promise<ModelsResponse> {
+    const response = await this.client._request("GET", `/api/v1/models/${provider}`);
+    const data = await response.json();
+    return {
+      language_models: data.language_models ?? [],
+      embedding_models: data.embedding_models ?? [],
+    };
+  }
+}

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -158,6 +158,18 @@ export interface SettingsUpdateResponse {
   message: string;
 }
 
+// Models types
+export interface ModelOption {
+  value: string;
+  label: string;
+  default?: boolean;
+}
+
+export interface ModelsResponse {
+  language_models: ModelOption[];
+  embedding_models: ModelOption[];
+}
+
 // Knowledge filter types
 /** Query configuration stored in a knowledge filter. */
 export interface KnowledgeFilterQueryData {

--- a/sdks/typescript/tests/integration.test.ts
+++ b/sdks/typescript/tests/integration.test.ts
@@ -126,6 +126,15 @@ describe.skipIf(SKIP_TESTS)("OpenRAG TypeScript SDK Integration", () => {
     });
   });
 
+  describe("Models", () => {
+    it("should list models for a provider", async () => {
+      const models = await client.models.list("openai");
+
+      expect(Array.isArray(models.language_models)).toBe(true);
+      expect(Array.isArray(models.embedding_models)).toBe(true);
+    });
+  });
+
   describe("Knowledge Filters", () => {
     let createdFilterId: string;
 


### PR DESCRIPTION
Adds TypeScript SDK support for listing provider models via the existing public `/v1/models/{provider}` endpoint. This brings the TypeScript SDK to parity with the Python SDK, which already exposes `client.models.list(provider)`.

  ## What changed

  - Added `client.models.list(provider)`.
  - Added `ModelsClient`.
  - Added `ModelOption` and `ModelsResponse` types.
  - Exported the new models client and types.
  - Added a README example.
  - Added an integration test for `client.models.list("openai")`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * New Models API allows developers to retrieve available language models and embedding models for a given provider.

* **Documentation**
  * TypeScript SDK README updated with a new Models section, including example code showing how to list models.

* **Tests**
  * Integration test added to verify Models API functionality and response structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->