### PR TITLE
fix: forward allowed_principals through connector Langflow ingestion

### DIFF
--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -951,10 +951,14 @@ class ConnectorFileProcessor(TaskProcessor):
                     # Extract ACL information
                     allowed_users: list[str] = []
                     allowed_groups: list[str] = []
+                    allowed_principals: list[str] = []
+                    allowed_principal_labels: list[dict[str, Any]] = []
                     if document.acl:
                         try:
                             allowed_users = document.acl.allowed_users or []
                             allowed_groups = document.acl.allowed_groups or []
+                            allowed_principals = document.acl.allowed_principals or []
+                            allowed_principal_labels = document.acl.allowed_principal_labels or []
                         except AttributeError:
                             pass
 
@@ -986,6 +990,8 @@ class ConnectorFileProcessor(TaskProcessor):
                         source_url=document.source_url,
                         allowed_users=allowed_users,
                         allowed_groups=allowed_groups,
+                        allowed_principals=allowed_principals,
+                        allowed_principal_labels=allowed_principal_labels,
                     )
                     # Langflow returns "success" even when no text was extracted
                     # (e.g. image files without OCR). Verify the document actually


### PR DESCRIPTION

Cherry-pick of #1900 onto `main`.

Documents shared via connector sync were invisible to connector-alias users in DLS-enabled deployments. The `ConnectorFileProcessor` extracted `allowed_users` and `allowed_groups` from the document ACL but silently dropped `allowed_principals` and `allowed_principal_labels` — so the Langflow ingestion call never received them, and indexed documents ended up with no principals, making them unreachable via DLS access checks.

**Fix:** Extract `allowed_principals` / `allowed_principal_labels` from `document.acl` and pass them through to the `process_item` call, matching the existing pattern for `allowed_users` / `allowed_groups`.

## Changes

- `src/models/processors.py` — extract and forward `allowed_principals` and `allowed_principal_labels` inside `ConnectorFileProcessor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded file ingestion permissions to carry principal-level access details, improving permission fidelity during uploads.
  * Files now preserve additional ACL information when available, alongside existing user and group permissions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->