### PR TITLE
fix: add warning logs for 10k aggregation limit

### DIFF
--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -33,6 +33,12 @@ from utils.telemetry import Category, MessageId, TelemetryClient
 
 logger = get_logger(__name__)
 
+# Maximum number of buckets returned by a single OpenSearch terms aggregation.
+# Results are silently truncated when the true cardinality exceeds this value.
+# See get_synced_file_ids_for_connector / get_synced_id_to_filename_map.
+# TODO: replace with composite aggregation + pagination to handle arbitrary cardinality.
+OPENSEARCH_TERMS_AGG_LIMIT = 10_000
+
 
 async def _connector_access_denied(
     request: Request,
@@ -98,10 +104,14 @@ async def get_synced_file_ids_for_connector(
             "query": {"term": {"connector_type": connector_type}},
             "aggs": {
                 "unique_connector_file_ids": {
-                    "terms": {"field": "connector_file_id", "size": 10000}
+                    "terms": {"field": "connector_file_id", "size": OPENSEARCH_TERMS_AGG_LIMIT}
                 },
-                "unique_document_ids": {"terms": {"field": "document_id", "size": 10000}},
-                "unique_filenames": {"terms": {"field": "filename", "size": 10000}},
+                "unique_document_ids": {
+                    "terms": {"field": "document_id", "size": OPENSEARCH_TERMS_AGG_LIMIT}
+                },
+                "unique_filenames": {
+                    "terms": {"field": "filename", "size": OPENSEARCH_TERMS_AGG_LIMIT}
+                },
             },
         }
 
@@ -113,7 +123,7 @@ async def get_synced_file_ids_for_connector(
             result.get("aggregations", {}).get("unique_connector_file_ids", {}).get("buckets", [])
         )
         connector_file_ids = [b["key"] for b in connector_file_id_buckets if b["key"]]
-        if len(connector_file_id_buckets) == 10000:
+        if len(connector_file_id_buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
             logger.warning(
             "Connector file ID aggregation hit 10k limit - results may be truncated",
             connector_type=connector_type,
@@ -128,7 +138,7 @@ async def get_synced_file_ids_for_connector(
                 result.get("aggregations", {}).get("unique_document_ids", {}).get("buckets", [])
             )
             file_ids = [b["key"] for b in doc_id_buckets if b["key"]]
-            if len(doc_id_buckets) == 10000:
+            if len(doc_id_buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
                 logger.warning("Document ID aggregation hit 10k limit - results may be truncated",
                 connector_type=connector_type, returned_count=len(file_ids),)
             id_field = "document_id"
@@ -137,7 +147,7 @@ async def get_synced_file_ids_for_connector(
             result.get("aggregations", {}).get("unique_filenames", {}).get("buckets", [])
         )
         filenames = [b["key"] for b in filename_buckets if b["key"]]
-        if len(filename_buckets) == 10000:
+        if len(filename_buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
             logger.warning("Filename aggregation hit 10k limit - results may be truncated", 
             connector_type=connector_type, returned_count=len(filenames),)
         logger.debug(
@@ -178,7 +188,7 @@ async def get_synced_id_to_filename_map(
             "query": {"term": {"connector_type": connector_type}},
             "aggs": {
                 "by_document_id": {
-                    "terms": {"field": "document_id", "size": 10000},
+                    "terms": {"field": "document_id", "size": OPENSEARCH_TERMS_AGG_LIMIT},
                     "aggs": {
                         "top_filename": {"terms": {"field": "filename", "size": 1}},
                     },
@@ -188,7 +198,7 @@ async def get_synced_id_to_filename_map(
 
         result = await opensearch_client.search(index=get_index_name(), body=query_body)
         buckets = result.get("aggregations", {}).get("by_document_id", {}).get("buckets", [])
-        if len(buckets) == 10000:
+        if len(buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
             logger.warning("Document ID to filename mapping hit 10k limit - results may be truncated",
             connector_type=connector_type, returned_count=len(buckets),)
 

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -113,7 +113,12 @@ async def get_synced_file_ids_for_connector(
             result.get("aggregations", {}).get("unique_connector_file_ids", {}).get("buckets", [])
         )
         connector_file_ids = [b["key"] for b in connector_file_id_buckets if b["key"]]
-
+        if len(connector_file_id_buckets) == 10000:
+            logger.warning(
+            "Connector file ID aggregation hit 10k limit - results may be truncated",
+            connector_type=connector_type,
+            returned_count=len(connector_file_ids),
+    )
         if connector_file_ids:
             file_ids = connector_file_ids
             id_field = "connector_file_id"
@@ -123,13 +128,18 @@ async def get_synced_file_ids_for_connector(
                 result.get("aggregations", {}).get("unique_document_ids", {}).get("buckets", [])
             )
             file_ids = [b["key"] for b in doc_id_buckets if b["key"]]
+            if len(doc_id_buckets) == 10000:
+                logger.warning("Document ID aggregation hit 10k limit - results may be truncated",
+                connector_type=connector_type, returned_count=len(file_ids),)
             id_field = "document_id"
 
         filename_buckets = (
             result.get("aggregations", {}).get("unique_filenames", {}).get("buckets", [])
         )
         filenames = [b["key"] for b in filename_buckets if b["key"]]
-
+        if len(filename_buckets) == 10000:
+            logger.warning("Filename aggregation hit 10k limit - results may be truncated", 
+            connector_type=connector_type, returned_count=len(filenames),)
         logger.debug(
             "Found synced files for connector",
             connector_type=connector_type,
@@ -178,6 +188,9 @@ async def get_synced_id_to_filename_map(
 
         result = await opensearch_client.search(index=get_index_name(), body=query_body)
         buckets = result.get("aggregations", {}).get("by_document_id", {}).get("buckets", [])
+        if len(buckets) == 10000:
+            logger.warning("Document ID to filename mapping hit 10k limit - results may be truncated",
+            connector_type=connector_type, returned_count=len(buckets),)
 
         mapping: dict[str, str] = {}
         for bucket in buckets:

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -125,10 +125,10 @@ async def get_synced_file_ids_for_connector(
         connector_file_ids = [b["key"] for b in connector_file_id_buckets if b["key"]]
         if len(connector_file_id_buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
             logger.warning(
-            "Connector file ID aggregation hit 10k limit - results may be truncated",
-            connector_type=connector_type,
-            returned_count=len(connector_file_ids),
-    )
+                "Connector file ID aggregation hit 10k limit - results may be truncated",
+                connector_type=connector_type,
+                returned_count=len(connector_file_ids),
+            )
         if connector_file_ids:
             file_ids = connector_file_ids
             id_field = "connector_file_id"
@@ -139,8 +139,11 @@ async def get_synced_file_ids_for_connector(
             )
             file_ids = [b["key"] for b in doc_id_buckets if b["key"]]
             if len(doc_id_buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
-                logger.warning("Document ID aggregation hit 10k limit - results may be truncated",
-                connector_type=connector_type, returned_count=len(file_ids),)
+                logger.warning(
+                    "Document ID aggregation hit 10k limit - results may be truncated",
+                    connector_type=connector_type,
+                    returned_count=len(file_ids),
+                )
             id_field = "document_id"
 
         filename_buckets = (
@@ -148,8 +151,11 @@ async def get_synced_file_ids_for_connector(
         )
         filenames = [b["key"] for b in filename_buckets if b["key"]]
         if len(filename_buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
-            logger.warning("Filename aggregation hit 10k limit - results may be truncated", 
-            connector_type=connector_type, returned_count=len(filenames),)
+            logger.warning(
+                "Filename aggregation hit 10k limit - results may be truncated",
+                connector_type=connector_type,
+                returned_count=len(filenames),
+            )
         logger.debug(
             "Found synced files for connector",
             connector_type=connector_type,
@@ -199,8 +205,11 @@ async def get_synced_id_to_filename_map(
         result = await opensearch_client.search(index=get_index_name(), body=query_body)
         buckets = result.get("aggregations", {}).get("by_document_id", {}).get("buckets", [])
         if len(buckets) == OPENSEARCH_TERMS_AGG_LIMIT:
-            logger.warning("Document ID to filename mapping hit 10k limit - results may be truncated",
-            connector_type=connector_type, returned_count=len(buckets),)
+            logger.warning(
+                "Document ID to filename mapping hit 10k limit - results may be truncated",
+                connector_type=connector_type,
+                returned_count=len(buckets),
+            )
 
         mapping: dict[str, str] = {}
         for bucket in buckets:


### PR DESCRIPTION
Temporarily fixes Issue #1548
Added warning logs to alert operators when OpenSearch terms aggregations
hit the 10,000 bucket limit in connector sync operations. This helps
detect potential data truncation issues in workspaces with >10k unique
document IDs, filenames, or connector file IDs.

Affected functions:

get_synced_file_ids_for_connector(): Warns when connector_file_id,
document_id, or filename aggregations reach the limit
get_synced_id_to_filename_map(): Warns when document_id aggregation
reaches the limit
This is an interim solution to surface the issue. A future enhancement
should implement composite aggregation with pagination to handle
arbitrarily large result sets without truncation.

Related: Connector sync may miss documents when workspace exceeds 10k
unique values per field

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of large connector result sets so file and name lookups are less likely to return incomplete data.
  * Added warnings when result counts reach a limit, helping surface cases where data may be truncated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->