### PR TITLE
Fix: Stale api keys no longer display on the page once revoked

### DIFF
--- a/src/services/api_key_service.py
+++ b/src/services/api_key_service.py
@@ -237,7 +237,7 @@ class APIKeyService:
         jwt_token: str = None,
     ) -> dict[str, Any]:
         """
-        List all API keys for a user (without the actual keys).
+        List all active (non-revoked) API keys for a user (without the actual keys).
 
         Args:
             user_id: The user's ID
@@ -251,7 +251,14 @@ class APIKeyService:
 
             # Search for user's keys
             search_body = {
-                "query": {"term": {"user_id": user_id}},
+                "query": {
+                    "bool": {
+                        "must": [
+                            {"term": {"user_id": user_id}},
+                            {"term": {"revoked": False }},
+                        ]
+                    }
+                },
                 "sort": [{"created_at": {"order": "desc"}}],
                 "_source": [
                     "key_id",

--- a/tests/unit/test_api_key_service.py
+++ b/tests/unit/test_api_key_service.py
@@ -92,3 +92,46 @@ async def test_validate_key_accepts_and_migrates_legacy_hash(monkeypatch):
     update_doc = opensearch_client.update.await_args.kwargs["body"]["doc"]
     assert update_doc["key_hash"] == keyed_hash
     assert "last_used_at" in update_doc
+
+@pytest.mark.asyncio
+async def test_list_keys_returns_only_non_revoked_api_keys(monkeypatch) -> None:
+    from services.api_key_service import APIKeyService
+
+    service = APIKeyService()
+
+    opensearch_client = AsyncMock()
+    opensearch_client.search.return_value = {
+        "hits": {
+            "hits": [
+                {
+                    "_source": {
+                        "key_id": "key-1",
+                        "key_prefix": "orag_aaaaaaaa",
+                        "name": "active key",
+                        "created_at": "2026-06-15T10:03:58.016280",
+                        "last_used_at": None,
+                        "revoked": False,
+                    }
+                },
+            ]
+        }
+    }
+    monkeypatch.setattr("config.settings.clients.opensearch", opensearch_client)
+
+    result = await service.list_keys(user_id="user-1")
+
+    assert result["success"] is True
+    assert result["keys"] == [
+        {
+            "key_id": "key-1",
+            "key_prefix": "orag_aaaaaaaa",
+            "name": "active key",
+            "created_at": "2026-06-15T10:03:58.016280",
+            "last_used_at": None,
+            "revoked": False,
+        }
+    ]
+
+    query_must = opensearch_client.search.await_args.kwargs["body"]["query"]["bool"]["must"]                                                                              
+    assert {"term": {"user_id": "user-1"}} in query_must                                                                                                                  
+    assert {"term": {"revoked": False}} in query_must


### PR DESCRIPTION
## Summary

Fixes #1877, Updates the opensearch query to only fetch non revoked (revoked = False) api keys so the frontend recieves only non-revoked keys to display.

## Demo (Before)
[screen-capture (6).webm](https://github.com/user-attachments/assets/811a9a09-1809-4055-9461-d43679c5eef3)

## Demo (After)
[screen-capture (7).webm](https://github.com/user-attachments/assets/4b9acbe2-8708-4125-a4f4-7aed8619e333)


## Changes
- updates `api_key_service.py` list_keys opensearch query to also filter for keys that have revoked set to false
- Added a unit test to verify that query is sent correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * API key listing now returns only active keys, excluding revoked ones.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->