### PR TITLE
refactor: hide provider ingest settings

### DIFF
--- a/frontend/app/api/queries/useGetSettingsQuery.ts
+++ b/frontend/app/api/queries/useGetSettingsQuery.ts
@@ -76,6 +76,7 @@ export interface Settings {
   };
   localhost_url?: string;
   ingest_via_chat?: boolean;
+  show_provider_ingest_settings?: boolean;
   segment_write_key?: string;
   environment?: string;
 }

--- a/frontend/components/cloud-picker/unified-cloud-picker.tsx
+++ b/frontend/components/cloud-picker/unified-cloud-picker.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
+import { useAuth } from "@/contexts/auth-context";
 import { FileList } from "./file-list";
 import { IngestSettings } from "./ingest-settings";
 import { PickerHeader } from "./picker-header";
@@ -25,6 +27,13 @@ export const UnifiedCloudPicker = ({
   onIngestSettingsChange,
   onSettingsChange,
 }: UnifiedCloudPickerProps) => {
+  const { isNoAuthMode } = useAuth();
+  const { data: apiSettings } = useGetSettingsQuery({
+    enabled: isAuthenticated || isNoAuthMode,
+  });
+  const showIngestSettings =
+    apiSettings?.show_provider_ingest_settings ?? false;
+
   const [isPickerLoaded, setIsPickerLoaded] = useState(false);
   const [isPickerOpen, setIsPickerOpen] = useState(false);
   const [isIngestSettingsOpen, setIsIngestSettingsOpen] = useState(false);
@@ -207,12 +216,14 @@ export const UnifiedCloudPicker = ({
         shouldDisableActions={isIngesting}
       />
 
-      <IngestSettings
-        isOpen={isIngestSettingsOpen}
-        onOpenChange={setIsIngestSettingsOpen}
-        settings={ingestSettings}
-        onSettingsChange={handleIngestSettingsChange}
-      />
+      {showIngestSettings && (
+        <IngestSettings
+          isOpen={isIngestSettingsOpen}
+          onOpenChange={setIsIngestSettingsOpen}
+          settings={ingestSettings}
+          onSettingsChange={handleIngestSettingsChange}
+        />
+      )}
     </div>
   );
 };

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -5,10 +5,12 @@ import { ArrowLeft, FileSearch, FolderOpen, RefreshCw } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
 import type { useSyncConnector } from "@/app/api/mutations/useSyncConnector";
+import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import { IngestSettings } from "@/components/cloud-picker/ingest-settings";
 import { getIngestChunkSettingsError } from "@/components/cloud-picker/types";
 import { FileBrowserDialog } from "@/components/file-browser-dialog";
 import { Button } from "@/components/ui/button";
+import { useAuth } from "@/contexts/auth-context";
 import { useSessionIngestSettings } from "@/hooks/useSessionIngestSettings";
 
 export interface SharedBucketViewProps {
@@ -37,6 +39,13 @@ export function SharedBucketView({
   onDone,
 }: SharedBucketViewProps) {
   const queryClient = useQueryClient();
+  const { isAuthenticated, isNoAuthMode } = useAuth();
+  const { data: apiSettings } = useGetSettingsQuery({
+    enabled: isAuthenticated || isNoAuthMode,
+  });
+  const showIngestSettings =
+    apiSettings?.show_provider_ingest_settings ?? false;
+
   const [selectedBuckets, setSelectedBuckets] = useState<Set<string>>(
     new Set(),
   );
@@ -234,12 +243,14 @@ export function SharedBucketView({
           </div>
         )}
 
-        <IngestSettings
-          isOpen={isSettingsOpen}
-          onOpenChange={setIsSettingsOpen}
-          settings={ingestSettings}
-          onSettingsChange={setIngestSettings}
-        />
+        {showIngestSettings && (
+          <IngestSettings
+            isOpen={isSettingsOpen}
+            onOpenChange={setIsSettingsOpen}
+            settings={ingestSettings}
+            onSettingsChange={setIngestSettings}
+          />
+        )}
       </div>
 
       <div className="max-w-3xl mx-auto mt-6 sticky bottom-0 left-0 right-0 pb-6 bg-background pt-4">

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -63,6 +63,7 @@ from config.settings import (
     LANGFLOW_URL,
     LOCALHOST_URL,
     OPENRAG_INGEST_VIA_CHAT,
+    OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS,
     SEGMENT_WRITE_KEY,
     clients,
     config_manager,
@@ -235,6 +236,7 @@ async def get_settings(
             langflow_ingest_edit_url=langflow_ingest_edit_url,
             ingestion_defaults=ingestion_defaults_obj,
             ingest_via_chat=OPENRAG_INGEST_VIA_CHAT,
+            show_provider_ingest_settings=OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS,
             segment_write_key=SEGMENT_WRITE_KEY or None,
             environment=ENVIRONMENT or None,
         )

--- a/src/api/settings/models.py
+++ b/src/api/settings/models.py
@@ -161,6 +161,7 @@ class SettingsResponse(BaseModel):
     langflow_ingest_edit_url: str | None = None
     ingestion_defaults: IngestionDefaultsConfig | None = None
     ingest_via_chat: bool = False
+    show_provider_ingest_settings: bool = False
     segment_write_key: str | None = None
     environment: str | None = None
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -462,6 +462,11 @@ OPENRAG_INGEST_VIA_CHAT = os.getenv("OPENRAG_INGEST_VIA_CHAT", "false").lower() 
     "yes",
 )
 
+# Show per-upload ingest settings (chunk size, overlap, OCR, etc.) in cloud picker flows
+OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS = os.getenv(
+    "OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS", "false"
+).lower() in ("true", "1", "yes")
+
 # Ingest sample data configuration
 INGEST_SAMPLE_DATA = os.getenv("INGEST_SAMPLE_DATA", "true").lower() in ("true", "1", "yes")
 


### PR DESCRIPTION
Creates `OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS` feature flag and by default hides the ingest settings for providers

<img width="966" height="457" alt="Screenshot 2026-06-17 at 12 20 28 PM" src="https://github.com/user-attachments/assets/ced912c7-7311-46d2-b747-8a61c9fc867a" />
