### PR TITLE
chore: fix ci

### DIFF
--- a/sdks/typescript/tests/integration.test.ts
+++ b/sdks/typescript/tests/integration.test.ts
@@ -271,11 +271,33 @@ describe.skipIf(SKIP_TESTS)("OpenRAG TypeScript SDK Integration", () => {
     });
 
     it("should delete a document", async () => {
+      // Use a uniquely named file so this test doesn't inherit chunks left in
+      // the index by the two ingest tests above (which share testFilePath /
+      // "sdk_test_doc.md"). Otherwise a zero-successful-files re-ingest here can
+      // still find the earlier document, making delete succeed when the
+      // else-branch expects a no-op — i.e. ingest's reported successful_files
+      // would no longer reflect whether THIS document exists in the index.
+      const deleteDir = fs.mkdtempSync(path.join(os.tmpdir(), "sdk-del-"));
+      const deleteFilePath = path.join(
+        deleteDir,
+        `sdk_delete_doc_${Date.now()}.md`
+      );
+      fs.writeFileSync(
+        deleteFilePath,
+        "# SDK Delete Test Document\n\n" +
+          "This document tests document deletion via the OpenRAG TypeScript SDK.\n" +
+          "It contains unique content about teal dolphins swimming.\n"
+      );
+
       // First ingest (wait for completion)
-      const ingestResult = await client.documents.ingest({ filePath: testFilePath });
+      const ingestResult = await client.documents.ingest({
+        filePath: deleteFilePath,
+      });
 
       // Then delete
-      const result = await client.documents.delete(path.basename(testFilePath));
+      const result = await client.documents.delete(
+        path.basename(deleteFilePath)
+      );
 
       // If ingestion produced indexed chunks, delete should succeed.
       // In unstable flow environments, ingestion can complete with zero successful files.

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -852,7 +852,16 @@ class ConnectorFileProcessor(TaskProcessor):
                     )
                     # Langflow returns "success" even when no text was extracted
                     # (e.g. image files without OCR). Verify the document actually
-                    # landed in OpenSearch before declaring success.
+                    # landed in OpenSearch before declaring success. Refresh first
+                    # so the just-indexed chunks are visible (OpenSearch's ~1s
+                    # near-real-time window would otherwise yield a false negative).
+                    try:
+                        await opensearch_client.indices.refresh(index=get_index_name())
+                    except Exception as refresh_error:
+                        logger.warning(
+                            "Failed to refresh index before verification",
+                            error=str(refresh_error),
+                        )
                     if not await self.check_document_exists(document.id, opensearch_client):
                         result = {
                             "status": "error",
@@ -1131,10 +1140,23 @@ class LangflowFileProcessor(TaskProcessor):
                 file_task=file_task,
             )
 
-            # Langflow returns "success" even when no text was extracted.
-            # Verify the document actually landed in OpenSearch.
-            file_hash = hash_id(item)
-            if not await self.check_document_exists(file_hash, opensearch_client):
+            # Langflow returns "success" even when no text was extracted
+            # (e.g. image files without OCR). Verify the document actually
+            # landed in OpenSearch before declaring success. We key off the
+            # filename — the identifier this path already uses for dedup and
+            # delete (see check_filename_exists / delete_document_by_filename
+            # above) — because Langflow assigns its own document_id here, so
+            # hash_id(item) is not stored as document_id.
+            from config.settings import get_index_name
+
+            try:
+                await opensearch_client.indices.refresh(index=get_index_name())
+            except Exception as refresh_error:
+                logger.warning(
+                    "Failed to refresh index before verification",
+                    error=str(refresh_error),
+                )
+            if not await self.check_filename_exists(original_filename, opensearch_client):
                 file_task.status = TaskStatus.FAILED
                 file_task.error = "No text content could be extracted from document"
                 file_task.updated_at = time.time()

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -43,10 +43,19 @@ class TaskProcessor:
         self,
         file_hash: str,
         opensearch_client,
+        *,
+        wait_for_visibility: bool = False,
     ) -> bool:
         """
         Check if a document with the given hash already exists in OpenSearch.
         Consolidated hash checking for all processors.
+
+        When ``wait_for_visibility`` is True, an empty result is retried a few
+        times with backoff before concluding the document is absent. This is for
+        post-ingest verification: chunks that were just written may not be
+        searchable yet within OpenSearch's near-real-time refresh window
+        (default ~1s), and the user-scoped client cannot force an
+        ``indices:admin/refresh`` (it lacks the privilege).
         """
         max_retries = 3
         retry_delay = 1.0
@@ -62,7 +71,15 @@ class TaskProcessor:
                     },
                 )
                 hits = response.get("hits", {}).get("hits", [])
-                return bool(hits)
+                if hits:
+                    return True
+                # No hits. For post-ingest verification, the document may not be
+                # visible yet within the near-real-time refresh window — retry.
+                if wait_for_visibility and attempt < max_retries - 1:
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
+                    continue
+                return False
             except (TimeoutError, Exception) as e:
                 if attempt == max_retries - 1:
                     logger.error(
@@ -93,10 +110,19 @@ class TaskProcessor:
         self,
         filename: str,
         opensearch_client,
+        *,
+        wait_for_visibility: bool = False,
     ) -> bool:
         """
         Check if a document with the given filename already exists in OpenSearch.
         Returns True if any chunks with this filename exist.
+
+        When ``wait_for_visibility`` is True, an empty result is retried a few
+        times with backoff before concluding the document is absent. This is for
+        post-ingest verification: chunks that were just written may not be
+        searchable yet within OpenSearch's near-real-time refresh window
+        (default ~1s), and the user-scoped client cannot force an
+        ``indices:admin/refresh`` (it lacks the privilege).
         """
         max_retries = 3
         retry_delay = 1.0
@@ -127,6 +153,14 @@ class TaskProcessor:
                     # Successfully checked this alias with no hits; don't
                     # re-query it on future retries.
                     pending_candidates.pop(i)
+                    continue
+                # All aliases checked with no hits. For post-ingest verification,
+                # the document may not be visible yet within the near-real-time
+                # refresh window — re-check every alias after a short delay.
+                if wait_for_visibility and attempt < max_retries - 1:
+                    pending_candidates = list(candidate_filenames)
+                    await asyncio.sleep(retry_delay)
+                    retry_delay *= 2
                     continue
                 return False
 
@@ -852,17 +886,13 @@ class ConnectorFileProcessor(TaskProcessor):
                     )
                     # Langflow returns "success" even when no text was extracted
                     # (e.g. image files without OCR). Verify the document actually
-                    # landed in OpenSearch before declaring success. Refresh first
-                    # so the just-indexed chunks are visible (OpenSearch's ~1s
-                    # near-real-time window would otherwise yield a false negative).
-                    try:
-                        await opensearch_client.indices.refresh(index=get_index_name())
-                    except Exception as refresh_error:
-                        logger.warning(
-                            "Failed to refresh index before verification",
-                            error=str(refresh_error),
-                        )
-                    if not await self.check_document_exists(document.id, opensearch_client):
+                    # landed in OpenSearch before declaring success.
+                    # wait_for_visibility polls on an empty result to ride out
+                    # OpenSearch's ~1s near-real-time window (the user-scoped
+                    # client cannot force an indices:admin/refresh — it 403s).
+                    if not await self.check_document_exists(
+                        document.id, opensearch_client, wait_for_visibility=True
+                    ):
                         result = {
                             "status": "error",
                             "error": "No text content could be extracted from document",
@@ -1147,16 +1177,14 @@ class LangflowFileProcessor(TaskProcessor):
             # delete (see check_filename_exists / delete_document_by_filename
             # above) — because Langflow assigns its own document_id here, so
             # hash_id(item) is not stored as document_id.
-            from config.settings import get_index_name
-
-            try:
-                await opensearch_client.indices.refresh(index=get_index_name())
-            except Exception as refresh_error:
-                logger.warning(
-                    "Failed to refresh index before verification",
-                    error=str(refresh_error),
-                )
-            if not await self.check_filename_exists(original_filename, opensearch_client):
+            #
+            # wait_for_visibility polls on an empty result so the just-written
+            # chunks become visible within OpenSearch's near-real-time refresh
+            # window. We cannot force a refresh here: the user-scoped client
+            # lacks the indices:admin/refresh privilege (it 403s).
+            if not await self.check_filename_exists(
+                original_filename, opensearch_client, wait_for_visibility=True
+            ):
                 file_task.status = TaskStatus.FAILED
                 file_task.error = "No text content could be extracted from document"
                 file_task.updated_at = time.time()


### PR DESCRIPTION
## Summary

Fixes the `e2e` and `tests` CI failures introduced by the new post-ingest verification (mark a file **FAILED** when its document isn't found in OpenSearch after Langflow reports success). That verification was producing **false negatives** for legitimately-ingested text documents, breaking onboarding and the SDK delete test.

Two root causes, both in how the verification looked up the just-ingested document:

1. **Wrong lookup key on the direct/Langflow path.** `LangflowFileProcessor` verified with `check_document_exists(hash_id(item))`, but on this path Langflow assigns its own `document_id` (the backend never passes one), so `hash_id(item)` was never stored — the term query never matched. This path already identifies documents **by filename** (used for dedup and delete), so verification now does too.

2. **Stale read inside OpenSearch's near-real-time window.** The first attempt forced an `indices.refresh()` before the check, but the processor's OpenSearch client is **user-scoped** (`anonymous` / `openrag_user`) and lacks the `indices:admin/refresh` privilege — the call 403'd on every ingest. The verifying search then read a stale index (~1s refresh window) and got 0 hits. Confirmed from the e2e service logs: the document *was* indexed (`Deleted 1 chunks for filename test-document.md`) while verification reported `successful_files: 0`. Instead of refreshing, verification now **polls the existence check on an empty result** to ride out the window — which needs no special privilege.

## Changes

**`src/models/processors.py`**
- `LangflowFileProcessor` verification now keys off the **filename** (`check_filename_exists`) instead of `hash_id(item)`.
- Added a `wait_for_visibility` option to `check_document_exists` and `check_filename_exists` that retries an **empty** result (~3×, 1s/2s backoff) to absorb OpenSearch's near-real-time refresh window. Both post-ingest verification sites (connector + Langflow) pass `wait_for_visibility=True`.
- Removed the `indices.refresh()` calls that always 403 under the user-scoped client.

**`sdks/typescript/tests/integration.test.ts`**
- "should delete a document" now ingests/deletes a **uniquely named** temp file instead of the shared `sdk_test_doc.md`, removing cross-test contamination from the two earlier ingests of the same filename (which made a 0-file re-ingest still find an older doc and flip the `success` assertion at L286).

## Behavior preserved

The OCR intent of the original change is intact: an image that genuinely produces no text still ends up **FAILED** (it just polls for ~3s first before concluding the document is absent).

## Failures addressed

- `e2e` › `onboarding.spec.ts:4` "can configure OpenAI provider" — `No text content could be extracted from document`
- `e2e` › `tasks-unified-panel.spec.ts:138` — `beforeEach` timeout cascading from the broken onboarding upload
- `tests` › `integration.test.ts` "should delete a document" — `AssertionError: expected true to be false`

## Verification

- `ruff check` and `python -c "ast.parse(...)"` pass on `processors.py`; `tsc --noEmit` passes on the SDK suite.
- Final confirmation requires a fresh CI run, since this is timing/privilege behavior in the live stack.

