### PR TITLE
fix: enhance error handling for document processing and add OCR requirement check for image files

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -55,7 +55,8 @@ RUN pip install --no-cache-dir \
     torch \
     torchvision \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
-    uv
+    uv \
+    && pip uninstall -y clickhouse-connect
 
 # Create a symlink for backwards compatibility with the 'langflow' command
 RUN ln -s /opt/app-root/bin/langflow-base /usr/local/bin/langflow

--- a/sdks/typescript/tests/integration.test.ts
+++ b/sdks/typescript/tests/integration.test.ts
@@ -271,11 +271,33 @@ describe.skipIf(SKIP_TESTS)("OpenRAG TypeScript SDK Integration", () => {
     });
 
     it("should delete a document", async () => {
+      // Use a uniquely named file so this test doesn't inherit chunks left in
+      // the index by the two ingest tests above (which share testFilePath /
+      // "sdk_test_doc.md"). Otherwise a zero-successful-files re-ingest here can
+      // still find the earlier document, making delete succeed when the
+      // else-branch expects a no-op — i.e. ingest's reported successful_files
+      // would no longer reflect whether THIS document exists in the index.
+      const deleteDir = fs.mkdtempSync(path.join(os.tmpdir(), "sdk-del-"));
+      const deleteFilePath = path.join(
+        deleteDir,
+        `sdk_delete_doc_${Date.now()}.md`
+      );
+      fs.writeFileSync(
+        deleteFilePath,
+        "# SDK Delete Test Document\n\n" +
+          "This document tests document deletion via the OpenRAG TypeScript SDK.\n" +
+          "It contains unique content about teal dolphins swimming.\n"
+      );
+
       // First ingest (wait for completion)
-      const ingestResult = await client.documents.ingest({ filePath: testFilePath });
+      const ingestResult = await client.documents.ingest({
+        filePath: deleteFilePath,
+      });
 
       // Then delete
-      const result = await client.documents.delete(path.basename(testFilePath));
+      const result = await client.documents.delete(
+        path.basename(deleteFilePath)
+      );
 
       // If ingestion produced indexed chunks, delete should succeed.
       // In unstable flow environments, ingestion can complete with zero successful files.

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -560,10 +560,16 @@ class DocumentFileProcessor(TaskProcessor):
                 **standard_kwargs,
             )
 
-            file_task.status = TaskStatus.COMPLETED
-            file_task.result = result
-            file_task.updated_at = time.time()
-            upload_task.successful_files += 1
+            if result.get("status") == "error":
+                file_task.status = TaskStatus.FAILED
+                file_task.error = result.get("error", "Failed to process document")
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+            else:
+                file_task.status = TaskStatus.COMPLETED
+                file_task.result = result
+                file_task.updated_at = time.time()
+                upload_task.successful_files += 1
 
         except Exception as e:
             file_task.status = TaskStatus.FAILED
@@ -844,6 +850,14 @@ class ConnectorFileProcessor(TaskProcessor):
                         allowed_users=allowed_users,
                         allowed_groups=allowed_groups,
                     )
+                    # Langflow returns "success" even when no text was extracted
+                    # (e.g. image files without OCR). Verify the document actually
+                    # landed in OpenSearch before declaring success.
+                    if not await self.check_document_exists(document.id, opensearch_client):
+                        result = {
+                            "status": "error",
+                            "error": "No text content could be extracted from document",
+                        }
                 else:
                     # Standard OpenRAG processing pipeline (process_document_standard)
                     standard_kwargs: dict[str, Any] = {}
@@ -892,10 +906,16 @@ class ConnectorFileProcessor(TaskProcessor):
                         }
                     )
 
-            file_task.status = TaskStatus.COMPLETED
-            file_task.result = result
-            file_task.updated_at = time.time()
-            upload_task.successful_files += 1
+            if result.get("status") == "error":
+                file_task.status = TaskStatus.FAILED
+                file_task.error = result.get("error", "Failed to process document")
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+            else:
+                file_task.status = TaskStatus.COMPLETED
+                file_task.result = result
+                file_task.updated_at = time.time()
+                upload_task.successful_files += 1
 
         except Exception as e:
             file_task.status = TaskStatus.FAILED
@@ -970,9 +990,14 @@ class S3FileProcessor(TaskProcessor):
                 )
 
                 result["path"] = f"s3://{self.bucket}/{item}"
-                file_task.status = TaskStatus.COMPLETED
-                file_task.result = result
-                upload_task.successful_files += 1
+                if result.get("status") == "error":
+                    file_task.status = TaskStatus.FAILED
+                    file_task.error = result.get("error", "Failed to process document")
+                    upload_task.failed_files += 1
+                else:
+                    file_task.status = TaskStatus.COMPLETED
+                    file_task.result = result
+                    upload_task.successful_files += 1
 
         except Exception as e:
             file_task.status = TaskStatus.FAILED
@@ -1106,11 +1131,20 @@ class LangflowFileProcessor(TaskProcessor):
                 file_task=file_task,
             )
 
-            # Update task with success
-            file_task.status = TaskStatus.COMPLETED
-            file_task.result = result
-            file_task.updated_at = time.time()
-            upload_task.successful_files += 1
+            # Langflow returns "success" even when no text was extracted.
+            # Verify the document actually landed in OpenSearch.
+            file_hash = hash_id(item)
+            if not await self.check_document_exists(file_hash, opensearch_client):
+                file_task.status = TaskStatus.FAILED
+                file_task.error = "No text content could be extracted from document"
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+            else:
+                # Update task with success
+                file_task.status = TaskStatus.COMPLETED
+                file_task.result = result
+                file_task.updated_at = time.time()
+                upload_task.successful_files += 1
 
         except Exception as e:
             # Update task with failure

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -43,10 +43,19 @@ class TaskProcessor:
         self,
         file_hash: str,
         opensearch_client,
+        *,
+        wait_for_visibility: bool = False,
     ) -> bool:
         """
         Check if a document with the given hash already exists in OpenSearch.
         Consolidated hash checking for all processors.
+
+        When ``wait_for_visibility`` is True, an empty result is retried a few
+        times with backoff before concluding the document is absent. This is for
+        post-ingest verification: chunks that were just written may not be
+        searchable yet within OpenSearch's near-real-time refresh window
+        (default ~1s), and the user-scoped client cannot force an
+        ``indices:admin/refresh`` (it lacks the privilege).
         """
         max_retries = 3
         retry_delay = 1.0
@@ -62,7 +71,15 @@ class TaskProcessor:
                     },
                 )
                 hits = response.get("hits", {}).get("hits", [])
-                return bool(hits)
+                if hits:
+                    return True
+                # No hits. For post-ingest verification, the document may not be
+                # visible yet within the near-real-time refresh window — retry.
+                if wait_for_visibility and attempt < max_retries - 1:
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
+                    continue
+                return False
             except (TimeoutError, Exception) as e:
                 if attempt == max_retries - 1:
                     logger.error(
@@ -93,10 +110,19 @@ class TaskProcessor:
         self,
         filename: str,
         opensearch_client,
+        *,
+        wait_for_visibility: bool = False,
     ) -> bool:
         """
         Check if a document with the given filename already exists in OpenSearch.
         Returns True if any chunks with this filename exist.
+
+        When ``wait_for_visibility`` is True, an empty result is retried a few
+        times with backoff before concluding the document is absent. This is for
+        post-ingest verification: chunks that were just written may not be
+        searchable yet within OpenSearch's near-real-time refresh window
+        (default ~1s), and the user-scoped client cannot force an
+        ``indices:admin/refresh`` (it lacks the privilege).
         """
         max_retries = 3
         retry_delay = 1.0
@@ -127,6 +153,14 @@ class TaskProcessor:
                     # Successfully checked this alias with no hits; don't
                     # re-query it on future retries.
                     pending_candidates.pop(i)
+                    continue
+                # All aliases checked with no hits. For post-ingest verification,
+                # the document may not be visible yet within the near-real-time
+                # refresh window — re-check every alias after a short delay.
+                if wait_for_visibility and attempt < max_retries - 1:
+                    pending_candidates = list(candidate_filenames)
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
                     continue
                 return False
 
@@ -853,7 +887,12 @@ class ConnectorFileProcessor(TaskProcessor):
                     # Langflow returns "success" even when no text was extracted
                     # (e.g. image files without OCR). Verify the document actually
                     # landed in OpenSearch before declaring success.
-                    if not await self.check_document_exists(document.id, opensearch_client):
+                    # wait_for_visibility polls on an empty result to ride out
+                    # OpenSearch's ~1s near-real-time window (the user-scoped
+                    # client cannot force an indices:admin/refresh — it 403s).
+                    if not await self.check_document_exists(
+                        document.id, opensearch_client, wait_for_visibility=True
+                    ):
                         result = {
                             "status": "error",
                             "error": "No text content could be extracted from document",
@@ -1131,10 +1170,21 @@ class LangflowFileProcessor(TaskProcessor):
                 file_task=file_task,
             )
 
-            # Langflow returns "success" even when no text was extracted.
-            # Verify the document actually landed in OpenSearch.
-            file_hash = hash_id(item)
-            if not await self.check_document_exists(file_hash, opensearch_client):
+            # Langflow returns "success" even when no text was extracted
+            # (e.g. image files without OCR). Verify the document actually
+            # landed in OpenSearch before declaring success. We key off the
+            # filename — the identifier this path already uses for dedup and
+            # delete (see check_filename_exists / delete_document_by_filename
+            # above) — because Langflow assigns its own document_id here, so
+            # hash_id(item) is not stored as document_id.
+            #
+            # wait_for_visibility polls on an empty result so the just-written
+            # chunks become visible within OpenSearch's near-real-time refresh
+            # window. We cannot force a refresh here: the user-scoped client
+            # lacks the indices:admin/refresh privilege (it 403s).
+            if not await self.check_filename_exists(
+                original_filename, opensearch_client, wait_for_visibility=True
+            ):
                 file_task.status = TaskStatus.FAILED
                 file_task.error = "No text content could be extracted from document"
                 file_task.updated_at = time.time()

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -64,9 +64,20 @@ _TRANSIENT_CONNECTIVITY_ERROR_MARKERS = (
 )
 
 
+# Raster image formats that require OCR to produce any text content.
+_OCR_REQUIRED_EXTENSIONS = frozenset({"bmp", "jpeg", "jpg", "png", "tiff", "webp"})
+
+
 def _is_non_retryable_file_error(error: str) -> bool:
     lowered = error.lower()
     return any(marker in lowered for marker in _NON_RETRYABLE_FILE_ERROR_MARKERS)
+
+
+def _is_ocr_required_file(filename: str) -> bool:
+    """Return True if the file is a raster image that requires OCR to produce text."""
+    if not filename or "." not in filename:
+        return False
+    return filename.rsplit(".", 1)[-1].lower() in _OCR_REQUIRED_EXTENSIONS
 
 
 def _is_transient_connectivity_error(error: str) -> bool:
@@ -958,6 +969,20 @@ class TaskService:
 
         # First, check if the error is non-retryable based on common markers
         if _is_non_retryable_file_error(error):
+            # Image files that produced no text almost certainly failed because OCR
+            # is disabled — not because the file is corrupted. Give a targeted tip.
+            filename = file_task.filename or file_task.file_path or ""
+            if "no text content could be extracted" in error.lower() and _is_ocr_required_file(filename):
+                return {
+                    "component": "docling",
+                    "failure_phase": "parsing",
+                    "user_facing_message": (
+                        "No text content could be extracted from this image file. "
+                        "Enable OCR in Settings > Knowledge Base and retry ingestion."
+                    ),
+                    "actionable_by": "RETRYABLE",
+                }
+
             if phase == IngestionPhase.LANGFLOW:
                 component = "langflow"
                 failure_phase = "unknown"

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -972,7 +972,9 @@ class TaskService:
             # Image files that produced no text almost certainly failed because OCR
             # is disabled — not because the file is corrupted. Give a targeted tip.
             filename = file_task.filename or file_task.file_path or ""
-            if "no text content could be extracted" in error.lower() and _is_ocr_required_file(filename):
+            if "no text content could be extracted" in error.lower() and _is_ocr_required_file(
+                filename
+            ):
                 return {
                     "component": "docling",
                     "failure_phase": "parsing",


### PR DESCRIPTION
# Supported File Types by Ingestion Path

There are currently **two different supported file type lists** depending on how content is ingested into OpenRAG.

## Direct Upload (Frontend File Picker)

Defined in `knowledge-dropdown.tsx` (lines 60–76).

| Category | Extensions |
|-----------|------------|
| Documents | `.txt`, `.md`, `.pdf`, `.docx`, `.html`, `.htm`, `.adoc`, `.asciidoc`, `.asc` |
| Spreadsheets | `.csv`, `.xlsx` |
| Presentations | `.pptx` |

---

## Connector Ingestion (Backend Validator)

Defined in `processors.py` (lines 645–668).

Includes **all file types supported by Direct Upload**, plus additional Office formats, XHTML, and image formats.

| Category | Extensions |
|-----------|------------|
| Documents | `.txt`, `.md`, `.pdf`, `.docx`, `.html`, `.htm`, `.adoc`, `.asciidoc`, `.asc` |
| Additional Office Documents | `.dotx`, `.dotm`, `.docm` |
| Spreadsheets | `.csv`, `.xlsx`, `.xls` |
| Presentations | `.pptx`, `.potx`, `.ppsx`, `.pptm`, `.potm`, `.ppsm` |
| Web Documents | `.xhtml` |
| Images | `.jpg`, `.jpeg`, `.png`, `.tiff`, `.bmp`, `.webp` |

---

## Root Cause of the Reported Defect

The image formats (`.jpg`, `.jpeg`, `.png`, `.tiff`, `.bmp`, `.webp`) are the source of the reported issue.

### What Happens

1. The connector ingestion validator accepts image files based on extension.
2. The files are sent through the ingestion pipeline.
3. Images only produce extractable text when **Docling OCR** is enabled.
4. When OCR is disabled, no text content is extracted.
5. No chunks are generated for indexing.
6. The updated ingestion logic now correctly marks these files as **Failed** rather than **Active**.

---

## Existing Frontend Limitation

The frontend intentionally excludes several file types that are accepted by connector ingestion.

A TODO comment in `knowledge-dropdown.tsx` (line 57) states:

> Re-add other MIME/extension groups (images, xlsx/xls/ppt, rtf/odt, etc.) once ingestion is verified end-to-end in Langflow.

This indicates that support for images and additional document types was intentionally withheld from the file picker until end-to-end ingestion behavior was fully validated.

---

## Gap Between Frontend and Connector Validation

| Area | Images Allowed? |
|--------|----------------|
| Frontend File Picker | ❌ No |
| Connector Ingestion Validator | ✅ Yes |

This inconsistency allows image files to be ingested through connectors while bypassing the frontend restrictions, creating the gap that exposed the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved validation of document processing results to ensure failures are correctly detected and reported when content is not properly indexed
- Enhanced error messages for image files to provide specific guidance when OCR processing is required for content extraction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->