### PR TITLE
fix: check backend health inside container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1003,7 +1003,15 @@ health: ## Check health of all services
 	@printf "$(CYAN)Frontend:$(NC)   "
 	@if curl -s -k --fail http://127.0.0.1:$${FRONTEND_PORT:-3000}/ >/dev/null 2>&1; then printf "$(GREEN)Healthy$(NC)\n"; else printf "$(RED)Not responding$(NC)\n"; fi
 	@printf "$(CYAN)Backend:$(NC)    "
-	@if curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then printf "$(GREEN)Healthy$(NC)\n"; else printf "$(RED)Not responding$(NC)\n"; fi
+	@if curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then \
+		printf "$(GREEN)Healthy$(NC)\n"; \
+	elif command -v podman >/dev/null 2>&1 && podman ps --format "{{.Names}}" | grep -q "^openrag-backend$$" && podman exec openrag-backend curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then \
+		printf "$(GREEN)Healthy$(NC)\n"; \
+	elif command -v docker >/dev/null 2>&1 && docker ps --format "{{.Names}}" | grep -q "^openrag-backend$$" && docker exec openrag-backend curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then \
+		printf "$(GREEN)Healthy$(NC)\n"; \
+	else \
+		printf "$(RED)Not responding$(NC)\n"; \
+	fi
 	@printf "$(CYAN)Langflow:$(NC)   "
 	@if curl -s -k --fail http://127.0.0.1:$${LANGFLOW_PORT:-7860}/health >/dev/null 2>&1; then printf "$(GREEN)Healthy$(NC)\n"; else printf "$(RED)Not responding$(NC)\n"; fi
 	@printf "$(CYAN)OpenSearch:$(NC) "


### PR DESCRIPTION
Fixes #1880

## Summary

Updates `make health` so the backend check first tries the existing host health endpoint, then falls back to checking the `/health` endpoint inside the running `openrag-backend` container using Podman or Docker.

This fixes a false negative where `make health` reports:

```text
Backend:    Not responding
```

even though the backend container is healthy and returns:

```json
{"status":"ok"}
```

## Testing

Tested with backend running:

```bash
make health
```

Result:

```text
Backend:    Healthy
```

Tested with backend stopped:

```bash
podman stop openrag-backend
make health
```

Result:

```text
Backend:    Not responding
```

Restored backend:

```bash
podman start openrag-backend
make health
```

Result:

```text
Backend:    Healthy
```
