### PR TITLE
fix: make connector webhooks work end-to-end (Drive routing, Graph subscriptions, change discovery)

### DIFF
--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -989,6 +989,11 @@ async def connector_status(
     )
 
 
+# Drive watches registered with a legacy webhook URL may point at
+# /connectors/google/webhook; accept them until those channels expire.
+LEGACY_WEBHOOK_TYPE_ALIASES = {"google": "google_drive"}
+
+
 async def connector_webhook(
     connector_type: str,
     request: Request,
@@ -997,6 +1002,15 @@ async def connector_webhook(
     session: AsyncSession = Depends(get_db_session),
 ):
     """Handle webhook notifications from any connector type"""
+
+    canonical_type = LEGACY_WEBHOOK_TYPE_ALIASES.get(connector_type)
+    if canonical_type:
+        logger.warning(
+            "Legacy webhook connector type received, aliasing",
+            received=connector_type,
+            canonical=canonical_type,
+        )
+        connector_type = canonical_type
 
     if denied := await _connector_access_denied(request, session, connector_type):
         return denied
@@ -1091,12 +1105,15 @@ async def connector_webhook(
                 user = session_manager.get_user(connection.user_id)
                 jwt_token = user.jwt_token if user else None
 
-                # Trigger incremental sync for affected files
+                # Trigger incremental sync for affected files. The webhook fires
+                # because the file changed, so replace the indexed copy instead of
+                # tripping the duplicate-filename guard meant for manual uploads.
                 task_id = await connector_service.sync_specific_files(
                     connection.connection_id,
                     connection.user_id,
                     affected_files,
                     jwt_token=jwt_token,
+                    replace_duplicates=_connector_sync_should_replace(connector_type),
                 )
 
                 result = {

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -523,7 +523,14 @@ def is_no_auth_mode():
 # Webhook configuration - must be set to enable webhooks
 WEBHOOK_BASE_URL = os.getenv("WEBHOOK_BASE_URL")  # No default - must be explicitly configured
 
-# Legacy per-connector webhook URL override (takes precedence over WEBHOOK_BASE_URL)
+# Legacy per-connector webhook URL override (takes precedence over WEBHOOK_BASE_URL).
+# If set, it must end in /connectors/google_drive/webhook.
+#
+# Drive watch addresses resolve config webhook_url -> this var -> WEBHOOK_BASE_URL
+# (google_drive/connector.py _resolve_webhook_address). Watches registered against
+# the legacy /connectors/google/webhook path (e.g. via a stale webhook_url persisted
+# in connections.json) are tolerated by LEGACY_WEBHOOK_TYPE_ALIASES in api/connectors.py;
+# the real fix is correcting the stored webhook_url (e.g. reconnect the data source).
 GOOGLE_DRIVE_WEBHOOK_URL = os.getenv("GOOGLE_DRIVE_WEBHOOK_URL")
 
 # OAuth callback broker URL -- when set, Google (and other providers) redirect

--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -507,6 +507,20 @@ class ConnectionManager:
 
     async def get_connection_by_webhook_id(self, webhook_id: str) -> ConnectionConfig | None:
         """Find a connection by its webhook/subscription ID"""
+        connection = self._find_connection_by_webhook_id(webhook_id)
+        if connection:
+            return connection
+
+        # The subscription may have been created by another replica or before a
+        # restart; re-read the persisted store once before giving up.
+        try:
+            await self.load_connections()
+        except Exception as e:
+            logger.error(f"Failed to reload connections for webhook lookup: {e}")
+            return None
+        return self._find_connection_by_webhook_id(webhook_id)
+
+    def _find_connection_by_webhook_id(self, webhook_id: str) -> ConnectionConfig | None:
         for connection in self.connections.values():
             # Check if the webhook ID is stored in the connection config
             if connection.config.get("webhook_channel_id") == webhook_id:

--- a/src/connectors/onedrive/connector.py
+++ b/src/connectors/onedrive/connector.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -66,6 +66,8 @@ class OneDriveConnector(BaseConnector):
         self.client_id = None
         self.client_secret = None
         self.redirect_uri = config.get("redirect_uri", "http://localhost")
+        # Graph delta link for webhook change tracking (in-memory per instance)
+        self._delta_link: str | None = None
         self._base_url = config.get("base_url")  # Generic URL field for OneDrive/SharePoint domain
         logger.debug(f"OneDrive connector initialized with base_url from config: {self._base_url}")
 
@@ -352,7 +354,9 @@ class OneDriveConnector(BaseConnector):
             resource = "/me/drive/root"
 
             subscription_data = {
-                "changeType": "created,updated,deleted",
+                # Graph driveItem subscriptions only support "updated"; creates and
+                # deletes still surface through the delta query the webhook triggers.
+                "changeType": "updated",
                 # webhook_url is already the full endpoint
                 # ({WEBHOOK_BASE_URL}/connectors/onedrive/webhook, set at connect time)
                 "notificationUrl": webhook_url,
@@ -372,6 +376,10 @@ class OneDriveConnector(BaseConnector):
                 response = await client.post(
                     url, json=subscription_data, headers=headers, timeout=30
                 )
+                if response.status_code >= 400:
+                    logger.error(
+                        f"Graph subscription request rejected: {response.status_code} {response.text}"
+                    )
                 response.raise_for_status()
 
                 result = response.json()
@@ -1078,15 +1086,64 @@ class OneDriveConnector(BaseConnector):
         return None
 
     async def handle_webhook(self, payload: dict[str, Any]) -> list[str]:
-        """Handle webhook notification and return affected file IDs."""
-        affected_files: list[str] = []
-        notifications = payload.get("value", [])
-        for notification in notifications:
-            resource = notification.get("resource")
-            if resource and "/drive/items/" in resource:
-                file_id = resource.split("/drive/items/")[-1]
-                affected_files.append(file_id)
-        return affected_files
+        """Handle webhook notification and return affected file IDs.
+
+        Graph driveItem notifications never identify the changed items — the
+        notification resource is the subscribed drive root — so run a delta
+        query against the drive to discover what changed.
+        """
+        if not payload.get("value"):
+            return []
+
+        try:
+            if not await self.authenticate():
+                logger.error("OneDrive authentication failed during webhook handling")
+                return []
+
+            token = self.oauth.get_access_token()
+            headers = {"Authorization": f"Bearer {token}"}
+
+            # Without a stored delta link (first notification for this instance)
+            # the delta query enumerates the whole drive, so only keep recently
+            # modified files instead of re-syncing everything.
+            first_sweep = self._delta_link is None
+            url = self._delta_link or f"{self._graph_base_url}/me/drive/root/delta"
+            cutoff = datetime.now(UTC) - timedelta(minutes=10)
+
+            affected_files: list[str] = []
+            async with httpx.AsyncClient() as client:
+                while url:
+                    response = await client.get(url, headers=headers, timeout=30)
+                    response.raise_for_status()
+                    data = response.json()
+
+                    for item in data.get("value", []):
+                        if "file" not in item or "deleted" in item:
+                            continue
+                        if first_sweep:
+                            modified = item.get("lastModifiedDateTime")
+                            if not modified:
+                                continue
+                            try:
+                                modified_at = datetime.fromisoformat(
+                                    modified.replace("Z", "+00:00")
+                                )
+                            except ValueError:
+                                continue
+                            if modified_at < cutoff:
+                                continue
+                        affected_files.append(item["id"])
+
+                    delta_link = data.get("@odata.deltaLink")
+                    if delta_link:
+                        self._delta_link = delta_link
+                    url = data.get("@odata.nextLink")
+
+            return list(dict.fromkeys(affected_files))
+
+        except Exception as e:
+            logger.error(f"OneDrive webhook delta query failed: {e}")
+            return []
 
     async def cleanup_subscription(self, subscription_id: str) -> bool:
         """Clean up subscription - BaseConnector interface."""

--- a/src/connectors/onedrive/connector.py
+++ b/src/connectors/onedrive/connector.py
@@ -1,4 +1,3 @@
-import logging
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
@@ -7,6 +6,7 @@ from urllib.parse import urlparse
 import httpx
 
 from utils.group_acl import unique_acl_principal_labels
+from utils.logging_config import get_logger
 
 from ..base import BaseConnector, ConnectorDocument, DocumentACL
 from ..microsoft_graph_acl import (
@@ -21,7 +21,7 @@ from ..microsoft_graph_acl import (
 )
 from .oauth import OneDriveOAuth
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class OneDriveConnector(BaseConnector):

--- a/src/connectors/onedrive/connector.py
+++ b/src/connectors/onedrive/connector.py
@@ -1124,7 +1124,14 @@ class OneDriveConnector(BaseConnector):
                     data = response.json()
 
                     for item in data.get("value", []):
-                        if "file" not in item or "deleted" in item:
+                        if "deleted" in item:
+                            # Deleted at source: propagate the id so the processor
+                            # runs its deleted-at-source cleanup
+                            # (get_file_content -> 404 -> delete indexed chunks).
+                            if "folder" not in item:
+                                affected_files.append(item["id"])
+                            continue
+                        if "file" not in item:
                             continue
                         if first_sweep:
                             modified = item.get("lastModifiedDateTime")

--- a/src/connectors/sharepoint/connector.py
+++ b/src/connectors/sharepoint/connector.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -67,6 +67,8 @@ class SharePointConnector(BaseConnector):
         self.client_id = None
         self.client_secret = None
         self.tenant_id = config.get("tenant_id", "common")
+        # Graph delta link for webhook change tracking (in-memory per instance)
+        self._delta_link: str | None = None
         # base_url is the generic field name, sharepoint_url is kept for backward compatibility
         self.sharepoint_url = config.get("base_url") or config.get("sharepoint_url")
         logger.debug(
@@ -390,7 +392,9 @@ class SharePointConnector(BaseConnector):
                 resource = "/me/drive/root"
 
             subscription_data = {
-                "changeType": "created,updated,deleted",
+                # Graph driveItem subscriptions only support "updated"; creates and
+                # deletes still surface through the delta query the webhook triggers.
+                "changeType": "updated",
                 # webhook_url is already the full endpoint
                 # ({WEBHOOK_BASE_URL}/connectors/sharepoint/webhook, set at connect time)
                 "notificationUrl": webhook_url,
@@ -407,6 +411,10 @@ class SharePointConnector(BaseConnector):
                 response = await client.post(
                     url, json=subscription_data, headers=headers, timeout=30
                 )
+                if response.status_code >= 400:
+                    logger.error(
+                        f"Graph subscription request rejected: {response.status_code} {response.text}"
+                    )
                 response.raise_for_status()
 
                 result = response.json()
@@ -1015,18 +1023,72 @@ class SharePointConnector(BaseConnector):
         return None
 
     async def handle_webhook(self, payload: dict[str, Any]) -> list[str]:
-        """Handle webhook notification and return affected file IDs"""
-        affected_files = []
+        """Handle webhook notification and return affected file IDs.
 
-        # Process Microsoft Graph webhook payload
-        notifications = payload.get("value", [])
-        for notification in notifications:
-            resource = notification.get("resource")
-            if resource and "/drive/items/" in resource:
-                file_id = resource.split("/drive/items/")[-1]
-                affected_files.append(file_id)
+        Graph driveItem notifications never identify the changed items — the
+        notification resource is the subscribed drive root — so run a delta
+        query against the drive to discover what changed.
+        """
+        if not payload.get("value"):
+            return []
 
-        return affected_files
+        try:
+            if not await self.authenticate():
+                logger.error("SharePoint authentication failed during webhook handling")
+                return []
+
+            token = self.oauth.get_access_token()
+            headers = {"Authorization": f"Bearer {token}"}
+
+            site_info = self._parse_sharepoint_url()
+            if site_info:
+                resource = (
+                    f"sites/{site_info['host_name']}:/sites/{site_info['site_name']}:/drive/root"
+                )
+            else:
+                resource = "me/drive/root"
+
+            # Without a stored delta link (first notification for this instance)
+            # the delta query enumerates the whole drive, so only keep recently
+            # modified files instead of re-syncing everything.
+            first_sweep = self._delta_link is None
+            url = self._delta_link or f"{self._graph_base_url}/{resource}/delta"
+            cutoff = datetime.now(UTC) - timedelta(minutes=10)
+
+            affected_files: list[str] = []
+            async with httpx.AsyncClient() as client:
+                while url:
+                    response = await client.get(url, headers=headers, timeout=30)
+                    response.raise_for_status()
+                    data = response.json()
+
+                    for item in data.get("value", []):
+                        if "file" not in item or "deleted" in item:
+                            continue
+                        if first_sweep:
+                            modified = item.get("lastModifiedDateTime")
+                            if not modified:
+                                continue
+                            try:
+                                modified_at = datetime.fromisoformat(
+                                    modified.replace("Z", "+00:00")
+                                )
+                            except ValueError:
+                                continue
+                            if modified_at < cutoff:
+                                continue
+                        affected_files.append(item["id"])
+
+                    delta_link = data.get("@odata.deltaLink")
+                    if delta_link:
+                        self._delta_link = delta_link
+                    url = data.get("@odata.nextLink")
+
+            return list(dict.fromkeys(affected_files))
+
+        except Exception as e:
+            logger.error(f"SharePoint webhook delta query failed: {e}")
+            return []
 
     async def cleanup_subscription(self, subscription_id: str) -> bool:
         """Clean up subscription - BaseConnector interface"""

--- a/src/connectors/sharepoint/connector.py
+++ b/src/connectors/sharepoint/connector.py
@@ -1069,7 +1069,14 @@ class SharePointConnector(BaseConnector):
                     data = response.json()
 
                     for item in data.get("value", []):
-                        if "file" not in item or "deleted" in item:
+                        if "deleted" in item:
+                            # Deleted at source: propagate the id so the processor
+                            # runs its deleted-at-source cleanup
+                            # (get_file_content -> 404 -> delete indexed chunks).
+                            if "folder" not in item:
+                                affected_files.append(item["id"])
+                            continue
+                        if "file" not in item:
                             continue
                         if first_sweep:
                             modified = item.get("lastModifiedDateTime")

--- a/src/services/auth_service.py
+++ b/src/services/auth_service.py
@@ -446,6 +446,20 @@ class AuthService:
             except Exception:
                 logger.exception("[AUTH] Auto-detect base URL failed")
 
+        # Register the change-notification subscription now that the connection is
+        # authenticated. Data-source connections don't go through update_connection
+        # (which handles this for the app-auth flow), so without this no webhook
+        # subscription is ever created for them.
+        try:
+            connection_manager = self.connector_service.connection_manager
+            connector = await connection_manager.get_connector(connection_id)
+            if connector:
+                await connection_manager._setup_webhook_if_needed(
+                    connection_id, connection_config, connector
+                )
+        except Exception:
+            logger.exception("[AUTH] Webhook subscription setup failed")
+
         return result
 
     async def get_user_info(self, request) -> dict | None:

--- a/tests/unit/connectors/test_webhook_notification_url.py
+++ b/tests/unit/connectors/test_webhook_notification_url.py
@@ -26,6 +26,9 @@ if str(SRC) not in sys.path:
 
 
 class _FakeResponse:
+    status_code = 200
+    text = ""
+
     def __init__(self, payload: dict):
         self._payload = payload
 
@@ -109,6 +112,9 @@ async def test_graph_notification_url_is_config_webhook_url_verbatim(
     # Regression: must not re-append a /webhook/<type> segment to the
     # already-complete endpoint (yields a 404 route, Graph rejects it).
     assert f"/webhook/{connector_type}" not in body["notificationUrl"]
+    # Graph driveItem subscriptions only support "updated"; anything else
+    # (e.g. "created,updated,deleted") is rejected with 400 Bad Request.
+    assert body["changeType"] == "updated"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/connectors/test_webhook_type_alias.py
+++ b/tests/unit/connectors/test_webhook_type_alias.py
@@ -29,7 +29,7 @@ class _FakeRequest:
     def __init__(self, headers: dict[str, str]):
         self.method = "POST"
         self.headers = headers
-        self.query_params = {}
+        self.query_params: dict[str, str] = {}
 
     async def json(self):
         return {}

--- a/tests/unit/connectors/test_webhook_type_alias.py
+++ b/tests/unit/connectors/test_webhook_type_alias.py
@@ -13,6 +13,7 @@ another replica or before a restart).
 
 import json
 import sys
+from datetime import UTC
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -158,6 +159,197 @@ async def test_webhook_unknown_type_is_ignored_not_500():
     assert response.status_code == 200
     body = json.loads(response.body)
     assert body == {"status": "ignored", "reason": "no_channel_id"}
+
+
+# ---------------------------------------------------------------------------
+# SharePoint/OneDrive handle_webhook — delta query for changed files
+# ---------------------------------------------------------------------------
+
+
+GRAPH_CONNECTORS = [
+    ("connectors.sharepoint.connector", "SharePointConnector", "sharepoint"),
+    ("connectors.onedrive.connector", "OneDriveConnector", "onedrive"),
+]
+
+
+class _FakeOAuth:
+    def get_access_token(self) -> str:
+        return "access-token"
+
+
+def _graph_connector(module_path: str, cls_name: str, tmp_path, webhook_url: str | None):
+    import importlib
+
+    cls = getattr(importlib.import_module(module_path), cls_name)
+    config = {"token_file": str(tmp_path / "token.json")}
+    if webhook_url:
+        config["webhook_url"] = webhook_url
+    connector = cls(config)
+    connector.authenticate = AsyncMock(return_value=True)
+    connector.oauth = _FakeOAuth()
+    return connector
+
+
+class _FakeDeltaClient:
+    """Stands in for httpx.AsyncClient; serves Graph delta GET responses."""
+
+    def __init__(self, pages: list[dict]):
+        self._pages = pages
+        self.requested_urls: list[str] = []
+
+    def __call__(self, *args, **kwargs):
+        return self
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def get(self, url, headers=None, timeout=None):
+        self.requested_urls.append(url)
+
+        class _Resp:
+            status_code = 200
+
+            def __init__(self, payload):
+                self._payload = payload
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return self._payload
+
+        return _Resp(self._pages[len(self.requested_urls) - 1])
+
+
+GRAPH_NOTIFICATION = {"value": [{"resource": "me/drive/root", "changeType": "updated"}]}
+
+
+def _recent_iso():
+    from datetime import datetime
+
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("module_path,cls_name,connector_type", GRAPH_CONNECTORS)
+async def test_graph_webhook_runs_delta_query(
+    tmp_path, monkeypatch, module_path, cls_name, connector_type
+):
+    """Graph notifications don't name the changed items; the connector must
+    discover them via a drive delta query."""
+    import httpx
+
+    connector = _graph_connector(module_path, cls_name, tmp_path, webhook_url=None)
+
+    delta_page = {
+        "value": [
+            {"id": "file-recent", "file": {}, "lastModifiedDateTime": _recent_iso()},
+            {"id": "file-old", "file": {}, "lastModifiedDateTime": "2020-01-01T00:00:00Z"},
+            {"id": "folder-1", "folder": {}, "lastModifiedDateTime": _recent_iso()},
+            {"id": "file-gone", "file": {}, "deleted": {}, "lastModifiedDateTime": _recent_iso()},
+        ],
+        "@odata.deltaLink": "https://graph.microsoft.com/v1.0/delta?token=abc",
+    }
+    fake_client = _FakeDeltaClient([delta_page])
+    monkeypatch.setattr(httpx, "AsyncClient", fake_client)
+
+    affected = await connector.handle_webhook(GRAPH_NOTIFICATION)
+
+    # First sweep: only recently-modified, non-deleted files count.
+    assert affected == ["file-recent"]
+    assert connector._delta_link == "https://graph.microsoft.com/v1.0/delta?token=abc"
+    assert fake_client.requested_urls[0].endswith("/delta")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("module_path,cls_name,connector_type", GRAPH_CONNECTORS)
+async def test_graph_webhook_uses_stored_delta_link(
+    tmp_path, monkeypatch, module_path, cls_name, connector_type
+):
+    import httpx
+
+    connector = _graph_connector(module_path, cls_name, tmp_path, webhook_url=None)
+    connector._delta_link = "https://graph.microsoft.com/v1.0/delta?token=prev"
+
+    delta_page = {
+        # With a delta link the results ARE the changes — no recency filter.
+        "value": [{"id": "file-old", "file": {}, "lastModifiedDateTime": "2020-01-01T00:00:00Z"}],
+        "@odata.deltaLink": "https://graph.microsoft.com/v1.0/delta?token=next",
+    }
+    fake_client = _FakeDeltaClient([delta_page])
+    monkeypatch.setattr(httpx, "AsyncClient", fake_client)
+
+    affected = await connector.handle_webhook(GRAPH_NOTIFICATION)
+
+    assert affected == ["file-old"]
+    assert fake_client.requested_urls == ["https://graph.microsoft.com/v1.0/delta?token=prev"]
+    assert connector._delta_link == "https://graph.microsoft.com/v1.0/delta?token=next"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("module_path,cls_name,connector_type", GRAPH_CONNECTORS)
+async def test_graph_webhook_empty_payload_skips_delta(
+    tmp_path, module_path, cls_name, connector_type
+):
+    connector = _graph_connector(module_path, cls_name, tmp_path, webhook_url=None)
+
+    assert await connector.handle_webhook({"value": []}) == []
+    connector.authenticate.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _handle_data_source_auth — subscription registration on connect
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_data_source_auth_registers_webhook_subscription():
+    """Data-source connections don't go through update_connection, so the OAuth
+    callback must register the change-notification subscription itself."""
+    from services.auth_service import AuthService
+
+    manager = MagicMock()
+    connector = MagicMock()
+    manager.get_connector = AsyncMock(return_value=connector)
+    manager._setup_webhook_if_needed = AsyncMock()
+
+    connector_service = MagicMock()
+    connector_service.connection_manager = manager
+    service = AuthService(session_manager=MagicMock(), connector_service=connector_service)
+
+    connection_config = MagicMock()
+    connection_config.connector_type = "google_drive"
+
+    result = await service._handle_data_source_auth("conn-1", connection_config)
+
+    assert result["status"] == "authenticated"
+    manager._setup_webhook_if_needed.assert_awaited_once_with(
+        "conn-1", connection_config, connector
+    )
+
+
+@pytest.mark.asyncio
+async def test_data_source_auth_survives_subscription_failure():
+    """Webhook registration failure must not fail the OAuth connect itself."""
+    from services.auth_service import AuthService
+
+    manager = MagicMock()
+    manager.get_connector = AsyncMock(return_value=MagicMock())
+    manager._setup_webhook_if_needed = AsyncMock(side_effect=RuntimeError("graph down"))
+
+    connector_service = MagicMock()
+    connector_service.connection_manager = manager
+    service = AuthService(session_manager=MagicMock(), connector_service=connector_service)
+
+    connection_config = MagicMock()
+    connection_config.connector_type = "google_drive"
+
+    result = await service._handle_data_source_auth("conn-1", connection_config)
+
+    assert result["status"] == "authenticated"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/connectors/test_webhook_type_alias.py
+++ b/tests/unit/connectors/test_webhook_type_alias.py
@@ -249,7 +249,8 @@ async def test_graph_webhook_runs_delta_query(
             {"id": "file-recent", "file": {}, "lastModifiedDateTime": _recent_iso()},
             {"id": "file-old", "file": {}, "lastModifiedDateTime": "2020-01-01T00:00:00Z"},
             {"id": "folder-1", "folder": {}, "lastModifiedDateTime": _recent_iso()},
-            {"id": "file-gone", "file": {}, "deleted": {}, "lastModifiedDateTime": _recent_iso()},
+            {"id": "file-gone", "deleted": {}},
+            {"id": "folder-gone", "folder": {}, "deleted": {}},
         ],
         "@odata.deltaLink": "https://graph.microsoft.com/v1.0/delta?token=abc",
     }
@@ -258,8 +259,10 @@ async def test_graph_webhook_runs_delta_query(
 
     affected = await connector.handle_webhook(GRAPH_NOTIFICATION)
 
-    # First sweep: only recently-modified, non-deleted files count.
-    assert affected == ["file-recent"]
+    # First sweep: recently-modified files count regardless of the cutoff applied
+    # to live files; deleted files propagate so indexed chunks get cleaned up,
+    # deleted folders don't.
+    assert affected == ["file-recent", "file-gone"]
     assert connector._delta_link == "https://graph.microsoft.com/v1.0/delta?token=abc"
     assert fake_client.requested_urls[0].endswith("/delta")
 

--- a/tests/unit/connectors/test_webhook_type_alias.py
+++ b/tests/unit/connectors/test_webhook_type_alias.py
@@ -1,0 +1,215 @@
+"""Webhook endpoint legacy-type aliasing and channel lookup resilience.
+
+Pins the fix for SaaS Google Drive push notifications being silently dropped:
+watches registered via the legacy ``GOOGLE_DRIVE_WEBHOOK_URL`` override pointed
+at ``/connectors/google/webhook`` (connector type ``google``, which doesn't
+exist), so every notification died with "Unknown connector type: google".
+``connector_webhook`` now aliases ``google`` -> ``google_drive``.
+
+Also pins ``get_connection_by_webhook_id`` re-reading the persisted store when
+a channel id is missing from the in-memory dict (subscription created by
+another replica or before a restart).
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+class _FakeRequest:
+    def __init__(self, headers: dict[str, str]):
+        self.method = "POST"
+        self.headers = headers
+        self.query_params = {}
+
+    async def json(self):
+        return {}
+
+    async def body(self):
+        return b"{}"
+
+
+class _FakeDriveConnector:
+    """Stands in for the temp GoogleDriveConnector used by the webhook route."""
+
+    def handle_webhook_validation(self, method, headers, query_params):
+        return None
+
+    def extract_webhook_channel_id(self, payload, headers):
+        normalized = {k.lower(): v for k, v in headers.items()}
+        return normalized.get("x-goog-channel-id")
+
+
+def _webhook_service(channel_id: str, connection):
+    """connector_service mock wired so a matching channel resolves `connection`."""
+    service = MagicMock()
+    service.connection_manager._create_connector = MagicMock(return_value=_FakeDriveConnector())
+    service.connection_manager.get_connection_by_webhook_id = AsyncMock(
+        side_effect=lambda cid: connection if cid == channel_id else None
+    )
+    handler = MagicMock()
+    handler.handle_webhook = AsyncMock(return_value=[])
+    service._get_connector = AsyncMock(return_value=handler)
+    return service
+
+
+@pytest.fixture(autouse=True)
+def _quiet_endpoint(monkeypatch):
+    import api.connectors as api_connectors
+
+    monkeypatch.setattr(api_connectors.TelemetryClient, "send_event", AsyncMock(return_value=None))
+    monkeypatch.setattr(api_connectors, "is_connector_access_policy_enforced", lambda: False)
+
+
+# ---------------------------------------------------------------------------
+# connector_webhook — legacy type aliasing
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path_type", ["google", "google_drive"])
+async def test_webhook_accepts_legacy_google_type(path_type):
+    from api.connectors import connector_webhook
+
+    connection = MagicMock()
+    connection.connection_id = "conn-1"
+    connection.user_id = "user-1"
+    connection.is_active = True
+
+    service = _webhook_service("chan-1", connection)
+    session_manager = MagicMock()
+    session_manager.get_user = MagicMock(return_value=None)
+
+    request = _FakeRequest({"content-type": "application/json", "x-goog-channel-id": "chan-1"})
+    response = await connector_webhook(
+        path_type,
+        request,
+        connector_service=service,
+        session_manager=session_manager,
+        session=MagicMock(),
+    )
+
+    body = json.loads(response.body)
+    assert body["status"] == "processed"
+    # The legacy path segment must be normalized before any connector lookup.
+    assert body["connector_type"] == "google_drive"
+    assert body["connection_id"] == "conn-1"
+
+
+@pytest.mark.asyncio
+async def test_webhook_sync_replaces_existing_files():
+    """A webhook fires because the file changed, so the triggered sync must
+    replace the indexed copy instead of failing the duplicate-filename guard."""
+    from api.connectors import connector_webhook
+
+    connection = MagicMock()
+    connection.connection_id = "conn-1"
+    connection.user_id = "user-1"
+    connection.is_active = True
+
+    service = _webhook_service("chan-1", connection)
+    handler = MagicMock()
+    handler.handle_webhook = AsyncMock(return_value=["file-1"])
+    service._get_connector = AsyncMock(return_value=handler)
+    service.sync_specific_files = AsyncMock(return_value="task-1")
+
+    request = _FakeRequest({"content-type": "application/json", "x-goog-channel-id": "chan-1"})
+    response = await connector_webhook(
+        "google_drive",
+        request,
+        connector_service=service,
+        session_manager=MagicMock(),
+        session=MagicMock(),
+    )
+
+    body = json.loads(response.body)
+    assert body["status"] == "processed"
+    assert body["task_id"] == "task-1"
+    sync_kwargs = service.sync_specific_files.await_args.kwargs
+    assert sync_kwargs["replace_duplicates"] is True
+
+
+@pytest.mark.asyncio
+async def test_webhook_unknown_type_is_ignored_not_500():
+    from api.connectors import connector_webhook
+
+    service = MagicMock()
+    service.connection_manager._create_connector = MagicMock(
+        side_effect=ValueError("Unknown connector type: box2")
+    )
+
+    request = _FakeRequest({"content-type": "application/json"})
+    response = await connector_webhook(
+        "box2",
+        request,
+        connector_service=service,
+        session_manager=MagicMock(),
+        session=MagicMock(),
+    )
+
+    assert response.status_code == 200
+    body = json.loads(response.body)
+    assert body == {"status": "ignored", "reason": "no_channel_id"}
+
+
+# ---------------------------------------------------------------------------
+# get_connection_by_webhook_id — reload-from-disk fallback
+# ---------------------------------------------------------------------------
+
+
+def _write_connections_file(path: Path, channel_id: str):
+    path.write_text(
+        json.dumps(
+            {
+                "connections": [
+                    {
+                        "connection_id": "conn-disk",
+                        "connector_type": "google_drive",
+                        "name": "drive",
+                        "config": {"webhook_channel_id": channel_id},
+                        "user_id": "user-1",
+                        "created_at": "2026-06-12T16:00:00",
+                        "is_active": True,
+                    }
+                ]
+            }
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_webhook_lookup_reloads_persisted_store(tmp_path):
+    from connectors.connection_manager import ConnectionManager
+
+    connections_file = tmp_path / "connections.json"
+    _write_connections_file(connections_file, "chan-disk")
+
+    # Fresh manager that has NOT loaded the file (e.g. channel registered by
+    # another replica after this one started).
+    manager = ConnectionManager(connections_file=str(connections_file))
+    assert manager.connections == {}
+
+    connection = await manager.get_connection_by_webhook_id("chan-disk")
+
+    assert connection is not None
+    assert connection.connection_id == "conn-disk"
+
+
+@pytest.mark.asyncio
+async def test_webhook_lookup_returns_none_for_unknown_channel(tmp_path):
+    from connectors.connection_manager import ConnectionManager
+
+    connections_file = tmp_path / "connections.json"
+    _write_connections_file(connections_file, "chan-disk")
+
+    manager = ConnectionManager(connections_file=str(connections_file))
+
+    assert await manager.get_connection_by_webhook_id("chan-other") is None


### PR DESCRIPTION
Description:

  ## Problem

  Webhook-driven ingestion was broken across every connector, each for a different reason. Triggering changes in Google Drive or SharePoint produced no updates in OpenRAG.

  Diagnosed from SaaS backend logs and reproduced/verified locally (ngrok + `make backend`):

  1. **Google Drive (SaaS):** push notifications arrived at the legacy path `/connectors/google/webhook`. The backend has no connector type `google`, so every notification died
  with `Unknown connector type: google` and was silently dropped with HTTP 200.
  2. **Webhook updates of existing files failed** with *"A file with this name already exists"*: the webhook sync path never passed `replace_duplicates`, so the duplicate-filename
  guard meant for manual uploads rejected the re-ingest.
  3. **SharePoint/OneDrive never received notifications at all:** the data-source OAuth flow never registered a Graph subscription — `_setup_webhook_if_needed` had zero callers
  (only the Google *login* flow set up watches, via `update_connection`).
  4. **Graph rejected subscription creation with 400:** the request sent `changeType: "created,updated,deleted"`, but driveItem subscriptions only support `updated`. The error body
  was discarded, making this invisible.
  5. **Notifications that did arrive were no-ops:** SharePoint/OneDrive `handle_webhook` parsed file ids out of the notification resource, but Graph driveItem notifications never
  identify changed items (the resource is always the subscribed drive root) — so `affected_files` was always empty.

  ## Changes

  - **`api/connectors.py`** — alias legacy `google` → `google_drive` on the webhook endpoint (keeps already-registered watches alive until expiry); pass
  `replace_duplicates=_connector_sync_should_replace(...)` on webhook-triggered syncs so changed files update the indexed copy.
  - **`services/auth_service.py`** — `_handle_data_source_auth` now registers the webhook subscription after authentication (failures logged, never fail the connect).
  - **`connectors/sharepoint` & `connectors/onedrive`** — Graph `changeType` fixed to `updated`; Graph error response bodies logged before raising; `handle_webhook` now runs the
  drive delta query (paginated, `@odata.deltaLink` reused across notifications) to discover changed files. Deleted files propagate so the processor runs its deleted-at-source
  cleanup (aligned with #1852); deleted folders are excluded. First notification after a restart sweeps the full delta but only keeps files modified in the last 10 minutes.
  - **`connectors/connection_manager.py`** — `get_connection_by_webhook_id` re-reads the persisted store once on a miss (covers restarts / channels registered by another replica).
  - **`config/settings.py`** — documented the `GOOGLE_DRIVE_WEBHOOK_URL` / stored `webhook_url` precedence pitfall behind the legacy-path registrations.

  Also merges latest `main`, including periodic webhook subscription renewal (#1852); the delta `handle_webhook` was reconciled with its delete-event contract.

  ## Verification

  - 65 unit tests pass (`tests/unit/connectors/`), including new coverage for the type alias, `replace_duplicates` on webhook syncs, data-source subscription registration,
  `changeType=updated`, delta-query discovery (modified/deleted/folder cases, delta-link reuse), and the connections-store reload fallback.
  - Verified live locally via ngrok: SharePoint reconnect → `SharePoint subscription created` → file edit → notification → delta query → `Webhook connection files affected (1)` →
  `Ingestion completed successfully`; same flow confirmed for Google Drive, including updates replacing the existing document instead of erroring.
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic webhook subscription registration after successful authentication.
  * Delta-based real-time sync for SharePoint/OneDrive with persisted delta tracking and a “first sweep” cutoff for recent changes.
  * Legacy Google → Google Drive webhook type aliasing.

* **Bug Fixes**
  * Webhook-triggered sync honors connector duplicate-replace behavior.
  * Webhook connection lookup reloads persisted store when missing in memory.
  * Improved logging for subscription creation errors.

* **Documentation**
  * Clarified webhook URL override precedence and legacy path handling.

* **Tests**
  * Expanded tests for webhook routing, delta queries, subscription registration, and lookup resilience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->