### PR TITLE
Fix: add ppc64le build and dev server support for frontend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -735,11 +735,11 @@ frontend: ## Run frontend locally
 		echo "$(YELLOW)Detected Power architecture ($$ARCH) — using Webpack fallback$(NC)"; \
 		npx next dev --webpack \
 			--port $$PORT \
-			--hostname $(hostname); \
+			--hostname $$(hostname); \
 	else \
 		npx next dev \
 			--port $$PORT \
-			--hostname $(hostname); \
+			--hostname $$(hostname); \
 	fi
 
 docling: ## Start docling-serve for document processing

--- a/Makefile
+++ b/Makefile
@@ -725,14 +725,22 @@ backend: ## Run backend locally
 frontend: ## Run frontend locally
 	@echo "$(YELLOW)Starting frontend locally...$(NC)"
 	@if [ ! -d "frontend/node_modules" ]; then echo "$(YELLOW)Installing frontend dependencies first...$(NC)"; cd frontend && npm install; fi
+	@ARCH=$$(uname -m); \
+	export ENV_FILE="$(abspath $(ENV_FILE))"; \
+	PORT=$${FRONTEND_PORT:-3000}; \
+	export NEXT_DIST_DIR=$${NEXT_DIST_DIR:-$$( [ "$$PORT" = "3000" ] && echo .next || echo .next-$$PORT )}; \
 	cd frontend && \
-		export ENV_FILE="$(abspath $(ENV_FILE))"; \
-		PORT=$${FRONTEND_PORT:-3000}; \
-		export NEXT_DIST_DIR=$${NEXT_DIST_DIR:-$$( [ "$$PORT" = "3000" ] && echo .next || echo .next-$$PORT )}; \
-		echo "$(YELLOW)Using distDir $$NEXT_DIST_DIR$(NC)"; \
+	echo "$(YELLOW)Using distDir $$NEXT_DIST_DIR$(NC)"; \
+	if [ "$$ARCH" = "ppc64le" ] || [ "$$ARCH" = "ppc64" ]; then \
+		echo "$(YELLOW)Detected Power architecture ($$ARCH) — using Webpack fallback$(NC)"; \
+		npx next dev --webpack \
+			--port $$PORT \
+			--hostname $(hostname); \
+	else \
 		npx next dev \
 			--port $$PORT \
-			--hostname $(hostname)
+			--hostname $(hostname); \
+	fi
 
 docling: ## Start docling-serve for document processing
 	@echo "$(YELLOW)Starting docling-serve...$(NC)"

--- a/frontend/build.js
+++ b/frontend/build.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const { execSync } = require("child_process");
+
+// Detect architecture
+const arch = process.arch;
+const isPPC64 = arch === "ppc64";
+
+// Choose build command
+const buildCmd = isPPC64 ? "next build --webpack" : "next build";
+
+console.log(`Building for ${arch} using: ${buildCmd}`);
+
+// Execute build
+try {
+  execSync(buildCmd, { stdio: "inherit" });
+} catch (error) {
+  process.exit(error.status || 1);
+}

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,7 +6,7 @@ import path from "path";
 // the Makefile) so per-instance env files like `.env.instance2` are respected;
 // defaults to `.env`. Absolute ENV_FILE paths are used as-is.
 dotenv.config({
-  path: path.resolve(__dirname, "..", process.env.ENV_FILE || ".env"),
+  path: path.join(process.cwd(), "..", process.env.ENV_FILE || ".env"),
 });
 
 function getAllowedDevOrigins(): string[] {

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -6,7 +6,7 @@ import path from "path";
 // the Makefile) so per-instance env files like `.env.instance2` are respected;
 // defaults to `.env`. Absolute ENV_FILE paths are used as-is.
 dotenv.config({
-  path: path.join(process.cwd(), "..", process.env.ENV_FILE || ".env"),
+  path: path.resolve(process.cwd(), "..", process.env.ENV_FILE || ".env"),
 });
 
 function getAllowedDevOrigins(): string[] {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,7 +7,7 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "node build.js",
     "start": "next start",
     "lint": "biome check .",
     "typecheck": "tsc --noEmit",


### PR DESCRIPTION
**Fixes** #2088

**What changed**

- `frontend/next.config.ts` — replace `__dirname` with `process.cwd()` (fixes crash when Next.js compiles config as an ES module under the WASM runtime)
- `frontend/build.js` — new arch-detection wrapper that adds `--webpack` flag on ppc64le
- `frontend/package.json` — change build script from `next build` to `node build.js`
- `Makefile` — add ppc64le arch check to `make frontend` dev server target, passes `--webpack` on Power hardware

**Why**

`next-swc` has no native bindings for `linux/ppc64le`. The WASM fallback compiles `next.config.ts` as an ES module where `__dirname` is undefined, crashing both the build and dev server. Forcing `--webpack` and using `process.cwd()` instead makes the build work correctly on ppc64le while remaining unchanged on x86_64 and arm64.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added PowerPC architecture support for frontend development and production builds, including a Webpack fallback when needed.
  - Introduced an automated build launcher to select the correct build command by architecture.

- **Bug Fixes**
  - Improved environment file lookup by resolving the `.env` path relative to the runtime working directory.
  - Preserved configured host/port behavior across development startup and build workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->