### PR TITLE
fix: target agent component when updating chat flow system prompt

### DIFF
--- a/src/api/settings/langflow_sync.py
+++ b/src/api/settings/langflow_sync.py
@@ -222,8 +222,7 @@ async def _update_langflow_model_values(
 async def _update_langflow_system_prompt(config, flows_service):
     """Update system prompt in chat flow"""
     try:
-        llm_provider = config.agent.llm_provider.lower()
-        await flows_service.update_chat_flow_system_prompt(config.agent.system_prompt, llm_provider)
+        await flows_service.update_chat_flow_system_prompt(config.agent.system_prompt)
         logger.info("Successfully updated chat flow system prompt")
     except Exception as e:
         logger.error(f"Failed to update chat flow system prompt: {str(e)}")

--- a/src/services/flows_service.py
+++ b/src/services/flows_service.py
@@ -705,16 +705,13 @@ class FlowsService:
             LANGFLOW_CHAT_FLOW_ID, "model_name", model_name, node_display_name=target_llm_id
         )
 
-    async def update_chat_flow_system_prompt(self, system_prompt: str, provider: str):
+    async def update_chat_flow_system_prompt(self, system_prompt: str):
         """Helper function to update the system prompt in the chat flow"""
         if not LANGFLOW_CHAT_FLOW_ID:
             raise ValueError("LANGFLOW_CHAT_FLOW_ID is not configured")
 
-        # Determine target component IDs based on provider
-        target_agent_id = self._get_provider_component_ids(provider)[1]
-
         await self._update_flow_field(
-            LANGFLOW_CHAT_FLOW_ID, "system_prompt", system_prompt, node_display_name=target_agent_id
+            LANGFLOW_CHAT_FLOW_ID, "system_prompt", system_prompt, node_display_name=AGENT_COMPONENT_DISPLAY_NAME
         )
 
     async def update_flow_docling_preset(self, preset: str, preset_config: dict):

--- a/src/services/flows_service.py
+++ b/src/services/flows_service.py
@@ -711,7 +711,10 @@ class FlowsService:
             raise ValueError("LANGFLOW_CHAT_FLOW_ID is not configured")
 
         await self._update_flow_field(
-            LANGFLOW_CHAT_FLOW_ID, "system_prompt", system_prompt, node_display_name=AGENT_COMPONENT_DISPLAY_NAME
+            LANGFLOW_CHAT_FLOW_ID,
+            "system_prompt",
+            system_prompt,
+            node_display_name=AGENT_COMPONENT_DISPLAY_NAME,
         )
 
     async def update_flow_docling_preset(self, preset: str, preset_config: dict):

--- a/tests/unit/test_langflow_agent_system_prompt.py
+++ b/tests/unit/test_langflow_agent_system_prompt.py
@@ -1,0 +1,53 @@
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, AsyncMock
+
+import pytest
+
+
+def _load_flow(flow_path: str) -> dict:
+    """Load a Langflow flow JSON file from the given path."""
+    return json.loads(Path(flow_path).read_text(encoding="utf-8"))
+
+
+def _find_node_by_display_name(flow: dict, display_name: str):
+    """Return the first flow node whose display_name matches, or None."""
+    return next(
+        (
+            node
+            for node in flow["data"]["nodes"]
+            if node.get("data", {}).get("node", {}).get("display_name") == display_name
+        ),
+        None,
+    )
+
+
+def test_agent_flow_has_agent_node_with_system_prompt():
+    """The Agent node must exist in openrag_agent.json and expose a system_prompt field."""
+    flow = _load_flow("flows/openrag_agent.json")
+    agent_node = _find_node_by_display_name(flow, "Agent")
+
+    assert agent_node is not None, "No node with display_name='Agent' found in openrag_agent.json"
+    template = agent_node.get("data", {}).get("node", {}).get("template", {})
+    assert "system_prompt" in template, "Agent node does not have a system_prompt field in its template"
+
+
+@pytest.mark.asyncio
+async def test_update_chat_flow_system_prompt_updates_agent_node(monkeypatch):
+    """update_chat_flow_system_prompt must write the new value into the Agent node's system_prompt field."""
+    from services.flows_service import FlowsService
+
+    get_response = MagicMock(status_code=200)
+    get_response.json.return_value = _load_flow("flows/openrag_agent.json")
+    patch_response = MagicMock(status_code=200)
+
+    request = AsyncMock(side_effect=[get_response, patch_response])
+    monkeypatch.setattr("services.flows_service.LANGFLOW_CHAT_FLOW_ID", "test-flow-id")
+    monkeypatch.setattr("services.flows_service.clients.langflow_request", request)
+
+    await FlowsService().update_chat_flow_system_prompt("updated system prompt for testing purposes")
+
+    sent_flow = request.call_args_list[1].kwargs["json"]
+    agent_node = _find_node_by_display_name(sent_flow, "Agent")
+    assert agent_node is not None, "Agent node missing from PATCHed flow data"
+    assert agent_node["data"]["node"]["template"]["system_prompt"]["value"] == "updated system prompt for testing purposes"

--- a/tests/unit/test_langflow_agent_system_prompt.py
+++ b/tests/unit/test_langflow_agent_system_prompt.py
@@ -1,6 +1,6 @@
 import json
 from pathlib import Path
-from unittest.mock import MagicMock, AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -29,7 +29,9 @@ def test_agent_flow_has_agent_node_with_system_prompt():
 
     assert agent_node is not None, "No node with display_name='Agent' found in openrag_agent.json"
     template = agent_node.get("data", {}).get("node", {}).get("template", {})
-    assert "system_prompt" in template, "Agent node does not have a system_prompt field in its template"
+    assert "system_prompt" in template, (
+        "Agent node does not have a system_prompt field in its template"
+    )
 
 
 @pytest.mark.asyncio
@@ -45,9 +47,14 @@ async def test_update_chat_flow_system_prompt_updates_agent_node(monkeypatch):
     monkeypatch.setattr("services.flows_service.LANGFLOW_CHAT_FLOW_ID", "test-flow-id")
     monkeypatch.setattr("services.flows_service.clients.langflow_request", request)
 
-    await FlowsService().update_chat_flow_system_prompt("updated system prompt for testing purposes")
+    await FlowsService().update_chat_flow_system_prompt(
+        "updated system prompt for testing purposes"
+    )
 
     sent_flow = request.call_args_list[1].kwargs["json"]
     agent_node = _find_node_by_display_name(sent_flow, "Agent")
     assert agent_node is not None, "Agent node missing from PATCHed flow data"
-    assert agent_node["data"]["node"]["template"]["system_prompt"]["value"] == "updated system prompt for testing purposes"
+    assert (
+        agent_node["data"]["node"]["template"]["system_prompt"]["value"]
+        == "updated system prompt for testing purposes"
+    )

--- a/tests/unit/test_langflow_agent_system_prompt.py
+++ b/tests/unit/test_langflow_agent_system_prompt.py
@@ -5,9 +5,12 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 
+_REPO_ROOT = Path(__file__).parent.parent.parent
+
+
 def _load_flow(flow_path: str) -> dict:
-    """Load a Langflow flow JSON file from the given path."""
-    return json.loads(Path(flow_path).read_text(encoding="utf-8"))
+    """Load a Langflow flow JSON file resolved relative to the repository root."""
+    return json.loads((_REPO_ROOT / flow_path).read_text(encoding="utf-8"))
 
 
 def _find_node_by_display_name(flow: dict, display_name: str):

--- a/tests/unit/test_langflow_agent_system_prompt.py
+++ b/tests/unit/test_langflow_agent_system_prompt.py
@@ -4,7 +4,6 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-
 _REPO_ROOT = Path(__file__).parent.parent.parent
 
 


### PR DESCRIPTION
## Summary
Port of PR #1918 to target main, Fixes https://github.com/langflow-ai/openrag/issues/1514. update_chat_flow_system_prompt  was targeting the LLM provider component (e.g. "Ollama", "WatsonX") instead of the Agent component where the system_prompt field lives. As a result, saving new agent instructions in OpenRAG settings never updates langflow

## Changes:
- Updated update_chat_flow_system_prompt to use AGENT_COMPONENT_DISPLAY_NAME as the target component
- Added unit tests verifying the value is written to the Agent component in the flow


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * System prompt updates now reliably apply to the chat agent component and no longer depend on provider-specific selection logic.
  * Updates are simplified to always target the agent’s `system_prompt`, improving consistency.

* **Tests**
  * Added unit tests to verify the Agent node includes a `system_prompt` template and that update requests send the correct PATCH payload reflecting the new prompt.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->