### PR TITLE
fix: adds safety guard to ag grid

### DIFF
--- a/frontend/app/chat/page.tsx
+++ b/frontend/app/chat/page.tsx
@@ -164,10 +164,11 @@ function ChatPage() {
   });
 
   // Show warning if waiting too long (20 seconds)
+  const hasStreamingMessage = !!streamingMessage;
   useEffect(() => {
     let timeoutId: NodeJS.Timeout | null = null;
 
-    if (isChatStreaming && !streamingMessage) {
+    if (isChatStreaming && !hasStreamingMessage) {
       timeoutId = setTimeout(() => {
         setWaitingTooLong(true);
       }, 20000); // 20 seconds
@@ -178,7 +179,7 @@ function ChatPage() {
     return () => {
       if (timeoutId) clearTimeout(timeoutId);
     };
-  }, [isChatStreaming, streamingMessage]);
+  }, [isChatStreaming, hasStreamingMessage]);
 
   const handleEndpointChange = (newEndpoint: EndpointType) => {
     setEndpoint(newEndpoint);

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -453,6 +453,12 @@ function SearchPage() {
 
   const gridRows = fileResults;
   const gridRef = useRef<AgGridReact>(null);
+  const gridReadyRef = useRef(false);
+
+  const getGridApi = useCallback(() => {
+    if (!gridReadyRef.current) return null;
+    return gridRef.current?.api ?? null;
+  }, []);
 
   // Re-run only when row identity/status changes, not on every list poll reference.
   const gridRowsSelectionKey = useMemo(
@@ -466,7 +472,7 @@ function SearchPage() {
   );
 
   useEffect(() => {
-    const api = gridRef.current?.api;
+    const api = getGridApi();
     if (!api) {
       return;
     }
@@ -475,7 +481,7 @@ function SearchPage() {
     setSelectedRows((current) =>
       sameFileSelection(current, nextSelected) ? current : nextSelected,
     );
-  }, [gridRowsSelectionKey, isDeletableKnowledgeRow]);
+  }, [gridRowsSelectionKey, isDeletableKnowledgeRow, getGridApi]);
 
   const columnDefs: ColDef<File>[] = [
     {
@@ -745,17 +751,18 @@ function SearchPage() {
   };
 
   const onSelectionChanged = useCallback(() => {
-    if (!gridRef.current) {
+    const api = getGridApi();
+    if (!api) {
       return;
     }
     const nextSelected = syncGridSelectionToDeletableRows(
-      gridRef.current.api,
+      api,
       isDeletableKnowledgeRow,
     );
     setSelectedRows((current) =>
       sameFileSelection(current, nextSelected) ? current : nextSelected,
     );
-  }, [isDeletableKnowledgeRow]);
+  }, [isDeletableKnowledgeRow, getGridApi]);
 
   const handleBulkDelete = async () => {
     const rowsToDelete = selectedRows.filter(isDeletableKnowledgeRow);
@@ -826,9 +833,7 @@ function SearchPage() {
       setShowBulkDeleteDialog(false);
 
       // Clear selection in the grid
-      if (gridRef.current) {
-        gridRef.current.api.deselectAll();
-      }
+      getGridApi()?.deselectAll();
     } catch (error) {
       toast.error(
         error instanceof Error
@@ -886,7 +891,7 @@ function SearchPage() {
                 onDelete={() => setShowBulkDeleteDialog(true)}
                 onCancel={() => {
                   setSelectedRows([]);
-                  gridRef.current?.api.deselectAll();
+                  getGridApi()?.deselectAll();
                 }}
               />
             </div>
@@ -1011,6 +1016,9 @@ function SearchPage() {
             }
             isRowSelectable={(params) => isDeletableKnowledgeRow(params.data)}
             domLayout="normal"
+            onGridReady={() => {
+              gridReadyRef.current = true;
+            }}
             onSelectionChanged={onSelectionChanged}
             pagination={pagination}
             paginationPageSize={paginationPageSize}
@@ -1045,6 +1053,9 @@ function SearchPage() {
             }
             isRowSelectable={(params) => isDeletableKnowledgeRow(params.data)}
             domLayout="normal"
+            onGridReady={() => {
+              gridReadyRef.current = true;
+            }}
             onSelectionChanged={onSelectionChanged}
             pagination={pagination}
             paginationPageSize={paginationPageSize}

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -455,6 +455,14 @@ function SearchPage() {
   const gridRef = useRef<AgGridReact>(null);
   const gridReadyRef = useRef(false);
 
+  const handleGridReady = useCallback(() => {
+    gridReadyRef.current = true;
+  }, []);
+
+  const handleGridPreDestroyed = useCallback(() => {
+    gridReadyRef.current = false;
+  }, []);
+
   const getGridApi = useCallback(() => {
     if (!gridReadyRef.current) return null;
     return gridRef.current?.api ?? null;
@@ -1016,9 +1024,8 @@ function SearchPage() {
             }
             isRowSelectable={(params) => isDeletableKnowledgeRow(params.data)}
             domLayout="normal"
-            onGridReady={() => {
-              gridReadyRef.current = true;
-            }}
+            onGridReady={handleGridReady}
+            onGridPreDestroyed={handleGridPreDestroyed}
             onSelectionChanged={onSelectionChanged}
             pagination={pagination}
             paginationPageSize={paginationPageSize}
@@ -1053,9 +1060,8 @@ function SearchPage() {
             }
             isRowSelectable={(params) => isDeletableKnowledgeRow(params.data)}
             domLayout="normal"
-            onGridReady={() => {
-              gridReadyRef.current = true;
-            }}
+            onGridReady={handleGridReady}
+            onGridPreDestroyed={handleGridPreDestroyed}
             onSelectionChanged={onSelectionChanged}
             pagination={pagination}
             paginationPageSize={paginationPageSize}

--- a/frontend/components/AgGrid/registerAgGridModules.ts
+++ b/frontend/components/AgGrid/registerAgGridModules.ts
@@ -9,6 +9,7 @@ import {
   ModuleRegistry,
   PaginationModule,
   QuickFilterModule,
+  RowApiModule,
   RowSelectionModule,
   TextFilterModule,
   ValidationModule,
@@ -28,6 +29,7 @@ ModuleRegistry.registerModules([
   DateFilterModule,
   EventApiModule,
   GridStateModule,
+  RowApiModule,
   RowSelectionModule,
   // The ValidationModule adds helpful console warnings/errors that can help identify bad configuration during development.
   ...(process.env.NODE_ENV !== "production" ? [ValidationModule] : []),


### PR DESCRIPTION
**Problem**: Calling `api.forEachNode()` / `api.getSelectedRows()` before AG Grid's row model is fully initialized causes a `RowApiModule not registered` error. This is a timing-dependent race condition on mount — more likely on slower machines or with React strict mode.

**Fix**: Added a `gridReadyRef` flag set by AG Grid's `onGridReady` callback, and a `getGridApi()` helper that returns null until the grid is ready. All 5 grid API call sites now go through this helper, so they safely no-op if called before initialization.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes
* Improved reliability of selection and bulk-delete operations on the Knowledge page by guarding grid actions until the grid is fully initialized (and safely handling teardown).
* Enhanced the chat “waiting too long” timeout behavior by correcting the timer trigger logic to respond reliably to streaming state.
* Improved AG Grid runtime support by registering the required Row API module so related grid functionality is available at runtime.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->