### PR TITLE
fix: bump versions of packages to fix cves for langflow

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -39,6 +39,11 @@ FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS runtime
 WORKDIR /opt/app-root/src
 USER 0
 
+# Fix CVEs in global npm nested dependencies
+RUN cd /usr/lib/node_modules_22/npm && \
+    npm install @sigstore/core@3.2.1 sigstore@4.1.1 tar@7.5.16
+
+
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -39,11 +39,6 @@ FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS runtime
 WORKDIR /opt/app-root/src
 USER 0
 
-# Fix CVEs in global npm nested dependencies
-RUN cd /usr/lib/node_modules_22/npm && \
-    npm install @sigstore/core@3.2.1 sigstore@4.1.1 tar@7.5.16
-
-
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1

--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -20,7 +20,9 @@ RUN pip install --no-cache-dir \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
     "ibm-watsonx-ai>=1.3.1,<2.0.0" \
     "langchain-ibm~=1.1.0" \
+    "langchain-anthropic>=1.4.6" \
     uv \
+    && pip install --no-cache-dir --no-deps "langchain==1.3.9" \
     && pip uninstall -y clickhouse-connect \
     && pip uninstall -y ragstack-ai-knowledge-store
 


### PR DESCRIPTION
This pull request updates the dependencies in the `Dockerfile.langflow` to add support for Anthropic via LangChain and to ensure a specific version of LangChain is installed. These changes improve compatibility and add new integration capabilities.

Dependency updates and additions:

* Added the `langchain-anthropic` package (version >=1.4.6) to enable Anthropic integration.
* Explicitly installed `langchain` version 1.3.9 to ensure compatibility and avoid issues with dependency mismatches.