### PR TITLE
fix: OAuth connector callback redirect fix

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -71,10 +71,10 @@ jobs:
       - name: React Doctor score check
         working-directory: frontend
         run: |
-          SCORE=$(npx -y react-doctor@0.5.8 --score --yes)
+          SCORE=$(npx -y react-doctor@0.7.2 --score --yes)
           echo "React Doctor score: $SCORE"
           if [ "$SCORE" -lt 40 ]; then
             echo "::error::React Doctor score $SCORE is below the minimum threshold of 40"
-            npx -y react-doctor@0.5.8 --verbose --yes
+            npx -y react-doctor@0.7.2 --verbose --yes
             exit 1
           fi

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: millionco/react-doctor@v2
         with:
           directory: frontend
-          version: "0.5.8"
+          version: "0.7.2"
         # Advisory by default: React Doctor reports findings on every PR — a
         # sticky summary comment, inline review comments, and a commit status
         # with the health score — but never fails the check, so it won't red-X

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -81,15 +81,15 @@ function AuthCallbackContent() {
   });
 
   useEffect(() => {
-    const callbackKey = `callback_processed_${code}`;
-
-    if (sessionStorage.getItem(callbackKey)) return;
-    sessionStorage.setItem(callbackKey, "true");
-
     if (validationError) {
       cleanupOAuthStorage();
       return;
     }
+
+    const callbackKey = `callback_processed_${code}`;
+
+    if (sessionStorage.getItem(callbackKey)) return;
+    sessionStorage.setItem(callbackKey, "true");
 
     let parsedConnectionId = finalConnectorId!;
 

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -24,36 +24,31 @@ function AuthCallbackContent() {
   );
   const [error, setError] = useState<string | null>(null);
   const [purpose, setPurpose] = useState<string>("app_auth");
+  const [redirectTarget, setRedirectTarget] = useState<string | null>(null);
 
+  // Handle the OAuth callback exchange
   useEffect(() => {
     const code = searchParams.get("code");
     const callbackKey = `callback_processed_${code}`;
 
-    // Prevent double execution across component remounts
     if (sessionStorage.getItem(callbackKey)) {
       return;
     }
     sessionStorage.setItem(callbackKey, "true");
 
-    let cancelled = false;
-    let redirectTimeoutId: NodeJS.Timeout;
-
     const handleCallback = async () => {
       try {
-        // Get parameters from URL
         const state = searchParams.get("state");
         const errorParam = searchParams.get("error");
 
         console.log("OAuth callback state (raw):", state);
 
-        // Get stored auth info
         const connectorId = localStorage.getItem("connecting_connector_id");
         const storedConnectorType = localStorage.getItem(
           "connecting_connector_type",
         );
         const authPurpose = localStorage.getItem("auth_purpose");
 
-        // Determine purpose - default to app_auth for login, data_source for connectors
         const detectedPurpose =
           authPurpose ||
           (storedConnectorType && storedConnectorType !== "app_auth"
@@ -61,7 +56,6 @@ function AuthCallbackContent() {
             : "app_auth");
         setPurpose(detectedPurpose);
 
-        // Debug logging
         console.log("OAuth Callback Debug:", {
           urlParams: { code: !!code, state: !!state, error: errorParam },
           localStorage: { connectorId, storedConnectorType, authPurpose },
@@ -69,7 +63,6 @@ function AuthCallbackContent() {
           fullUrl: window.location.href,
         });
 
-        // Use state parameter as connection_id if localStorage is missing
         const finalConnectorId = connectorId || state;
 
         if (errorParam) {
@@ -85,12 +78,9 @@ function AuthCallbackContent() {
           throw new Error("Missing required parameters for OAuth callback");
         }
 
-        // Send callback data to backend
         const stateParam = searchParams.get("state");
         let parsedConnectionId = finalConnectorId;
-        let stateReturnUrl: string | null = null;
 
-        // In IBM auth mode, state is base64-encoded: id=<connection_id>&return=<broker_callback_url>
         if (isIbmAuthMode && stateParam) {
           try {
             const decodedState = decodeBase64(stateParam);
@@ -99,28 +89,23 @@ function AuthCallbackContent() {
 
             if (params.has("id")) {
               parsedConnectionId = params.get("id") || finalConnectorId;
-              stateReturnUrl = params.get("return");
               console.log("Parsed Base64 state parameter:", {
                 parsedConnectionId,
-                stateReturnUrl,
+                stateReturnUrl: params.get("return"),
               });
             } else if (stateParam.includes("id=")) {
-              // Fallback: If not base64 but contains id=, try to parse as raw for backward compatibility
               const rawParams = new URLSearchParams(stateParam);
               parsedConnectionId = rawParams.get("id") || finalConnectorId;
-              stateReturnUrl = rawParams.get("return");
             }
           } catch (e) {
             console.error(
               "Failed to Base64 decode or parse state parameter",
               e,
             );
-            // Fallback: If decoding fails, try to parse as raw if it contains id=
             if (stateParam.includes("id=")) {
               try {
                 const params = new URLSearchParams(stateParam);
                 parsedConnectionId = params.get("id") || finalConnectorId;
-                stateReturnUrl = params.get("return");
               } catch (innerE) {
                 console.error("Failed to parse raw state parameter", innerE);
               }
@@ -143,10 +128,7 @@ function AuthCallbackContent() {
         const result = await response.json();
 
         if (response.ok) {
-          setStatus("success");
-
           if (result.purpose === "app_auth" || detectedPurpose === "app_auth") {
-            // App authentication - refresh auth context and redirect to home/original page
             await refreshAuth();
 
             const redirectTo =
@@ -154,33 +136,20 @@ function AuthCallbackContent() {
               searchParams.get("redirect") ||
               "/chat";
 
-            // Clean up localStorage
             localStorage.removeItem("connecting_connector_id");
             localStorage.removeItem("connecting_connector_type");
             localStorage.removeItem("auth_purpose");
             localStorage.removeItem("auth_redirect_to");
 
-            // Redirect to the original page or home
-            if (!cancelled) {
-              redirectTimeoutId = setTimeout(() => {
-                if (!cancelled) router.push(redirectTo);
-              }, 2000);
-            }
+            setRedirectTarget(redirectTo);
           } else {
-            // Connector authentication - redirect to connectors page
-
-            // Clean up localStorage
             localStorage.removeItem("connecting_connector_id");
             localStorage.removeItem("connecting_connector_type");
             localStorage.removeItem("auth_purpose");
 
-            // Redirect to settings page with success indicator
-            if (!cancelled) {
-              redirectTimeoutId = setTimeout(() => {
-                if (!cancelled) router.push("/settings?oauth_success=true");
-              }, 2000);
-            }
+            setRedirectTarget("/settings?oauth_success=true");
           }
+          setStatus("success");
         } else {
           throw new Error(result.error || "Authentication failed");
         }
@@ -189,7 +158,6 @@ function AuthCallbackContent() {
         setError(err instanceof Error ? err.message : "Unknown error occurred");
         setStatus("error");
 
-        // Clean up localStorage on error too
         localStorage.removeItem("connecting_connector_id");
         localStorage.removeItem("connecting_connector_type");
         localStorage.removeItem("auth_purpose");
@@ -198,11 +166,18 @@ function AuthCallbackContent() {
     };
 
     handleCallback();
-    return () => {
-      cancelled = true;
-      clearTimeout(redirectTimeoutId);
-    };
-  }, [searchParams, router, refreshAuth]);
+  }, [searchParams, refreshAuth, isIbmAuthMode]);
+
+  // Redirect after successful callback — separate effect so it works
+  // regardless of which mount's async callback set the status.
+  useEffect(() => {
+    if (status === "success" && redirectTarget) {
+      const timeoutId = setTimeout(() => {
+        router.push(redirectTarget);
+      }, 2000);
+      return () => clearTimeout(timeoutId);
+    }
+  }, [status, redirectTarget, router]);
 
   // Dynamic UI content based on purpose
   const isAppAuth = purpose === "app_auth";

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, CheckCircle, Loader2, XCircle } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { Suspense, useEffect, useState } from "react";
@@ -15,120 +16,113 @@ import {
 import { useAuth } from "@/contexts/auth-context";
 import { decodeBase64 } from "@/lib/utils";
 
+function cleanupOAuthStorage() {
+  localStorage.removeItem("connecting_connector_id");
+  localStorage.removeItem("connecting_connector_type");
+  localStorage.removeItem("auth_purpose");
+  localStorage.removeItem("auth_redirect_to");
+}
+
 function AuthCallbackContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const queryClient = useQueryClient();
   const { refreshAuth, isIbmAuthMode } = useAuth();
-  const [status, setStatus] = useState<"processing" | "success" | "error">(
-    "processing",
-  );
-  const [error, setError] = useState<string | null>(null);
-  const [purpose, setPurpose] = useState<string>("app_auth");
   const [redirectTarget, setRedirectTarget] = useState<string | null>(null);
 
-  // Handle the OAuth callback exchange
+  const [purpose] = useState(() => {
+    const authPurpose = localStorage.getItem("auth_purpose");
+    const storedConnectorType = localStorage.getItem(
+      "connecting_connector_type",
+    );
+    return (
+      authPurpose ||
+      (storedConnectorType && storedConnectorType !== "app_auth"
+        ? "data_source"
+        : "app_auth")
+    );
+  });
+
+  const errorParam = searchParams.get("error");
+  const code = searchParams.get("code");
+  const state = searchParams.get("state");
+  const finalConnectorId =
+    localStorage.getItem("connecting_connector_id") || state;
+
+  const validationError = errorParam
+    ? `OAuth error: ${errorParam}`
+    : !code || !state || !finalConnectorId
+      ? "Missing required parameters for OAuth callback"
+      : null;
+
+  const { mutate: exchangeCode, ...callbackMutation } = useMutation({
+    mutationFn: async (params: {
+      connectionId: string;
+      code: string;
+      state: string;
+    }) => {
+      const response = await fetch("/api/auth/callback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          connection_id: params.connectionId,
+          authorization_code: params.code,
+          state: params.state,
+        }),
+      });
+      const result = await response.json();
+      if (!response.ok) {
+        throw new Error(result.error || "Authentication failed");
+      }
+      return result as { purpose?: string };
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ["connectors"], exact: false });
+    },
+  });
+
   useEffect(() => {
-    const code = searchParams.get("code");
     const callbackKey = `callback_processed_${code}`;
 
-    if (sessionStorage.getItem(callbackKey)) {
-      return;
-    }
+    if (sessionStorage.getItem(callbackKey)) return;
     sessionStorage.setItem(callbackKey, "true");
 
-    const handleCallback = async () => {
+    if (validationError) {
+      cleanupOAuthStorage();
+      return;
+    }
+
+    let parsedConnectionId = finalConnectorId!;
+
+    if (isIbmAuthMode && state) {
       try {
-        const state = searchParams.get("state");
-        const errorParam = searchParams.get("error");
+        const decodedState = decodeBase64(state);
+        const params = new URLSearchParams(decodedState);
 
-        console.log("OAuth callback state (raw):", state);
-
-        const connectorId = localStorage.getItem("connecting_connector_id");
-        const storedConnectorType = localStorage.getItem(
-          "connecting_connector_type",
-        );
-        const authPurpose = localStorage.getItem("auth_purpose");
-
-        const detectedPurpose =
-          authPurpose ||
-          (storedConnectorType && storedConnectorType !== "app_auth"
-            ? "data_source"
-            : "app_auth");
-        setPurpose(detectedPurpose);
-
-        console.log("OAuth Callback Debug:", {
-          urlParams: { code: !!code, state: !!state, error: errorParam },
-          localStorage: { connectorId, storedConnectorType, authPurpose },
-          detectedPurpose,
-          fullUrl: window.location.href,
-        });
-
-        const finalConnectorId = connectorId || state;
-
-        if (errorParam) {
-          throw new Error(`OAuth error: ${errorParam}`);
+        if (params.has("id")) {
+          parsedConnectionId = params.get("id") || finalConnectorId!;
+        } else if (state.includes("id=")) {
+          const rawParams = new URLSearchParams(state);
+          parsedConnectionId = rawParams.get("id") || finalConnectorId!;
         }
-
-        if (!code || !state || !finalConnectorId) {
-          console.error("Missing OAuth callback parameters:", {
-            code: !!code,
-            state: !!state,
-            finalConnectorId: !!finalConnectorId,
-          });
-          throw new Error("Missing required parameters for OAuth callback");
-        }
-
-        const stateParam = searchParams.get("state");
-        let parsedConnectionId = finalConnectorId;
-
-        if (isIbmAuthMode && stateParam) {
+      } catch (e) {
+        console.error("Failed to Base64 decode or parse state parameter", e);
+        if (state.includes("id=")) {
           try {
-            const decodedState = decodeBase64(stateParam);
-            console.log("OAuth callback state (decoded):", decodedState);
-            const params = new URLSearchParams(decodedState);
-
-            if (params.has("id")) {
-              parsedConnectionId = params.get("id") || finalConnectorId;
-              console.log("Parsed Base64 state parameter:", {
-                parsedConnectionId,
-                stateReturnUrl: params.get("return"),
-              });
-            } else if (stateParam.includes("id=")) {
-              const rawParams = new URLSearchParams(stateParam);
-              parsedConnectionId = rawParams.get("id") || finalConnectorId;
-            }
-          } catch (e) {
-            console.error(
-              "Failed to Base64 decode or parse state parameter",
-              e,
-            );
-            if (stateParam.includes("id=")) {
-              try {
-                const params = new URLSearchParams(stateParam);
-                parsedConnectionId = params.get("id") || finalConnectorId;
-              } catch (innerE) {
-                console.error("Failed to parse raw state parameter", innerE);
-              }
-            }
+            const params = new URLSearchParams(state);
+            parsedConnectionId = params.get("id") || finalConnectorId!;
+          } catch (innerE) {
+            console.error("Failed to parse raw state parameter", innerE);
           }
         }
+      }
+    }
 
-        const response = await fetch("/api/auth/callback", {
-          method: "POST",
-          headers: {
-            "Content-Type": "application/json",
-          },
-          body: JSON.stringify({
-            connection_id: parsedConnectionId,
-            authorization_code: code,
-            state: state,
-          }),
-        });
-
-        const result = await response.json();
-
-        if (response.ok) {
-          if (result.purpose === "app_auth" || detectedPurpose === "app_auth") {
+    exchangeCode(
+      { connectionId: parsedConnectionId, code: code!, state: state! },
+      {
+        onSuccess: async (result) => {
+          if (result.purpose === "app_auth" || purpose === "app_auth") {
             await refreshAuth();
 
             const redirectTo =
@@ -136,40 +130,43 @@ function AuthCallbackContent() {
               searchParams.get("redirect") ||
               "/chat";
 
-            localStorage.removeItem("connecting_connector_id");
-            localStorage.removeItem("connecting_connector_type");
-            localStorage.removeItem("auth_purpose");
-            localStorage.removeItem("auth_redirect_to");
-
+            cleanupOAuthStorage();
             setRedirectTarget(redirectTo);
           } else {
-            localStorage.removeItem("connecting_connector_id");
-            localStorage.removeItem("connecting_connector_type");
-            localStorage.removeItem("auth_purpose");
-
+            cleanupOAuthStorage();
             setRedirectTarget("/settings?oauth_success=true");
           }
-          setStatus("success");
-        } else {
-          throw new Error(result.error || "Authentication failed");
-        }
-      } catch (err) {
-        console.error("OAuth callback error:", err);
-        setError(err instanceof Error ? err.message : "Unknown error occurred");
-        setStatus("error");
+        },
+        onError: () => {
+          cleanupOAuthStorage();
+        },
+      },
+    );
+  }, [
+    code,
+    state,
+    finalConnectorId,
+    validationError,
+    searchParams,
+    isIbmAuthMode,
+    exchangeCode,
+    refreshAuth,
+    purpose,
+  ]);
 
-        localStorage.removeItem("connecting_connector_id");
-        localStorage.removeItem("connecting_connector_type");
-        localStorage.removeItem("auth_purpose");
-        localStorage.removeItem("auth_redirect_to");
-      }
-    };
+  const status: "processing" | "success" | "error" =
+    validationError || callbackMutation.isError
+      ? "error"
+      : callbackMutation.isSuccess
+        ? "success"
+        : "processing";
 
-    handleCallback();
-  }, [searchParams, refreshAuth, isIbmAuthMode]);
+  const error =
+    validationError ||
+    (callbackMutation.error instanceof Error
+      ? callbackMutation.error.message
+      : null);
 
-  // Redirect after successful callback — separate effect so it works
-  // regardless of which mount's async callback set the status.
   useEffect(() => {
     if (status === "success" && redirectTarget) {
       const timeoutId = setTimeout(() => {
@@ -179,7 +176,6 @@ function AuthCallbackContent() {
     }
   }, [status, redirectTarget, router]);
 
-  // Dynamic UI content based on purpose
   const isAppAuth = purpose === "app_auth";
 
   const getTitle = () => {

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -144,7 +144,8 @@ function AuthCallbackContent() {
         },
         onError: () => {
           cleanupOAuthStorage();
-        },
+          sessionStorage.removeItem(callbackKey);
+        }
       },
     );
 

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -3,7 +3,7 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, CheckCircle, Loader2, XCircle } from "lucide-react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { Suspense, useEffect, useState } from "react";
+import { Suspense, useEffect, useRef, useState } from "react";
 import AnimatedProcessingIcon from "@/components/icons/animated-processing-icon";
 import { Button } from "@/components/ui/button";
 import {
@@ -28,8 +28,7 @@ function AuthCallbackContent() {
   const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { refreshAuth, isIbmAuthMode } = useAuth();
-  const [redirectTarget, setRedirectTarget] = useState<string | null>(null);
-
+  const redirectTimeoutRef = useRef<ReturnType<typeof setTimeout>>(undefined);
   const [purpose] = useState(() => {
     const authPurpose = localStorage.getItem("auth_purpose");
     const storedConnectorType = localStorage.getItem(
@@ -131,10 +130,16 @@ function AuthCallbackContent() {
               "/chat";
 
             cleanupOAuthStorage();
-            setRedirectTarget(redirectTo);
+            redirectTimeoutRef.current = setTimeout(
+              () => router.push(redirectTo),
+              2000,
+            );
           } else {
             cleanupOAuthStorage();
-            setRedirectTarget("/settings?oauth_success=true");
+            redirectTimeoutRef.current = setTimeout(
+              () => router.push("/settings?oauth_success=true"),
+              2000,
+            );
           }
         },
         onError: () => {
@@ -142,6 +147,8 @@ function AuthCallbackContent() {
         },
       },
     );
+
+    return () => clearTimeout(redirectTimeoutRef.current);
   }, [
     code,
     state,
@@ -152,6 +159,7 @@ function AuthCallbackContent() {
     exchangeCode,
     refreshAuth,
     purpose,
+    router,
   ]);
 
   const status: "processing" | "success" | "error" =
@@ -166,15 +174,6 @@ function AuthCallbackContent() {
     (callbackMutation.error instanceof Error
       ? callbackMutation.error.message
       : null);
-
-  useEffect(() => {
-    if (status === "success" && redirectTarget) {
-      const timeoutId = setTimeout(() => {
-        router.push(redirectTarget);
-      }, 2000);
-      return () => clearTimeout(timeoutId);
-    }
-  }, [status, redirectTarget, router]);
 
   const isAppAuth = purpose === "app_auth";
 

--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -145,7 +145,7 @@ function AuthCallbackContent() {
         onError: () => {
           cleanupOAuthStorage();
           sessionStorage.removeItem(callbackKey);
-        }
+        },
       },
     );
 

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -252,9 +252,9 @@ export function AuthProvider({ children }: AuthProviderProps) {
     }
   };
 
-  const refreshAuth = async () => {
+  const refreshAuth = useCallback(async () => {
     await checkAuth();
-  };
+  }, [checkAuth]);
 
   const [permissions, setPermissions] = useState<Set<string>>(new Set());
   const [roles, setRoles] = useState<string[]>([]);


### PR DESCRIPTION
**The Issue**
Users get stuck on the connector redirect page

This can be tested using Google OAuth or Sharepoint

**The Bug**
The callback page's `handleCallback` async function and redirect timeout were both inside a single `useEffect` that used a cancelled closure variable. Two things killed the redirect:

1. In dev (React Strict Mode): React double-mounts → cleanup sets cancelled = true → the async `handleCallback` from the first mount continues and sets `status = "success"`, but the `if (!cancelled)` guard prevents the redirect timeout from being scheduled.
2. In pre-prod/production: `refreshAuth` was not wrapped in `useCallback`, so it got a new function reference on every `AuthProvider` render. Since `refreshAuth` was in the effect's dependency array, any `AuthProvider` re-render (from `checkAuth()` or `fetchPermissions()` running on mount) triggered the effect cleanup/re-run cycle, producing the same `cancelled = true` race condition.

The fix (two changes):

- `callback/page.tsx`: Split the redirect into a separate `useEffect` that reacts to `status === "success" && redirectTarget`. This is state-driven and works regardless of how many times the callback effect's closure gets "cancelled."
- `auth-context.tsx`: Wrapped `refreshAuth` in `useCallback` to stabilize its reference, preventing unnecessary effect re-runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth callback handling to complete the backend exchange reliably and redirect users after sign-in in both connector and IBM flows.
  * Added stronger validation, clearer UI status/error rendering, and more robust cleanup to prevent stale or duplicate callback processing.
* **Refactor**
  * Updated auth refresh to use a stable function reference while preserving existing behavior.
* **Chores**
  * Upgraded React Doctor tooling in CI for more reliable frontend health checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->