### PR TITLE
chore: default OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE to true

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -508,10 +508,10 @@ OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS = os.getenv(
 
 # Show the "Make documents available to all users" (shared) toggle for COS bucket
 # ingestion, independent of OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS. Deployments that
-# hide the general per-upload ingest tuning knobs (e.g. SaaS) can still opt back into
-# just this toggle by setting this flag on its own.
+# hide the general per-upload ingest tuning knobs (e.g. SaaS) still get just this
+# toggle. On by default; set to "false" to hide it.
 OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE = os.getenv(
-    "OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE", "false"
+    "OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE", "true"
 ).lower() in ("true", "1", "yes")
 
 # Ingest sample data configuration

--- a/tests/unit/config/test_show_shared_upload_toggle.py
+++ b/tests/unit/config/test_show_shared_upload_toggle.py
@@ -37,9 +37,14 @@ def _read_flag(env: dict[str, str]) -> str:
     return result.stdout.splitlines()[-1].strip()
 
 
-def test_defaults_false_when_unset():
+def test_defaults_true_when_unset():
     env = {"PYTHONPATH": str(SRC)}
     env.pop("OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE", None)
+    assert _read_flag(env) == "True"
+
+
+def test_false_when_disabled():
+    env = {"OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE": "false", "PYTHONPATH": str(SRC)}
     assert _read_flag(env) == "False"
 
 


### PR DESCRIPTION
Flips the default of `OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE` from `false` to `true`, so the COS "Make documents available to all users" (share-all) toggle is shown out of the box.

## Why

The flag was introduced in #2025 to expose the share-all toggle independently of `OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS` (which gates the rest of the per-upload ingest tuning knobs). It defaulted to `false`, so in SaaS / IBM-auth deployments the toggle was hidden unless the env var was explicitly set — the common case wanted it visible. Making it on by default removes that per-deployment setup step.

## Behavior

- **Default (unset):** share-all toggle is now **visible** in COS bucket ingestion, including SaaS / IBM-auth mode where the advanced ingest settings (embedding model, chunk size, OCR, picture descriptions) stay hidden.
- **To hide it:** set `OPENRAG_SHOW_SHARED_UPLOAD_TOGGLE=false`.
- No change to `OPENRAG_SHOW_PROVIDER_INGEST_SETTINGS` — the two flags remain independent.

## Changes

- `src/config/settings.py` — default `"false"` → `"true"`, updated comment.
- `tests/unit/config/test_show_shared_upload_toggle.py` — updated default-value test and added a case for explicitly disabling via `=false`.