### PR TITLE
fix: require explicit opt-in for anonymous mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -136,6 +136,9 @@ OPENRAG_ENSURE_INDEX_REPLICAS_ON_STARTUP=false
 # instead of Google OAuth. The raw IBM JWT is also passed directly to OpenSearch.
 # When enabled, GOOGLE_OAUTH_CLIENT_ID/SECRET are not required for login.
 IBM_AUTH_ENABLED=false
+# Local-development escape hatch only. When false (default), leaving Google OAuth
+# credentials blank does NOT enable anonymous access.
+OPENRAG_ALLOW_NO_AUTH=false
 # URL to fetch IBM's JWT public key (used to validate ibm-openrag-session tokens).
 IBM_JWT_PUBLIC_KEY_URL=
 # Cookie name set by Traefik after successful IBM AMS authentication (default: ibm-openrag-session).
@@ -150,6 +153,8 @@ IBM_PASSWORD=
 IBM_AUTH_DEV_MODE=false
 
 # make here https://console.cloud.google.com/apis/credentials
+# Required for Google-login deployments unless IBM_AUTH_ENABLED=true or you
+# explicitly opt into OPENRAG_ALLOW_NO_AUTH=true for local development.
 GOOGLE_OAUTH_CLIENT_ID=
 GOOGLE_OAUTH_CLIENT_SECRET=
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -185,6 +185,11 @@ SESSION_SECRET = os.getenv("SESSION_SECRET") or "your-secret-key-change-in-produ
 JWT_SIGNING_KEY = os.getenv("JWT_SIGNING_KEY")
 GOOGLE_OAUTH_CLIENT_ID = os.getenv("GOOGLE_OAUTH_CLIENT_ID")
 GOOGLE_OAUTH_CLIENT_SECRET = os.getenv("GOOGLE_OAUTH_CLIENT_SECRET")
+OPENRAG_ALLOW_NO_AUTH = os.getenv("OPENRAG_ALLOW_NO_AUTH", "false").lower() in (
+    "true",
+    "1",
+    "yes",
+)
 
 # IBM AMS authentication (Watsonx Data embedded mode)
 IBM_AUTH_ENABLED = os.getenv("IBM_AUTH_ENABLED", "false").lower() in ("true", "1", "yes")
@@ -567,9 +572,16 @@ DOCLING_ERROR_DETAIL_MAX_LENGTH = get_env_int("DOCLING_ERROR_DETAIL_MAX_LENGTH",
 
 
 def is_no_auth_mode():
-    """Check if we're running in no-auth mode (OAuth credentials missing)"""
+    """Check if we're running in explicit no-auth mode.
+
+    Missing Google OAuth credentials must not silently open the application.
+    Anonymous mode is now opt-in via ``OPENRAG_ALLOW_NO_AUTH=true`` and is
+    intended for local development only.
+    """
     if IBM_AUTH_ENABLED:
         return False  # IBM cookie auth is a valid auth mode (variable name kept for now as per instructions)
+    if not OPENRAG_ALLOW_NO_AUTH:
+        return False
     result = not (GOOGLE_OAUTH_CLIENT_ID and GOOGLE_OAUTH_CLIENT_SECRET)
     return result
 

--- a/tests/unit/config/test_no_auth_mode.py
+++ b/tests/unit/config/test_no_auth_mode.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import config.settings as app_settings  # noqa: E402
+
+
+def test_missing_google_oauth_does_not_enable_no_auth_by_default(monkeypatch):
+    monkeypatch.setattr(app_settings, "IBM_AUTH_ENABLED", False, raising=True)
+    monkeypatch.setattr(app_settings, "OPENRAG_ALLOW_NO_AUTH", False, raising=True)
+    monkeypatch.setattr(app_settings, "GOOGLE_OAUTH_CLIENT_ID", "", raising=True)
+    monkeypatch.setattr(app_settings, "GOOGLE_OAUTH_CLIENT_SECRET", "", raising=True)
+
+    assert app_settings.is_no_auth_mode() is False
+
+
+def test_explicit_no_auth_flag_keeps_local_dev_mode_available(monkeypatch):
+    monkeypatch.setattr(app_settings, "IBM_AUTH_ENABLED", False, raising=True)
+    monkeypatch.setattr(app_settings, "OPENRAG_ALLOW_NO_AUTH", True, raising=True)
+    monkeypatch.setattr(app_settings, "GOOGLE_OAUTH_CLIENT_ID", "", raising=True)
+    monkeypatch.setattr(app_settings, "GOOGLE_OAUTH_CLIENT_SECRET", "", raising=True)
+
+    assert app_settings.is_no_auth_mode() is True

--- a/tests/unit/dependencies/test_auth_jwt_attachment.py
+++ b/tests/unit/dependencies/test_auth_jwt_attachment.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+from fastapi import HTTPException
 
 ROOT = Path(__file__).resolve().parent.parent.parent.parent
 SRC = ROOT / "src"
@@ -78,6 +79,18 @@ async def test_optional_user_no_auth_gets_effective_jwt(monkeypatch):
     assert user.jwt_token == "Bearer generated-anonymous-token"
     assert request.state.user.jwt_token == "Bearer generated-anonymous-token"
     assert session_manager.effective_token_calls == [("anonymous", None)]
+
+
+@pytest.mark.asyncio
+async def test_current_user_without_cookie_and_without_no_auth_raises(monkeypatch):
+    monkeypatch.setattr("config.settings.is_no_auth_mode", lambda: False)
+    session_manager = FakeSessionManager()
+    request = _request()
+
+    with pytest.raises(HTTPException) as exc:
+        await get_current_user(request, session_manager=session_manager)
+
+    assert exc.value.status_code == 401
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- require explicit `OPENRAG_ALLOW_NO_AUTH=true` before anonymous mode activates
- document that leaving Google OAuth credentials blank no longer silently enables unauthenticated access
- add regression coverage for the no-auth opt-in gate and missing-cookie auth behavior

## Security context
OpenRAG currently treats missing Google OAuth credentials as an implicit no-auth mode when IBM auth is disabled. In default OSS configuration, that can turn unauthenticated requests into authenticated `AnonymousUser` requests and expose protected application surfaces. This patch makes anonymous mode an explicit local-development opt-in instead of a silent fallback.

## Validation
- `python3 -m py_compile src/config/settings.py tests/unit/config/test_no_auth_mode.py tests/unit/dependencies/test_auth_jwt_attachment.py`
- full pytest was not available in the audit workspace because repo dependencies were not installed there

## Notes
- no public submission has been created yet; this branch is prepared for maintainer review only



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tightened anonymous access behavior so blank Google OAuth credentials no longer automatically allow no-auth mode.
  * Added a safer local-development option to explicitly enable anonymous access when needed.
  * Improved login error handling so requests without authentication now return a clear 401 response.

* **Tests**
  * Added coverage for the updated no-auth and unauthenticated request behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->