### PR TITLE
fix: reset dialog state and abort in-flight test on cancel (#2048)

### DIFF
--- a/frontend/app/settings/_components/connector-cards.tsx
+++ b/frontend/app/settings/_components/connector-cards.tsx
@@ -126,11 +126,19 @@ export default function ConnectorCards() {
       </div>
 
       {dialogDescriptors.map((descriptor) => {
+        // Render only while open so the component unmounts on close, which
+        // resets all useState/useForm state automatically and eliminates
+        // stale field values, error messages, and stuck loading indicators
+        // on reopen. The exit animation is foregone — an acceptable tradeoff
+        // for correctness.
+        if (openDialog !== descriptor.connectorType) return null;
         const Dialog = descriptor.SettingsDialog!;
         return (
           <Dialog
             key={descriptor.connectorType}
-            open={openDialog === descriptor.connectorType}
+            // mounted only while open; open is always true here,
+            // unmount handles "close"
+            open={true}
             setOpen={(open: boolean) =>
               setOpenDialog(open ? descriptor.connectorType : null)
             }

--- a/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useQueryClient } from "@tanstack/react-query";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { Button } from "@/components/ui/button";
@@ -62,7 +62,24 @@ export default function AzureBlobSettingsDialog({
 
   const configureMutation = useAzureBlobConfigureMutation();
 
+  // Holds the AbortController for the currently in-flight test request so it
+  // can be cancelled if the user closes the dialog or starts a new test.
+  const testAbortRef = useRef<AbortController | null>(null);
+
+  // Abort any in-flight test request when the component unmounts (i.e. when
+  // the dialog is closed, since connector-cards renders it only while open).
+  useEffect(() => {
+    return () => {
+      testAbortRef.current?.abort();
+    };
+  }, []);
+
   const handleTestConnection = handleSubmit(async (data) => {
+    // Cancel any previous in-flight test before starting a new one.
+    testAbortRef.current?.abort();
+    const controller = new AbortController();
+    testAbortRef.current = controller;
+
     setIsFetchingContainers(true);
     setContainersError(null);
     setFormError(null);
@@ -74,6 +91,7 @@ export default function AzureBlobSettingsDialog({
       const res = await fetch("/api/connectors/azure_blob/test", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        signal: controller.signal,
         body: JSON.stringify({
           auth_mode: data.auth_mode,
           connection_string: data.connection_string || undefined,
@@ -90,11 +108,20 @@ export default function AzureBlobSettingsDialog({
       setContainers(fetched);
       setSelectedContainers((prev) => prev.filter((c) => fetched.includes(c)));
     } catch (err: unknown) {
+      // Ignore cancellations — they are intentional (dialog closed or new test
+      // started) and must not surface an error message to the user.
+      if (err instanceof DOMException && err.name === "AbortError") return;
       setContainersError(
         err instanceof Error ? err.message : "Connection failed",
       );
     } finally {
-      setIsFetchingContainers(false);
+      // Only clear the loading flag if this invocation is still the active one.
+      // If the user started a second test while this one was in flight, the
+      // second call already replaced testAbortRef.current; clearing here would
+      // flicker the spinner off for the still-running request.
+      if (testAbortRef.current === controller) {
+        setIsFetchingContainers(false);
+      }
     }
   });
 


### PR DESCRIPTION
Fixes #2048 on main.

## Root cause

Connector settings dialogs (Azure Blob, S3, IBM COS) are rendered
unconditionally in `connector-cards.tsx` with a stable `key`, so the
component never unmounts when the user closes the dialog. All
`useState` and `useForm` state — the connection-string field value,
the `formError` "Test the connection first…" message, and the
`isFetchingContainers` loading flag — survive Cancel and reappear on
the next open.

Additionally, the Azure Blob test-connection handler called
`fetch("/api/connectors/azure_blob/test")` with no `AbortController`.
Clicking Cancel while a test was in flight left `isFetchingContainers`
stuck at `true` until the underlying TCP connection timed out, keeping
the button locked on "Connecting…" on reopen.

## Fix

**1 — `connector-cards.tsx`: unmount on close**

Render each `SettingsDialog` only while `openDialog === descriptor.connectorType`;
return `null` otherwise. The component unmounts on close, React destroys all
internal state, and every field and error message is fresh on the next open.
This also resolves the same latent stale-state bug in the S3 and IBM COS
dialogs at no extra cost, since they go through the same rendering loop.

**2 — `azure-blob/settings-dialog.tsx`: AbortController on the test fetch**

- A `useRef<AbortController | null>` tracks the currently in-flight test request.
- At the top of `handleTestConnection`, any prior call is aborted before a new
  controller is created — cancels a stuck request if the user clicks the button
  twice.
- `signal: controller.signal` is passed to `fetch`; `AbortError` is caught and
  swallowed silently (no error state set to the user).
- A `useEffect` cleanup aborts on unmount, so closing the dialog mid-request
  immediately cancels the network call rather than letting it run to TCP timeout.
- The `finally` block is guarded with `testAbortRef.current === controller` so
  that an aborted call's `finally` does not clear `isFetchingContainers` while a
  superseding request is still in flight (prevents spinner flicker).

## Known tradeoff

Unmount-on-close skips the Radix exit animation — the dialog disappears
immediately rather than fading out. Intentional; correctness takes priority over
the transition.

## Deferred follow-up

S3 (`s3-settings-dialog.tsx`) and IBM COS (`ibm-cos/settings-dialog.tsx`) both
use a `mutateAsync` + raw `fetch` sequence in their test paths. The raw `fetch`
portion is equally abortable, but adding `AbortController` to both is deferred
to keep this PR scoped to #2048.

## Verification

- `biome check` and `tsc --noEmit` on the two changed files: no new warnings or
  errors vs. the baseline on `main`.
- Manual reproduction of all three symptoms from #2048 against a production
  container build of this branch (Azurite down): connection string, stale error
  message, and stuck loading state all confirmed fixed after Cancel + reopen.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connector settings dialogs so they close and reset cleanly.
  * Cancelled previous connection tests when a new test starts or the dialog closes.
  * Prevented cancelled requests from showing errors or incorrectly changing loading indicators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->