### PR TITLE
fix: onboarding timeout cleanup issue

### DIFF
--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -196,6 +196,10 @@ const OnboardingCard = ({
   // Track which tasks we've already handled to prevent infinite loops
   const handledFailedTasksRef = useRef<Set<string>>(new Set());
 
+  // Ref for the completion timeout so it persists across effect re-runs
+  const completeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
+  useEffect(() => () => clearTimeout(completeTimeoutRef.current), []);
+
   // Query tasks to track completion
   const { data: tasks } = useGetTasksQuery({
     enabled: currentStep !== null && !isCompleted, // Only poll when onboarding has started and stop once step is complete
@@ -277,7 +281,6 @@ const OnboardingCard = ({
 
   // Monitor tasks and call onComplete when all tasks are done
   useEffect(() => {
-    let completeTimeoutId: NodeJS.Timeout;
     if (currentStep === null || !tasks || !isEmbedding) {
       return;
     }
@@ -376,6 +379,7 @@ const OnboardingCard = ({
         failed_files: taskWithFailure.failed_files,
       });
 
+      clearTimeout(completeTimeoutRef.current);
       setError(errorMessage);
       setCurrentStep(totalSteps);
       rollbackMutation.mutate({ embedding_only: isEmbedding });
@@ -409,13 +413,12 @@ const OnboardingCard = ({
 
       // Set to final step to show "Done"
       setCurrentStep(totalSteps);
-      // Wait a bit before completing
-      completeTimeoutId = setTimeout(() => {
+      // Wait a bit before completing — stored in a ref so the timeout
+      // survives the re-render caused by setCurrentStep above.
+      completeTimeoutRef.current = setTimeout(() => {
         onComplete();
       }, 1000);
     }
-
-    return () => clearTimeout(completeTimeoutId);
   }, [
     tasks,
     currentStep,

--- a/frontend/app/onboarding/_components/onboarding-upload.tsx
+++ b/frontend/app/onboarding/_components/onboarding-upload.tsx
@@ -18,6 +18,7 @@ interface OnboardingUploadProps {
 
 const OnboardingUpload = ({ onComplete }: OnboardingUploadProps) => {
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const completeTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [isUploading, setIsUploading] = useState(false);
   const [currentStep, setCurrentStep] = useState<number | null>(null);
   const [uploadedFilename, setUploadedFilename] = useState<string | null>(null);
@@ -44,10 +45,11 @@ const OnboardingUpload = ({ onComplete }: OnboardingUploadProps) => {
 
   const { refetch: refetchNudges } = useGetNudgesQuery(null);
 
+  useEffect(() => () => clearTimeout(completeTimeoutRef.current), []);
+
   // Monitor tasks and call onComplete when file processing is done
   useEffect(() => {
     let cancelled = false;
-    let completeTimeoutId: NodeJS.Timeout;
     if (currentStep === null || !tasks || !uploadedTaskId) {
       return;
     }
@@ -95,6 +97,7 @@ const OnboardingUpload = ({ onComplete }: OnboardingUploadProps) => {
         }
       }
 
+      clearTimeout(completeTimeoutRef.current);
       setError(errorMessage);
       setCurrentStep(null);
       setUploadedTaskId(null);
@@ -159,33 +162,25 @@ const OnboardingUpload = ({ onComplete }: OnboardingUploadProps) => {
           })
           .finally(() => {
             setIsCreatingFilter(false);
-            // Refetch nudges to get new ones
             refetchNudges();
 
-            // Wait a bit before completing (after filter is created)
-            if (!cancelled) {
-              completeTimeoutId = setTimeout(() => {
-                if (!cancelled) onComplete();
+            if (!cancelled && !completeTimeoutRef.current) {
+              completeTimeoutRef.current = setTimeout(() => {
+                onComplete();
               }, 1000);
             }
           });
-      } else if (!isCreatingFilter) {
-        // No filter to create, just complete
-        // Refetch nudges to get new ones
+      } else if (!isCreatingFilter && !completeTimeoutRef.current) {
         refetchNudges();
 
-        // Wait a bit before completing
-        if (!cancelled) {
-          completeTimeoutId = setTimeout(() => {
-            if (!cancelled) onComplete();
-          }, 1000);
-        }
+        completeTimeoutRef.current = setTimeout(() => {
+          onComplete();
+        }, 1000);
       }
     }
 
     return () => {
       cancelled = true;
-      clearTimeout(completeTimeoutId);
     };
   }, [
     tasks,


### PR DESCRIPTION
The bug: In the task monitoring effect (line ~283), when embedding tasks complete, the code calls setCurrentStep(totalSteps) to show "Done" and setTimeout(onComplete, 1000) to advance to the next step after a delay. But currentStep is in the effect's dependency array, so changing it immediately triggers effect cleanup, which calls clearTimeout(completeTimeoutId) — killing the timeout before onComplete ever fires.

The fix: Store the timeout in a ref instead of a local variable so the effect cleanup doesn't clear it. The ref-based timeout persists across the re-render caused by setCurrentStep. Added explicit cleanup on unmount and in the error handler path.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved onboarding completion timing so it is more reliable across screen updates.
  * Prevented completion actions from firing after failures or cancellation.
  * Added cleanup for pending onboarding delays when leaving the page, reducing unexpected behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->