### PR TITLE
fix: leak of keys on logs during exception

### DIFF
--- a/src/agent.py
+++ b/src/agent.py
@@ -284,6 +284,11 @@ async def async_response(
     previous_response_id: str = None,
     log_prefix: str = "response",
 ):
+    # extra_headers/request_params carry raw secrets (JWT, provider API keys,
+    # x-api-key — see langflow_headers.py). Never pass them to a logger call
+    # (e.g. logger.info(..., extra_headers=extra_headers)) — that logs the
+    # secrets directly, bypassing the show_locals=False traceback protection
+    # in utils/logging_config.py.
     try:
         logger.info("User prompt received", prompt=prompt)
 

--- a/src/services/chat_service.py
+++ b/src/services/chat_service.py
@@ -76,7 +76,10 @@ class ChatService:
                 "LANGFLOW_URL and LANGFLOW_CHAT_FLOW_ID environment variables are required"
             )
 
-        # Prepare extra headers for JWT authentication and embedding model
+        # Prepare extra headers for JWT authentication and embedding model.
+        # NOTE: extra_headers accumulates raw secrets (JWT, provider API keys —
+        # see add_provider_credentials_to_headers below). Never log this dict or
+        # pass it to a logger call (e.g. logger.info(..., extra_headers=...)).
         extra_headers = {}
         if jwt_token:
             extra_headers["X-LANGFLOW-GLOBAL-VAR-JWT"] = jwt_token
@@ -244,7 +247,10 @@ class ChatService:
         if not LANGFLOW_URL or not NUDGES_FLOW_ID:
             raise ValueError("LANGFLOW_URL and NUDGES_FLOW_ID environment variables are required")
 
-        # Prepare extra headers for JWT authentication and embedding model
+        # Prepare extra headers for JWT authentication and embedding model.
+        # NOTE: extra_headers accumulates raw secrets (JWT, provider API keys —
+        # see add_provider_credentials_to_headers below). Never log this dict or
+        # pass it to a logger call (e.g. logger.info(..., extra_headers=...)).
         extra_headers = {}
         if jwt_token:
             extra_headers["X-LANGFLOW-GLOBAL-VAR-JWT"] = jwt_token
@@ -488,7 +494,10 @@ class ChatService:
         conversation_user_id = storage_user_id or user_id
 
         if endpoint == "langflow":
-            # Prepare extra headers for JWT authentication and embedding model
+            # Prepare extra headers for JWT authentication and embedding model.
+            # NOTE: extra_headers accumulates raw secrets (JWT, provider API keys).
+            # Never log this dict or pass it to a logger call
+            # (e.g. logger.info(..., extra_headers=...)).
             extra_headers = {}
             if jwt_token:
                 extra_headers["X-LANGFLOW-GLOBAL-VAR-JWT"] = jwt_token

--- a/src/utils/langflow_headers.py
+++ b/src/utils/langflow_headers.py
@@ -65,6 +65,10 @@ async def add_provider_credentials_to_headers(
         jwt_token: Optional credential string (``'Basic <b64>'`` or ``'Bearer <jwt>'``).
                    When IBM_AUTH_ENABLED, injected as Langflow global variables. Basic
                    credentials additionally provide OPENSEARCH_USERNAME and OPENSEARCH_PASSWORD.
+
+    NOTE: `headers` ends up holding raw API keys/JWTs after this call. Never log
+    it directly (e.g. logger.info(..., headers=headers) / extra_headers=...) —
+    use utils.logging_config.sanitize_headers() if a header dict must be logged.
     """
     # Add OpenAI credentials
     if config.providers.openai.api_key:

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -151,9 +151,15 @@ def configure_logging(
     _shared_processors = list(base_processors)
 
     if use_json:
-        # Production: structured tracebacks (queryable in ELK/Datadog/Splunk)
+        # Production: structured tracebacks (queryable in ELK/Datadog/Splunk).
+        # show_locals=False: local variables routinely hold API keys, JWTs, and
+        # other request headers (see extra_headers/request_params in agent.py) —
+        # they must never be serialized into logs. dict_tracebacks defaults to
+        # show_locals=True, which leaked exactly that into production logs.
         render_processors = [
-            structlog.processors.dict_tracebacks,
+            structlog.processors.ExceptionRenderer(
+                structlog.tracebacks.ExceptionDictTransformer(show_locals=False)
+            ),
             structlog.processors.JSONRenderer(),
         ]
     else:

--- a/tests/unit/utils/test_logging_config.py
+++ b/tests/unit/utils/test_logging_config.py
@@ -1,0 +1,59 @@
+"""Unit tests for ``utils.logging_config`` — production JSON logs must never
+serialize exception-frame locals, since those routinely hold API keys, JWTs,
+and other request headers (see src/agent.py's extra_headers/request_params)."""
+
+import io
+import json
+
+import structlog
+
+from utils import logging_config
+
+FAKE_SECRET = "sk-test-should-not-leak-0123456789"
+
+
+def _raise_with_secret():
+    api_key = FAKE_SECRET  # noqa: F841 - intentionally kept as a local
+    raise ValueError("boom")
+
+
+def _capture_json_exception_log() -> dict:
+    logging_config.configure_logging(json_logs=True, include_timestamps=False)
+    stream = io.StringIO()
+    structlog.configure(
+        processors=structlog.get_config()["processors"],
+        wrapper_class=structlog.get_config()["wrapper_class"],
+        context_class=dict,
+        logger_factory=structlog.WriteLoggerFactory(stream),
+        cache_logger_on_first_use=True,
+    )
+    logger = structlog.get_logger()
+    try:
+        _raise_with_secret()
+    except ValueError:
+        logger.exception("something failed")
+    return json.loads(stream.getvalue())
+
+
+def test_json_exception_logs_do_not_leak_locals():
+    event = _capture_json_exception_log()
+
+    raw = json.dumps(event)
+    assert FAKE_SECRET not in raw
+
+    exception = event["exception"]
+    assert exception, "expected a rendered exception traceback"
+    for stack in exception:
+        for frame in stack.get("frames", []):
+            assert not frame.get("locals"), (
+                f"frame {frame.get('name')} unexpectedly serialized locals: {frame.get('locals')}"
+            )
+
+
+def test_json_exception_logs_still_include_frame_identity():
+    event = _capture_json_exception_log()
+
+    exception = event["exception"]
+    frame_names = [f.get("name") for stack in exception for f in stack.get("frames", [])]
+    assert "_raise_with_secret" in frame_names
+    assert exception[0]["exc_type"] == "ValueError"


### PR DESCRIPTION
This pull request strengthens the application's protection against leaking sensitive information (such as API keys and JWTs) into logs. It does so by improving documentation, updating logging configuration to avoid serializing local variables in exception tracebacks, and adding unit tests to ensure secrets are never exposed in production logs.

**Logging and Security Improvements:**

* Updated comments and documentation in `src/agent.py`, `src/services/chat_service.py`, and `src/utils/langflow_headers.py` to warn developers never to log or pass header dictionaries (which may contain secrets) to loggers, and to use sanitization if logging is required. [[1]](diffhunk://#diff-3f21ad1752eea52d46c1770fecd891a347976b44142baa2a02235d239cc6e016R287-R291) [[2]](diffhunk://#diff-a656d24ea3c40e5b3ba0c8c3e11af85a45cad1ba6f2ffd9ddf83af25408a6739L79-R82) [[3]](diffhunk://#diff-a656d24ea3c40e5b3ba0c8c3e11af85a45cad1ba6f2ffd9ddf83af25408a6739L247-R253) [[4]](diffhunk://#diff-a656d24ea3c40e5b3ba0c8c3e11af85a45cad1ba6f2ffd9ddf83af25408a6739L491-R500) [[5]](diffhunk://#diff-62094c4bdc99f526cd5a3f567d7fba2be315cd159906e3279fcded67c2896894R68-R71)

**Logging Configuration Changes:**

* Modified `configure_logging` in `src/utils/logging_config.py` to ensure production JSON logs do not serialize exception-frame locals, which could leak secrets. Now uses `ExceptionRenderer` with `show_locals=False` for structured tracebacks.

**Testing and Validation:**

* Added unit tests in `tests/unit/utils/test_logging_config.py` to verify that JSON exception logs do not leak local variables (such as API keys) and still include necessary frame information for debugging.