### PR TITLE
fix: issue 2043, revising connector cards display and ui for better user understanding.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,6 +121,11 @@ services:
       - MAX_WORKERS=${MAX_WORKERS:-4}
       - IBM_AUTH_ENABLED=${IBM_AUTH_ENABLED:-false}
       - OPENRAG_AZURE_BLOB_ENABLED=${OPENRAG_AZURE_BLOB_ENABLED:-true}
+      - OPENRAG_DEV_AZURE_BLOB=${OPENRAG_DEV_AZURE_BLOB:-false}
+      - AZURE_STORAGE_CONNECTION_STRING=${AZURE_STORAGE_CONNECTION_STRING}
+      - AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME}
+      - AZURE_STORAGE_ACCOUNT_KEY=${AZURE_STORAGE_ACCOUNT_KEY}
+      - AZURE_STORAGE_ENDPOINT=${AZURE_STORAGE_ENDPOINT}
       - PLATFORM_AUTH_DEV_MODE=${PLATFORM_AUTH_DEV_MODE:-false}
       - PLATFORM_USERNAME=${PLATFORM_USERNAME}
       - PLATFORM_PASSWORD=${PLATFORM_PASSWORD}
@@ -160,7 +165,7 @@ services:
       - "${LANGFLOW_PORT:-7860}:7860"
     volumes:
       - ${OPENRAG_FLOWS_PATH:-./flows}:/app/flows:U,z
-      - ${LANGFLOW_DATA_PATH:-./langflow-data}:/app/langflow-data:U,z
+      - ${LANGFLOW_DATA_PATH:-./langflow-data}:/app/langflow-data
     # Linux: Docker Engine does not auto-inject host.docker.internal; map it to the host gateway
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -121,11 +121,6 @@ services:
       - MAX_WORKERS=${MAX_WORKERS:-4}
       - IBM_AUTH_ENABLED=${IBM_AUTH_ENABLED:-false}
       - OPENRAG_AZURE_BLOB_ENABLED=${OPENRAG_AZURE_BLOB_ENABLED:-true}
-      - OPENRAG_DEV_AZURE_BLOB=${OPENRAG_DEV_AZURE_BLOB:-false}
-      - AZURE_STORAGE_CONNECTION_STRING=${AZURE_STORAGE_CONNECTION_STRING}
-      - AZURE_STORAGE_ACCOUNT_NAME=${AZURE_STORAGE_ACCOUNT_NAME}
-      - AZURE_STORAGE_ACCOUNT_KEY=${AZURE_STORAGE_ACCOUNT_KEY}
-      - AZURE_STORAGE_ENDPOINT=${AZURE_STORAGE_ENDPOINT}
       - PLATFORM_AUTH_DEV_MODE=${PLATFORM_AUTH_DEV_MODE:-false}
       - PLATFORM_USERNAME=${PLATFORM_USERNAME}
       - PLATFORM_PASSWORD=${PLATFORM_PASSWORD}
@@ -165,7 +160,7 @@ services:
       - "${LANGFLOW_PORT:-7860}:7860"
     volumes:
       - ${OPENRAG_FLOWS_PATH:-./flows}:/app/flows:U,z
-      - ${LANGFLOW_DATA_PATH:-./langflow-data}:/app/langflow-data
+      - ${LANGFLOW_DATA_PATH:-./langflow-data}:/app/langflow-data:U,z
     # Linux: Docker Engine does not auto-inject host.docker.internal; map it to the host gateway
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/frontend/app/api/queries/useGetConnectorsQuery.ts
+++ b/frontend/app/api/queries/useGetConnectorsQuery.ts
@@ -133,7 +133,7 @@ export interface Connector {
   name: string;
   description: string;
   icon: string; // The icon name from the API
-  status: "not_connected" | "connected" | "error";
+  status: "not_connected" | "configured" | "connected" | "error";
   type: string;
   connectionId?: string;
   clientId?: string;
@@ -141,6 +141,7 @@ export interface Connector {
   access_token?: string;
   selectedFiles?: GoogleDriveFile[] | OneDriveFile[];
   available?: boolean;
+  requiresOAuth?: boolean;
 }
 
 interface Connection {
@@ -189,6 +190,11 @@ export const useGetConnectorsQuery = (
         let status: Connector["status"] = "not_connected";
         let connectionId: string | undefined;
 
+        // Determine if this connector requires OAuth based on connector kind
+        // "oauth" connectors require OAuth flow (Google Drive, OneDrive, SharePoint)
+        // "bucket" connectors use credential-based auth (Azure Blob, S3, IBM COS)
+        const requiresOAuth = connectorData.kind === "oauth";
+
         if (statusResponse.ok) {
           const statusData = await statusResponse.json();
           const connections = statusData.connections || [];
@@ -210,7 +216,13 @@ export const useGetConnectorsQuery = (
               clientId: activeConnection.client_id,
               baseUrl: activeConnection.base_url,
               available: connectorData.available,
+              requiresOAuth,
             } as Connector;
+          }
+
+          // For OAuth connectors: check if credentials are configured in .env
+          if (requiresOAuth && statusData.has_env_credentials) {
+            status = "configured";
           }
         }
 
@@ -223,6 +235,7 @@ export const useGetConnectorsQuery = (
           type,
           connectionId,
           available: connectorData.available,
+          requiresOAuth,
         } as Connector;
       }),
     );

--- a/frontend/app/settings/_components/connector-card.tsx
+++ b/frontend/app/settings/_components/connector-card.tsx
@@ -106,9 +106,11 @@ export default function ConnectorCard({
               >
                 {isConnected
                   ? `${connector.name} is connected.`
-                  : isConfigured || connector?.available
+                  : isConfigured
                     ? `${connector.name} is configured.`
-                    : "Allowed for this workspace — OAuth credentials not configured yet."}
+                    : connector?.available && !connector.requiresOAuth
+                      ? `${connector.name} is available to connect.`
+                      : "Allowed for this workspace — OAuth credentials not configured yet."}
               </CardDescription>
             </div>
           </div>

--- a/frontend/app/settings/_components/connector-card.tsx
+++ b/frontend/app/settings/_components/connector-card.tsx
@@ -24,6 +24,7 @@ export interface Connector {
   available?: boolean;
   status?: string;
   connectionId?: string;
+  requiresOAuth?: boolean;
 }
 
 interface ConnectorCardProps {
@@ -56,6 +57,7 @@ export default function ConnectorCard({
   const canUpload = can("knowledge:upload");
   const isConnected =
     connector.status === "connected" && connector.connectionId;
+  const isConfigured = connector.status === "configured";
 
   return (
     <Card
@@ -102,9 +104,11 @@ export default function ConnectorCard({
                   isCloudBrand && "!text-layer-contextual-foreground",
                 )}
               >
-                {isConnected || connector?.available
-                  ? `${connector.name} is configured.`
-                  : "Allowed for this workspace — OAuth credentials not configured yet."}
+                {isConnected
+                  ? `${connector.name} is connected.`
+                  : isConfigured || connector?.available
+                    ? `${connector.name} is configured.`
+                    : "Allowed for this workspace — OAuth credentials not configured yet."}
               </CardDescription>
             </div>
           </div>

--- a/frontend/app/settings/_components/connector-cards.tsx
+++ b/frontend/app/settings/_components/connector-cards.tsx
@@ -51,7 +51,12 @@ export default function ConnectorCards() {
   }, []);
 
   const connectors = queryConnectors
-    .filter((c) => c.available !== false)
+    .filter((c) => {
+      // Keep OAuth connectors regardless of availability
+      if (c.requiresOAuth) return true;
+      // Only hide credential-based connectors when unavailable
+      return c.available !== false;
+    })
     .map((c) => ({
       ...c,
       icon: getConnectorIcon(c.type),

--- a/frontend/app/settings/_components/connector-cards.tsx
+++ b/frontend/app/settings/_components/connector-cards.tsx
@@ -50,10 +50,12 @@ export default function ConnectorCards() {
     return <Icon />;
   }, []);
 
-  const connectors = queryConnectors.map((c) => ({
-    ...c,
-    icon: getConnectorIcon(c.type),
-  })) as Connector[];
+  const connectors = queryConnectors
+    .filter((c) => c.available !== false)
+    .map((c) => ({
+      ...c,
+      icon: getConnectorIcon(c.type),
+    })) as Connector[];
 
   const handleConnect = async (connector: Connector) => {
     connectMutation.mutate({
@@ -94,36 +96,82 @@ export default function ConnectorCards() {
     (d) => d.SettingsDialog,
   );
 
+  // Split connectors into OAuth and credential-based
+  const oauthConnectors = connectors.filter((c) => c.requiresOAuth);
+  const credentialConnectors = connectors.filter((c) => !c.requiresOAuth);
+
   return (
     <>
-      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
-        {connectorsLoading ? (
-          <>
-            <ConnectorsSkeleton />
-            <ConnectorsSkeleton />
-            <ConnectorsSkeleton />
-          </>
-        ) : (
-          connectors.map((connector) => (
-            <ConnectorCard
-              key={connector.id}
-              connector={connector}
-              isConnecting={
-                connectMutation.isPending &&
-                connectMutation.variables?.connector.id === connector.id
-              }
-              isDisconnecting={
-                disconnectMutation.isPending &&
-                (disconnectMutation.variables as any)?.type === connector.type
-              }
-              onConnect={handleConnect}
-              onDisconnect={handleDisconnect}
-              onNavigateToKnowledge={navigateToKnowledgePage}
-              onConfigure={getConfigureHandler(connector)}
-            />
-          ))
-        )}
-      </div>
+      {/* OAuth Connectors Section */}
+      {(connectorsLoading || oauthConnectors.length > 0) && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">OAuth Connectors</h3>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {connectorsLoading ? (
+              <>
+                <ConnectorsSkeleton />
+                <ConnectorsSkeleton />
+                <ConnectorsSkeleton />
+              </>
+            ) : (
+              oauthConnectors.map((connector) => (
+                <ConnectorCard
+                  key={connector.id}
+                  connector={connector}
+                  isConnecting={
+                    connectMutation.isPending &&
+                    connectMutation.variables?.connector.id === connector.id
+                  }
+                  isDisconnecting={
+                    disconnectMutation.isPending &&
+                    (disconnectMutation.variables as any)?.type ===
+                      connector.type
+                  }
+                  onConnect={handleConnect}
+                  onDisconnect={handleDisconnect}
+                  onNavigateToKnowledge={navigateToKnowledgePage}
+                  onConfigure={getConfigureHandler(connector)}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* Credential-Based Connectors Section */}
+      {(connectorsLoading || credentialConnectors.length > 0) && (
+        <div className="space-y-4">
+          <h3 className="text-lg font-semibold">Credential-Based Connectors</h3>
+          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+            {connectorsLoading ? (
+              <>
+                <ConnectorsSkeleton />
+                <ConnectorsSkeleton />
+              </>
+            ) : (
+              credentialConnectors.map((connector) => (
+                <ConnectorCard
+                  key={connector.id}
+                  connector={connector}
+                  isConnecting={
+                    connectMutation.isPending &&
+                    connectMutation.variables?.connector.id === connector.id
+                  }
+                  isDisconnecting={
+                    disconnectMutation.isPending &&
+                    (disconnectMutation.variables as any)?.type ===
+                      connector.type
+                  }
+                  onConnect={handleConnect}
+                  onDisconnect={handleDisconnect}
+                  onNavigateToKnowledge={navigateToKnowledgePage}
+                  onConfigure={getConfigureHandler(connector)}
+                />
+              ))
+            )}
+          </div>
+        </div>
+      )}
 
       {dialogDescriptors.map((descriptor) => {
         // Render only while open so the component unmounts on close, which

--- a/frontend/app/settings/_components/connector-cards.tsx
+++ b/frontend/app/settings/_components/connector-cards.tsx
@@ -50,17 +50,17 @@ export default function ConnectorCards() {
     return <Icon />;
   }, []);
 
-  const connectors = queryConnectors
-    .filter((c) => {
-      // Keep OAuth connectors regardless of availability
-      if (c.requiresOAuth) return true;
-      // Only hide credential-based connectors when unavailable
-      return c.available !== false;
-    })
-    .map((c) => ({
-      ...c,
-      icon: getConnectorIcon(c.type),
-    })) as Connector[];
+  const connectors = queryConnectors.reduce<Connector[]>((acc, c) => {
+    // Keep OAuth connectors regardless of availability
+    // Only hide credential-based connectors when unavailable
+    if (c.requiresOAuth || c.available !== false) {
+      acc.push({
+        ...c,
+        icon: getConnectorIcon(c.type),
+      } as Connector);
+    }
+    return acc;
+  }, []);
 
   const handleConnect = async (connector: Connector) => {
     connectMutation.mutate({

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -1407,19 +1407,9 @@ async def connector_status(
     has_authenticated_connection = len(verified_active_connections) > 0
 
     # Check if OAuth credentials are configured in environment (for OAuth connectors only)
-    has_env_credentials = False
-    try:
-        from connectors.registry import get_connector_class
-        connector_cls = get_connector_class(connector_type)
-        if connector_cls and connector_cls.CONNECTOR_KIND == "oauth":
-            # Try to instantiate and check for credentials
-            test_connector = connector_cls({})
-            test_connector.get_client_id()
-            test_connector.get_client_secret()
-            has_env_credentials = True
-    except Exception:
-        # Credentials not found in environment
-        has_env_credentials = False
+    has_env_credentials = connector_service.connection_manager.has_env_credentials(
+        connector_type
+    )
 
     return JSONResponse(
         {

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -1407,9 +1407,7 @@ async def connector_status(
     has_authenticated_connection = len(verified_active_connections) > 0
 
     # Check if OAuth credentials are configured in environment (for OAuth connectors only)
-    has_env_credentials = connector_service.connection_manager.has_env_credentials(
-        connector_type
-    )
+    has_env_credentials = connector_service.connection_manager.has_env_credentials(connector_type)
 
     return JSONResponse(
         {

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -1410,6 +1410,7 @@ async def connector_status(
     has_env_credentials = False
     try:
         from connectors.registry import get_connector_class
+
         connector_cls = get_connector_class(connector_type)
         if connector_cls and connector_cls.CONNECTOR_KIND == "oauth":
             # Try to instantiate and check for credentials

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -1406,11 +1406,27 @@ async def connector_status(
     # Only count connections that are both active AND actually authenticated
     has_authenticated_connection = len(verified_active_connections) > 0
 
+    # Check if OAuth credentials are configured in environment (for OAuth connectors only)
+    has_env_credentials = False
+    try:
+        from connectors.registry import get_connector_class
+        connector_cls = get_connector_class(connector_type)
+        if connector_cls and connector_cls.CONNECTOR_KIND == "oauth":
+            # Try to instantiate and check for credentials
+            test_connector = connector_cls({})
+            test_connector.get_client_id()
+            test_connector.get_client_secret()
+            has_env_credentials = True
+    except Exception:
+        # Credentials not found in environment
+        has_env_credentials = False
+
     return JSONResponse(
         {
             "connector_type": connector_type,
             "authenticated": has_authenticated_connection,
             "status": "connected" if has_authenticated_connection else "not_connected",
+            "has_env_credentials": has_env_credentials,
             "connections": [
                 {
                     "connection_id": conn.connection_id,

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -278,14 +278,15 @@ def is_dev_ibm_cos_enabled() -> bool:
 
 
 def is_azure_blob_enabled() -> bool:
-    """Feature flag for the Azure Blob connector (default: disabled).
+    """Feature kill switch for the Azure Blob connector (default: enabled).
 
-    In OSS mode, both OPENRAG_AZURE_BLOB_ENABLED=true and OPENRAG_DEV_AZURE_BLOB=true
-    must be set to show the connector (mirrors IBM COS pattern). In Enterprise/SaaS
-    mode (IBM_AUTH_ENABLED), only this flag needs to be true. Set to false to
-    force-hide the connector even when IBM auth is on.
+    Independent of ``IBM_AUTH_ENABLED``. Set ``OPENRAG_AZURE_BLOB_ENABLED=false``
+    to force-hide the connector in the UI even when IBM auth is on. When true
+    (the default), availability still requires the Enterprise/SaaS gate
+    (``IBM_AUTH_ENABLED``) or the ``OPENRAG_DEV_AZURE_BLOB`` dev bypass -- this
+    flag is subtractive (AND-ed with that gate), not an override.
     """
-    raw = os.getenv("OPENRAG_AZURE_BLOB_ENABLED", "false").strip().lower()
+    raw = os.getenv("OPENRAG_AZURE_BLOB_ENABLED", "true").strip().lower()
     return raw in ("true", "1", "yes", "on")
 
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -278,15 +278,14 @@ def is_dev_ibm_cos_enabled() -> bool:
 
 
 def is_azure_blob_enabled() -> bool:
-    """Feature kill switch for the Azure Blob connector (default: enabled).
+    """Feature flag for the Azure Blob connector (default: disabled).
 
-    Independent of ``IBM_AUTH_ENABLED``. Set ``OPENRAG_AZURE_BLOB_ENABLED=false``
-    to force-hide the connector in the UI even when IBM auth is on. When true
-    (the default), availability still requires the Enterprise/SaaS gate
-    (``IBM_AUTH_ENABLED``) or the ``OPENRAG_DEV_AZURE_BLOB`` dev bypass -- this
-    flag is subtractive (AND-ed with that gate), not an override.
+    In OSS mode, both OPENRAG_AZURE_BLOB_ENABLED=true and OPENRAG_DEV_AZURE_BLOB=true
+    must be set to show the connector (mirrors IBM COS pattern). In Enterprise/SaaS
+    mode (IBM_AUTH_ENABLED), only this flag needs to be true. Set to false to
+    force-hide the connector even when IBM auth is on.
     """
-    raw = os.getenv("OPENRAG_AZURE_BLOB_ENABLED", "true").strip().lower()
+    raw = os.getenv("OPENRAG_AZURE_BLOB_ENABLED", "false").strip().lower()
     return raw in ("true", "1", "yes", "on")
 
 

--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -476,6 +476,7 @@ class ConnectionManager:
                 "description": cls.CONNECTOR_DESCRIPTION,
                 "icon": cls.CONNECTOR_ICON,
                 "available": cls.is_available(self, user_id),
+                "kind": cls.CONNECTOR_KIND,
             }
         return result
 

--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -512,6 +512,24 @@ class ConnectionManager:
                 continue
         return False
 
+    def has_env_credentials(self, connector_type: str) -> bool:
+        """Check if OAuth connector has credentials configured in environment.
+
+        Returns True if the connector is OAuth-based and has valid environment
+        credentials (CLIENT_ID and CLIENT_SECRET), False otherwise.
+        """
+        try:
+            connector_cls = get_connector_class(connector_type)
+            if not connector_cls or connector_cls.CONNECTOR_KIND != "oauth":
+                return False
+            # Try to instantiate and check for credentials
+            test_connector = connector_cls({})
+            test_connector.get_client_id()
+            test_connector.get_client_secret()
+            return True
+        except Exception:
+            return False
+
     def _create_connector(self, config: ConnectionConfig) -> BaseConnector:
         """Factory method to create connector instances via the registry."""
         try:


### PR DESCRIPTION
Fixes issue #2043 

## Problem
After disconnecting a connector (Azure Blob Storage, AWS S3, etc.), the card still displayed "{Connector name} is configured." instead of showing the expected "credentials not configured yet" message.

## Root Cause
The condition in `connector-card.tsx` was checking `isConnected || connector?.available`, where `available` indicates whether the connector is allowed for the workspace. This field remains `true` after disconnection, causing the incorrect message to persist.

## Solution
Hide unavailable connectors and improve connector status detection

Fixes connector visibility and status detection issues.

### Changes
- Hide non OAuth connectors when `available: false` in frontend
- Add `requiresOAuth` field to distinguish OAuth vs credential-based connectors  
- Split connector UI into OAuth and credential-based sections
- Improve connector status detection by checking env credentials
- Update connector card descriptions to distinguish connected vs configured states
- Connectors now say "is configured" if credentials are in the environment and can be connected, "is connected" if connectors are actively connected and can be used to ingest knowledge, and "not configured" if not configured in the environment.
- 
### Backend
- Added `has_env_credentials` check in connector status endpoint for OAuth connectors
- Enhanced `get_available_connector_types` to return `requiresOAuth` field

### Frontend  
- Filter out unavailable connectors before rendering
- Organize connectors into OAuth and credential-based sections
- Updated card descriptions to show appropriate status messages

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth and credential-based connectors are now shown in separate sections.
  * Connector cards now show a clearer state: **connected**, **configured**, or **OAuth credentials not configured yet** (when applicable).
  * Connector availability now reflects whether required OAuth environment credentials are present.
  * Connector metadata now includes a **kind** attribute for improved connector categorization.
* **Bug Fixes**
  * Ensured Azurite data storage is properly declared in the container setup.
  * Azure Blob connector is now **disabled by default** unless explicitly enabled (according to the mode rules).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->