### PR TITLE
fix: improve error handling and status updates for document processing and add OCR requirement check for image files

### DIFF
--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -560,10 +560,16 @@ class DocumentFileProcessor(TaskProcessor):
                 **standard_kwargs,
             )
 
-            file_task.status = TaskStatus.COMPLETED
-            file_task.result = result
-            file_task.updated_at = time.time()
-            upload_task.successful_files += 1
+            if result.get("status") == "error":
+                file_task.status = TaskStatus.FAILED
+                file_task.error = result.get("error", "Failed to process document")
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+            else:
+                file_task.status = TaskStatus.COMPLETED
+                file_task.result = result
+                file_task.updated_at = time.time()
+                upload_task.successful_files += 1
 
         except Exception as e:
             file_task.status = TaskStatus.FAILED
@@ -844,6 +850,14 @@ class ConnectorFileProcessor(TaskProcessor):
                         allowed_users=allowed_users,
                         allowed_groups=allowed_groups,
                     )
+                    # Langflow returns "success" even when no text was extracted
+                    # (e.g. image files without OCR). Verify the document actually
+                    # landed in OpenSearch before declaring success.
+                    if not await self.check_document_exists(document.id, opensearch_client):
+                        result = {
+                            "status": "error",
+                            "error": "No text content could be extracted from document",
+                        }
                 else:
                     # Standard OpenRAG processing pipeline (process_document_standard)
                     standard_kwargs: dict[str, Any] = {}
@@ -892,10 +906,16 @@ class ConnectorFileProcessor(TaskProcessor):
                         }
                     )
 
-            file_task.status = TaskStatus.COMPLETED
-            file_task.result = result
-            file_task.updated_at = time.time()
-            upload_task.successful_files += 1
+            if result.get("status") == "error":
+                file_task.status = TaskStatus.FAILED
+                file_task.error = result.get("error", "Failed to process document")
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+            else:
+                file_task.status = TaskStatus.COMPLETED
+                file_task.result = result
+                file_task.updated_at = time.time()
+                upload_task.successful_files += 1
 
         except Exception as e:
             file_task.status = TaskStatus.FAILED
@@ -970,9 +990,14 @@ class S3FileProcessor(TaskProcessor):
                 )
 
                 result["path"] = f"s3://{self.bucket}/{item}"
-                file_task.status = TaskStatus.COMPLETED
-                file_task.result = result
-                upload_task.successful_files += 1
+                if result.get("status") == "error":
+                    file_task.status = TaskStatus.FAILED
+                    file_task.error = result.get("error", "Failed to process document")
+                    upload_task.failed_files += 1
+                else:
+                    file_task.status = TaskStatus.COMPLETED
+                    file_task.result = result
+                    upload_task.successful_files += 1
 
         except Exception as e:
             file_task.status = TaskStatus.FAILED
@@ -1106,11 +1131,20 @@ class LangflowFileProcessor(TaskProcessor):
                 file_task=file_task,
             )
 
-            # Update task with success
-            file_task.status = TaskStatus.COMPLETED
-            file_task.result = result
-            file_task.updated_at = time.time()
-            upload_task.successful_files += 1
+            # Langflow returns "success" even when no text was extracted.
+            # Verify the document actually landed in OpenSearch.
+            file_hash = hash_id(item)
+            if not await self.check_document_exists(file_hash, opensearch_client):
+                file_task.status = TaskStatus.FAILED
+                file_task.error = "No text content could be extracted from document"
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+            else:
+                # Update task with success
+                file_task.status = TaskStatus.COMPLETED
+                file_task.result = result
+                file_task.updated_at = time.time()
+                upload_task.successful_files += 1
 
         except Exception as e:
             # Update task with failure

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -64,9 +64,20 @@ _TRANSIENT_CONNECTIVITY_ERROR_MARKERS = (
 )
 
 
+# Raster image formats that require OCR to produce any text content.
+_OCR_REQUIRED_EXTENSIONS = frozenset({"bmp", "jpeg", "jpg", "png", "tiff", "webp"})
+
+
 def _is_non_retryable_file_error(error: str) -> bool:
     lowered = error.lower()
     return any(marker in lowered for marker in _NON_RETRYABLE_FILE_ERROR_MARKERS)
+
+
+def _is_ocr_required_file(filename: str) -> bool:
+    """Return True if the file is a raster image that requires OCR to produce text."""
+    if not filename or "." not in filename:
+        return False
+    return filename.rsplit(".", 1)[-1].lower() in _OCR_REQUIRED_EXTENSIONS
 
 
 def _is_transient_connectivity_error(error: str) -> bool:
@@ -958,6 +969,23 @@ class TaskService:
 
         # First, check if the error is non-retryable based on common markers
         if _is_non_retryable_file_error(error):
+                        # Image files that produced no text almost certainly failed because OCR
+            # is disabled — not because the file is corrupted. Give a targeted tip.
+            filename = file_task.filename or file_task.file_path or ""
+            if "no text content could be extracted" in error.lower() and _is_ocr_required_file(
+                filename
+            ):
+                return {
+                    "component": "docling",
+                    "failure_phase": "parsing",
+                    "user_facing_message": (
+                        "No text content could be extracted from this image file. "
+                        "Enable OCR in Settings > Knowledge Base and retry ingestion."
+                    ),
+                    "actionable_by": "RETRYABLE",
+                }
+
+
             if phase == IngestionPhase.LANGFLOW:
                 component = "langflow"
                 failure_phase = "unknown"

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -969,7 +969,7 @@ class TaskService:
 
         # First, check if the error is non-retryable based on common markers
         if _is_non_retryable_file_error(error):
-                        # Image files that produced no text almost certainly failed because OCR
+            # Image files that produced no text almost certainly failed because OCR
             # is disabled — not because the file is corrupted. Give a targeted tip.
             filename = file_task.filename or file_task.file_path or ""
             if "no text content could be extracted" in error.lower() and _is_ocr_required_file(
@@ -984,7 +984,6 @@ class TaskService:
                     ),
                     "actionable_by": "RETRYABLE",
                 }
-
 
             if phase == IngestionPhase.LANGFLOW:
                 component = "langflow"


### PR DESCRIPTION
# Supported File Types by Ingestion Path

There are currently **two different supported file type lists** depending on how content is ingested into OpenRAG.

## Direct Upload (Frontend File Picker)

Defined in `knowledge-dropdown.tsx` (lines 60–76).

| Category | Extensions |
|-----------|------------|
| Documents | `.txt`, `.md`, `.pdf`, `.docx`, `.html`, `.htm`, `.adoc`, `.asciidoc`, `.asc` |
| Spreadsheets | `.csv`, `.xlsx` |
| Presentations | `.pptx` |

---

## Connector Ingestion (Backend Validator)

Defined in `processors.py` (lines 645–668).

Includes **all file types supported by Direct Upload**, plus additional Office formats, XHTML, and image formats.

| Category | Extensions |
|-----------|------------|
| Documents | `.txt`, `.md`, `.pdf`, `.docx`, `.html`, `.htm`, `.adoc`, `.asciidoc`, `.asc` |
| Additional Office Documents | `.dotx`, `.dotm`, `.docm` |
| Spreadsheets | `.csv`, `.xlsx`, `.xls` |
| Presentations | `.pptx`, `.potx`, `.ppsx`, `.pptm`, `.potm`, `.ppsm` |
| Web Documents | `.xhtml` |
| Images | `.jpg`, `.jpeg`, `.png`, `.tiff`, `.bmp`, `.webp` |

---

## Root Cause of the Reported Defect

The image formats (`.jpg`, `.jpeg`, `.png`, `.tiff`, `.bmp`, `.webp`) are the source of the reported issue.

### What Happens

1. The connector ingestion validator accepts image files based on extension.
2. The files are sent through the ingestion pipeline.
3. Images only produce extractable text when **Docling OCR** is enabled.
4. When OCR is disabled, no text content is extracted.
5. No chunks are generated for indexing.
6. The updated ingestion logic now correctly marks these files as **Failed** rather than **Active**.

---

## Existing Frontend Limitation

The frontend intentionally excludes several file types that are accepted by connector ingestion.

A TODO comment in `knowledge-dropdown.tsx` (line 57) states:

> Re-add other MIME/extension groups (images, xlsx/xls/ppt, rtf/odt, etc.) once ingestion is verified end-to-end in Langflow.

This indicates that support for images and additional document types was intentionally withheld from the file picker until end-to-end ingestion behavior was fully validated.

---

## Gap Between Frontend and Connector Validation

| Area | Images Allowed? |
|--------|----------------|
| Frontend File Picker | ❌ No |
| Connector Ingestion Validator | ✅ Yes |

This inconsistency allows image files to be ingested through connectors while bypassing the frontend restrictions, creating the gap that exposed the bug.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
- Improved validation of document processing results to ensure failures are correctly detected and reported when content is not properly indexed
- Enhanced error messages for image files to provide specific guidance when OCR processing is required for content extraction
<!-- end of auto-generated comment: release notes by coderabbit.ai -->