### PR TITLE
feat: implement OCR handling for embedded images and add warnings

### DIFF
--- a/frontend/lib/task-utils.ts
+++ b/frontend/lib/task-utils.ts
@@ -30,8 +30,17 @@ export function isTaskFileFailed(fileInfo: TaskFileEntry): boolean {
   return fileInfo.status === "failed" || fileInfo.status === "error";
 }
 
+function hasTaskFileResultWarning(fileInfo: TaskFileEntry): boolean {
+  const result = fileInfo.result;
+  if (!result || typeof result !== "object" || !("warning" in result)) {
+    return false;
+  }
+  const warning = result.warning;
+  return typeof warning === "string" && warning.trim().length > 0;
+}
+
 export function isTaskFileWarning(fileInfo: TaskFileEntry): boolean {
-  return fileInfo.status === "skipped";
+  return fileInfo.status === "skipped" || hasTaskFileResultWarning(fileInfo);
 }
 
 export function getTaskFileDialogStatusLabel(
@@ -288,7 +297,11 @@ export function isCompletedTotalFailure(task: Task): boolean {
 }
 
 export function isFailureLikeTask(task: Task): boolean {
-  return isTerminalFailedTask(task) || isCompletedWithFailures(task);
+  return (
+    isTerminalFailedTask(task) ||
+    isCompletedWithFailures(task) ||
+    getWarningFileEntries(task).length > 0
+  );
 }
 
 export function isTaskInProgressStatus(status: Task["status"]): boolean {
@@ -332,7 +345,8 @@ export function didTaskReachCompleted(
 
 /**
  * File paths present on the previous enhanced-list payload but omitted now.
- * The enhanced list drops completed files from `files` while a task is still running.
+ * The enhanced list drops completed files from `files` while a task is still running,
+ * except completed files that still need a warning surfaced.
  */
 /** Stable overlay key before the backend temp path is known. */
 function pendingTaskFileSourceUrl(taskId: string, filename: string): string {
@@ -419,7 +433,7 @@ export function finalizeProcessingOverlaysForEnhancedTask<
       return { ...file, status: "failed" as const, error };
     }
 
-    // Left the enhanced list (completed files are omitted) or task finished.
+    // Left the enhanced list (completed files without warnings are omitted) or task finished.
     changed = true;
     return { ...file, status: "active" as const, error: undefined };
   });

--- a/src/api/v1/documents.py
+++ b/src/api/v1/documents.py
@@ -90,8 +90,8 @@ async def all_tasks_enhanced_endpoint(
     added to any failed file entry whose cause can be classified.
 
     Note: completed files are omitted from each task's ``files`` dict to
-    reduce payload size; use GET /v1/tasks/{task_id}/enhanced for the full
-    file list of a specific task.
+    reduce payload size unless they carry a warning; use
+    GET /v1/tasks/{task_id}/enhanced for the full file list of a specific task.
     """
     tasks = task_service.get_all_tasks2(user.user_id)
     return JSONResponse({"tasks": tasks})

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -74,9 +74,7 @@ def is_image_file(filename: str) -> bool:
 def get_ocr_disabled_image_error(filename: str) -> str | None:
     if bool(getattr(get_openrag_config().knowledge, "ocr", False)) or not is_image_file(filename):
         return None
-    return (
-        f"The file '{filename}' is an image file and cannot be ingested because OCR is disabled."
-    )
+    return f"The file '{filename}' is an image file and cannot be ingested because OCR is disabled."
 
 
 class TaskProcessor:
@@ -474,7 +472,9 @@ class TaskProcessor:
             slim_doc["filename"] = original_filename
 
         warning = None
-        warning_filename = original_filename or slim_doc.get("filename") or os.path.basename(file_path)
+        warning_filename = (
+            original_filename or slim_doc.get("filename") or os.path.basename(file_path)
+        )
         if (
             not effective_ocr
             and slim_doc.get("has_embedded_images")

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from config.settings import clients, get_embedding_model, get_index_name, get_openrag_config
 from session_manager import AnonymousUser
 from utils.document_processing import (
+    EMBEDDED_IMAGES_OCR_DISABLED_WARNING,
     extract_relevant,
     process_text_file,
     resplit_chunks_character_windows,
@@ -29,6 +30,7 @@ logger = get_logger(__name__)
 
 DOCLING_PARSER_LABEL = "Docling Serve 1.20.0"
 TEXT_PARSER_LABEL = "Text Parser"
+IMAGE_EXTENSIONS = {"bmp", "jpeg", "jpg", "png", "tiff", "tif", "webp"}
 
 if TYPE_CHECKING:
     from connectors.base import DocumentACL
@@ -62,6 +64,19 @@ def resolve_shared_owner_fields(
         _anon = AnonymousUser()
         return None, _anon.name, _anon.email
     return user_id, owner_name, owner_email
+
+
+def is_image_file(filename: str) -> bool:
+    ext = filename.rsplit(".", 1)[-1].lower() if "." in filename else ""
+    return ext in IMAGE_EXTENSIONS
+
+
+def get_ocr_disabled_image_error(filename: str) -> str | None:
+    if bool(getattr(get_openrag_config().knowledge, "ocr", False)) or not is_image_file(filename):
+        return None
+    return (
+        f"The file '{filename}' is an image file and cannot be ingested because OCR is disabled."
+    )
 
 
 class TaskProcessor:
@@ -411,8 +426,10 @@ class TaskProcessor:
         # Use provided embedding model or configured model.
         # get_embedding_model() returns empty string when Langflow ingest is enabled,
         # but OpenRAG processors still need a concrete embedding model.
-        configured_embedding_model = get_openrag_config().knowledge.embedding_model
+        config = get_openrag_config()
+        configured_embedding_model = config.knowledge.embedding_model
         embedding_model = embedding_model or configured_embedding_model or get_embedding_model()
+        effective_ocr = bool(getattr(config.knowledge, "ocr", False)) if ocr is None else bool(ocr)
 
         # Get user's OpenSearch client with JWT for OIDC auth
         opensearch_client = self.document_service.session_manager.get_user_opensearch_client(
@@ -446,7 +463,7 @@ class TaskProcessor:
                 file_path,
                 user_id=owner_user_id,
                 auth_header=jwt_token,
-                ocr=ocr,
+                ocr=effective_ocr,
                 picture_descriptions=picture_descriptions,
             )
             slim_doc = extract_relevant(full_doc)
@@ -455,6 +472,15 @@ class TaskProcessor:
         # Override filename with original_filename if provided
         if original_filename:
             slim_doc["filename"] = original_filename
+
+        warning = None
+        warning_filename = original_filename or slim_doc.get("filename") or os.path.basename(file_path)
+        if (
+            not effective_ocr
+            and slim_doc.get("has_embedded_images")
+            and not is_image_file(warning_filename)
+        ):
+            warning = EMBEDDED_IMAGES_OCR_DISABLED_WARNING
 
         if chunk_size is not None:
             try:
@@ -619,7 +645,10 @@ class TaskProcessor:
             for i, (chunk, vect) in enumerate(zip(slim_doc["chunks"], embeddings, strict=True))
         ]
         await document_index_writer.index_chunks(index_context, index_chunks, final=True)
-        return {"status": "indexed", "id": file_hash}
+        result = {"status": "indexed", "id": file_hash}
+        if warning:
+            result["warning"] = warning
+        return result
 
     async def process_item(self, upload_task: UploadTask, item: Any, file_task: FileTask) -> None:
         """
@@ -687,6 +716,12 @@ class DocumentFileProcessor(TaskProcessor):
             # Use the ORIGINAL filename stored in file_task (not the transformed temp path)
             # This ensures we check/store the original filename with spaces, etc.
             original_filename = file_task.filename or os.path.basename(item)
+            if image_error := get_ocr_disabled_image_error(original_filename):
+                file_task.status = TaskStatus.FAILED
+                file_task.error = image_error
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+                return
 
             # Check if document with same filename already exists
             if self.session_manager is None:
@@ -883,6 +918,7 @@ class ConnectorFileProcessor(TaskProcessor):
                 "xls",
                 "xlsx",
                 "xhtml",
+                "tif",
                 "webp",
             }
             # Only pre-validate when we have a real filename. When the filename
@@ -895,6 +931,12 @@ class ConnectorFileProcessor(TaskProcessor):
                 if ext not in VALID_EXTENSIONS:
                     file_task.status = TaskStatus.FAILED
                     file_task.error = f"The file '{file_task.filename}' has an incompatible type."
+                    file_task.updated_at = time.time()
+                    upload_task.failed_files += 1
+                    return
+                if image_error := get_ocr_disabled_image_error(file_task.filename):
+                    file_task.status = TaskStatus.FAILED
+                    file_task.error = image_error
                     file_task.updated_at = time.time()
                     upload_task.failed_files += 1
                     return
@@ -951,6 +993,12 @@ class ConnectorFileProcessor(TaskProcessor):
             if ext not in VALID_EXTENSIONS:
                 file_task.status = TaskStatus.FAILED
                 file_task.error = f"The file '{name}' has an incompatible type."
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+                return
+            if image_error := get_ocr_disabled_image_error(name):
+                file_task.status = TaskStatus.FAILED
+                file_task.error = image_error
                 file_task.updated_at = time.time()
                 upload_task.failed_files += 1
                 return
@@ -1359,6 +1407,12 @@ class LangflowFileProcessor(TaskProcessor):
             # Use the ORIGINAL filename stored in file_task (not the transformed temp path)
             # This ensures we check/store the original filename with spaces, etc.
             original_filename = file_task.filename or os.path.basename(item)
+            if image_error := get_ocr_disabled_image_error(original_filename):
+                file_task.status = TaskStatus.FAILED
+                file_task.error = image_error
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+                return
 
             # Check if document with same filename already exists
             opensearch_client = self.session_manager.get_user_opensearch_client(

--- a/src/services/docling_polling_service.py
+++ b/src/services/docling_polling_service.py
@@ -10,6 +10,7 @@ import asyncio
 import time
 from dataclasses import dataclass
 from enum import StrEnum
+from typing import Any
 
 from services.docling_service import (
     DoclingServeError,
@@ -36,6 +37,7 @@ class DoclingPollResult:
     detail: str | None = None
     last_snapshot: DoclingStatusSnapshot | None = None
     elapsed_seconds: float = 0.0
+    document_json_content: dict[str, Any] | None = None
 
 
 class DoclingPollingService:
@@ -93,6 +95,7 @@ class DoclingPollingService:
 
             if snapshot.state == DoclingTaskState.SUCCESS:
                 result_fetch_errors = 0
+                document_json_content: dict[str, Any] | None = None
                 while True:
                     now = time.monotonic()
                     elapsed = now - start
@@ -116,7 +119,7 @@ class DoclingPollingService:
                             elapsed_seconds=elapsed,
                         )
                     try:
-                        await self.docling_service.fetch_task_result(
+                        document_json_content = await self.docling_service.fetch_task_result(
                             task_id, user_id=user_id, auth_header=auth_header
                         )
                         break
@@ -170,6 +173,7 @@ class DoclingPollingService:
                     outcome=PollOutcome.SUCCESS,
                     last_snapshot=snapshot,
                     elapsed_seconds=elapsed,
+                    document_json_content=document_json_content,
                 )
 
             if snapshot.state == DoclingTaskState.FAILED:

--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -18,6 +18,7 @@ from config.settings import (
     get_ingest_callback_url,
 )
 from services.document_index_writer import DocumentIndexContext
+from utils.document_processing import EMBEDDED_IMAGES_OCR_DISABLED_WARNING, has_embedded_images
 from utils.hash_utils import hash_id
 from utils.logging_config import get_logger
 
@@ -999,6 +1000,8 @@ class LangflowFileService:
                     "elapsed_seconds": round(poll_result.elapsed_seconds, 2),
                 },
             )
+        else:
+            poll_result = None
 
         # ── Phase 2: trigger Langflow ingestion ─────────────────────────
         final_tweaks = LangflowFileService.merge_ui_ingest_settings_into_tweaks(tweaks, settings)
@@ -1056,9 +1059,16 @@ class LangflowFileService:
             # fields coherent. Idempotent for the polling path.
             file_task.docling_status = DoclingPhaseStatus.SUCCESS
 
-        return {
+        result = {
             "status": "success",
             "docling_task_id": task_id,
             "ingestion": ingest_result,
             "message": f"File '{filename}' processed via Docling and ingested successfully",
         }
+        if (
+            ocr_override is False
+            and poll_result is not None
+            and has_embedded_images(poll_result.document_json_content)
+        ):
+            result["warning"] = EMBEDDED_IMAGES_OCR_DISABLED_WARNING
+        return result

--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -16,6 +16,7 @@ from config.settings import (
     OPENRAG_BACKEND_ROUTER_ENABLE,
     clients,
     get_ingest_callback_url,
+    get_openrag_config,
 )
 from services.document_index_writer import DocumentIndexContext
 from utils.document_processing import EMBEDDED_IMAGES_OCR_DISABLED_WARNING, has_embedded_images
@@ -925,6 +926,12 @@ class LangflowFileService:
         filename, content, _ = file_tuple
 
         ocr_override = settings.get("ocr") if isinstance(settings, dict) else None
+        config = get_openrag_config()
+        effective_ocr = (
+            bool(getattr(config.knowledge, "ocr", False))
+            if ocr_override is None
+            else bool(ocr_override)
+        )
         pic_desc_override = (
             settings.get("pictureDescriptions") if isinstance(settings, dict) else None
         )
@@ -1066,7 +1073,7 @@ class LangflowFileService:
             "message": f"File '{filename}' processed via Docling and ingested successfully",
         }
         if (
-            ocr_override is False
+            not effective_ocr
             and poll_result is not None
             and has_embedded_images(poll_result.document_json_content)
         ):

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -935,6 +935,14 @@ class TaskService:
             "docling_task_id": file_task.docling_task_id,
         }
 
+    def _file_task_has_warning(self, file_task: FileTask) -> bool:
+        """Return True when a file task result carries a user-visible warning."""
+        result = file_task.result
+        if not isinstance(result, dict):
+            return False
+        warning = result.get("warning")
+        return isinstance(warning, str) and bool(warning.strip())
+
     def _infer_failure_metadata(self, file_task: FileTask) -> dict | None:
         """Infer structured failure metadata for a failed FileTask.
 
@@ -1216,7 +1224,10 @@ class TaskService:
                 file_statuses = {}
 
                 for file_path, file_task in upload_task.file_tasks.items():
-                    if file_task.status != TaskStatus.COMPLETED:
+                    if (
+                        file_task.status != TaskStatus.COMPLETED
+                        or self._file_task_has_warning(file_task)
+                    ):
                         entry = self._serialize_file_task(file_task)
                         if file_task.status == TaskStatus.FAILED:
                             metadata = self._infer_failure_metadata(file_task)
@@ -1273,7 +1284,10 @@ class TaskService:
                 file_statuses = {}
 
                 for file_path, file_task in upload_task.file_tasks.items():
-                    if file_task.status.value != "completed":
+                    if (
+                        file_task.status != TaskStatus.COMPLETED
+                        or self._file_task_has_warning(file_task)
+                    ):
                         file_statuses[file_path] = {
                             "status": file_task.status.value,
                             "result": file_task.result,

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -1224,9 +1224,8 @@ class TaskService:
                 file_statuses = {}
 
                 for file_path, file_task in upload_task.file_tasks.items():
-                    if (
-                        file_task.status != TaskStatus.COMPLETED
-                        or self._file_task_has_warning(file_task)
+                    if file_task.status != TaskStatus.COMPLETED or self._file_task_has_warning(
+                        file_task
                     ):
                         entry = self._serialize_file_task(file_task)
                         if file_task.status == TaskStatus.FAILED:
@@ -1284,9 +1283,8 @@ class TaskService:
                 file_statuses = {}
 
                 for file_path, file_task in upload_task.file_tasks.items():
-                    if (
-                        file_task.status != TaskStatus.COMPLETED
-                        or self._file_task_has_warning(file_task)
+                    if file_task.status != TaskStatus.COMPLETED or self._file_task_has_warning(
+                        file_task
                     ):
                         file_statuses[file_path] = {
                             "status": file_task.status.value,

--- a/src/utils/document_processing.py
+++ b/src/utils/document_processing.py
@@ -1,9 +1,47 @@
 import os
 from collections import defaultdict
+from typing import Any
 
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+EMBEDDED_IMAGES_OCR_DISABLED_WARNING = (
+    "OCR is disabled. Embedded images were skipped, so text inside images was not extracted."
+)
+
+_IMAGE_COLLECTION_KEYS = ("pictures", "figures", "images")
+_IMAGE_REF_MARKERS = ("#/pictures/", "#/figures/", "#/images/")
+_IMAGE_LABELS = {"picture", "figure", "image"}
+
+
+def has_embedded_images(doc_dict: dict[str, Any] | None) -> bool:
+    """Return True when a Docling JSON export contains embedded image artifacts."""
+    if not isinstance(doc_dict, dict):
+        return False
+
+    for key in _IMAGE_COLLECTION_KEYS:
+        value = doc_dict.get(key)
+        if isinstance(value, list) and len(value) > 0:
+            return True
+        if isinstance(value, dict) and len(value) > 0:
+            return True
+
+    return _references_image_collection(doc_dict.get("body"))
+
+
+def _references_image_collection(value: Any) -> bool:
+    if isinstance(value, str):
+        lowered = value.lower()
+        return any(marker in lowered for marker in _IMAGE_REF_MARKERS)
+    if isinstance(value, list):
+        return any(_references_image_collection(item) for item in value)
+    if isinstance(value, dict):
+        label = str(value.get("label") or value.get("type") or "").lower()
+        if label in _IMAGE_LABELS:
+            return True
+        return any(_references_image_collection(item) for item in value.values())
+    return False
 
 
 def process_text_file(file_path: str) -> dict:
@@ -136,6 +174,7 @@ def extract_relevant(doc_dict: dict) -> dict:
         "filename": origin.get("filename"),
         "mimetype": origin.get("mimetype"),
         "chunks": chunks,
+        "has_embedded_images": has_embedded_images(doc_dict),
     }
 
 

--- a/tests/unit/test_document_processing_resplit.py
+++ b/tests/unit/test_document_processing_resplit.py
@@ -119,6 +119,44 @@ def test_extract_relevant_safeguard_none_table_data():
     )  # should handle None data and produce empty string or no cells
 
 
+def test_extract_relevant_marks_embedded_images():
+    from src.utils.document_processing import extract_relevant
+
+    doc_dict = {
+        "origin": {
+            "binary_hash": "hash789",
+            "filename": "report.pdf",
+            "mimetype": "application/pdf",
+        },
+        "texts": [{"text": "Selectable text", "prov": [{"page_no": 1}]}],
+        "tables": [],
+        "pictures": [{"self_ref": "#/pictures/0", "prov": [{"page_no": 1}]}],
+    }
+
+    result = extract_relevant(doc_dict)
+
+    assert result["has_embedded_images"] is True
+
+
+def test_extract_relevant_marks_no_embedded_images():
+    from src.utils.document_processing import extract_relevant
+
+    doc_dict = {
+        "origin": {
+            "binary_hash": "hash790",
+            "filename": "report.pdf",
+            "mimetype": "application/pdf",
+        },
+        "texts": [{"text": "Selectable text", "prov": [{"page_no": 1}]}],
+        "tables": [],
+        "pictures": [],
+    }
+
+    result = extract_relevant(doc_dict)
+
+    assert result["has_embedded_images"] is False
+
+
 def test_split_chunks_by_max_tokens_emoji_token_override():
     from src.utils.document_processing import split_chunks_by_max_tokens
 

--- a/tests/unit/test_langflow_file_service_two_phase.py
+++ b/tests/unit/test_langflow_file_service_two_phase.py
@@ -121,6 +121,44 @@ async def test_two_phase_success_warns_when_ocr_disabled_and_docling_found_image
 
 
 @pytest.mark.asyncio
+async def test_two_phase_success_warns_when_config_ocr_disabled_without_override(
+    monkeypatch, langflow_service, mock_polling_service, file_tuple, file_task
+):
+    from services import langflow_file_service as langflow_file_service_mod
+
+    monkeypatch.setattr(
+        langflow_file_service_mod,
+        "get_openrag_config",
+        lambda: SimpleNamespace(knowledge=SimpleNamespace(ocr=False)),
+        raising=False,
+    )
+    mock_polling_service.poll_until_ready.return_value = DoclingPollResult(
+        outcome=PollOutcome.SUCCESS,
+        elapsed_seconds=2.5,
+        document_json_content={
+            "origin": {
+                "binary_hash": "doc-hash",
+                "filename": "test.pdf",
+                "mimetype": "application/pdf",
+            },
+            "texts": [{"text": "Selectable text", "prov": [{"page_no": 1}]}],
+            "tables": [],
+            "pictures": [{"self_ref": "#/pictures/0", "prov": [{"page_no": 1}]}],
+        },
+    )
+
+    result = await langflow_service.upload_and_ingest_file(
+        file_tuple=file_tuple,
+        settings={},
+        docling_polling_service=mock_polling_service,
+        file_task=file_task,
+    )
+
+    assert result["status"] == "success"
+    assert "Embedded images were skipped" in result["warning"]
+
+
+@pytest.mark.asyncio
 async def test_langflow_not_invoked_on_docling_failure(
     langflow_service, mock_polling_service, file_tuple, file_task
 ):

--- a/tests/unit/test_langflow_file_service_two_phase.py
+++ b/tests/unit/test_langflow_file_service_two_phase.py
@@ -71,6 +71,8 @@ async def test_two_phase_success_invokes_langflow_with_task_id(
         b"PDFDATA",
         user_id="owner-123",
         auth_header="Bearer jwt-token",
+        ocr=None,
+        picture_descriptions=None,
     )
 
     # Langflow was invoked exactly once, with the docling_task_id forwarded.
@@ -86,6 +88,36 @@ async def test_two_phase_success_invokes_langflow_with_task_id(
     # Result envelope.
     assert result["status"] == "success"
     assert result["docling_task_id"] == "task-abc-123"
+
+
+@pytest.mark.asyncio
+async def test_two_phase_success_warns_when_ocr_disabled_and_docling_found_images(
+    langflow_service, mock_polling_service, file_tuple, file_task
+):
+    mock_polling_service.poll_until_ready.return_value = DoclingPollResult(
+        outcome=PollOutcome.SUCCESS,
+        elapsed_seconds=2.5,
+        document_json_content={
+            "origin": {
+                "binary_hash": "doc-hash",
+                "filename": "test.pdf",
+                "mimetype": "application/pdf",
+            },
+            "texts": [{"text": "Selectable text", "prov": [{"page_no": 1}]}],
+            "tables": [],
+            "pictures": [{"self_ref": "#/pictures/0", "prov": [{"page_no": 1}]}],
+        },
+    )
+
+    result = await langflow_service.upload_and_ingest_file(
+        file_tuple=file_tuple,
+        settings={"ocr": False},
+        docling_polling_service=mock_polling_service,
+        file_task=file_task,
+    )
+
+    assert result["status"] == "success"
+    assert "Embedded images were skipped" in result["warning"]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_processors_clear_stale_chunks.py
+++ b/tests/unit/test_processors_clear_stale_chunks.py
@@ -314,7 +314,7 @@ async def test_connector_file_id_absent_when_not_provided(monkeypatch):
         Path(tmp_path).unlink(missing_ok=True)
 
     assert len(index_calls) == 1
-    assert index_calls[0]["chunks"][0].metadata == {}
+    assert "connector_file_id" not in index_calls[0]["chunks"][0].metadata
 
 
 def test_document_index_writer_outputs_connector_file_id_when_present():

--- a/tests/unit/test_processors_embedded_image_warning.py
+++ b/tests/unit/test_processors_embedded_image_warning.py
@@ -1,0 +1,176 @@
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from models.processors import TaskProcessor
+
+
+@pytest.mark.asyncio
+async def test_standard_processor_warns_for_embedded_images_when_ocr_disabled(
+    monkeypatch, tmp_path: Path
+):
+    from models import processors as processors_mod
+    from services import document_service as document_service_mod
+
+    user_client = AsyncMock()
+    user_client.search = AsyncMock(return_value={"hits": {"hits": []}})
+    session_manager = MagicMock()
+    session_manager.get_user_opensearch_client = MagicMock(return_value=user_client)
+
+    index_calls = []
+
+    class FakeDocumentIndexWriter:
+        async def index_chunks(self, context, chunks, *, final=False):
+            index_calls.append({"context": context, "chunks": chunks, "final": final})
+            return {"indexed_chunks": len(chunks)}
+
+    document_service = SimpleNamespace(
+        session_manager=session_manager,
+        document_index_writer=FakeDocumentIndexWriter(),
+    )
+    models_service = MagicMock()
+    models_service.get_litellm_model_name = AsyncMock(return_value="text-embedding-3-small")
+    docling_service = MagicMock()
+    docling_service.convert_file = AsyncMock(
+        return_value={
+            "origin": {
+                "binary_hash": "doc-hash",
+                "filename": "report.pdf",
+                "mimetype": "application/pdf",
+            },
+            "texts": [{"text": "Selectable report text", "prov": [{"page_no": 1}]}],
+            "tables": [],
+            "pictures": [{"self_ref": "#/pictures/0", "prov": [{"page_no": 1}]}],
+        }
+    )
+
+    fake_config = SimpleNamespace(
+        knowledge=SimpleNamespace(embedding_model="text-embedding-3-small", ocr=False)
+    )
+    monkeypatch.setattr(processors_mod, "get_openrag_config", lambda: fake_config)
+    monkeypatch.setattr(processors_mod, "get_index_name", lambda: "documents")
+    monkeypatch.setattr(
+        document_service_mod,
+        "chunk_texts_for_embeddings",
+        lambda texts, max_tokens=8000: [list(texts)],
+    )
+
+    class FakeEmbeddingClient:
+        class Embeddings:
+            async def create(self, model, input):
+                return SimpleNamespace(
+                    data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3]) for _ in input]
+                )
+
+        embeddings = Embeddings()
+
+    monkeypatch.setattr(
+        processors_mod,
+        "clients",
+        SimpleNamespace(opensearch=AsyncMock(), patched_embedding_client=FakeEmbeddingClient()),
+    )
+
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"%PDF-1.4 fake")
+    processor = TaskProcessor(
+        document_service=document_service,
+        models_service=models_service,
+        docling_service=docling_service,
+    )
+
+    result = await processor.process_document_standard(
+        file_path=str(file_path),
+        file_hash="doc-hash",
+        owner_user_id="user-1",
+        original_filename="report.pdf",
+        jwt_token="jwt",
+        ocr=False,
+    )
+
+    assert result["status"] == "indexed"
+    assert "warning" in result
+    assert "Embedded images were skipped" in result["warning"]
+    assert len(index_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_standard_processor_does_not_warn_when_ocr_enabled(monkeypatch, tmp_path: Path):
+    from models import processors as processors_mod
+    from services import document_service as document_service_mod
+
+    user_client = AsyncMock()
+    user_client.search = AsyncMock(return_value={"hits": {"hits": []}})
+    session_manager = MagicMock()
+    session_manager.get_user_opensearch_client = MagicMock(return_value=user_client)
+
+    class FakeDocumentIndexWriter:
+        async def index_chunks(self, context, chunks, *, final=False):
+            return {"indexed_chunks": len(chunks)}
+
+    document_service = SimpleNamespace(
+        session_manager=session_manager,
+        document_index_writer=FakeDocumentIndexWriter(),
+    )
+    models_service = MagicMock()
+    models_service.get_litellm_model_name = AsyncMock(return_value="text-embedding-3-small")
+    docling_service = MagicMock()
+    docling_service.convert_file = AsyncMock(
+        return_value={
+            "origin": {
+                "binary_hash": "doc-hash",
+                "filename": "report.pdf",
+                "mimetype": "application/pdf",
+            },
+            "texts": [{"text": "Selectable report text", "prov": [{"page_no": 1}]}],
+            "tables": [],
+            "pictures": [{"self_ref": "#/pictures/0", "prov": [{"page_no": 1}]}],
+        }
+    )
+
+    fake_config = SimpleNamespace(
+        knowledge=SimpleNamespace(embedding_model="text-embedding-3-small", ocr=True)
+    )
+    monkeypatch.setattr(processors_mod, "get_openrag_config", lambda: fake_config)
+    monkeypatch.setattr(processors_mod, "get_index_name", lambda: "documents")
+    monkeypatch.setattr(
+        document_service_mod,
+        "chunk_texts_for_embeddings",
+        lambda texts, max_tokens=8000: [list(texts)],
+    )
+
+    class FakeEmbeddingClient:
+        class Embeddings:
+            async def create(self, model, input):
+                return SimpleNamespace(
+                    data=[SimpleNamespace(embedding=[0.1, 0.2, 0.3]) for _ in input]
+                )
+
+        embeddings = Embeddings()
+
+    monkeypatch.setattr(
+        processors_mod,
+        "clients",
+        SimpleNamespace(opensearch=AsyncMock(), patched_embedding_client=FakeEmbeddingClient()),
+    )
+
+    file_path = tmp_path / "report.pdf"
+    file_path.write_bytes(b"%PDF-1.4 fake")
+    processor = TaskProcessor(
+        document_service=document_service,
+        models_service=models_service,
+        docling_service=docling_service,
+    )
+
+    result = await processor.process_document_standard(
+        file_path=str(file_path),
+        file_hash="doc-hash",
+        owner_user_id="user-1",
+        original_filename="report.pdf",
+        jwt_token="jwt",
+        ocr=True,
+    )
+
+    assert result["status"] == "indexed"
+    assert "warning" not in result

--- a/tests/unit/test_processors_ocr_image_block.py
+++ b/tests/unit/test_processors_ocr_image_block.py
@@ -16,9 +16,7 @@ EXPECTED_ERROR = (
 def _disable_ocr(monkeypatch):
     monkeypatch.setattr(
         "models.processors.get_openrag_config",
-        lambda: SimpleNamespace(
-            knowledge=SimpleNamespace(ocr=False, picture_descriptions=False)
-        ),
+        lambda: SimpleNamespace(knowledge=SimpleNamespace(ocr=False, picture_descriptions=False)),
     )
 
 

--- a/tests/unit/test_processors_ocr_image_block.py
+++ b/tests/unit/test_processors_ocr_image_block.py
@@ -1,0 +1,166 @@
+"""Processor behavior for image ingestion when OCR is disabled."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.processors import ConnectorFileProcessor, DocumentFileProcessor, LangflowFileProcessor
+from models.tasks import FileTask, TaskStatus, UploadTask
+
+EXPECTED_ERROR = (
+    "The file 'scan.PNG' is an image file and cannot be ingested because OCR is disabled."
+)
+
+
+def _disable_ocr(monkeypatch):
+    monkeypatch.setattr(
+        "models.processors.get_openrag_config",
+        lambda: SimpleNamespace(
+            knowledge=SimpleNamespace(ocr=False, picture_descriptions=False)
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_document_processor_fails_image_early_when_ocr_disabled(monkeypatch, tmp_path):
+    _disable_ocr(monkeypatch)
+
+    session_manager = MagicMock()
+    session_manager.get_user_opensearch_client = MagicMock(return_value=AsyncMock())
+    document_service = MagicMock(session_manager=session_manager)
+    document_service.docling_service = MagicMock()
+
+    processor = DocumentFileProcessor(
+        document_service=document_service,
+        models_service=MagicMock(),
+        owner_user_id="user-1",
+        jwt_token="jwt",
+        session_manager=session_manager,
+    )
+    processor.check_filename_exists = AsyncMock(return_value=False)
+    processor.process_document_standard = AsyncMock(return_value={"status": "indexed"})
+
+    image = tmp_path / "scan.PNG"
+    image.write_bytes(b"fake image")
+    upload_task = UploadTask(task_id="task-1", total_files=1)
+    file_task = FileTask(file_path=str(image), filename="scan.PNG")
+
+    with patch("models.processors.hash_id") as mock_hash_id:
+        await processor.process_item(upload_task, str(image), file_task)
+
+    assert file_task.status == TaskStatus.FAILED
+    assert file_task.error == EXPECTED_ERROR
+    assert upload_task.failed_files == 1
+    assert upload_task.successful_files == 0
+    mock_hash_id.assert_not_called()
+    processor.process_document_standard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connector_processor_fails_image_early_when_ocr_disabled(monkeypatch):
+    _disable_ocr(monkeypatch)
+
+    connector = MagicMock()
+    connector.get_file_content = AsyncMock()
+    connector_service = MagicMock()
+    connector_service.get_connector = AsyncMock(return_value=connector)
+    connection = MagicMock(connector_type="google_drive")
+    connector_service.connection_manager.get_connection = AsyncMock(return_value=connection)
+
+    processor = ConnectorFileProcessor(
+        connector_service=connector_service,
+        connection_id="conn-id",
+        files_to_process=[],
+        user_id="user-1",
+        jwt_token="jwt",
+        document_service=MagicMock(),
+        models_service=MagicMock(),
+    )
+
+    upload_task = UploadTask(task_id="task-1", total_files=1)
+    file_task = FileTask(file_path="file-1", filename="scan.PNG")
+
+    await processor.process_item(upload_task, "file-1", file_task)
+
+    assert file_task.status == TaskStatus.FAILED
+    assert file_task.error == EXPECTED_ERROR
+    assert upload_task.failed_files == 1
+    assert upload_task.successful_files == 0
+    connector.get_file_content.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connector_processor_rechecks_loaded_filename_when_ocr_disabled(monkeypatch):
+    _disable_ocr(monkeypatch)
+
+    document = SimpleNamespace(
+        id="doc-1",
+        filename="scan.PNG",
+        mimetype="image/png",
+        content=b"fake image",
+        acl=None,
+    )
+    connector = MagicMock()
+    connector.get_file_content = AsyncMock(return_value=document)
+    connector_service = MagicMock()
+    connector_service.get_connector = AsyncMock(return_value=connector)
+    connection = MagicMock(connector_type="google_drive")
+    connector_service.connection_manager.get_connection = AsyncMock(return_value=connection)
+
+    processor = ConnectorFileProcessor(
+        connector_service=connector_service,
+        connection_id="conn-id",
+        files_to_process=[],
+        user_id="user-1",
+        jwt_token="jwt",
+        document_service=MagicMock(),
+        models_service=MagicMock(),
+    )
+    processor.process_document_standard = AsyncMock(return_value={"status": "indexed"})
+
+    upload_task = UploadTask(task_id="task-1", total_files=1)
+    file_task = FileTask(file_path="file-1", filename="file-1")
+
+    with patch("models.processors.hash_id") as mock_hash_id:
+        await processor.process_item(upload_task, "file-1", file_task)
+
+    assert file_task.status == TaskStatus.FAILED
+    assert file_task.filename == "scan.PNG"
+    assert file_task.error == EXPECTED_ERROR
+    assert upload_task.failed_files == 1
+    assert upload_task.successful_files == 0
+    connector.get_file_content.assert_awaited_once_with("file-1")
+    mock_hash_id.assert_not_called()
+    processor.process_document_standard.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_langflow_processor_fails_image_early_when_ocr_disabled(monkeypatch, tmp_path):
+    _disable_ocr(monkeypatch)
+
+    session_manager = MagicMock()
+    session_manager.get_user_opensearch_client = MagicMock(return_value=AsyncMock())
+    langflow_file_service = MagicMock()
+    langflow_file_service.upload_and_ingest_file = AsyncMock(return_value={"status": "indexed"})
+
+    processor = LangflowFileProcessor(
+        langflow_file_service=langflow_file_service,
+        session_manager=session_manager,
+        owner_user_id="user-1",
+        jwt_token="jwt",
+    )
+    processor.check_filename_exists = AsyncMock(return_value=False)
+
+    image = tmp_path / "scan.PNG"
+    image.write_bytes(b"fake image")
+    upload_task = UploadTask(task_id="task-1", total_files=1)
+    file_task = FileTask(file_path=str(image), filename="scan.PNG")
+
+    await processor.process_item(upload_task, str(image), file_task)
+
+    assert file_task.status == TaskStatus.FAILED
+    assert file_task.error == EXPECTED_ERROR
+    assert upload_task.failed_files == 1
+    assert upload_task.successful_files == 0
+    langflow_file_service.upload_and_ingest_file.assert_not_awaited()

--- a/tests/unit/test_task_service_get_task_status2.py
+++ b/tests/unit/test_task_service_get_task_status2.py
@@ -466,6 +466,77 @@ class TestGetTaskStatus2AnonymousFallback:
 
 
 # ---------------------------------------------------------------------------
+# get_all_tasks/get_all_tasks2 — completed warning files stay visible
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllTasksWarnings:
+    def test_get_all_tasks2_includes_completed_files_with_warning(self, task_service):
+        warned = _make_file_task(
+            file_path="warned.pdf",
+            filename="warned.pdf",
+            status=TaskStatus.COMPLETED,
+            phase=IngestionPhase.COMPLETE,
+            docling_status=DoclingPhaseStatus.SUCCESS,
+            error=None,
+        )
+        warned.result = {
+            "status": "success",
+            "warning": "OCR is disabled. Embedded images were skipped.",
+        }
+        plain = _make_file_task(
+            file_path="plain.pdf",
+            filename="plain.pdf",
+            status=TaskStatus.COMPLETED,
+            phase=IngestionPhase.COMPLETE,
+            docling_status=DoclingPhaseStatus.SUCCESS,
+            error=None,
+        )
+        plain.result = {"status": "success"}
+        task = _make_upload_task("warn-task", {"warned.pdf": warned, "plain.pdf": plain})
+        task.status = TaskStatus.COMPLETED
+        task.successful_files = 2
+        _store_task(task_service, "user1", task)
+
+        result = task_service.get_all_tasks2("user1")
+
+        files = result[0]["files"]
+        assert "warned.pdf" in files
+        assert files["warned.pdf"]["status"] == "completed"
+        assert files["warned.pdf"]["result"]["warning"] == (
+            "OCR is disabled. Embedded images were skipped."
+        )
+        assert "plain.pdf" not in files
+
+    def test_get_all_tasks_includes_completed_files_with_warning(self, task_service):
+        warned = _make_file_task(
+            file_path="warned.pdf",
+            filename="warned.pdf",
+            status=TaskStatus.COMPLETED,
+            phase=IngestionPhase.COMPLETE,
+            docling_status=DoclingPhaseStatus.SUCCESS,
+            error=None,
+        )
+        warned.result = {
+            "status": "success",
+            "warning": "OCR is disabled. Embedded images were skipped.",
+        }
+        task = _make_upload_task("warn-task", {"warned.pdf": warned})
+        task.status = TaskStatus.COMPLETED
+        task.successful_files = 1
+        _store_task(task_service, "user1", task)
+
+        result = task_service.get_all_tasks("user1")
+
+        files = result[0]["files"]
+        assert "warned.pdf" in files
+        assert files["warned.pdf"]["status"] == "completed"
+        assert files["warned.pdf"]["result"]["warning"] == (
+            "OCR is disabled. Embedded images were skipped."
+        )
+
+
+# ---------------------------------------------------------------------------
 # Regression: get_task_status remains unchanged
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
This pull request introduces comprehensive support for handling documents with embedded images when OCR is disabled. It ensures that users are notified with clear warnings if embedded images are present but OCR is turned off, preventing silent data loss. The changes add detection for embedded images, propagate warnings through the document processing pipeline, and include tests to verify this behavior.

**Embedded image detection and warning propagation:**
- Added the `has_embedded_images` field to the output of `extract_relevant` in `document_processing.py`, using a new `has_embedded_images` function to detect embedded images in Docling JSON exports. [[1]](diffhunk://#diff-3c1da33019c98bb4cf8a65dd19959914a8576531f815e3aa29e179b5f742e229R3-R45) [[2]](diffhunk://#diff-3c1da33019c98bb4cf8a65dd19959914a8576531f815e3aa29e179b5f742e229R177)
- Introduced `EMBEDDED_IMAGES_OCR_DISABLED_WARNING` and logic to attach a warning to processing results if embedded images are found and OCR is disabled, in both `process_document_standard` and `upload_and_ingest_file`. [[1]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7L622-R651) [[2]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958L1059-R1074)

**Image file handling and error reporting:**
- Added `is_image_file` and `get_ocr_disabled_image_error` helpers to identify image files and return user-friendly errors if OCR is disabled, preventing ingestion of image files without OCR. [[1]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R69-R81) [[2]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R719-R724) [[3]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R937-R942) [[4]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R999-R1004) [[5]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R1410-R1415)
- Updated supported image extensions and ensured consistent checking for images throughout the processing pipeline. [[1]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R33) [[2]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R921)

**Docling polling and result propagation:**
- Modified `DoclingPollResult` and `DoclingPollingService` to carry the full document JSON content, enabling downstream checks for embedded images. [[1]](diffhunk://#diff-4f1804e65cbd6e028ade63f12e0ae73de3499fbd1af8419c95ae1e10b2f7d6aeR40) [[2]](diffhunk://#diff-4f1804e65cbd6e028ade63f12e0ae73de3499fbd1af8419c95ae1e10b2f7d6aeR98) [[3]](diffhunk://#diff-4f1804e65cbd6e028ade63f12e0ae73de3499fbd1af8419c95ae1e10b2f7d6aeL119-R122) [[4]](diffhunk://#diff-4f1804e65cbd6e028ade63f12e0ae73de3499fbd1af8419c95ae1e10b2f7d6aeR176)

**Testing and validation:**
- Added unit tests to verify that the `has_embedded_images` field is set correctly and that warnings are issued when appropriate, including a new test for the two-phase Langflow ingestion flow. [[1]](diffhunk://#diff-53c180904d504e480b0c114fef70413991e6ae705a2a770311e00667da6b5953R122-R159) [[2]](diffhunk://#diff-b84bd42a01497fd9e873b3eb862726c267c7e21f536961962131a12edfd2a804R93-R122)

**Minor improvements:**
- Ensured that file ingestion fails early with a clear error if an image file is uploaded while OCR is disabled, improving user feedback and robustness. [[1]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R719-R724) [[2]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R937-R942) [[3]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R999-R1004) [[4]](diffhunk://#diff-c92d64751875ea78390bdb54d800625aa6dd39817344a741d2c640987e91d0f7R1410-R1415)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added OCR-disabled guard to block image ingestion early, returning a clear user-facing error.
  * Detects embedded images and surfaces an “embedded images were skipped” warning when OCR is disabled.

* **Bug Fixes**
  * Keeps successful indexing results while attaching warnings when embedded images are present.
  * Updated task/file visibility so completed items with warnings remain shown.

* **Tests**
  * Expanded unit and async coverage for embedded-image detection, OCR-disabled blocking, and warning behavior across ingestion and task listing/UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->