### PR TITLE
fix: ingesting single files in azure blob now properly navigates to knowledge page

### DIFF
--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -349,7 +349,9 @@ export function SharedBucketView({
               trackIngestTasks(result.task_ids);
               onDone();
             } else {
-              toast.info("No files were queued for ingestion.");
+              toast.info(
+                result.message ?? "No files were queued for ingestion.",
+              );
             }
           }}
         />

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -88,6 +88,12 @@ export function SharedBucketView({
     queryClient.invalidateQueries({ queryKey: invalidateQueryKey });
   };
 
+  const trackIngestTasks = (taskIds?: string[]) => {
+    for (const id of taskIds ?? []) {
+      addTask(id, { connectorType: connector.type, source: "connector" });
+    }
+  };
+
   const toggleBucket = (bucketName: string) => {
     setSelectedBuckets((prev) => {
       const next = new Set(prev);
@@ -131,12 +137,7 @@ export function SharedBucketView({
           if (result.task_ids?.length) {
             // The container path may return two tasks (new files + changed files);
             // track them all.
-            for (const id of result.task_ids) {
-              addTask(id, {
-                connectorType: connector.type,
-                source: "connector",
-              });
-            }
+            trackIngestTasks(result.task_ids);
             onDone();
           } else {
             toast.info(
@@ -342,6 +343,11 @@ export function SharedBucketView({
           connectorType={connector.type}
           connectionId={connector.connectionId}
           buckets={[browseDialogBucket]}
+          onIngestSuccess={(result) => {
+            invalidate();
+            trackIngestTasks(result.task_ids);
+            onDone();
+          }}
         />
       )}
     </>

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -345,8 +345,12 @@ export function SharedBucketView({
           buckets={[browseDialogBucket]}
           onIngestSuccess={(result) => {
             invalidate();
-            trackIngestTasks(result.task_ids);
-            onDone();
+            if (result.task_ids?.length) {
+              trackIngestTasks(result.task_ids);
+              onDone();
+            } else {
+              toast.info("No files were queued for ingestion.");
+            }
           }}
         />
       )}

--- a/frontend/components/file-browser-dialog.tsx
+++ b/frontend/components/file-browser-dialog.tsx
@@ -28,7 +28,7 @@ interface FileBrowserDialogProps {
   connectorType: string;
   connectionId: string;
   buckets?: string[];
-  onIngestSuccess?: (result: { task_ids?: string[] }) => void;
+  onIngestSuccess?: (result: { task_ids?: string[]; message?: string }) => void;
 }
 
 export function FileBrowserDialog({

--- a/frontend/components/file-browser-dialog.tsx
+++ b/frontend/components/file-browser-dialog.tsx
@@ -28,6 +28,7 @@ interface FileBrowserDialogProps {
   connectorType: string;
   connectionId: string;
   buckets?: string[];
+  onIngestSuccess?: (result: { task_ids?: string[] }) => void;
 }
 
 export function FileBrowserDialog({
@@ -36,6 +37,7 @@ export function FileBrowserDialog({
   connectorType,
   connectionId,
   buckets,
+  onIngestSuccess,
 }: FileBrowserDialogProps) {
   const [search, setSearch] = useState("");
   const [selectedBucket, setSelectedBucket] = useState<string | undefined>(
@@ -127,7 +129,7 @@ export function FileBrowserDialog({
     const hasStale = selectedFiles.some((f) => f.is_stale);
 
     try {
-      await syncMutation.mutateAsync({
+      const result = await syncMutation.mutateAsync({
         connectorType,
         body: {
           selected_files: selectedFiles.map((f) => ({
@@ -146,12 +148,19 @@ export function FileBrowserDialog({
 
       setSelectedFileIds(new Set());
       onOpenChange(false);
+      onIngestSuccess?.(result);
     } catch (err) {
       toast.error("Ingestion failed", {
         description: err instanceof Error ? err.message : "Unknown error",
       });
     }
-  }, [selectedFiles, connectorType, syncMutation, onOpenChange]);
+  }, [
+    selectedFiles,
+    connectorType,
+    syncMutation,
+    onOpenChange,
+    onIngestSuccess,
+  ]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
## Summary
Fixes #2041 , Before Ingesting individually-selected files from a bucket connector would close the file-browser but left the user stuck on the "Add from Azure Blob Storage" pane, because `FileBrowserDialog` discarded its sync result and never navigated or registered the ingest tasks. This pr adds a new `onIngestSuccess` callback so `SharedBucketView` which mirrors the container path (track `task_ids` + navigate to Knowledge) and fixes all bucket connectors

## Before
[screen-capture (9).webm](https://github.com/user-attachments/assets/0cca25be-623b-4340-a80c-c58fb9f78a67)

## After
[screen-capture (10).webm](https://github.com/user-attachments/assets/d51ad913-d5cd-4a69-a7ce-4f42e7a6a406)

## Changes
- `FileBrowserDialog` now accepts an optional `onIngestSuccess(result)` callback; `handleIngest` captures the sync mutation result (previously discarded) and invokes it after a successful ingest
- `SharedBucketView` wires `onIngestSuccess` to mirror its whole-container path — invalidate the container-status query, register the returned `task_ids`, and call `onDone()` to navigate to Knowledge
- Added a `trackIngestTasks` helper in `shared-bucket-view.tsx` to share the `task_ids` → `addTask` loop between the container and individual-file ingest paths

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved background task tracking after file ingestion for a more consistent, up-to-date UI.
  * The file browser dialog now supports an optional callback that runs after ingestion completes.

* **Bug Fixes**
  * Fixed inconsistencies in how newly created ingest tasks were tracked and how related refresh behavior triggered across both shared bucket and file browser ingestion flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->