### PR TITLE
fix: restrict ingestion to containers section shows up correctly and error message isn't duplicated

### DIFF
--- a/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
@@ -49,10 +49,12 @@ export default function AzureBlobSettingsDialog({
   const [selectedContainers, setSelectedContainers] = useState<string[]>(
     defaults?.container_names ?? [],
   );
+  const [showContainers, setShowContainers] = useState(false);
   useEffect(() => {
     if (defaults?.container_names?.length) {
       setContainers(defaults.container_names);
       setSelectedContainers(defaults.container_names);
+      setShowContainers(true);
     }
   }, [defaults]);
 
@@ -107,6 +109,7 @@ export default function AzureBlobSettingsDialog({
       const fetched: string[] = json.containers;
       setContainers(fetched);
       setSelectedContainers((prev) => prev.filter((c) => fetched.includes(c)));
+      setShowContainers(true);
     } catch (err: unknown) {
       // Ignore cancellations — they are intentional (dialog closed or new test
       // started) and must not surface an error message to the user.
@@ -114,6 +117,7 @@ export default function AzureBlobSettingsDialog({
       setContainersError(
         err instanceof Error ? err.message : "Connection failed",
       );
+      setShowContainers(false);
     } finally {
       // Only clear the loading flag if this invocation is still the active one.
       // If the user started a second test while this one was in flight, the
@@ -127,6 +131,7 @@ export default function AzureBlobSettingsDialog({
 
   const onSubmit = handleSubmit(async (data) => {
     setFormError(null);
+    setContainersError(null);
     if (containers === null) {
       setFormError("Test the connection first to validate credentials.");
       return;
@@ -197,6 +202,8 @@ export default function AzureBlobSettingsDialog({
               connectionStringSet={defaults?.connection_string_set}
               accountKeySet={defaults?.account_key_set}
               formError={formError}
+              showContainers={showContainers}
+              onAuthModeChange={() => setShowContainers(false)}
             />
 
             <DialogFooter className="mt-4">

--- a/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
@@ -56,11 +56,10 @@ export default function AzureBlobSettingsDialog({
   const [prevDefaults, setPrevDefaults] = useState(defaults);
   if (defaults !== prevDefaults) {
     setPrevDefaults(defaults);
-    if (defaults?.container_names?.length) {
-      setContainers(defaults.container_names);
-      setSelectedContainers(defaults.container_names);
-      setShowContainers(true);
-    }
+    const names = defaults?.container_names ?? [];
+    setContainers(names.length ? names : null);
+    setSelectedContainers(names);
+    setShowContainers(names.length > 0);
   }
 
   const [isFetchingContainers, setIsFetchingContainers] = useState(false);

--- a/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
@@ -72,13 +72,16 @@ export default function AzureBlobSettingsDialog({
   // can be cancelled if the user closes the dialog or starts a new test.
   const testAbortRef = useRef<AbortController | null>(null);
 
-  // Abort any in-flight test request when the component unmounts (i.e. when
-  // the dialog is closed, since connector-cards renders it only while open).
+  // Abort any in-flight test request when the dialog closes. The dialog
+  // component itself stays mounted (connector-cards renders it unconditionally
+  // and just toggles `open`), so an unmount-only cleanup would never fire here
+  // — without this, a canceled test could still resolve and repopulate the
+  // container list after the user closed the dialog.
   useEffect(() => {
-    return () => {
+    if (!open) {
       testAbortRef.current?.abort();
-    };
-  }, []);
+    }
+  }, [open]);
 
   const handleTestConnection = handleSubmit(async (data) => {
     // Cancel any previous in-flight test before starting a new one.

--- a/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
@@ -203,7 +203,10 @@ export default function AzureBlobSettingsDialog({
               accountKeySet={defaults?.account_key_set}
               formError={formError}
               showContainers={showContainers}
-              onAuthModeChange={() => setShowContainers(false)}
+              onAuthModeChange={() => {
+                setShowContainers(false);
+                setContainers(null);
+              }}
             />
 
             <DialogFooter className="mt-4">

--- a/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
@@ -49,14 +49,19 @@ export default function AzureBlobSettingsDialog({
   const [selectedContainers, setSelectedContainers] = useState<string[]>(
     defaults?.container_names ?? [],
   );
-  const [showContainers, setShowContainers] = useState(false);
-  useEffect(() => {
+  const [showContainers, setShowContainers] = useState(
+    !!defaults?.container_names?.length,
+  );
+
+  const [prevDefaults, setPrevDefaults] = useState(defaults);
+  if (defaults !== prevDefaults) {
+    setPrevDefaults(defaults);
     if (defaults?.container_names?.length) {
       setContainers(defaults.container_names);
       setSelectedContainers(defaults.container_names);
       setShowContainers(true);
     }
-  }, [defaults]);
+  }
 
   const [isFetchingContainers, setIsFetchingContainers] = useState(false);
   const [containersError, setContainersError] = useState<string | null>(null);
@@ -206,6 +211,8 @@ export default function AzureBlobSettingsDialog({
               onAuthModeChange={() => {
                 setShowContainers(false);
                 setContainers(null);
+                setContainersError(null);
+                setFormError(null);
               }}
             />
 

--- a/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-dialog.tsx
@@ -123,6 +123,7 @@ export default function AzureBlobSettingsDialog({
         err instanceof Error ? err.message : "Connection failed",
       );
       setShowContainers(false);
+      setContainers(null);
     } finally {
       // Only clear the loading flag if this invocation is still the active one.
       // If the user started a second test while this one was in flight, the

--- a/frontend/enhancements/connectors/azure-blob/settings-form.tsx
+++ b/frontend/enhancements/connectors/azure-blob/settings-form.tsx
@@ -29,6 +29,8 @@ interface AzureBlobSettingsFormProps {
   connectionStringSet?: boolean;
   accountKeySet?: boolean;
   formError?: string | null;
+  showContainers?: boolean;
+  onAuthModeChange?: () => void;
 }
 
 export function AzureBlobSettingsForm({
@@ -41,6 +43,8 @@ export function AzureBlobSettingsForm({
   connectionStringSet,
   accountKeySet,
   formError,
+  showContainers,
+  onAuthModeChange,
 }: AzureBlobSettingsFormProps) {
   const {
     register,
@@ -69,7 +73,13 @@ export function AzureBlobSettingsForm({
           control={control}
           name="auth_mode"
           render={({ field }) => (
-            <Tabs value={field.value} onValueChange={(v) => field.onChange(v)}>
+            <Tabs
+              value={field.value}
+              onValueChange={(v) => {
+                field.onChange(v);
+                onAuthModeChange?.();
+              }}
+            >
               <TabsList className="w-full">
                 <TabsTrigger value="connection_string">
                   <span className="font-semibold text-sm">
@@ -213,7 +223,7 @@ export function AzureBlobSettingsForm({
       )}
 
       {/* Container selector */}
-      {containers !== null && (
+      {containers !== null && showContainers && (
         <div className="space-y-2">
           <div className="flex items-center justify-between">
             <Label className="text-sm font-medium">


### PR DESCRIPTION
## Summary
Fixes #2047 .This PR adds a showContainers state to control when the "Restrict Ingestion to Containers" section shows up and onAuthModeChange to reset it when the user switches authentication methods, preventing stale container data from persisting across auth mode changes. The section also now hides on a failed test connection, so bad credentials clear any previously visible list. Additionally, setContainersError(null) is called at the start of onSubmit to prevent duplicate error messages when a stale connection error and a save validation error would otherwise both appear simultaneously.

## Before
[screen-capture (11).webm](https://github.com/user-attachments/assets/436bd365-23c9-466c-bbc2-1f534183e6c1)

## After
[screen-capture (13).webm](https://github.com/user-attachments/assets/b4a26979-e1fd-4c46-a2e5-1360839e75a7)

## Changes
- `settings-dialog.tsx`: adds showContainers state, sets it on test success/failure and auth mode change, clears containersError on submit
- `settings-form.tsx`: accepts showContainers + onAuthModeChange props, gates the container section on both, resets on tab switch


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Azure Blob setup flow so the container selector only appears when containers are available.
  * After a successful “test connection,” container options are fetched, filtered, and displayed automatically.
  * When switching authentication methods, the container selector is hidden and any container selection and related error messages are cleared.
  * If container loading fails, the correct error is shown while keeping the container selector hidden.
  * Saving now clears container-related error state as part of the submission flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->