### PR TITLE
Fix: resolve Pydantic delta serialization warnings in agent streaming

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -171,8 +171,16 @@ async def async_response_stream(
             try:
                 # Try to serialize the chunk object
                 if hasattr(chunk, "model_dump"):
-                    # Pydantic model
-                    chunk_data = chunk.model_dump()
+                    # Pydantic model. Exclude "delta" from serialization since Langflow's
+                    # /response SSE wraps text deltas as {"content": "..."} for every provider but
+                    # openai SDK's event models declare/expect delta to be str so model_dump() will
+                    # emit noisy logs (PydanticSerializationUnexpectedValue) for every chunk. Basically
+                    # just reattach the raw (unvalidated) value afterwards to preserve same shape.
+                    # TODO: replace this with just chunk.model_dump() if langflow's /response SSE matches openai's 
+                    # SDK's delta: str schema
+                    chunk_data = chunk.model_dump(exclude={"delta"})
+                    if hasattr(chunk, "delta"):
+                        chunk_data["delta"] = chunk.delta
                 elif hasattr(chunk, "__dict__"):
                     chunk_data = chunk.__dict__
                 else:

--- a/tests/unit/test_agent_stream_delta.py
+++ b/tests/unit/test_agent_stream_delta.py
@@ -1,0 +1,25 @@
+import warnings
+
+from pydantic import BaseModel
+
+
+class FakeTextDeltaEvent(BaseModel):
+    """Mirrors openai's ResponseTextDeltaEvent: `delta` is declared as `str`."""
+
+    delta: str
+    type: str
+
+
+def test_model_dump_excluding_delta_avoids_warning_and_preserves_dict_shape() -> None:
+    chunk = FakeTextDeltaEvent.model_construct(
+        delta={"content": "Hello"}, type="response.output_text.delta"
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+
+        chunk_data = chunk.model_dump(exclude={"delta"})
+        chunk_data["delta"] = chunk.delta
+
+    assert chunk_data["delta"] == {"content": "Hello"}
+    assert chunk_data["type"] == "response.output_text.delta"


### PR DESCRIPTION
## Summary
Fixes #1821. Resolves repeated `PydanticSerializationUnexpectedValue` warnings logged for every streamed chat chunk. Langflow's `/response` SSE always wraps text deltas as `{"content": "..."}` for every provider, but the openai SDK's response event models declare `delta: str`. When  `chunk.model_dump()` runs, Pydantic's serializer checks `delta` against that `str` type, finds a dict, and logs a warning for every chunk which pollutes the openrag-backend logs

## Changes
- exclude `delta` from `model_dump()`'s serialization (which is what triggers the type-check warning), then reattach the raw, unvalidated `delta` value back onto the resulting dict. Output shape sent to the frontend/SDK is unchanged and only the noisy serializer warning is avoided. 
- Added a comment above my agent.py changes explaining why and when this workaround can be removed.
- Added a simple regression unit test to verify that the pydantic warning isnt being raised and the fields to be expected

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Optimized streaming response serialization to reduce unnecessary noise in streamed payloads while maintaining data integrity.

* **Tests**
  * Added test coverage for response serialization validation and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->