### PR TITLE
fix: Stale api keys no longer display on the page once revoked

### DIFF
--- a/src/services/api_key_service.py
+++ b/src/services/api_key_service.py
@@ -205,7 +205,7 @@ class APIKeyService:
         jwt_token: str = None,
     ) -> Dict[str, Any]:
         """
-        List all API keys for a user (without the actual keys).
+        List all active (non-revoked) API keys for a user (without the actual keys).
 
         Args:
             user_id: The user's ID
@@ -220,7 +220,12 @@ class APIKeyService:
             # Search for user's keys
             search_body = {
                 "query": {
-                    "term": {"user_id": user_id}
+                    "bool": {
+                        "must": [
+                            {"term": {"user_id": user_id}},
+                            {"term": {"revoked": False }},
+                        ]
+                    }
                 },
                 "sort": [{"created_at": {"order": "desc"}}],
                 "_source": [

--- a/tests/unit/test_api_key_service.py
+++ b/tests/unit/test_api_key_service.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict
+
+import pytest
+from unittest.mock import AsyncMock, MagicMock
+
+from src.services.api_key_service import APIKeyService
+
+
+@pytest.fixture
+def api_key_service() -> tuple[APIKeyService, AsyncMock]:
+    """Create an APIKeyService instance with mocked OpenSearch client."""
+    service = APIKeyService()
+    mock_client = AsyncMock()
+    service._get_opensearch_client = MagicMock(return_value=mock_client)
+    return service, mock_client
+
+
+@pytest.mark.asyncio
+async def test_api_key_lifecycle(api_key_service: tuple[APIKeyService, AsyncMock]) -> None:
+    service, mock_client = api_key_service
+    
+    user_id = "test-user-123"
+    
+    mock_client.index = AsyncMock(return_value={"result": "created"})
+    create_result = await service.create_key(user_id=user_id, user_email="test@example.com", name="Test Key")
+    
+    assert create_result["success"] is True
+    assert create_result["api_key"].startswith("orag_")
+    
+    mock_client.search = AsyncMock(return_value={
+        "hits": {"hits": [{"_source": {"key_id": create_result["key_id"], "revoked": False}}]}
+    })
+    list_result: Dict[str, Any] = await service.list_keys(user_id=user_id)
+    
+    assert list_result["success"] is True
+    assert len(list_result["keys"]) == 1
+    
+    query_must = mock_client.search.call_args[1]["body"]["query"]["bool"]["must"]
+    assert {"term": {"revoked": False}} in query_must
+    
+    mock_client.get = AsyncMock(return_value={"_source": {"user_id": user_id}})
+    mock_client.update = AsyncMock(return_value={"result": "updated"})
+    revoke_result: Dict[str, Any] = await service.revoke_key(user_id=user_id, key_id=create_result["key_id"])
+    
+    assert revoke_result["success"] is True
+    
+    mock_client.search = AsyncMock(return_value={"hits": {"hits": []}})
+    list_result_after: Dict[str, Any] = await service.list_keys(user_id=user_id)
+    
+    assert list_result_after["success"] is True
+    assert len(list_result_after["keys"]) == 0


### PR DESCRIPTION
## Summary

Fixes #1877 , Updates the opensearch query to only fetch non revoked (revoked = False) api keys so the frontend recieves only non-revoked keys to display.

## Demo (Before)
[screen-capture (6).webm](https://github.com/user-attachments/assets/811a9a09-1809-4055-9461-d43679c5eef3)

## Demo (After)
[screen-capture (7).webm](https://github.com/user-attachments/assets/4b9acbe2-8708-4125-a4f4-7aed8619e333)


## Changes
- updates `api_key_service.py` list_keys opensearch query to also filter for keys that have revoked set to false
- Added a unit test to verify that query is sent correctly