### PR TITLE
fix: make delete requests not be concurrent and add logging

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -776,13 +776,21 @@ function SearchPage() {
     if (rowsToDelete.length === 0) return;
 
     try {
-      const deleteResults = await Promise.allSettled(
-        rowsToDelete.map((row) =>
-          deleteDocumentMutation.mutateAsync({
+      // Process deletions sequentially to prevent OpenSearch concurrent delete_by_query overload
+      const deleteResults: PromiseSettledResult<
+        Awaited<ReturnType<typeof deleteDocumentMutation.mutateAsync>>
+      >[] = [];
+
+      for (const row of rowsToDelete) {
+        try {
+          const value = await deleteDocumentMutation.mutateAsync({
             filename: resolveDeleteFilename(row),
-          }),
-        ),
-      );
+          });
+          deleteResults.push({ status: "fulfilled", value });
+        } catch (reason) {
+          deleteResults.push({ status: "rejected", reason });
+        }
+      }
 
       await refreshTasks();
       await queryClient.invalidateQueries({ queryKey: ["search"] });

--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -100,10 +100,10 @@ async def delete_documents_by_filename_core(
         )
     except Exception as e:
         import traceback
-        
+
         # Extract OpenSearch info if available (TransportError contains this)
         os_info = getattr(e, "info", None)
-        
+
         logger.error(
             "Error deleting documents by filename",
             filename=normalized_filename,

--- a/src/api/documents.py
+++ b/src/api/documents.py
@@ -99,10 +99,18 @@ async def delete_documents_by_filename_core(
             200,
         )
     except Exception as e:
+        import traceback
+        
+        # Extract OpenSearch info if available (TransportError contains this)
+        os_info = getattr(e, "info", None)
+        
         logger.error(
             "Error deleting documents by filename",
             filename=normalized_filename,
             error=str(e),
+            error_type=type(e).__name__,
+            os_info=os_info,
+            traceback=traceback.format_exc(),
         )
         error_str = str(e)
         status_code = 403 if "AuthenticationException" in error_str else 500


### PR DESCRIPTION
This pull request addresses issues related to deleting documents in bulk, specifically improving reliability and error reporting when interacting with OpenSearch. The main changes are to process deletions sequentially on the frontend to avoid overloading OpenSearch, and to enhance backend logging for better debugging of deletion errors.

**Improvements to deletion handling and reliability:**

- Modified the frontend (`page.tsx`) to process document deletions one at a time instead of in parallel, preventing OpenSearch from being overloaded by concurrent `delete_by_query` requests.

**Enhancements to error logging and debugging:**

- Improved backend error logging in `documents.py` to include exception type, OpenSearch-specific information (if present), and the full traceback, making it easier to diagnose issues during document deletion.