### PR TITLE
chore: add npm tag

### DIFF
--- a/.github/workflows/publish-sdk-typescript.yml
+++ b/.github/workflows/publish-sdk-typescript.yml
@@ -50,9 +50,20 @@ jobs:
         if: steps.check.outputs.exists == 'false'
         run: npm run build
 
+      - name: Determine npm tag
+        if: steps.check.outputs.exists == 'false'
+        id: tag
+        run: |
+          VERSION=${{ steps.version.outputs.version }}
+          if [[ "$VERSION" == *-* ]]; then
+            echo "tag=dev" >> $GITHUB_OUTPUT
+          else
+            echo "tag=latest" >> $GITHUB_OUTPUT
+          fi
+
       - name: Publish to npm
         if: steps.check.outputs.exists == 'false'
-        run: npm publish --access public --provenance
+        run: npm publish --access public --provenance --tag ${{ steps.tag.outputs.tag }}
 
       - name: Skip publish (version exists)
         if: steps.check.outputs.exists == 'true'


### PR DESCRIPTION
Adds tag to npm publish script

  - 0.4.0-dev0 → npm publish --tag dev (users must npm install openrag-sdk@dev to get it)
  - 1.0.0 → npm publish --tag latest (default install behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the TypeScript SDK publishing workflow to apply appropriate npm distribution tags based on version type. Prerelease versions now receive the `dev` tag while stable releases receive the `latest` tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->