### PR TITLE
fix: uninstall ragstack ai

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -55,7 +55,8 @@ RUN pip install --no-cache-dir \
     torch \
     torchvision \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
-    uv
+    uv \
+    && pip uninstall -y ragstack-ai-knowledge-store
 
 # Create a symlink for backwards compatibility with the 'langflow' command
 RUN ln -s /opt/app-root/bin/langflow-base /usr/local/bin/langflow

--- a/Dockerfile.langflow.dev
+++ b/Dockerfile.langflow.dev
@@ -48,7 +48,7 @@ RUN mkdir -p /app/src/backend/base/langflow/frontend && \
 # Return to app directory and install the project
 WORKDIR /app
 RUN uv sync --frozen --no-dev --no-editable --extra postgresql
-RUN uv pip uninstall litellm
+RUN uv pip uninstall litellm ragstack-ai-knowledge-store
 
 # Expose ports
 EXPOSE 7860


### PR DESCRIPTION
This pull request makes minor changes to the Docker build process for the project. The main update is the removal of the `ragstack-ai-knowledge-store` package from the installed dependencies in both the production and development Dockerfiles.

Dependency cleanup:

* [`Dockerfile.langflow`](diffhunk://#diff-6cf5d1cc7b94802c5f5a7659b53b398991b8c5875dd4f526a6cfd3b46763f2c5L58-R59): Uninstalls `ragstack-ai-knowledge-store` after installing dependencies to ensure it is not present in the final image.
* [`Dockerfile.langflow.dev`](diffhunk://#diff-639678df999952c74f59efad9c7591f93b0d89f362810f5c621fbca75d731e78L51-R51): Uninstalls both `litellm` and `ragstack-ai-knowledge-store` as part of the development image setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image build configurations to optimize Python package management across production and development environments.
  * Refined dependency handling procedures during container builds to streamline the runtime package set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->