### PR TITLE
fix: removed exception interpolation for 500 level errors

### DIFF
--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1161,9 +1161,7 @@ async def onboarding(
 
                     if not config_manager.save_config_file(current_config):
                         logger.error("Failed to save embedding model to config")
-                        return JSONResponse(
-                            {"error": "Failed to save configuration"}, status_code=500
-                        )
+                        return JSONResponse({"error": "Failed to save configuration"}, status_code=500)
 
                     provider_health_cache.invalidate()
 
@@ -1196,7 +1194,7 @@ async def onboarding(
                 except Exception as e:
                     logger.error("Failed to complete sample data ingestion", error=str(e))
                     return JSONResponse(
-                        {"error": f"Failed to ingest sample documents: {str(e)}"},
+                        {"error": "Failed to ingest sample documents. Please try again or contact support."},
                         status_code=500,
                     )
 
@@ -1279,7 +1277,7 @@ async def onboarding(
         logger.error("Failed to update onboarding settings", error=str(e))
         await TelemetryClient.send_event(Category.ONBOARDING, MessageId.ORB_ONBOARD_FAILED)
         return JSONResponse(
-            {"error": str(e)},
+            {"error": "Failed to complete onboarding. Please try again or contact support."},
             status_code=500,
         )
 
@@ -1315,7 +1313,7 @@ async def update_onboarding_state(
     except Exception as e:
         logger.error(f"Error updating onboarding state: {str(e)}")
         return JSONResponse(
-            {"error": f"Failed to update onboarding state: {str(e)}"},
+            {"error": "Failed to update onboarding state. Please try again or contact support."},
             status_code=500,
         )
 
@@ -1659,5 +1657,5 @@ async def refresh_openrag_docs(
         logger.error("Failed to refresh OpenRAG docs on demand", error=str(e))
         raise HTTPException(
             status_code=500,
-            detail=f"Failed to refresh OpenRAG docs: {str(e)}",
-        ) from e
+            detail="Failed to refresh OpenRAG docs. Please try again or contact support.",
+        )

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1161,7 +1161,9 @@ async def onboarding(
 
                     if not config_manager.save_config_file(current_config):
                         logger.error("Failed to save embedding model to config")
-                        return JSONResponse({"error": "Failed to save configuration"}, status_code=500)
+                        return JSONResponse(
+                            {"error": "Failed to save configuration"}, status_code=500
+                        )
 
                     provider_health_cache.invalidate()
 
@@ -1194,7 +1196,9 @@ async def onboarding(
                 except Exception as e:
                     logger.error("Failed to complete sample data ingestion", error=str(e))
                     return JSONResponse(
-                        {"error": "Failed to ingest sample documents. Please try again or contact support."},
+                        {
+                            "error": "Failed to ingest sample documents. Please try again or contact support."
+                        },
                         status_code=500,
                     )
 

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1662,4 +1662,4 @@ async def refresh_openrag_docs(
         raise HTTPException(
             status_code=500,
             detail="Failed to refresh OpenRAG docs. Please try again or contact support.",
-        )
+        ) from e


### PR DESCRIPTION
## Summary
Fixes Issue #1589 : CWE-209 (Information Exposure Through an Error Message) by removing raw str(e) interpolation from 500-level HTTP responses in src/api/settings/endpoints.py. Internal exception details are now kept server-side in logs only, preventing accidental exposure of file paths, library internals, or configuration fragments to API callers.

## Changes
- Replaced str(e) in four 500-level client responses with static, generic messages in onboarding (sample data ingestion and outer handler), update_onboarding_state, and refresh_openrag_docs

## Testing
Ran tests/unit/api/test_settings_endpoints.py, tests/unit/test_settings_refresh_endpoint.py, and tests/unit/services/test_onboarding_reset.py: all previously passing tests continue to pass with no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during onboarding and document refresh operations by showing clear, generic user-facing messages instead of exposing technical error details.
  * Existing HTTP status codes and workflows remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->