### PR TITLE
feat: apply selected files to filter

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -149,7 +149,9 @@ function SearchPage() {
   // Keep the filter context aware of checked rows so "Create New Filter"
   // can pre-populate its sources from the current selection.
   useEffect(() => {
-    setSelectedSources(selectedRows.map((row) => row.filename).filter(Boolean));
+    setSelectedSources(
+      selectedRows.flatMap((row) => (row.filename ? [row.filename] : [])),
+    );
     return () => setSelectedSources([]);
   }, [selectedRows, setSelectedSources]);
   const [showBulkDeleteDialog, setShowBulkDeleteDialog] = useState(false);

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -138,9 +138,20 @@ function SearchPage() {
     setRecentTasksExpanded,
     selectTask,
   } = useTask();
-  const { parsedFilterData, queryOverride, selectedFilter } =
-    useKnowledgeFilter();
+  const {
+    parsedFilterData,
+    queryOverride,
+    selectedFilter,
+    setSelectedSources,
+  } = useKnowledgeFilter();
   const [selectedRows, setSelectedRows] = useState<File[]>([]);
+
+  // Keep the filter context aware of checked rows so "Create New Filter"
+  // can pre-populate its sources from the current selection.
+  useEffect(() => {
+    setSelectedSources(selectedRows.map((row) => row.filename).filter(Boolean));
+    return () => setSelectedSources([]);
+  }, [selectedRows, setSelectedSources]);
   const [showBulkDeleteDialog, setShowBulkDeleteDialog] = useState(false);
   const lastErrorRef = useRef<string | null>(null);
   const hasInitializedFailedFilesRef = useRef(false);

--- a/frontend/contexts/knowledge-filter-context.tsx
+++ b/frontend/contexts/knowledge-filter-context.tsx
@@ -49,6 +49,9 @@ interface KnowledgeFilterContextType {
   endCreateMode: () => void;
   queryOverride: string;
   setQueryOverride: (query: string) => void;
+  /** Filenames checked in the knowledge table; seeds data_sources on create. */
+  selectedSources: string[];
+  setSelectedSources: (sources: string[]) => void;
 }
 
 const KnowledgeFilterContext = createContext<
@@ -82,6 +85,7 @@ export function KnowledgeFilterProvider({
   );
   const [createMode, setCreateMode] = useState(false);
   const [queryOverride, setQueryOverride] = useState("");
+  const [selectedSources, setSelectedSources] = useState<string[]>([]);
 
   const setSelectedFilter = (filter: KnowledgeFilter | null) => {
     setSelectedFilterState(filter);
@@ -145,14 +149,14 @@ export function KnowledgeFilterProvider({
   }, []);
 
   const startCreateMode = () => {
-    // Initialize defaults
+    // Initialize defaults; checked table rows pre-populate the sources filter
     setPanelMode("filters");
     setCreateMode(true);
     setSelectedFilterState(null);
     setParsedFilterData({
       query: "",
       filters: {
-        data_sources: ["*"],
+        data_sources: selectedSources.length > 0 ? [...selectedSources] : ["*"],
         document_types: ["*"],
         owners: ["*"],
         connector_types: ["*"],
@@ -192,6 +196,8 @@ export function KnowledgeFilterProvider({
     endCreateMode,
     queryOverride,
     setQueryOverride,
+    selectedSources,
+    setSelectedSources,
   };
 
   return (


### PR DESCRIPTION
I always felt like if you select files in the knowledge table then click create filter those files should be auto added now they are


https://github.com/user-attachments/assets/04d7e873-39ea-41f1-9a6f-fb1a3e0a00de



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Knowledge filters now stay in sync with your grid row selection, so selected sources always match what you’ve chosen.
  * When creating a new filter, the initial selected sources are prefilled from your current selection instead of always starting with the default “all sources” option.

* **Bug Fixes**
  * Prevents stale or mismatched source selections by clearing and updating the selected sources as the grid selection changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->