### PR TITLE
Add SDK support for owner and connector search filters

### DIFF
--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -137,7 +137,9 @@ results = await client.search.query(
     "API documentation",
     filters=SearchFilters(
         data_sources=["api-docs.pdf"],
-        document_types=["application/pdf"]
+        document_types=["application/pdf"],
+        owners=["user@example.com"],
+        connector_types=["google_drive"],
     ),
     limit=5,
     score_threshold=0.5

--- a/sdks/python/openrag_sdk/chat.py
+++ b/sdks/python/openrag_sdk/chat.py
@@ -1,7 +1,8 @@
 """OpenRAG SDK chat client with streaming support."""
 
 import json
-from typing import TYPE_CHECKING, Any, AsyncIterator, Literal, overload
+from collections.abc import AsyncIterator
+from typing import TYPE_CHECKING, Any, Literal, overload
 
 import httpx
 
@@ -253,7 +254,8 @@ class ChatClient:
             message: The message to send.
             stream: Whether to stream the response (default False).
             chat_id: ID of existing conversation to continue.
-            filters: Optional search filters (data_sources, document_types).
+            filters: Optional search filters (data_sources, document_types, owners,
+                connector_types).
             limit: Maximum number of search results (default 10).
             score_threshold: Minimum search score threshold (default 0).
             filter_id: Optional knowledge filter ID to apply.
@@ -414,7 +416,8 @@ class ChatClient:
         Args:
             message: The message to send.
             chat_id: ID of existing conversation to continue.
-            filters: Optional search filters (data_sources, document_types).
+            filters: Optional search filters (data_sources, document_types, owners,
+                connector_types).
             limit: Maximum number of search results (default 10).
             score_threshold: Minimum search score threshold (default 0).
             filter_id: Optional knowledge filter ID to apply.
@@ -500,7 +503,3 @@ class ChatClient:
             return data.get("success", False)
         except NotFoundError:
             return False
-
-
-# Import Literal for type hints
-from typing import Literal

--- a/sdks/python/openrag_sdk/models.py
+++ b/sdks/python/openrag_sdk/models.py
@@ -168,6 +168,8 @@ class SearchFilters(BaseModel):
 
     data_sources: list[str] | None = None
     document_types: list[str] | None = None
+    owners: list[str] | None = None
+    connector_types: list[str] | None = None
 
 
 # Settings update models

--- a/sdks/python/openrag_sdk/search.py
+++ b/sdks/python/openrag_sdk/search.py
@@ -2,8 +2,6 @@
 
 from typing import TYPE_CHECKING, Any
 
-import httpx
-
 from .models import SearchFilters, SearchResponse, SearchResult
 
 if TYPE_CHECKING:
@@ -30,7 +28,8 @@ class SearchClient:
 
         Args:
             query: The search query text.
-            filters: Optional filters (data_sources, document_types).
+            filters: Optional filters (data_sources, document_types, owners,
+                connector_types).
             limit: Maximum number of results (default 10).
             score_threshold: Minimum score threshold (default 0).
             filter_id: Optional knowledge filter ID to apply.

--- a/sdks/python/tests/test_models.py
+++ b/sdks/python/tests/test_models.py
@@ -1,0 +1,17 @@
+from openrag_sdk import SearchFilters
+
+
+def test_search_filters_include_owner_and_connector_filters():
+    filters = SearchFilters(
+        data_sources=["api-docs.pdf"],
+        document_types=["application/pdf"],
+        owners=["user@example.com"],
+        connector_types=["google_drive"],
+    )
+
+    assert filters.model_dump(exclude_none=True) == {
+        "data_sources": ["api-docs.pdf"],
+        "document_types": ["application/pdf"],
+        "owners": ["user@example.com"],
+        "connector_types": ["google_drive"],
+    }

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -160,6 +160,8 @@ const results = await client.search.query("API documentation", {
   filters: {
     data_sources: ["api-docs.pdf"],
     document_types: ["application/pdf"],
+    owners: ["user@example.com"],
+    connector_types: ["google_drive"],
   },
   limit: 5,
   scoreThreshold: 0.5,

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -52,6 +52,8 @@ export interface SearchResponse {
 export interface SearchFilters {
   data_sources?: string[];
   document_types?: string[];
+  owners?: string[];
+  connector_types?: string[];
 }
 
 // Document types

--- a/sdks/typescript/tests/types.test.ts
+++ b/sdks/typescript/tests/types.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from "vitest";
+import type { SearchFilters } from "../src";
+
+describe("SearchFilters", () => {
+  it("accepts owner and connector type filters", () => {
+    const filters: SearchFilters = {
+      data_sources: ["api-docs.pdf"],
+      document_types: ["application/pdf"],
+      owners: ["user@example.com"],
+      connector_types: ["google_drive"],
+    };
+
+    expect(filters).toEqual({
+      data_sources: ["api-docs.pdf"],
+      document_types: ["application/pdf"],
+      owners: ["user@example.com"],
+      connector_types: ["google_drive"],
+    });
+  });
+});


### PR DESCRIPTION
 ## Summary
  Added SDK support for owner and connector type search filters.

  ## What changed
  - Added `owners` to Python and TypeScript `SearchFilters`.
  - Added `connector_types` to Python and TypeScript `SearchFilters`.
  - Updated Python and TypeScript README examples.
  - Added SDK tests for the new filter fields.

  ## Notes
  - This uses existing public API filter behavior.
  - No internal APIs were exposed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended search filtering capabilities with new `owners` and `connector_types` filter options available in both Python and TypeScript SDKs.

* **Documentation**
  * Updated code examples demonstrating how to use the new filter fields in search queries.

* **Tests**
  * Added test coverage to validate the new filter functionality across SDKs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->