### PR TITLE
fix: Remove right gradient in nudges

### DIFF
--- a/frontend/app/chat/_components/nudges.tsx
+++ b/frontend/app/chat/_components/nudges.tsx
@@ -48,8 +48,6 @@ export default function Nudges({
                     </button>
                   ))}
                 </div>
-                {/* Fade out gradient on the right */}
-                <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-background to-transparent pointer-events-none"></div>
               </div>
             </div>
           </motion.div>


### PR DESCRIPTION
Removes gradient on the right of nudges in SaaS (gradient does nothing in OSS)

The issue:
<img width="1052" height="528" alt="Screenshot 2026-07-07 at 10 29 36 AM" src="https://github.com/user-attachments/assets/e737ab2d-a983-41e0-b78f-7f6eac236c08" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the right-side fade overlay from the nudges area during horizontal scrolling, so all nudges remain visible without the extra visual cover.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->