### PR TITLE
fix: forward end-user JWT to MCP/API callers via gateway-placed X-OpenRAG-API-JWT header

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -271,20 +271,22 @@ def get_jwt_auth_header() -> str:
 
 
 def get_api_jwt_header() -> str:
-    """Secondary JWT header for the /v1 API/MCP surface only.
+    """Secondary, gateway-placed JWT header for the /v1 API/MCP surface only.
 
     The primary JWT header (``get_jwt_auth_header()``, default ``Authorization``)
     is stripped by FastMCP's get_http_headers() before an MCP tool call is
     proxied to the underlying /v1 route, so it never reaches the /v1 auth
-    dependency. API/MCP callers (or the gateway) supply the JWT in this
-    add-on header instead, which FastMCP forwards verbatim. Read per-call so
+    dependency. The gateway (Traefik) therefore authenticates the MCP/API caller
+    (who supplies X-Username + X-Api-Key) and injects the minted user JWT into
+    this add-on header instead, which FastMCP forwards verbatim. Read per-call so
     tests can override via monkeypatch.setenv.
 
     TRUST NOTE: this header is read in addition to Authorization on the /v1
-    surface. It must be gateway-managed — Traefik should inject it and strip
-    any client-supplied value — OR signature verification
-    (``OPENRAG_JWT_VERIFY_SIGNATURE``) must be enabled, otherwise a client can
-    forge identity/roles (claims are decode-only when verification is off)."""
+    surface and is trusted as an identity source. It is gateway-managed: Traefik
+    mints and injects it, and MUST strip any client-supplied value at the edge
+    (standard internal-trust-header hygiene) so callers cannot forge it —
+    important because claims are decode-only unless ``OPENRAG_JWT_VERIFY_SIGNATURE``
+    is enabled."""
     return os.getenv("OPENRAG_API_JWT_HEADER", "X-OpenRAG-API-JWT")
 
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -270,6 +270,24 @@ def get_jwt_auth_header() -> str:
     return os.getenv("OPENRAG_JWT_AUTH_HEADER", "Authorization")
 
 
+def get_api_jwt_header() -> str:
+    """Secondary JWT header for the /v1 API/MCP surface only.
+
+    The primary JWT header (``get_jwt_auth_header()``, default ``Authorization``)
+    is stripped by FastMCP's get_http_headers() before an MCP tool call is
+    proxied to the underlying /v1 route, so it never reaches the /v1 auth
+    dependency. API/MCP callers (or the gateway) supply the JWT in this
+    add-on header instead, which FastMCP forwards verbatim. Read per-call so
+    tests can override via monkeypatch.setenv.
+
+    TRUST NOTE: this header is read in addition to Authorization on the /v1
+    surface. It must be gateway-managed — Traefik should inject it and strip
+    any client-supplied value — OR signature verification
+    (``OPENRAG_JWT_VERIFY_SIGNATURE``) must be enabled, otherwise a client can
+    forge identity/roles (claims are decode-only when verification is off)."""
+    return os.getenv("OPENRAG_API_JWT_HEADER", "X-OpenRAG-API-JWT")
+
+
 def get_jwt_issuer_verify_tls() -> bool:
     """Whether to verify TLS when fetching JWT signing keys from the token's
     ``iss`` URL (``verify_jwt_from_issuer``). Defaults to false for internal

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -844,13 +844,25 @@ async def get_api_key_user_async(
     # the user's roles (synced via request.state.jwt_roles ->
     # _attach_db_user_id), with a 401 when no recognized role is present.
     from auth.jwt_roles import jwt_roles_enabled
-    from config.settings import IBM_AUTH_ENABLED, get_jwt_auth_header
+    from config.settings import (
+        IBM_AUTH_ENABLED,
+        get_api_jwt_header,
+        get_jwt_auth_header,
+    )
     from config.utils import resolve_jwt_claims
 
-    raw_jwt = request.headers.get(get_jwt_auth_header(), "")
+    # Primary: the gateway-forwarded JWT header (default Authorization).
+    # Fallback: the API/MCP add-on header — FastMCP strips Authorization before
+    # proxying an MCP tool call to this /v1 handler, so MCP/API callers supply
+    # the JWT in get_api_jwt_header() instead.
+    jwt_header = get_jwt_auth_header()
+    raw_jwt = request.headers.get(jwt_header, "")
+    if not (raw_jwt and raw_jwt.strip()):
+        jwt_header = get_api_jwt_header()
+        raw_jwt = request.headers.get(jwt_header, "")
     logger.debug(
         "[AUTH] API-key path JWT header lookup",
-        header_name=get_jwt_auth_header(),
+        header_name=jwt_header,
         jwt_present=bool(raw_jwt and raw_jwt.strip()),
     )
     if raw_jwt and raw_jwt.strip():
@@ -883,14 +895,14 @@ async def get_api_key_user_async(
             # must not silently downgrade to the API-key identity.
             logger.error(
                 "[AUTH] JWT in request header failed verification/decode",
-                header_name=get_jwt_auth_header(),
+                header_name=jwt_header,
             )
             raise HTTPException(
                 status_code=401,
                 detail={
                     "error": "invalid_jwt",
                     "message": (
-                        f"The JWT in the '{get_jwt_auth_header()}' header could not be "
+                        f"The JWT in the '{jwt_header}' header could not be "
                         "verified or decoded. Ensure the gateway forwards a valid, "
                         "unexpired user JWT issued by a trusted identity provider."
                     ),

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -850,6 +850,14 @@ async def get_api_key_user_async(
         get_jwt_auth_header,
     )
     from config.utils import resolve_jwt_claims
+    from utils.run_mode_utils import is_run_mode_saas
+
+    # SaaS/RBAC: the gateway MUST forward the end-user JWT on every /v1 request.
+    # When it doesn't, we must NOT silently degrade to lakehouse Basic creds —
+    # that path does DB user writes under a degraded identity and can clobber the
+    # shared users row the same person sees on UI login. Fail loud (401) with no
+    # DB side effects instead; explicit orag_ API-key auth still works.
+    saas_rbac = is_run_mode_saas() and jwt_roles_enabled()
 
     # Primary: the gateway-forwarded JWT header (default Authorization).
     # Fallback: the API/MCP add-on header — FastMCP strips Authorization before
@@ -910,16 +918,27 @@ async def get_api_key_user_async(
             )
         # RBAC off + missing/invalid JWT -> fall through to the API-key path.
     else:
-        from utils.run_mode_utils import is_run_mode_saas
-
-        if is_run_mode_saas() and jwt_roles_enabled():
+        if saas_rbac:
             # In saas the gateway is responsible for forwarding the end-user
             # JWT on every API/MCP request; its absence is a gateway
-            # misconfiguration, not a normal client state.
+            # misconfiguration, not a normal client state. Fail fast here —
+            # before any lakehouse / X-Username / API-key fallback — so no DB
+            # user/role write ever runs under a degraded (roles-less) identity.
             logger.error(
                 "[AUTH] JWT not found in request header — run_mode=saas with "
                 "RBAC enabled requires the gateway to forward the user JWT",
-                header_name=get_jwt_auth_header(),
+                header_name=jwt_header,
+            )
+            raise HTTPException(
+                status_code=401,
+                detail={
+                    "error": "missing_user_jwt",
+                    "message": (
+                        "No user JWT was forwarded by the gateway. In SaaS/RBAC "
+                        "mode the gateway must forward the end-user JWT on every "
+                        "/v1 request."
+                    ),
+                },
             )
         if IBM_AUTH_ENABLED:
             # No JWT — fall back to lakehouse Basic credentials (credentials
@@ -977,6 +996,9 @@ async def get_api_key_user_async(
                 api_key = token
 
     if not api_key:
+        # saas_rbac is already handled by the fail-fast 401 above (no JWT ->
+        # missing_user_jwt), so reaching here means non-saas_rbac: prompt for
+        # an API key as before.
         raise HTTPException(
             status_code=401,
             detail={

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -2,18 +2,26 @@
 FastMCP streamable HTTP server integration.
 
 Exposes all /v1/ FastAPI endpoints as MCP tools over streamable HTTP transport.
-Auth headers passed by MCP clients are forwarded transparently to the underlying
-FastAPI endpoint handlers via FastMCP's internal proxy.
+Auth headers passed by MCP clients are forwarded to the underlying FastAPI
+endpoint handlers via FastMCP's internal proxy.
+
+IMPORTANT: FastMCP's proxy STRIPS the ``Authorization`` header before invoking
+the /v1 handler (it is in get_http_headers()'s exclude set), so neither an
+``Authorization`` JWT nor ``Authorization: Bearer orag_...`` survives the proxy.
+Use ``X-API-Key`` for API keys. For SaaS/IBM auth, the gateway (Traefik)
+authenticates the X-Username/X-Api-Key pair and injects the minted user JWT into
+the add-on ``X-OpenRAG-API-JWT`` header (OPENRAG_API_JWT_HEADER), which FastMCP
+forwards because it is not in the exclude set; the /v1 auth dependency reads it.
 
 Supported authentication methods:
 
 1. OpenRAG API Key:
    - X-API-Key: orag_...
-   - Authorization: Bearer orag_...
 
 2. IBM Auth (when IBM_AUTH_ENABLED=true):
    - X-Username: <ibm_username>
    - X-Api-Key: <ibm_api_key>
+   The gateway exchanges these for a user JWT placed in X-OpenRAG-API-JWT.
 
 Usage (MCP client config):
 

--- a/tests/unit/dependencies/test_jwt_header_auth.py
+++ b/tests/unit/dependencies/test_jwt_header_auth.py
@@ -138,6 +138,9 @@ async def test_valid_jwt_rbac_on_no_role_401(monkeypatch, _patch_attach):
         await get_api_key_user_async(req, api_key_service=None, session_manager=None)
     assert exc.value.status_code == 401
     assert exc.value.detail == "User has no OpenRAG roles assigned"
+    # 401 fires inside _stage_jwt_roles, before _attach_request_user -> no DB
+    # user/role write, so a roles-less JWT can never reach _sync_jwt_roles.
+    assert "user" not in _patch_attach
 
 
 @pytest.mark.asyncio
@@ -302,19 +305,57 @@ async def test_no_jwt_broken_store_still_returns_header_credentials(monkeypatch,
 
 
 @pytest.mark.asyncio
-async def test_no_jwt_saas_rbac_on_logs_error(monkeypatch, _patch_attach):
-    """saas + RBAC enabled + no JWT header -> a clear error is logged and the
-    request still proceeds via the credentials-header fallback."""
+async def test_no_jwt_saas_rbac_on_fails_loud_no_db_write(monkeypatch, _patch_attach):
+    """saas + RBAC + no gateway JWT -> fail loud with 401 missing_user_jwt and
+    do NOT silently fall back to lakehouse creds (no DB user/role write).
+
+    A roles-less / wrong-identity LH fallback here is what corrupted the shared
+    users row the same person sees on UI login; under saas_rbac we must 401
+    before any _attach_request_user instead.
+    """
     manager, services = _ibm_setup(monkeypatch)
     monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
     errors: list[str] = []
     monkeypatch.setattr(deps.logger, "error", lambda msg, **kw: errors.append(msg))
+    # Even with a valid LH-credentials header present, saas_rbac must not use it.
     req = _FakeRequest({"X-IBM-LH-Credentials": _B64}, services=services)
 
-    user = await get_api_key_user_async(req, api_key_service=None, session_manager=None)
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_user_async(req, api_key_service=None, session_manager=None)
 
-    assert user.jwt_token == f"Basic {_B64}"
+    assert exc.value.status_code == 401
+    assert exc.value.detail["error"] == "missing_user_jwt"
     assert any("JWT not found" in m for m in errors)
+    # No DB side effects: _attach_request_user was never reached, and the
+    # LH-credentials store was never written.
+    assert "user" not in _patch_attach
+    assert manager.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_no_jwt_saas_rbac_on_rejects_api_key_fail_fast(monkeypatch, _patch_attach):
+    """saas + RBAC + no gateway JWT -> fail fast even when a valid orag_ API key
+    is present. In SaaS the gateway JWT is mandatory; the API key must not be
+    consulted, and the key service must never be called (no DB side effects)."""
+    _ibm_setup(monkeypatch)
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+
+    calls: list[str] = []
+
+    class _KeySvc:
+        async def validate_key(self, key):
+            calls.append(key)
+            return {"user_id": "svc-user", "user_email": "svc@example.com", "key_id": "k1"}
+
+    req = _FakeRequest({"X-API-Key": "orag_live_key"})
+
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_user_async(req, api_key_service=_KeySvc(), session_manager=None)
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail["error"] == "missing_user_jwt"
+    assert calls == []  # API key never validated under saas_rbac
+    assert "user" not in _patch_attach  # no _attach_request_user / DB write
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem
MCP tool calls against the `/v1/*` surface fail with 403/401:
- `openrag_get_settings` / `update_settings` / `list_models` → 403 (`providers:read`, `config:write`)
- `openrag_search`, knowledge-filter reads/deletes → "403 (401 Unauthorized)" / 404

Root cause: every `/v1` request arriving via `/mcp` logs `jwt_present: false`. FastMCP's `from_fastapi` proxy rebuilds the request to the underlying `/v1` handler using `get_http_headers()`, whose hardcoded exclude set contains `authorization` — so the gateway-forwarded user JWT is **stripped** before it reaches the auth dependency. The caller then falls back to IBM lakehouse Basic credentials, which (a) carry no `openrag_roles` → RBAC 403, and (b) are rejected by OpenSearch → `AuthenticationException(401)`.

This is a proxy-layer issue, not a Traefik misconfiguration: the same JWT arrives fine (`jwt_present: true`) on UI/session routes where it isn't proxied through FastMCP.

## Fix
Read the JWT from a secondary, **gateway-placed** header that FastMCP does not strip. In SaaS, the MCP/API caller still authenticates with `X-Username` + `X-Api-Key`; Traefik exchanges those for the user JWT and injects it into the add-on header. The `/v1` API-key auth path reads it as a fallback to `Authorization`.

- `config/settings.py`: add `get_api_jwt_header()` → `OPENRAG_API_JWT_HEADER` (default `X-OpenRAG-API-JWT`).
- `dependencies.py` (`get_api_key_user_async`): use `Authorization`, then fall back to the add-on header; log/report whichever header actually supplied the token.
- `mcp_http/server.py`: correct the auth docstring (Authorization is stripped by the proxy; document the gateway-placed JWT header).

## Trust model
The add-on header is **gateway-managed**, not client-supplied — same trust boundary as today's `Authorization`. Because claims are decode-only unless `OPENRAG_JWT_VERIFY_SIGNATURE=true`, the header is trusted only because Traefik mints it. **Gateway requirement:** Traefik must inject `X-OpenRAG-API-JWT` on the `/mcp` route and strip any client-supplied value at the edge so it cannot be forged.

## Config
- `OPENRAG_API_JWT_HEADER` (default `X-OpenRAG-API-JWT`) — name of the add-on JWT header.

## Testing
- Existing auth-header unit tests pass (`tests/unit/dependencies/test_jwt_header_auth.py`, `tests/unit/config/test_jwt_auth_header.py`, `tests/unit/dependencies/test_ibm_header_auth.py`).
- Manual: with Traefik placing `X-OpenRAG-API-JWT`, call `openrag_get_settings` via MCP and confirm the `[AUTH] API-key path JWT header lookup` log flips to `jwt_present: true` (header_name `X-OpenRAG-API-JWT`), and `openrag_search` returns results with no OpenSearch 401.

## Follow-ups
- Add unit coverage for the add-on-header fallback in `get_api_key_user_async`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable JWT authentication header support for the `/v1` API surface, including gateway-forwarded header fallback.

* **Bug Fixes**
  * Improved JWT-in-header authentication behavior, including clearer 401 responses when the user JWT is missing and preventing unintended downstream auth/DB actions in SaaS+RBAC scenarios.

* **Documentation**
  * Clarified which authentication headers are supported for MCP→FastAPI and what headers the gateway injects for `/v1` handling.

* **Tests**
  * Strengthened coverage for “no roles” and missing-JWT RBAC failure paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->