### PR TITLE
fix: missing ingest settings for individual files in COS

### DIFF
--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -350,6 +350,8 @@ export function SharedBucketView({
           connectorType={connector.type}
           connectionId={connector.connectionId}
           buckets={[browseDialogBucket]}
+          showShared={showSharedToggle}
+          ingestSettings={ingestSettings}
         />
       )}
     </>

--- a/frontend/components/file-browser-dialog.tsx
+++ b/frontend/components/file-browser-dialog.tsx
@@ -8,6 +8,7 @@ import {
   type RemoteFile,
   useBrowseConnectionFiles,
 } from "@/app/api/queries/useBrowseConnectionFiles";
+import type { IngestSettings } from "@/components/cloud-picker/types";
 import { formatFileSize } from "@/lib/file-format";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";
@@ -28,6 +29,10 @@ interface FileBrowserDialogProps {
   connectorType: string;
   connectionId: string;
   buckets?: string[];
+  /** When true, apply the "Make documents available to all users" setting from `ingestSettings`. */
+  showShared?: boolean;
+  /** Ingest settings (embedding model, chunking, OCR, shared toggle) configured on the parent screen. */
+  ingestSettings?: IngestSettings;
 }
 
 export function FileBrowserDialog({
@@ -36,6 +41,8 @@ export function FileBrowserDialog({
   connectorType,
   connectionId,
   buckets,
+  showShared,
+  ingestSettings,
 }: FileBrowserDialogProps) {
   const [search, setSearch] = useState("");
   const [selectedBucket, setSelectedBucket] = useState<string | undefined>(
@@ -136,6 +143,8 @@ export function FileBrowserDialog({
             mimeType: "",
             size: f.size,
           })),
+          settings: ingestSettings,
+          shared: showShared ? (ingestSettings?.shared ?? false) : undefined,
           ...(hasStale ? { replace_duplicates: true } : {}),
         },
       });
@@ -151,7 +160,14 @@ export function FileBrowserDialog({
         description: err instanceof Error ? err.message : "Unknown error",
       });
     }
-  }, [selectedFiles, connectorType, syncMutation, onOpenChange]);
+  }, [
+    selectedFiles,
+    connectorType,
+    syncMutation,
+    onOpenChange,
+    showShared,
+    ingestSettings,
+  ]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>


### PR DESCRIPTION
FileBrowserDialog (the "Browse Files" individual-file picker) never read the "Make documents available to all users" toggle or ingest settings — it built its sync request with only selected_files, so shared silently defaulted to false on the backend. The whole-bucket ("folder") ingest path in SharedBucketView already did this correctly.

Changes (frontend-only, no backend changes needed — it already threads shared uniformly):
- frontend/components/file-browser-dialog.tsx: added showShared/ingestSettings props, and now includes settings and shared in the sync request body, mirroring the bucket-ingest path.
- frontend/components/connectors/shared-bucket-view.tsx: passes its existing showSharedToggle/ingestSettings state down into FileBrowserDialog.