### PR TITLE
fix: update bucket ingestion messages for clarity and pre-select saved buckets

### DIFF
--- a/frontend/app/settings/_components/s3-settings-dialog.tsx
+++ b/frontend/app/settings/_components/s3-settings-dialog.tsx
@@ -130,8 +130,8 @@ export default function S3SettingsDialog({
       toast.success("Amazon S3 configured", {
         description:
           selectedBuckets.length > 0
-            ? `Will ingest from: ${selectedBuckets.join(", ")}`
-            : "Will auto-discover and ingest all accessible buckets.",
+            ? `Filtered to: ${selectedBuckets.join(", ")}`
+            : "All accessible buckets are included.",
         icon: <AwsLogo className="w-4 h-4" />,
       });
 

--- a/frontend/app/settings/_components/s3-settings-form.tsx
+++ b/frontend/app/settings/_components/s3-settings-form.tsx
@@ -170,9 +170,9 @@ export function S3SettingsForm({
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label className="text-sm font-medium">
-              Select Buckets to Ingest
+              Restrict to Specific Buckets
               <span className="ml-1 text-muted-foreground font-normal">
-                (leave all unchecked to ingest everything)
+                (leave all unchecked to include all)
               </span>
             </Label>
             {buckets.length > 1 && (

--- a/frontend/components/connectors/aws-s3/bucket-view.tsx
+++ b/frontend/components/connectors/aws-s3/bucket-view.tsx
@@ -39,7 +39,11 @@ export function S3BucketView({
       addTask={addTask}
       onBack={onBack}
       onDone={onDone}
-      initialSelectedBuckets={defaults?.bucket_names}
+      initialSelectedBuckets={
+        defaults?.connection_id === connector.connectionId
+          ? defaults?.bucket_names
+          : undefined
+      }
     />
   );
 }

--- a/frontend/components/connectors/aws-s3/bucket-view.tsx
+++ b/frontend/components/connectors/aws-s3/bucket-view.tsx
@@ -2,6 +2,7 @@
 
 import type { useSyncConnector } from "@/app/api/mutations/useSyncConnector";
 import { useS3BucketStatusQuery } from "@/app/api/queries/useS3BucketStatusQuery";
+import { useS3DefaultsQuery } from "@/app/api/queries/useS3DefaultsQuery";
 import { SharedBucketView } from "../shared-bucket-view";
 
 export interface S3BucketViewProps {
@@ -25,6 +26,7 @@ export function S3BucketView({
     error: bucketsError,
     refetch,
   } = useS3BucketStatusQuery(connector.connectionId, { enabled: true });
+  const { data: defaults } = useS3DefaultsQuery({ enabled: true });
   return (
     <SharedBucketView
       connector={connector}
@@ -37,6 +39,7 @@ export function S3BucketView({
       addTask={addTask}
       onBack={onBack}
       onDone={onDone}
+      initialSelectedBuckets={defaults?.bucket_names}
     />
   );
 }

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -68,15 +68,17 @@ export function SharedBucketView({
       buckets?.length &&
       initialSelectedBuckets?.length
     ) {
-      const valid = initialSelectedBuckets.filter((name) =>
-        buckets.some((b) => b.name === name),
-      );
-      if (valid.length) {
-        setSelectedBuckets(new Set(valid));
-        hasAppliedInitial.current = true;
+      hasAppliedInitial.current = true;
+      if (selectedBuckets.size === 0) {
+        const valid = initialSelectedBuckets.filter((name) =>
+          buckets.some((b) => b.name === name),
+        );
+        if (valid.length) {
+          setSelectedBuckets(new Set(valid));
+        }
       }
     }
-  }, [buckets, initialSelectedBuckets]);
+  }, [buckets, initialSelectedBuckets]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: invalidateQueryKey });

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -2,7 +2,7 @@
 
 import { useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, FileSearch, FolderOpen, RefreshCw } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
 import type { useSyncConnector } from "@/app/api/mutations/useSyncConnector";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
@@ -28,6 +28,7 @@ export interface SharedBucketViewProps {
   ) => void;
   onBack: () => void;
   onDone: () => void;
+  initialSelectedBuckets?: string[];
 }
 
 export function SharedBucketView({
@@ -41,6 +42,7 @@ export function SharedBucketView({
   addTask,
   onBack,
   onDone,
+  initialSelectedBuckets,
 }: SharedBucketViewProps) {
   const queryClient = useQueryClient();
   const { isAuthenticated, isNoAuthMode } = useAuth();
@@ -53,11 +55,28 @@ export function SharedBucketView({
   const [selectedBuckets, setSelectedBuckets] = useState<Set<string>>(
     new Set(),
   );
+  const hasAppliedInitial = useRef(false);
   const [ingestSettings, setIngestSettings] = useSessionIngestSettings();
   const [isSettingsOpen, setIsSettingsOpen] = useState(false);
   const [browseDialogBucket, setBrowseDialogBucket] = useState<string | null>(
     null,
   );
+
+  useEffect(() => {
+    if (
+      !hasAppliedInitial.current &&
+      buckets?.length &&
+      initialSelectedBuckets?.length
+    ) {
+      const valid = initialSelectedBuckets.filter((name) =>
+        buckets.some((b) => b.name === name),
+      );
+      if (valid.length) {
+        setSelectedBuckets(new Set(valid));
+        hasAppliedInitial.current = true;
+      }
+    }
+  }, [buckets, initialSelectedBuckets]);
 
   const invalidate = () => {
     queryClient.invalidateQueries({ queryKey: invalidateQueryKey });

--- a/frontend/enhancements/connectors/ibm-cos/components/bucket-view.tsx
+++ b/frontend/enhancements/connectors/ibm-cos/components/bucket-view.tsx
@@ -3,6 +3,7 @@
 import type { useSyncConnector } from "@/app/api/mutations/useSyncConnector";
 import { SharedBucketView } from "@/components/connectors/shared-bucket-view";
 import { useIBMCOSBucketStatusQuery } from "../useIBMCOSBucketStatusQuery";
+import { useIBMCOSDefaultsQuery } from "../useIBMCOSDefaultsQuery";
 
 export interface IBMCOSBucketViewProps {
   connector: any;
@@ -25,6 +26,7 @@ export function IBMCOSBucketView({
     error: bucketsError,
     refetch,
   } = useIBMCOSBucketStatusQuery(connector.connectionId, { enabled: true });
+  const { data: defaults } = useIBMCOSDefaultsQuery({ enabled: true });
   return (
     <SharedBucketView
       connector={connector}
@@ -37,6 +39,7 @@ export function IBMCOSBucketView({
       addTask={addTask}
       onBack={onBack}
       onDone={onDone}
+      initialSelectedBuckets={defaults?.bucket_names}
     />
   );
 }

--- a/frontend/enhancements/connectors/ibm-cos/components/bucket-view.tsx
+++ b/frontend/enhancements/connectors/ibm-cos/components/bucket-view.tsx
@@ -39,7 +39,11 @@ export function IBMCOSBucketView({
       addTask={addTask}
       onBack={onBack}
       onDone={onDone}
-      initialSelectedBuckets={defaults?.bucket_names}
+      initialSelectedBuckets={
+        defaults?.connection_id === connector.connectionId
+          ? defaults?.bucket_names
+          : undefined
+      }
     />
   );
 }

--- a/frontend/enhancements/connectors/ibm-cos/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/ibm-cos/settings-dialog.tsx
@@ -136,8 +136,8 @@ export default function IBMCOSSettingsDialog({
       toast.success("IBM Cloud Object Storage configured", {
         description:
           selectedBuckets.length > 0
-            ? `Will ingest from: ${selectedBuckets.join(", ")}`
-            : "Will auto-discover and ingest all accessible buckets.",
+            ? `Filtered to: ${selectedBuckets.join(", ")}`
+            : "All accessible buckets are included.",
         icon: <IBMCOSIcon className="w-4 h-4" />,
       });
 

--- a/frontend/enhancements/connectors/ibm-cos/settings-form.tsx
+++ b/frontend/enhancements/connectors/ibm-cos/settings-form.tsx
@@ -275,9 +275,9 @@ export function IBMCOSSettingsForm({
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label className="text-sm font-medium">
-              Select Buckets to Ingest
+              Restrict to Specific Buckets
               <span className="ml-1 text-muted-foreground font-normal">
-                (leave all unchecked to ingest everything)
+                (leave all unchecked to include all)
               </span>
             </Label>
             {buckets.length > 1 && (


### PR DESCRIPTION
Port of 68cb5be9 from the CPD branch to main. Fixes two issues with S3 and IBM COS connectors: clarifies that the settings dialog's bucket selection sets a default filter (not an immediate ingest), and pre-populates the Add Knowledge upload page with the buckets already saved in the connector config so users don't have to re-select them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * S3 and IBM COS bucket configuration now pre-selects any available default buckets on initial load.

* **UI/UX Improvements**
  * Updated bucket selection label to **“Restrict to Specific Buckets”**.
  * Updated helper text to clarify that leaving all buckets unchecked will **include all**.
  * Updated success messages to show **“Filtered to: …”** when restricted, or **“All accessible buckets are included.”** when unrestricted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->