### PR TITLE
fix: preserve HTTPException status in update_docling_preset (#1586)

### DIFF
--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1601,7 +1601,9 @@ async def update_docling_preset(
             settings=settings_toggles,
             preset_config=preset_config,
         )
-
+    except HTTPException:
+        # Preserve intended HTTP status codes (e.g. 400 for an invalid preset)
+        raise
     except Exception as e:
         logger.error("Failed to update docling settings", error=str(e))
         raise HTTPException(

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1607,7 +1607,7 @@ async def update_docling_preset(
     except Exception as e:
         logger.error("Failed to update docling settings", error=str(e))
         raise HTTPException(
-            status_code=500, detail=f"Failed to update docling settings: {str(e)}"
+            status_code=500, detail="Failed to update docling settings"
         ) from e
 
 

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1606,9 +1606,7 @@ async def update_docling_preset(
         raise
     except Exception as e:
         logger.error("Failed to update docling settings", error=str(e))
-        raise HTTPException(
-            status_code=500, detail="Failed to update docling settings"
-        ) from e
+        raise HTTPException(status_code=500, detail="Failed to update docling settings") from e
 
 
 async def refresh_openrag_docs(

--- a/tests/unit/api/test_settings_endpoints.py
+++ b/tests/unit/api/test_settings_endpoints.py
@@ -1,0 +1,37 @@
+"""
+Unit tests for api.settings.endpoints
+Validates error handling in update_docling_preset endpoint.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from api.settings import DoclingPresetBody, update_docling_preset
+from session_manager import User
+
+
+@pytest.mark.asyncio
+async def test_update_docling_preset_invalid_preset_returns_400():
+    """Test that an invalid preset value returns 400 status code.
+
+    This test ensures that the HTTPException with status_code=400 raised
+    for invalid presets is not masked by the broad Exception handler.
+    Regression test for issue #1586.
+    """
+    # Create a body with an invalid preset
+    body = DoclingPresetBody(preset="nonexistent_preset")
+
+    # Mock dependencies
+    session_manager = AsyncMock()
+    user = MagicMock(spec=User)
+
+    # Call the endpoint and expect HTTPException with 400
+    with pytest.raises(HTTPException) as exc_info:
+        await update_docling_preset(body=body, session_manager=session_manager, user=user)
+
+    # Assert it's a 400 error (not 500)
+    assert exc_info.value.status_code == 400
+    assert "Invalid preset" in exc_info.value.detail
+    assert "nonexistent_preset" in exc_info.value.detail


### PR DESCRIPTION
Fixes #1586. Re-lands the fix from #1922 (merged into release-0.5.1) on a branch pushed directly to this repo, so CI has access to the secrets forked PRs can't use — see #1814 for why the forked version's E2E checks could never pass. Applied by hand rather than cherry-picked because src/api/settings.py has since been split into the src/api/settings/ package on main; the endpoint change now lives in src/api/settings/endpoints.py. Includes a unit regression test asserting an invalid preset returns 400, not 500.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserves the original error status when an invalid preset is submitted, so bad input continues to return a 400 response.
  * Unexpected failures now return a consistent 500 response with a clearer, fixed message instead of exposing internal error details.
* **Tests**
  * Added coverage for invalid preset handling to confirm the correct error code and message are returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->