### PR TITLE
fix: added ibm-watsonx-ai and langchain-ibm packages to Langflow image to fix WatsonX ingestion

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -12,11 +12,14 @@ RUN microdnf install -y \
     && microdnf clean all
 
 # Install Langflow with targeted extras and CPU-only wheels for PyTorch/Docling
+# ibm-watsonx-ai and langchain-ibm are needed because they are not included in the pip installation of langflow when python version is 3.14
 RUN pip install --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
     torch==2.10.0 \
     torchvision==0.25.0 \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
+    "ibm-watsonx-ai>=1.3.1,<2.0.0" \
+    "langchain-ibm~=1.1.0" \
     uv \
     && pip uninstall -y clickhouse-connect \
     && pip uninstall -y ragstack-ai-knowledge-store


### PR DESCRIPTION
This pull request updates the `Dockerfile.langflow` to ensure compatibility with Python 3.14 by explicitly installing additional dependencies that are not included by default. The most important change is:

Dependency management:

* Added installation of `ibm-watsonx-ai` and `langchain-ibm` Python packages to the `pip install` command, addressing missing dependencies when using Python 3.14.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the app’s Python 3.14 setup to include additional AI integration packages needed for compatibility.
  * Improved support for IBM and LangChain-related features in newer Python environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->