### PR TITLE
fix: cos share all

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -163,6 +163,26 @@ MICROSOFT_GRAPH_OAUTH_CLIENT_SECRET=
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=
 
+# --- IBM Cloud Object Storage connector (Enterprise/SaaS) ------------------
+# Enterprise/SaaS-only bucket connector, gated by IBM_AUTH_ENABLED (like the
+# AWS S3 / Azure Blob connectors). Credentials are normally entered per-connection
+# in the UI; these env vars are OPTIONAL fallbacks / defaults. Two auth modes are
+# supported: IAM (api_key + service_instance_id, default) or HMAC (access key +
+# secret, S3-compatible -- works against MinIO for local testing).
+IBM_COS_ENDPOINT=
+IBM_COS_API_KEY=
+IBM_COS_SERVICE_INSTANCE_ID=
+IBM_COS_HMAC_ACCESS_KEY_ID=
+IBM_COS_HMAC_SECRET_ACCESS_KEY=
+#
+# Local dev / MinIO testing: set OPENRAG_DEV_IBM_COS=true to enable the
+# connector without IBM_AUTH_ENABLED. NEVER use in production.
+# OPENRAG_DEV_IBM_COS=false
+# Frontend counterpart: also set NEXT_PUBLIC_DEV_IBM_COS=true so the Connectors
+# tab and admin Connectors Permission page show IBM COS locally (requires a
+# frontend restart to take effect -- Next.js reads NEXT_PUBLIC_* at startup).
+# NEXT_PUBLIC_DEV_IBM_COS=false
+
 # --- Azure Blob Storage connector (Enterprise/SaaS) ------------------------
 # Enterprise/SaaS-only bucket connector, gated by IBM_AUTH_ENABLED (like the
 # AWS S3 / IBM COS connectors). Credentials are normally entered per-connection

--- a/enhancements/connectors/ibm_cos/connector.py
+++ b/enhancements/connectors/ibm_cos/connector.py
@@ -1,4 +1,8 @@
-"""IBM Cloud Object Storage connector for OpenRAG."""
+"""IBM Cloud Object Storage connector for OpenRAG.
+
+Enterprise/SaaS-only ``bucket``-kind connector, gated by ``IBM_AUTH_ENABLED``
+(or ``OPENRAG_DEV_IBM_COS=true`` for local dev/MinIO testing).
+"""
 
 import mimetypes
 import os
@@ -6,7 +10,7 @@ from datetime import UTC, datetime
 from posixpath import basename
 from typing import Any
 
-from config.settings import IBM_AUTH_ENABLED
+from config.settings import IBM_AUTH_ENABLED, is_dev_ibm_cos_enabled
 from connectors.base import BaseConnector, ConnectorDocument, DocumentACL
 from utils.logging_config import get_logger
 
@@ -64,7 +68,10 @@ class IBMCOSConnector(BaseConnector):
 
     @classmethod
     def is_available(cls, manager, user_id=None) -> bool:
-        return IBM_AUTH_ENABLED
+        # Enterprise/SaaS gate is IBM_AUTH_ENABLED, like the other bucket
+        # connectors (aws_s3, azure_blob). OPENRAG_DEV_IBM_COS=true bypasses it
+        # for local dev (e.g. against MinIO in HMAC mode; never in production).
+        return IBM_AUTH_ENABLED or is_dev_ibm_cos_enabled()
 
     @classmethod
     def register_routes(cls, app) -> None:

--- a/frontend/lib/brand.ts
+++ b/frontend/lib/brand.ts
@@ -4,6 +4,14 @@ export type Brand = "oss" | "ibm";
 
 export const IBM_THEME_DEV = process.env.NEXT_PUBLIC_IBM_THEME_DEV === "true";
 
+/**
+ * Local dev: show the IBM COS connector in the Connectors tab / permission
+ * admin without IBM_AUTH_ENABLED. Mirrors the backend `OPENRAG_DEV_IBM_COS`
+ * bypass (see `enhancements/connectors/ibm_cos/connector.py`). Never enable
+ * in production.
+ */
+export const DEV_IBM_COS = process.env.NEXT_PUBLIC_DEV_IBM_COS === "true";
+
 /** Default when no localStorage — must match `BrandProvider` initial state. */
 export const DEFAULT_BRAND: Brand = IBM_THEME_DEV ? "ibm" : "oss";
 
@@ -82,7 +90,8 @@ export function isConnectorTypeVisible(
     isIbmAuthMode,
   }: { isCloudBrand: boolean; isIbmAuthMode: boolean },
 ): boolean {
-  if (type === "ibm_cos" || type === "aws_s3") return isIbmAuthMode;
+  if (type === "ibm_cos") return isIbmAuthMode || DEV_IBM_COS;
+  if (type === "aws_s3") return isIbmAuthMode;
   if (cloudBrand && type === "onedrive") return false;
   return true;
 }

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -1124,6 +1124,7 @@ async def connector_sync(
                             new_ids,
                             jwt_token=jwt_token,
                             ingest_settings=body.settings,
+                            shared=body.shared,
                         )
                     )
                 if changed_ids:
@@ -1135,6 +1136,7 @@ async def connector_sync(
                             jwt_token=jwt_token,
                             ingest_settings=body.settings,
                             replace_duplicates=True,
+                            shared=body.shared,
                         )
                     )
             else:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -258,6 +258,17 @@ def is_dev_azure_blob_enabled() -> bool:
     return raw in ("true", "1", "yes", "on")
 
 
+def is_dev_ibm_cos_enabled() -> bool:
+    """Local dev: enable the IBM COS connector without IBM_AUTH_ENABLED.
+
+    Allows testing the IBM COS connector (e.g. against MinIO in HMAC mode) in a
+    local environment where IBM auth is not configured. Never enable in
+    production. Requires ``OPENRAG_DEV_IBM_COS=true``.
+    """
+    raw = os.getenv("OPENRAG_DEV_IBM_COS", "false").strip().lower()
+    return raw in ("true", "1", "yes", "on")
+
+
 def is_azure_blob_enabled() -> bool:
     """Feature kill switch for the Azure Blob connector (default: enabled).
 

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -21,7 +21,7 @@ from utils.file_utils import (
 )
 from utils.hash_utils import hash_id
 from utils.logging_config import get_logger
-from utils.opensearch_queries import build_filename_search_body
+from utils.opensearch_queries import build_filename_search_body, build_replace_filename_query
 
 from .tasks import FileTask, TaskStatus, UploadTask
 
@@ -816,6 +816,58 @@ class ConnectorFileProcessor(TaskProcessor):
         self.connector_type = connector_type
         self.shared = shared
 
+    async def _reconcile_shared_owner(self, filename: str) -> None:
+        """Update owner fields on already-indexed chunks for `filename` to match
+        the connector's current `shared` setting.
+
+        Called on the duplicate/unchanged skip paths below, where a file's
+        content and name haven't changed since a prior sync but the connector's
+        "Make documents available to all users" setting may have been toggled
+        since then. Without this, those chunks would keep whatever owner they
+        got on their original ingest forever, since a byte-identical re-sync
+        never reaches resolve_shared_owner_fields(). Scoped to chunks owned by
+        this user or already ownerless (matching the same boundary
+        delete_document_by_filename uses), so it can't touch another user's
+        private document that happens to share this filename.
+        """
+        write_client = clients.opensearch
+        if write_client is None:
+            return
+        owner, owner_name, owner_email = resolve_shared_owner_fields(
+            self.user_id, self.owner_name, self.owner_email, self.shared
+        )
+        for candidate in get_filename_aliases(filename):
+            try:
+                await write_client.update_by_query(
+                    index=get_index_name(),
+                    body={
+                        "query": build_replace_filename_query(candidate, self.user_id),
+                        "script": {
+                            "source": """
+                                if (params.shared) {
+                                    ctx._source.remove('owner');
+                                } else {
+                                    ctx._source.owner = params.owner;
+                                }
+                                ctx._source.owner_name = params.owner_name;
+                                ctx._source.owner_email = params.owner_email;
+                            """,
+                            "params": {
+                                "shared": self.shared,
+                                "owner": owner,
+                                "owner_name": owner_name,
+                                "owner_email": owner_email,
+                            },
+                        },
+                    },
+                )
+            except Exception as e:
+                logger.warning(
+                    "Failed to reconcile owner fields for skipped duplicate",
+                    filename=candidate,
+                    error=str(e),
+                )
+
     async def process_item(self, upload_task: UploadTask, item: str, file_task: FileTask) -> None:
         """Process a connector file using unified methods"""
         file_task.status = TaskStatus.RUNNING
@@ -964,6 +1016,7 @@ class ConnectorFileProcessor(TaskProcessor):
 
             if await self.check_filename_exists(file_task.filename, opensearch_client):
                 if not self.replace_duplicates:
+                    await self._reconcile_shared_owner(file_task.filename)
                     file_task.status = TaskStatus.SKIPPED
                     file_task.error = None
                     file_task.result = {
@@ -994,6 +1047,7 @@ class ConnectorFileProcessor(TaskProcessor):
                 file_hash = hash_id(tmp_path)
 
                 if not renamed and await self.check_document_exists(file_hash, opensearch_client):
+                    await self._reconcile_shared_owner(file_task.filename)
                     file_task.status = TaskStatus.COMPLETED
                     file_task.result = {"status": "unchanged", "id": file_hash}
                     file_task.updated_at = time.time()

--- a/tests/unit/connectors/test_ibm_cos_connector.py
+++ b/tests/unit/connectors/test_ibm_cos_connector.py
@@ -29,3 +29,13 @@ def test_is_available_dev_flag_bypasses_ibm_auth(monkeypatch):
     monkeypatch.setattr(ibm_cos_connector, "IBM_AUTH_ENABLED", False)
     monkeypatch.setattr(ibm_cos_connector, "is_dev_ibm_cos_enabled", lambda: True)
     assert IBMCOSConnector.is_available(MagicMock()) is True
+
+
+def test_is_dev_ibm_cos_enabled_defaults_false_when_unset(monkeypatch):
+    """Regression: must default to disabled, or IBM COS becomes available in
+    every deployment (including production) whenever OPENRAG_DEV_IBM_COS is
+    simply unset, defeating the point of the dev-only bypass."""
+    from config.settings import is_dev_ibm_cos_enabled
+
+    monkeypatch.delenv("OPENRAG_DEV_IBM_COS", raising=False)
+    assert is_dev_ibm_cos_enabled() is False

--- a/tests/unit/connectors/test_ibm_cos_connector.py
+++ b/tests/unit/connectors/test_ibm_cos_connector.py
@@ -1,0 +1,31 @@
+"""Unit tests for the IBM COS connector's `is_available` gating.
+
+Covers IBM_AUTH_ENABLED / OPENRAG_DEV_IBM_COS, mirroring the equivalent
+Azure Blob coverage (tests/unit/connectors/test_azure_blob_connector.py).
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from enhancements.connectors.ibm_cos import connector as ibm_cos_connector  # noqa: E402
+from enhancements.connectors.ibm_cos.connector import IBMCOSConnector  # noqa: E402
+
+
+def test_is_available_gated_on_ibm_auth_enabled(monkeypatch):
+    monkeypatch.setattr(ibm_cos_connector, "IBM_AUTH_ENABLED", True)
+    monkeypatch.setattr(ibm_cos_connector, "is_dev_ibm_cos_enabled", lambda: False)
+    assert IBMCOSConnector.is_available(MagicMock()) is True
+    monkeypatch.setattr(ibm_cos_connector, "IBM_AUTH_ENABLED", False)
+    assert IBMCOSConnector.is_available(MagicMock()) is False
+
+
+def test_is_available_dev_flag_bypasses_ibm_auth(monkeypatch):
+    monkeypatch.setattr(ibm_cos_connector, "IBM_AUTH_ENABLED", False)
+    monkeypatch.setattr(ibm_cos_connector, "is_dev_ibm_cos_enabled", lambda: True)
+    assert IBMCOSConnector.is_available(MagicMock()) is True

--- a/tests/unit/test_connector_sync_bucket_filter_shared.py
+++ b/tests/unit/test_connector_sync_bucket_filter_shared.py
@@ -1,0 +1,90 @@
+"""Regression test: connector_sync's bucket_filter branch must forward
+`shared` to both sync_specific_files batches (new + changed files).
+
+This is the code path the COS connector UI's "Ingest N Buckets" button
+always hits (it sends bucket_filter, never selected_files/sync_all), so a
+dropped `shared` here means the "Make documents available to all users"
+toggle silently has no effect on real syncs.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from api.connectors import ConnectorSyncBody, connector_sync
+
+
+def _make_connection():
+    connection = MagicMock()
+    connection.connection_id = "conn-1"
+    connection.is_active = True
+    return connection
+
+
+def _make_connector():
+    connector = MagicMock()
+    connector.authenticate = AsyncMock(return_value=True)
+    connector.bucket_names = []
+    connector.list_files = AsyncMock(
+        return_value={
+            "files": [
+                {"id": "new-file-1", "modified_time": None},
+                {"id": "changed-file-1", "modified_time": None},
+            ],
+            "next_page_token": None,
+        }
+    )
+    return connector
+
+
+@pytest.mark.asyncio
+async def test_bucket_filter_sync_forwards_shared_to_new_and_changed_batches():
+    body = ConnectorSyncBody(bucket_filter=["bucket-a"], shared=True)
+
+    connector_service = MagicMock()
+    connection = _make_connection()
+    connector_service.connection_manager.list_connections = AsyncMock(
+        return_value=[connection]
+    )
+    connector = _make_connector()
+    connector_service.get_connector = AsyncMock(return_value=connector)
+    connector_service.sync_specific_files = AsyncMock(side_effect=["task-new", "task-changed"])
+
+    session_manager = MagicMock()
+    user = MagicMock()
+    user.jwt_token = "token"
+    user.user_id = "user-1"
+
+    with (
+        patch(
+            "api.connectors.get_synced_file_ids_for_connector",
+            new=AsyncMock(return_value=(["changed-file-1"], [], "connector_file_id")),
+        ),
+        patch(
+            "api.connectors.get_synced_id_to_modified_time_map",
+            new=AsyncMock(return_value={"changed-file-1": 0.0}),
+        ),
+        patch(
+            "api.connectors.classify_remote_file_change",
+            side_effect=lambda fid, *_a, **_k: "new" if fid == "new-file-1" else "changed",
+        ),
+    ):
+        response = await connector_sync(
+            connector_type="ibm_cos",
+            body=body,
+            request=MagicMock(),
+            connector_service=connector_service,
+            session_manager=session_manager,
+            user=user,
+            session=AsyncMock(),
+            rbac=MagicMock(),
+        )
+
+    assert response.status_code == 201
+    assert connector_service.sync_specific_files.await_count == 2
+
+    new_call, changed_call = connector_service.sync_specific_files.await_args_list
+    assert new_call.args[2] == ["new-file-1"]
+    assert new_call.kwargs["shared"] is True
+    assert changed_call.args[2] == ["changed-file-1"]
+    assert changed_call.kwargs["shared"] is True

--- a/tests/unit/test_connector_sync_bucket_filter_shared.py
+++ b/tests/unit/test_connector_sync_bucket_filter_shared.py
@@ -43,9 +43,7 @@ async def test_bucket_filter_sync_forwards_shared_to_new_and_changed_batches():
 
     connector_service = MagicMock()
     connection = _make_connection()
-    connector_service.connection_manager.list_connections = AsyncMock(
-        return_value=[connection]
-    )
+    connector_service.connection_manager.list_connections = AsyncMock(return_value=[connection])
     connector = _make_connector()
     connector_service.get_connector = AsyncMock(return_value=connector)
     connector_service.sync_specific_files = AsyncMock(side_effect=["task-new", "task-changed"])

--- a/tests/unit/test_reconcile_shared_owner.py
+++ b/tests/unit/test_reconcile_shared_owner.py
@@ -1,0 +1,90 @@
+"""Unit tests for ConnectorFileProcessor._reconcile_shared_owner.
+
+Covers the bug where re-syncing a COS bucket with "Make documents available
+to all users" newly toggled left already-indexed (unchanged content /
+duplicate filename) chunks with stale, non-shared ownership, since the
+resolve_shared_owner_fields() recompute is normally only reached on a fresh
+index write.
+"""
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+import config.settings as settings_module
+from models.processors import ConnectorFileProcessor
+
+
+def _make_processor(*, shared: bool, user_id: str = "user-1"):
+    return ConnectorFileProcessor(
+        connector_service=None,
+        connection_id="conn-1",
+        files_to_process=[],
+        user_id=user_id,
+        owner_name="Alice",
+        owner_email="alice@example.com",
+        shared=shared,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _restore_write_client():
+    original = settings_module.clients.opensearch
+    yield
+    settings_module.clients.opensearch = original
+
+
+@pytest.mark.asyncio
+async def test_reconcile_shared_true_omits_owner_via_script():
+    write_client = AsyncMock()
+    settings_module.clients.opensearch = write_client
+    processor = _make_processor(shared=True)
+
+    await processor._reconcile_shared_owner("report.pdf")
+
+    assert write_client.update_by_query.await_count >= 1
+    call = write_client.update_by_query.await_args_list[0]
+    body = call.kwargs["body"]
+    assert body["query"]["bool"]["filter"][0] == {"term": {"filename": "report.pdf"}}
+    params = body["script"]["params"]
+    assert params["shared"] is True
+    assert params["owner"] is None
+    assert params["owner_name"] == "Anonymous User"
+    assert params["owner_email"] == "anonymous@localhost"
+    assert "ctx._source.remove('owner')" in body["script"]["source"]
+
+
+@pytest.mark.asyncio
+async def test_reconcile_shared_false_sets_owner_via_script():
+    write_client = AsyncMock()
+    settings_module.clients.opensearch = write_client
+    processor = _make_processor(shared=False)
+
+    await processor._reconcile_shared_owner("report.pdf")
+
+    call = write_client.update_by_query.await_args_list[0]
+    params = call.kwargs["body"]["script"]["params"]
+    assert params["shared"] is False
+    assert params["owner"] == "user-1"
+    assert params["owner_name"] == "Alice"
+    assert params["owner_email"] == "alice@example.com"
+
+
+@pytest.mark.asyncio
+async def test_reconcile_shared_owner_noop_without_write_client():
+    settings_module.clients.opensearch = None
+    processor = _make_processor(shared=True)
+
+    # Must not raise even though there's nothing to write to.
+    await processor._reconcile_shared_owner("report.pdf")
+
+
+@pytest.mark.asyncio
+async def test_reconcile_shared_owner_swallows_update_errors():
+    write_client = AsyncMock()
+    write_client.update_by_query.side_effect = RuntimeError("boom")
+    settings_module.clients.opensearch = write_client
+    processor = _make_processor(shared=True)
+
+    # A failed reconciliation must not fail the (already-skipped) sync item.
+    await processor._reconcile_shared_owner("report.pdf")

--- a/tests/unit/test_shared_flag.py
+++ b/tests/unit/test_shared_flag.py
@@ -198,9 +198,12 @@ async def test_non_cos_connector_rejects_shared_true():
     response = await connector_sync(
         connector_type="google_drive",
         body=body,
+        request=MagicMock(),
         connector_service=connector_service,
         session_manager=session_manager,
         user=user,
+        session=AsyncMock(),
+        rbac=MagicMock(),
     )
     assert response.status_code == 400
     import json
@@ -229,9 +232,12 @@ async def test_ibm_cos_shared_true_does_not_hit_guard():
     response = await connector_sync(
         connector_type="ibm_cos",
         body=body,
+        request=MagicMock(),
         connector_service=connector_service,
         session_manager=session_manager,
         user=user,
+        session=AsyncMock(),
+        rbac=MagicMock(),
     )
     # 404 = "no active connections" error, not 400 = guard rejection
     assert response.status_code == 404


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes related to the IBM Cloud Object Storage (COS) connector, particularly focusing on local development enablement, correct handling of the "shared" ownership flag during connector sync, and robust unit testing for these behaviors. The changes ensure that the IBM COS connector can be safely enabled for local development, that ownership fields are properly updated for unchanged files when toggling the "shared" setting, and that these behaviors are thoroughly tested.

**IBM COS connector: Local development enablement and gating**

* Added new environment variables (`OPENRAG_DEV_IBM_COS`, `NEXT_PUBLIC_DEV_IBM_COS`) and corresponding logic to allow the IBM COS connector to be enabled for local development and testing (e.g., with MinIO), bypassing the `IBM_AUTH_ENABLED` gate, but never in production. This includes both backend (`is_dev_ibm_cos_enabled`) and frontend (`DEV_IBM_COS`) support, and updates to visibility logic in the UI. (.env.example [[1]](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cR166-R185) enhancements/connectors/ibm_cos/connector.py [[2]](diffhunk://#diff-1e762debb0f309abf3c5abb929c37bf311a2c524cbbeb17a94fcdc9fe99c9062L1-R13) [[3]](diffhunk://#diff-1e762debb0f309abf3c5abb929c37bf311a2c524cbbeb17a94fcdc9fe99c9062L67-R74) src/config/settings.py [[4]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690R261-R271) frontend/lib/brand.ts [[5]](diffhunk://#diff-18a92532afb23b76ac0b020b10608a07fab2fccd0f662ecd7b8d67c380c5f66bR7-R14) [[6]](diffhunk://#diff-18a92532afb23b76ac0b020b10608a07fab2fccd0f662ecd7b8d67c380c5f66bL85-R94)

**Connector sync: Correct propagation and handling of the "shared" flag**

* Ensured that the `shared` flag is correctly forwarded to all relevant sync batches (new and changed files) when syncing connectors via the `bucket_filter` path, fixing a bug where the "Make documents available to all users" toggle had no effect for IBM COS syncs. (src/api/connectors.py [[1]](diffhunk://#diff-e072fa320915014cf46bdf01548a1bd72bd0e1953e556c08fa0849e5fb205680R1127) [[2]](diffhunk://#diff-e072fa320915014cf46bdf01548a1bd72bd0e1953e556c08fa0849e5fb205680R1139)

**Ownership reconciliation: Fix for unchanged/duplicate files**

* Implemented `_reconcile_shared_owner` in `ConnectorFileProcessor` to update ownership fields in already-indexed chunks when the "shared" setting is toggled, even if the file content and name are unchanged. This prevents stale ownership metadata for files skipped as duplicates or unchanged during sync. (src/models/processors.py [[1]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R819-R870) [[2]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R1019) [[3]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R1050)

**Unit tests: Coverage for new gating, shared flag, and reconciliation logic**

* Added unit tests to verify IBM COS connector gating (auth/dev flags), correct propagation of the `shared` flag in sync, and correct behavior of `_reconcile_shared_owner` (including error handling and script logic). (tests/unit/connectors/test_ibm_cos_connector.py [[1]](diffhunk://#diff-bcb8d69f0f29d28ab4bb5ccf499c4e4d65a12098b20da5fe9fcf74f65ce0d811R1-R41) tests/unit/test_connector_sync_bucket_filter_shared.py [[2]](diffhunk://#diff-cee922d6abf4806b53b92c391bb209a0f52fdff37721ff24acf7c6a0c85ab65aR1-R90) tests/unit/test_reconcile_shared_owner.py [[3]](diffhunk://#diff-efc0c9919b5cec74c301c6307b0df4fa6899745b6f9991695e9af713cf1d65acR1-R90) tests/unit/test_shared_flag.py [[4]](diffhunk://#diff-7b03ec9dcec42ef48e50678567ad094c4c09c8aad91bb3e3ea83a83c366d95c0R201-R206) [[5]](diffhunk://#diff-7b03ec9dcec42ef48e50678567ad094c4c09c8aad91bb3e3ea83a83c366d95c0R235-R240)

These changes collectively improve the reliability, testability, and developer experience of the IBM COS connector, especially around local development and document sharing features.