### PR TITLE
fix: restore LLM model values in reapply_all_settings fallback (#1587)

### DIFF
--- a/src/api/settings/helpers.py
+++ b/src/api/settings/helpers.py
@@ -18,9 +18,20 @@ from utils.logging_config import get_logger
 logger = get_logger(__name__)
 
 
+# Provider names in priority order. LLM supports anthropic; embeddings do not.
+_LLM_PROVIDER_NAMES = ("openai", "anthropic", "watsonx", "ollama")
+_EMBEDDING_PROVIDER_NAMES = ("openai", "watsonx", "ollama")
+
+
+def _configured_provider_names(config, provider_names) -> list:
+    """Return the provider names from `provider_names` marked configured in the OpenRAG config."""
+    providers = config.providers
+    return [name for name in provider_names if getattr(providers, name).configured]
+
+
 def _first_configured_llm_provider(config, excluding: str) -> str:
     """Return the first configured LLM provider that isn't `excluding`."""
-    for p in ["openai", "anthropic", "watsonx", "ollama"]:
+    for p in _LLM_PROVIDER_NAMES:
         if p != excluding and getattr(config.providers, p).configured:
             return p
     return "openai"
@@ -28,7 +39,7 @@ def _first_configured_llm_provider(config, excluding: str) -> str:
 
 def _first_configured_embedding_provider(config, excluding: str) -> str:
     """Return the first configured embedding provider (openai/watsonx/ollama) that isn't `excluding`, or "" if none."""
-    for p in ["openai", "watsonx", "ollama"]:
+    for p in _EMBEDDING_PROVIDER_NAMES:
         if p != excluding and getattr(config.providers, p).configured:
             return p
     return ""

--- a/src/api/settings/langflow_sync.py
+++ b/src/api/settings/langflow_sync.py
@@ -206,18 +206,12 @@ async def _update_langflow_model_values(
             for provider in llm_providers:
                 # Use configured model for current provider, or None (first available) for others
                 provider_llm_model = (
-                    config.agent.llm_model
-                    if provider == current_llm_provider
-                    else None
+                    config.agent.llm_model if provider == current_llm_provider else None
                 )
                 await flows_service.change_langflow_model_value(
-                        provider,
-                        llm_model=provider_llm_model,
-                        force_llm_update=True
-                    )
-                logger.info(
-                    f"Successfully updated Langflow flows for LLM provider {provider}"
+                    provider, llm_model=provider_llm_model, force_llm_update=True
                 )
+                logger.info(f"Successfully updated Langflow flows for LLM provider {provider}")
 
             # 2. Update ALL configured embedding providers
             embedding_providers = _configured_provider_names(config, _EMBEDDING_PROVIDER_NAMES)

--- a/src/api/settings/langflow_sync.py
+++ b/src/api/settings/langflow_sync.py
@@ -12,7 +12,12 @@ Lifted verbatim from the original `src/api/settings.py` (lines 46,
 
 import asyncio
 
-from api.settings.helpers import _get_flows_service
+from api.settings.helpers import (
+    _EMBEDDING_PROVIDER_NAMES,
+    _LLM_PROVIDER_NAMES,
+    _configured_provider_names,
+    _get_flows_service,
+)
 from config.settings import clients, get_openrag_config
 from services.docling_service import get_docling_preset_configs
 from utils.logging_config import get_logger
@@ -191,14 +196,31 @@ async def _update_langflow_model_values(
             )
 
         if not (embedding_model or embedding_provider or llm_model or llm_provider):
+            # 1. Update ALL configured LLM providers.
+            # Regression fix (#1587): the no-argument fallback used by
+            # reapply_all_settings previously only reapplied embedding providers,
+            # leaving LLM model values unset whenever flows were reset.
+            llm_providers = _configured_provider_names(config, _LLM_PROVIDER_NAMES)
+
+            current_llm_provider = config.agent.llm_provider.lower()
+            for provider in llm_providers:
+                # Use configured model for current provider, or None (first available) for others
+                provider_llm_model = (
+                    config.agent.llm_model
+                    if provider == current_llm_provider
+                    else None
+                )
+                await flows_service.change_langflow_model_value(
+                        provider,
+                        llm_model=provider_llm_model,
+                        force_llm_update=True
+                    )
+                logger.info(
+                    f"Successfully updated Langflow flows for LLM provider {provider}"
+                )
+
             # 2. Update ALL configured embedding providers
-            embedding_providers = []
-            if config.providers.openai.configured:
-                embedding_providers.append("openai")
-            if config.providers.watsonx.configured:
-                embedding_providers.append("watsonx")
-            if config.providers.ollama.configured:
-                embedding_providers.append("ollama")
+            embedding_providers = _configured_provider_names(config, _EMBEDDING_PROVIDER_NAMES)
 
             current_embedding_provider = config.knowledge.embedding_provider.lower()
             for provider in embedding_providers:

--- a/tests/unit/api/test_langflow_sync_bug_1587.py
+++ b/tests/unit/api/test_langflow_sync_bug_1587.py
@@ -1,0 +1,130 @@
+"""
+Unit tests for api.settings.langflow_sync._update_langflow_model_values
+
+Regression tests for issue #1587: the no-argument fallback used by
+reapply_all_settings (triggered when Langflow flows are detected as reset)
+must reapply LLM model values for every configured LLM provider, not only
+embedding providers.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from api.settings.langflow_sync import _update_langflow_model_values
+
+# Providers a mock config can advertise as configured. LLM supports anthropic;
+# embeddings do not, so embedding reapplication should skip it.
+_ALL_PROVIDERS = ("openai", "anthropic", "watsonx", "ollama")
+_EXPECTED_LLM_PROVIDERS = {"openai", "anthropic", "watsonx", "ollama"}
+_EXPECTED_EMBEDDING_PROVIDERS = {"openai", "watsonx", "ollama"}
+
+
+@pytest.fixture
+def mock_config():
+    config = MagicMock()
+    for name in _ALL_PROVIDERS:
+        getattr(config.providers, name).configured = True
+    config.knowledge.embedding_provider = "openai"
+    config.knowledge.embedding_model = "text-embedding-3-small"
+    config.agent.llm_provider = "anthropic"
+    config.agent.llm_model = "claude-3-5-sonnet-20241022"
+    return config
+
+
+def _calls_by_kwarg(flows_service, kwarg):
+    """Return {provider: kwarg_value} for change_langflow_model_value calls carrying `kwarg`."""
+    result = {}
+    for call in flows_service.change_langflow_model_value.await_args_list:
+        if kwarg in call.kwargs:
+            provider = call.args[0] if call.args else call.kwargs.get("provider")
+            result[provider] = call.kwargs[kwarg]
+    return result
+
+
+@pytest.mark.asyncio
+async def test_fallback_reapplies_llm_for_all_configured_providers(mock_config):
+    """No-arg fallback must call change_langflow_model_value for every configured LLM provider.
+
+    Regression test for #1587: previously only embedding providers were reapplied,
+    so LLM model values were silently dropped after a flow reset.
+    """
+    flows_service = MagicMock()
+    flows_service.change_langflow_model_value = AsyncMock()
+
+    # No model/provider arguments => the reapply_all_settings fallback path.
+    await _update_langflow_model_values(mock_config, flows_service)
+
+    llm_calls = _calls_by_kwarg(flows_service, "llm_model")
+    assert set(llm_calls.keys()) == _EXPECTED_LLM_PROVIDERS
+
+    # Every LLM call must force the update.
+    for call in flows_service.change_langflow_model_value.await_args_list:
+        if "llm_model" in call.kwargs:
+            assert call.kwargs.get("force_llm_update") is True
+
+
+@pytest.mark.asyncio
+async def test_fallback_uses_configured_model_only_for_current_llm_provider(mock_config):
+    """The active provider keeps its configured model; others reset to None (first available)."""
+    flows_service = MagicMock()
+    flows_service.change_langflow_model_value = AsyncMock()
+
+    await _update_langflow_model_values(mock_config, flows_service)
+
+    llm_calls = _calls_by_kwarg(flows_service, "llm_model")
+    assert llm_calls["anthropic"] == "claude-3-5-sonnet-20241022"
+    assert llm_calls["openai"] is None
+    assert llm_calls["watsonx"] is None
+    assert llm_calls["ollama"] is None
+
+
+@pytest.mark.asyncio
+async def test_fallback_still_reapplies_embedding_providers(mock_config):
+    """The fix must not regress the existing embedding reapplication behavior."""
+    flows_service = MagicMock()
+    flows_service.change_langflow_model_value = AsyncMock()
+
+    await _update_langflow_model_values(mock_config, flows_service)
+
+    embedding_calls = _calls_by_kwarg(flows_service, "embedding_model")
+    # anthropic is not a valid embedding provider and must be skipped.
+    assert set(embedding_calls.keys()) == _EXPECTED_EMBEDDING_PROVIDERS
+    assert embedding_calls["openai"] == "text-embedding-3-small"
+    assert embedding_calls["watsonx"] is None
+    assert embedding_calls["ollama"] is None
+
+
+@pytest.mark.asyncio
+async def test_fallback_only_reapplies_configured_providers(mock_config):
+    """Unconfigured providers must not be touched in the fallback path."""
+    mock_config.providers.watsonx.configured = False
+    mock_config.providers.ollama.configured = False
+
+    flows_service = MagicMock()
+    flows_service.change_langflow_model_value = AsyncMock()
+
+    await _update_langflow_model_values(mock_config, flows_service)
+
+    llm_calls = _calls_by_kwarg(flows_service, "llm_model")
+    assert set(llm_calls.keys()) == {"openai", "anthropic"}
+
+
+@pytest.mark.asyncio
+async def test_explicit_llm_arguments_bypass_fallback(mock_config):
+    """When explicit llm args are passed, only that provider is updated (no fallback loop)."""
+    flows_service = MagicMock()
+    flows_service.change_langflow_model_value = AsyncMock()
+
+    await _update_langflow_model_values(
+        mock_config,
+        flows_service,
+        llm_model="gpt-4o",
+        llm_provider="openai",
+    )
+
+    flows_service.change_langflow_model_value.assert_awaited_once()
+    call = flows_service.change_langflow_model_value.await_args
+    assert call.args[0] == "openai"
+    assert call.kwargs["llm_model"] == "gpt-4o"
+    assert call.kwargs.get("force_llm_update") is True


### PR DESCRIPTION
Fixes #1587 on main. Ports the reviewed version of this fix from #1932 (approved and merged into release-0.5.1, including @Wallgau's review feedback from that PR) back to main's package layout: the provider-name constants and _configured_provider_names helper land in src/api/settings/helpers.py, and the no-arg fallback's LLM loop lands in src/api/settings/langflow_sync.py. Supersedes the closed #1926, which targeted main but predates the review feedback. The test file is #1932's reviewed test file with only the import path adapted; the 3 LLM-specific tests fail on current main and pass with the fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed settings reapplication so saved AI provider selections are restored more reliably.
  * Improved fallback behavior to update all configured language model providers and keep the active provider’s model while leaving others unselected.
  * Embedding settings are now reapplied correctly for supported providers only, without affecting unrelated providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->