### PR TITLE
feat: add dedicated OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE flag for COS "share all" toggle

### DIFF
--- a/frontend/app/api/queries/useGetSettingsQuery.ts
+++ b/frontend/app/api/queries/useGetSettingsQuery.ts
@@ -77,6 +77,7 @@ export interface Settings {
   localhost_url?: string;
   ingest_via_chat?: boolean;
   show_provider_ingest_settings?: boolean;
+  show_shared_upload_toggle?: boolean;
   segment_write_key?: string;
   environment?: string;
 }

--- a/frontend/components/cloud-picker/ingest-settings.tsx
+++ b/frontend/components/cloud-picker/ingest-settings.tsx
@@ -44,6 +44,13 @@ interface IngestSettingsProps {
   onSettingsChange?: (settings: IngestSettingsType) => void;
   /** When true, show the "Make documents available to all users" toggle. COS ingestion only. */
   showShared?: boolean;
+  /**
+   * When false, hide the embedding model, chunking, OCR, and picture description
+   * controls, leaving only the shared toggle (if `showShared` is also true). Lets
+   * deployments that disable per-upload ingest tuning (e.g. SaaS) still expose the
+   * shared toggle on its own. Defaults to true.
+   */
+  showAdvancedSettings?: boolean;
 }
 
 export const IngestSettings = ({
@@ -52,6 +59,7 @@ export const IngestSettings = ({
   settings,
   onSettingsChange,
   showShared = false,
+  showAdvancedSettings = true,
 }: IngestSettingsProps) => {
   const { isAuthenticated, isNoAuthMode } = useAuth();
 
@@ -158,118 +166,125 @@ export const IngestSettings = ({
       </CollapsibleTrigger>
 
       <CollapsibleContent className="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:slide-up-2 data-[state=open]:slide-down-2">
-        <div className="mt-6">
-          {/* Embedding model selection */}
-          <LabelWrapper
-            helperText="Model used for knowledge ingest and retrieval"
-            id="embedding-model-select"
-            label="Embedding model"
-          >
-            <Select
-              disabled={false}
-              value={selectEmbeddingValue}
-              onValueChange={(value) =>
-                handleSettingsChange({ embeddingModel: value })
+        {showAdvancedSettings && (
+          <div className="mt-6">
+            {/* Embedding model selection */}
+            <LabelWrapper
+              helperText="Model used for knowledge ingest and retrieval"
+              id="embedding-model-select"
+              label="Embedding model"
+            >
+              <Select
+                disabled={false}
+                value={selectEmbeddingValue}
+                onValueChange={(value) =>
+                  handleSettingsChange({ embeddingModel: value })
+                }
+              >
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <SelectTrigger id="embedding-model-select">
+                      <SelectValue placeholder="Select an embedding model" />
+                    </SelectTrigger>
+                  </TooltipTrigger>
+                  <TooltipContent>
+                    Choose the embedding model for this upload
+                  </TooltipContent>
+                </Tooltip>
+                <SelectContent>
+                  <ModelSelectItems
+                    models={embeddingSelectOptions}
+                    fallbackModels={[]}
+                    provider={currentProvider}
+                  />
+                </SelectContent>
+              </Select>
+            </LabelWrapper>
+          </div>
+        )}
+        {showAdvancedSettings && (
+          <div className="mt-6">
+            <div className="flex items-center gap-4 w-full mb-6">
+              <div className="w-full">
+                <NumberInput
+                  id="chunk-size"
+                  label="Chunk size"
+                  value={currentSettings.chunkSize}
+                  onChange={(value) => handleSettingsChange({ chunkSize: value })}
+                  unit="characters"
+                />
+              </div>
+              <div className="w-full">
+                <NumberInput
+                  id="chunk-overlap"
+                  label="Chunk overlap"
+                  value={currentSettings.chunkOverlap}
+                  onChange={(value) =>
+                    handleSettingsChange({ chunkOverlap: value })
+                  }
+                  unit="characters"
+                />
+              </div>
+            </div>
+
+            {/* <div className="flex gap-2 items-center justify-between">
+              <div>
+                <div className="text-sm font-semibold pb-2">Table Structure</div>
+                <div className="text-sm text-muted-foreground">
+                  Capture table structure during ingest.
+                </div>
+              </div>
+              <Switch
+                id="table-structure"
+                checked={currentSettings.tableStructure}
+                onCheckedChange={(checked) =>
+                  handleSettingsChange({ tableStructure: checked })
+                }
+              />
+            </div> */}
+
+            <div className="flex items-center justify-between border-b pb-3 mb-3">
+              <div>
+                <div className="text-sm font-semibold pb-2">OCR</div>
+                <div className="text-sm text-muted-foreground">
+                  Extracts text from images/PDFs. Ingest is slower when enabled.
+                </div>
+              </div>
+              <Switch
+                checked={currentSettings.ocr}
+                onCheckedChange={(checked) =>
+                  handleSettingsChange({ ocr: checked })
+                }
+              />
+            </div>
+
+            <div
+              className={
+                showShared
+                  ? "flex items-center justify-between border-b pb-3 mb-3"
+                  : "flex items-center justify-between"
               }
             >
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <SelectTrigger id="embedding-model-select">
-                    <SelectValue placeholder="Select an embedding model" />
-                  </SelectTrigger>
-                </TooltipTrigger>
-                <TooltipContent>
-                  Choose the embedding model for this upload
-                </TooltipContent>
-              </Tooltip>
-              <SelectContent>
-                <ModelSelectItems
-                  models={embeddingSelectOptions}
-                  fallbackModels={[]}
-                  provider={currentProvider}
-                />
-              </SelectContent>
-            </Select>
-          </LabelWrapper>
-        </div>
-        <div className="mt-6">
-          <div className="flex items-center gap-4 w-full mb-6">
-            <div className="w-full">
-              <NumberInput
-                id="chunk-size"
-                label="Chunk size"
-                value={currentSettings.chunkSize}
-                onChange={(value) => handleSettingsChange({ chunkSize: value })}
-                unit="characters"
-              />
-            </div>
-            <div className="w-full">
-              <NumberInput
-                id="chunk-overlap"
-                label="Chunk overlap"
-                value={currentSettings.chunkOverlap}
-                onChange={(value) =>
-                  handleSettingsChange({ chunkOverlap: value })
+              <div>
+                <div className="text-sm pb-2 font-semibold">
+                  Picture descriptions
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  Adds captions for images. Ingest is more expensive when
+                  enabled.
+                </div>
+              </div>
+              <Switch
+                checked={currentSettings.pictureDescriptions}
+                onCheckedChange={(checked) =>
+                  handleSettingsChange({ pictureDescriptions: checked })
                 }
-                unit="characters"
               />
             </div>
           </div>
+        )}
 
-          {/* <div className="flex gap-2 items-center justify-between">
-            <div>
-              <div className="text-sm font-semibold pb-2">Table Structure</div>
-              <div className="text-sm text-muted-foreground">
-                Capture table structure during ingest.
-              </div>
-            </div>
-            <Switch
-              id="table-structure"
-              checked={currentSettings.tableStructure}
-              onCheckedChange={(checked) =>
-                handleSettingsChange({ tableStructure: checked })
-              }
-            />
-          </div> */}
-
-          <div className="flex items-center justify-between border-b pb-3 mb-3">
-            <div>
-              <div className="text-sm font-semibold pb-2">OCR</div>
-              <div className="text-sm text-muted-foreground">
-                Extracts text from images/PDFs. Ingest is slower when enabled.
-              </div>
-            </div>
-            <Switch
-              checked={currentSettings.ocr}
-              onCheckedChange={(checked) =>
-                handleSettingsChange({ ocr: checked })
-              }
-            />
-          </div>
-
-          <div
-            className={
-              showShared
-                ? "flex items-center justify-between border-b pb-3 mb-3"
-                : "flex items-center justify-between"
-            }
-          >
-            <div>
-              <div className="text-sm pb-2 font-semibold">
-                Picture descriptions
-              </div>
-              <div className="text-sm text-muted-foreground">
-                Adds captions for images. Ingest is more expensive when enabled.
-              </div>
-            </div>
-            <Switch
-              checked={currentSettings.pictureDescriptions}
-              onCheckedChange={(checked) =>
-                handleSettingsChange({ pictureDescriptions: checked })
-              }
-            />
-          </div>
-
+        <div className={showAdvancedSettings ? "" : "mt-6"}>
           {showShared && (
             <div className="flex items-center justify-between">
               <div>

--- a/frontend/components/cloud-picker/ingest-settings.tsx
+++ b/frontend/components/cloud-picker/ingest-settings.tsx
@@ -210,7 +210,9 @@ export const IngestSettings = ({
                   id="chunk-size"
                   label="Chunk size"
                   value={currentSettings.chunkSize}
-                  onChange={(value) => handleSettingsChange({ chunkSize: value })}
+                  onChange={(value) =>
+                    handleSettingsChange({ chunkSize: value })
+                  }
                   unit="characters"
                 />
               </div>

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -55,6 +55,11 @@ export function SharedBucketView({
   });
   const showIngestSettings =
     apiSettings?.show_provider_ingest_settings ?? false;
+  // The shared toggle can be exposed on its own (e.g. for SaaS deployments that
+  // hide the general per-upload ingest tuning knobs) via a dedicated flag.
+  const showSharedToggle =
+    showShared &&
+    (showIngestSettings || (apiSettings?.show_shared_upload_toggle ?? false));
 
   const [selectedBuckets, setSelectedBuckets] = useState<Set<string>>(
     new Set(),
@@ -122,7 +127,7 @@ export function SharedBucketView({
           selected_files: [],
           bucket_filter: Array.from(selectedBuckets),
           settings: ingestSettings,
-          shared: showShared ? (ingestSettings.shared ?? false) : undefined,
+          shared: showSharedToggle ? (ingestSettings.shared ?? false) : undefined,
         },
       },
       {
@@ -298,13 +303,14 @@ export function SharedBucketView({
           </div>
         )}
 
-        {showIngestSettings && (
+        {(showIngestSettings || showSharedToggle) && (
           <IngestSettings
             isOpen={isSettingsOpen}
             onOpenChange={setIsSettingsOpen}
             settings={ingestSettings}
             onSettingsChange={setIngestSettings}
-            showShared={showShared}
+            showShared={showSharedToggle}
+            showAdvancedSettings={showIngestSettings}
           />
         )}
       </div>

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -127,7 +127,9 @@ export function SharedBucketView({
           selected_files: [],
           bucket_filter: Array.from(selectedBuckets),
           settings: ingestSettings,
-          shared: showSharedToggle ? (ingestSettings.shared ?? false) : undefined,
+          shared: showSharedToggle
+            ? (ingestSettings.shared ?? false)
+            : undefined,
         },
       },
       {

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -66,6 +66,7 @@ from config.settings import (
     LOCALHOST_URL,
     OPENRAG_INGEST_VIA_CHAT,
     OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS,
+    OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE,
     SEGMENT_WRITE_KEY,
     clients,
     config_manager,
@@ -239,6 +240,7 @@ async def get_settings(
             ingestion_defaults=ingestion_defaults_obj,
             ingest_via_chat=OPENRAG_INGEST_VIA_CHAT,
             show_provider_ingest_settings=OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS,
+            show_shared_upload_toggle=OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE,
             segment_write_key=SEGMENT_WRITE_KEY or None,
             environment=ENVIRONMENT or None,
         )

--- a/src/api/settings/models.py
+++ b/src/api/settings/models.py
@@ -162,6 +162,7 @@ class SettingsResponse(BaseModel):
     ingestion_defaults: IngestionDefaultsConfig | None = None
     ingest_via_chat: bool = False
     show_provider_ingest_settings: bool = False
+    show_shared_upload_toggle: bool = False
     segment_write_key: str | None = None
     environment: str | None = None
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -506,6 +506,14 @@ OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS = os.getenv(
     "OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS", "false"
 ).lower() in ("true", "1", "yes")
 
+# Show the "Make documents available to all users" (shared) toggle for COS bucket
+# ingestion, independent of OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS. Deployments that
+# hide the general per-upload ingest tuning knobs (e.g. SaaS) can still opt back into
+# just this toggle by setting this flag on its own.
+OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE = os.getenv(
+    "OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE", "false"
+).lower() in ("true", "1", "yes")
+
 # Ingest sample data configuration
 INGEST_SAMPLE_DATA = os.getenv("INGEST_SAMPLE_DATA", "true").lower() in ("true", "1", "yes")
 

--- a/tests/unit/config/test_show_shared_upload_toggle.py
+++ b/tests/unit/config/test_show_shared_upload_toggle.py
@@ -3,6 +3,7 @@
 This flag lets deployments expose the COS "Make documents available to all
 users" toggle independently of OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS, which
 gates the rest of the per-upload ingest tuning knobs (chunk size, OCR, etc.).
+Make sure to update this test when the flag is removed.
 """
 
 import os

--- a/tests/unit/config/test_show_shared_upload_toggle.py
+++ b/tests/unit/config/test_show_shared_upload_toggle.py
@@ -1,0 +1,71 @@
+"""Regression tests for the OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE flag.
+
+This flag lets deployments expose the COS "Make documents available to all
+users" toggle independently of OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS, which
+gates the rest of the per-upload ingest tuning knobs (chunk size, OCR, etc.).
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+
+
+def _python_env(env: dict[str, str]) -> dict[str, str]:
+    merged = os.environ.copy()
+    merged.update(env)
+    return merged
+
+
+def _read_flag(env: dict[str, str]) -> str:
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from config import settings; print(settings.OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_python_env(env),
+        cwd=str(ROOT),
+    )
+    return result.stdout.splitlines()[-1].strip()
+
+
+def test_defaults_false_when_unset():
+    env = {"PYTHONPATH": str(SRC)}
+    env.pop("OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE", None)
+    assert _read_flag(env) == "False"
+
+
+def test_true_when_enabled():
+    env = {"OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE": "true", "PYTHONPATH": str(SRC)}
+    assert _read_flag(env) == "True"
+
+
+def test_independent_of_show_provider_ingest_settings():
+    """The shared-only flag can be enabled while the general flag stays off."""
+    env = {
+        "OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE": "true",
+        "OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS": "false",
+        "PYTHONPATH": str(SRC),
+    }
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from config import settings; "
+            "print(settings.OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE, "
+            "settings.OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=_python_env(env),
+        cwd=str(ROOT),
+    )
+    assert result.stdout.splitlines()[-1].strip() == "True False"


### PR DESCRIPTION
## Summary
The COS "Make documents available to all users" (share all) toggle is rendered
inside the shared `IngestSettings` component, which was only mounted when
`OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS` was true. Disabling that flag for SaaS
(to hide chunk size/OCR/picture-description tuning) also hid "share all" as a
side effect, with no way to show one without the other.

This PR decouples the two:
- Adds a new, independent env flag `OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE`
  (default `false`), exposed via `/api/settings` as `show_shared_upload_toggle`.
- `IngestSettings` gains a `showAdvancedSettings` prop that gates only the
  embedding model / chunk size / OCR / picture-description controls, while
  `showShared` continues to control the shared switch independently.
- `SharedBucketView` now shows the ingest settings panel if *either*
  `show_provider_ingest_settings` or `show_shared_upload_toggle` is on, only
  exposing the shared switch when the connector supports it and one of the
  two flags allows it.

## Behavior
- Both flags default to `false` — no behavior change for existing deployments.
- Set `OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE=true` to bring back "share all" for
  COS uploads without re-exposing chunk/OCR/picture-description knobs.
- Set `OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS=true` (as before) to show
  everything, including "share all".