### PR TITLE
fix: OAuth connector callback redirect fix (backport of #2054)

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -16,6 +16,7 @@ import {
 import { useAuth } from "@/contexts/auth-context";
 import { decodeBase64 } from "@/lib/utils";
 
+// remove from localStorage any keys related to the OAuth flow
 function cleanupOAuthStorage() {
   localStorage.removeItem("connecting_connector_id");
   localStorage.removeItem("connecting_connector_type");


### PR DESCRIPTION
## Summary
Backports #2054 from `release-saas-ga-0.6.2` to `main`.

Most of #2054's substance (the `refreshAuth` `useCallback` fix, CI workflow tweaks) was already merged to `main` independently via #2052. The only remaining diff after cherry-picking is a single explanatory comment in `frontend/app/auth/callback/page.tsx` that wasn't carried over.

## Test plan
- [ ] CI passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added an inline clarification describing OAuth storage cleanup behavior.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->