### PR TITLE
fix: forward allowed_principals through connector Langflow ingestion (DLS shares were invisible)

### DIFF
--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -936,6 +936,8 @@ class ConnectorFileProcessor(TaskProcessor):
                     # Extract ACL information
                     allowed_users: list[str] = []
                     allowed_groups: list[str] = []
+                    allowed_principals: list[str] = []
+                    allowed_principal_labels: list[dict[str, Any]] = []
                     if document.acl:
                         try:
                             allowed_users = document.acl.allowed_users or []
@@ -943,8 +945,7 @@ class ConnectorFileProcessor(TaskProcessor):
                             allowed_principals = document.acl.allowed_principals or []
                             allowed_principal_labels = document.acl.allowed_principal_labels or []
                         except AttributeError:
-                            allowed_principals = []
-                            allowed_principal_labels = []
+                            pass
 
                     # Prepare tweaks
                     connector_tweak_settings = None

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -940,8 +940,11 @@ class ConnectorFileProcessor(TaskProcessor):
                         try:
                             allowed_users = document.acl.allowed_users or []
                             allowed_groups = document.acl.allowed_groups or []
+                            allowed_principals = document.acl.allowed_principals or []
+                            allowed_principal_labels = document.acl.allowed_principal_labels or []
                         except AttributeError:
-                            pass
+                            allowed_principals = []
+                            allowed_principal_labels = []
 
                     # Prepare tweaks
                     connector_tweak_settings = None
@@ -971,6 +974,8 @@ class ConnectorFileProcessor(TaskProcessor):
                         source_url=document.source_url,
                         allowed_users=allowed_users,
                         allowed_groups=allowed_groups,
+                        allowed_principals=allowed_principals,
+                        allowed_principal_labels=allowed_principal_labels,
                     )
                     # Langflow returns "success" even when no text was extracted
                     # (e.g. image files without OCR). Verify the document actually


### PR DESCRIPTION
 ## Problem

  Documents synced from connectors (Google Drive, etc.) were indexed into OpenSearch with an **empty `allowed_principals`** field, even though the connector's ACL extraction (`_extract_google_drive_acl`) computed them correctly. As a result, document-level security (DLS) could not match users by their connector identity: a user logged in via one identity (e.g. IBM email) who was granted access via a connected alias (e.g. their Gmail) could **not see documents shared to that alias**. Only shares matching the user's login email worked.

  ## Root cause

  The Langflow connector-ingestion branch in `ConnectorFileProcessor` (`src/models/processors.py`) forwarded only `allowed_users` and `allowed_groups` to `upload_and_ingest_file` — it **silently dropped `allowed_principals` and `allowed_principal_labels`**. The principals were computed upstream but lost before indexing, so DLS's `allowed_principals` terms-lookup never matched.

  (The non-Langflow path was unaffected — it passes `acl=document.acl` straight into `process_document_standard`, which already reads `acl.allowed_principals`.)

  ## Fix

  - Forward `allowed_principals` and `allowed_principal_labels` from `document.acl` into `upload_and_ingest_file`.
  - Initialize all four ACL lists **before** the `if document.acl:` block so a document with no ACL can't (a) raise `UnboundLocalError` or (b) inherit the previous loop iteration's principals (cross-document leak). The `except AttributeError` now simply `pass`es onto the safe defaults.