### PR TITLE
fix: prevent partial matches for exact token searches

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -2,6 +2,7 @@ import asyncio
 import copy
 import os
 import json
+import re
 from collections import Counter
 from typing import Any, Dict
 from agentd.tool_decorator import tool
@@ -20,6 +21,19 @@ EMBED_RETRY_MAX_DELAY = 8.0
 
 # Variable used to store the active instance for the tool wrapper
 _global_search_service = None
+
+
+def _is_exact_token_query(query: str) -> bool:
+    """Return True for code/token-like queries that should not allow partial fuzzy matches."""
+    if not query or len(query.strip()) < 3:
+        return False
+
+    query = query.strip()
+
+    if re.search(r"[^a-zA-Z0-9\s]", query):
+        return True
+
+    return bool(re.search(r"[a-zA-Z]", query) and re.search(r"\d", query))
 
 
 def register_search_service(service: "SearchService") -> None:
@@ -584,8 +598,17 @@ class SearchService:
                     )
                 )
             }
-            if exact_files:
-                chunks = [chunk for chunk in chunks if chunk.get("filename") in exact_files]
+            
+            # Determine if we should apply exact-token filtering
+            should_filter_exact = bool(exact_files) or _is_exact_token_query(query)
+            
+            if should_filter_exact:
+                if exact_files:
+                    # Filter to only chunks from files with exact matches
+                    chunks = [chunk for chunk in chunks if chunk.get("filename") in exact_files]
+                else:
+                    # No exact matches found for a token-like query - return empty results
+                    chunks = []
 
                 def _build_terms_agg(field: str) -> Dict[str, Any]:
                     counts = Counter(


### PR DESCRIPTION
Fixes #1351

## Summary

Fixes an issue where searching for an exact-looking token could return results even when that exact token was not in the knowledge base.

For example, searching `ZX-49-RAG` could return a document containing `ZX-4819-RAG` because the search matched similar token pieces.

This change keeps the existing search behavior, but adds a final check for code/token-like queries. If the exact query text is not found in the returned filename or chunk text, the result is removed.

## Testing

Manually tested in Project Knowledge search:

* Document contains `ZX-4819-RAG`
* Search `ZX-49-RAG`

  * Result: no results returned
* Search `ZX-4819-RAG`

  * Result: `Project.code.for.QA.validation.is.ZX.docx` returned

