### PR TITLE
feat: Azure Blog Connector - "Ingested" status badge is missing

### DIFF
--- a/src/utils/opensearch_init.py
+++ b/src/utils/opensearch_init.py
@@ -216,7 +216,13 @@ async def _ensure_opensearch_index():
             await _ensure_keyword_mappings(
                 clients.opensearch,
                 index_name,
-                ["allowed_users", "allowed_groups", "allowed_principals", "ingest_run_id"],
+                [
+                    "allowed_users",
+                    "allowed_groups",
+                    "allowed_principals",
+                    "ingest_run_id",
+                    "connector_file_id",
+                ],
             )
             await _ensure_field_mappings(
                 clients.opensearch,
@@ -297,7 +303,13 @@ async def init_index(opensearch_client=None, admin_username: str = None):
             await _ensure_keyword_mappings(
                 os_client,
                 index_name,
-                ["allowed_users", "allowed_groups", "allowed_principals", "ingest_run_id"],
+                [
+                    "allowed_users",
+                    "allowed_groups",
+                    "allowed_principals",
+                    "ingest_run_id",
+                    "connector_file_id",
+                ],
             )
             await _ensure_field_mappings(
                 os_client,


### PR DESCRIPTION
### ℹ️ Issue

- https://github.com/langflow-ai/openrag/issues/2084

### ℹ️ Summary

- Fixed a startup self-heal gap that let `connector_file_id` drift to a `text` mapping on existing OpenSearch indices, breaking the terms aggregation used to compute per-connector "ingested" status and hiding the badge in the Browse Files dialog (reproduced on Azure Blob).

---

### ✅ OpenSearch Index Mapping

- Added `connector_file_id` to the keyword self-heal field list in both `_ensure_opensearch_index()` and `init_index()` (`src/utils/opensearch_init.py`), so existing indices missing this field get it created as `keyword` on startup instead of falling back to OpenSearch's dynamic `text` mapping on first write.