### PR TITLE
fix: prevent partial matches for exact token searches

### DIFF
--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1,6 +1,5 @@
 import asyncio
 import copy
-import json
 import os
 import re
 from collections import Counter

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1,7 +1,7 @@
 import asyncio
 import copy
-import os
 import json
+import os
 import re
 from collections import Counter
 from typing import Any
@@ -596,10 +596,10 @@ class SearchService:
                     )
                 )
             }
-            
+
             # Determine if we should apply exact-token filtering
             should_filter_exact = bool(exact_files) or _is_exact_token_query(query)
-            
+
             if should_filter_exact:
                 if exact_files:
                     # Filter to only chunks from files with exact matches

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -1,6 +1,8 @@
 import asyncio
 import copy
 import os
+import json
+import re
 from collections import Counter
 from typing import Any
 
@@ -21,6 +23,19 @@ EMBED_RETRY_MAX_DELAY = 8.0
 
 # Variable used to store the active instance for the tool wrapper
 _global_search_service = None
+
+
+def _is_exact_token_query(query: str) -> bool:
+    """Return True for code/token-like queries that should not allow partial fuzzy matches."""
+    if not query or len(query.strip()) < 3:
+        return False
+
+    query = query.strip()
+
+    if re.search(r"[^a-zA-Z0-9\s]", query):
+        return True
+
+    return bool(re.search(r"[a-zA-Z]", query) and re.search(r"\d", query))
 
 
 def register_search_service(service: "SearchService") -> None:
@@ -581,8 +596,17 @@ class SearchService:
                     )
                 )
             }
-            if exact_files:
-                chunks = [chunk for chunk in chunks if chunk.get("filename") in exact_files]
+            
+            # Determine if we should apply exact-token filtering
+            should_filter_exact = bool(exact_files) or _is_exact_token_query(query)
+            
+            if should_filter_exact:
+                if exact_files:
+                    # Filter to only chunks from files with exact matches
+                    chunks = [chunk for chunk in chunks if chunk.get("filename") in exact_files]
+                else:
+                    # No exact matches found for a token-like query - return empty results
+                    chunks = []
 
                 def _build_terms_agg(field: str) -> dict[str, Any]:
                     counts = Counter(


### PR DESCRIPTION
## Summary

Cherry-picks the exact-token search fix from `release-0.5.1` into `main`.

This prevents exact-looking token queries from returning partial or fuzzy matches when the exact token does not appear in the returned filename or chunk text.

## Testing

- Cherry-picked merged release PR #1937 into `main`.
- Ran:

```bash
uv run python -m py_compile src/services/search_service.py

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved search behavior for short or identifier-like queries so results now stay exact and avoid broader unrelated matches.
  * When no exact file matches are found for these queries, search now returns no snippets instead of showing loosely related content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->