### PR TITLE
fix: Standardize OpenSearch node-count readiness flag on OPENSEARCH_NODE_COUNT_CHECK_ENABLED

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -113,6 +113,8 @@ OPENSEARCH_PORT=9200
 # LANGFLOW_OPENSEARCH_HOST=opensearch
 # LANGFLOW_OPENSEARCH_PORT=9200
 OPENSEARCH_USERNAME=admin
+# Disable the OpenSearch node-count readiness gate for single-node local setups.
+OPENSEARCH_NODE_COUNT_CHECK_ENABLED=false
 
 # OpenSearch index name for storing documents
 # Default: documents

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,7 +75,7 @@ services:
       - OPENSEARCH_PASSWORD=${OPENSEARCH_PASSWORD}
       # Single-node compose clusters don't meet the multi-node readiness counts,
       # so default the node-count check off here (override to re-enable).
-      - OPENSEARCH_NODE_COUNT_CHECK=${OPENSEARCH_NODE_COUNT_CHECK:-false}
+      - OPENSEARCH_NODE_COUNT_CHECK_ENABLED=${OPENSEARCH_NODE_COUNT_CHECK_ENABLED:-false}
       - OPENAI_API_KEY=${OPENAI_API_KEY}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
       - WATSONX_API_KEY=${WATSONX_API_KEY}

--- a/docs/docs/reference/configuration.mdx
+++ b/docs/docs/reference/configuration.mdx
@@ -148,6 +148,7 @@ Configure OpenSearch database authentication.
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `OPENSEARCH_PASSWORD` | Not set | Required. OpenSearch administrator password. Must adhere to the [OpenSearch password complexity requirements](https://docs.opensearch.org/latest/security/configuration/demo-configuration/#setting-up-a-custom-admin-password). You must set this directly in the `.env` or in the terminal's [**Reconfigure**](/install-uvx#setup) option. |
+| `OPENSEARCH_NODE_COUNT_CHECK_ENABLED` | `false` in local single-node setups; otherwise `true` | Enables the startup readiness gate that waits for the expected OpenSearch node counts. Keep this `false` for local single-node compose/dev environments. |
 | `OPENSEARCH_INDEX_NAME` | `documents` | The name of the [OpenSearch index](/knowledge#index). |
 | `OPENSEARCH_HOST` | `localhost` | OpenSearch service host. |
 | `OPENSEARCH_PORT` | `9200` | OpenSearch service port. |

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -42,7 +42,7 @@ OPENSEARCH_PASSWORD = os.getenv("OPENSEARCH_PASSWORD")
 # Gate the OpenSearch node-count readiness check ("OS node_count" flag).
 # Enabled by default; set to false on small/single-node clusters.
 OPENSEARCH_NODE_COUNT_CHECK_ENABLED = os.getenv(
-    "OPENSEARCH_NODE_COUNT_CHECK", "true"
+    "OPENSEARCH_NODE_COUNT_CHECK_ENABLED", "true"
 ).strip().lower() in ("true", "1", "yes")
 
 # Expected cluster size, used only when the node-count check is enabled.

--- a/tests/unit/config/test_opensearch_node_count_check_enabled.py
+++ b/tests/unit/config/test_opensearch_node_count_check_enabled.py
@@ -1,0 +1,37 @@
+"""Regression tests for the OpenSearch node-count readiness toggle."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+
+
+def _python_env(env: dict[str, str]) -> dict[str, str]:
+    merged = os.environ.copy()
+    merged.update(env)
+    return merged
+
+
+def test_settings_reads_canonical_node_count_env_var():
+    env = _python_env(
+        {
+            "OPENSEARCH_NODE_COUNT_CHECK_ENABLED": "false",
+            "PYTHONPATH": str(SRC),
+        }
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from config import settings; print(settings.OPENSEARCH_NODE_COUNT_CHECK_ENABLED)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    assert result.stdout.splitlines()[-1].strip() == "False"

--- a/tests/unit/test_opensearch_wait_node_count.py
+++ b/tests/unit/test_opensearch_wait_node_count.py
@@ -1,6 +1,6 @@
 """The OpenSearch readiness probe (wait_for_opensearch) gates on data-node,
-cluster-manager, and coordinating-node counts behind the OPENSEARCH_NODE_COUNT_CHECK
-flag.
+cluster-manager, and coordinating-node counts behind the
+OPENSEARCH_NODE_COUNT_CHECK_ENABLED flag.
 
 Cases:
   * Flag on, all counts met (>= expected):   returns without raising.


### PR DESCRIPTION
This PR renames the OpenSearch node-count readiness toggle to OPENSEARCH_NODE_COUNT_CHECK_ENABLED everywhere it is user-facing and consumed by the backend.

 ### Changes:

  - Updates backend config parsing to read OPENSEARCH_NODE_COUNT_CHECK_ENABLED
  - Updates docker-compose.yml to pass the canonical flag
  - Updates .env.example to document the canonical flag
  - Adds the flag to the OpenSearch configuration docs
  - Adds a regression test covering the canonical env var load path
  - Keeps the OpenSearch readiness behavior unchanged aside from the flag rename

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenSearch startup behavior for local single-node setups by using the correct readiness-check setting.
  * Fixed configuration so the node-count check can be disabled as expected in compose and local environments.

* **Documentation**
  * Updated the configuration reference to document the new setting name and its default behavior.

* **Tests**
  * Added regression coverage to ensure the new environment variable is honored correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->