### PR TITLE
fix: make small pageless documents work on langflowless ingestion

### DIFF
--- a/frontend/components/AgGrid/registerAgGridModules.ts
+++ b/frontend/components/AgGrid/registerAgGridModules.ts
@@ -9,6 +9,7 @@ import {
   ModuleRegistry,
   PaginationModule,
   QuickFilterModule,
+  RowApiModule,
   RowSelectionModule,
   TextFilterModule,
   ValidationModule,
@@ -28,6 +29,7 @@ ModuleRegistry.registerModules([
   DateFilterModule,
   EventApiModule,
   GridStateModule,
+  RowApiModule,
   RowSelectionModule,
   // The ValidationModule adds helpful console warnings/errors that can help identify bad configuration during development.
   ...(process.env.NODE_ENV !== "production" ? [ValidationModule] : []),

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -258,11 +258,16 @@ class TaskProcessor:
         """
         from services.document_service import chunk_texts_for_embeddings
 
-        # Use provided embedding model or configured model.
-        # get_embedding_model() returns empty string when Langflow ingest is enabled,
-        # but OpenRAG processors still need a concrete embedding model.
         configured_embedding_model = get_openrag_config().knowledge.embedding_model
         embedding_model = embedding_model or configured_embedding_model or get_embedding_model()
+
+        # Fall back to workspace config settings if not explicitly passed
+        config = get_openrag_config()
+        if chunk_size is None:
+            chunk_size = config.knowledge.chunk_size
+        if chunk_overlap is None:
+            chunk_overlap = config.knowledge.chunk_overlap
+
 
         # Get user's OpenSearch client with JWT for OIDC auth
         opensearch_client = self.document_service.session_manager.get_user_opensearch_client(

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -268,7 +268,6 @@ class TaskProcessor:
         if chunk_overlap is None:
             chunk_overlap = config.knowledge.chunk_overlap
 
-
         # Get user's OpenSearch client with JWT for OIDC auth
         opensearch_client = self.document_service.session_manager.get_user_opensearch_client(
             owner_user_id, jwt_token

--- a/src/utils/document_processing.py
+++ b/src/utils/document_processing.py
@@ -110,7 +110,6 @@ def extract_relevant(doc_dict: dict) -> dict:
         if page_no is None:
             page_no = 1
 
-
         # group cells by their row index
         rows = defaultdict(list)
         table_data = table.get("data")

--- a/src/utils/document_processing.py
+++ b/src/utils/document_processing.py
@@ -91,7 +91,9 @@ def extract_relevant(doc_dict: dict) -> dict:
     page_texts = defaultdict(list)
     for txt in doc_dict.get("texts", []):
         prov = txt.get("prov", [])
-        page_no = prov[0].get("page_no") if prov else None
+        page_no = None
+        if prov and isinstance(prov[0], dict):
+            page_no = prov[0].get("page_no")
         if page_no is None:
             page_no = 1
         page_texts[page_no].append(txt.get("text", "").strip())
@@ -102,9 +104,12 @@ def extract_relevant(doc_dict: dict) -> dict:
     # 2) process tables
     for t_idx, table in enumerate(doc_dict.get("tables", [])):
         prov = table.get("prov", [])
-        page_no = prov[0].get("page_no") if prov else None
+        page_no = None
+        if prov and isinstance(prov[0], dict):
+            page_no = prov[0].get("page_no")
         if page_no is None:
             page_no = 1
+
 
         # group cells by their row index
         rows = defaultdict(list)


### PR DESCRIPTION
This pull request introduces several improvements and fixes across both the frontend and backend. The main changes include registering the `RowApiModule` for AG Grid in the frontend, enhancing the robustness of document processing utilities, and ensuring configuration values for chunking are properly set in the document processor.

**Frontend Enhancements:**

* AG Grid configuration:
  - Registered the `RowApiModule` in both the module imports and the `ModuleRegistry.registerModules` call to enable additional row-level API features in AG Grid. [[1]](diffhunk://#diff-f2c824f8530a03e0f6edbf4727b39a008e54b0d915fa1258933c581a8e62a145R12) [[2]](diffhunk://#diff-f2c824f8530a03e0f6edbf4727b39a008e54b0d915fa1258933c581a8e62a145R32)

**Backend Improvements:**

* Document processing utilities:
  - Improved extraction of `page_no` in `extract_relevant` by adding a type check for provenance data, preventing errors if the provenance is not a dictionary. [[1]](diffhunk://#diff-3c1da33019c98bb4cf8a65dd19959914a8576531f815e3aa29e179b5f742e229L94-R96) [[2]](diffhunk://#diff-3c1da33019c98bb4cf8a65dd19959914a8576531f815e3aa29e179b5f742e229L105-R113)

* Document processor configuration:
  - Updated `process_document_standard` to fall back to workspace configuration values for `chunk_size` and `chunk_overlap` if they are not explicitly provided, ensuring consistent chunking behavior.