### PR TITLE
feat: Migrate CPD to Universal Token

### DIFF
--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1102,38 +1102,36 @@ async def onboarding(
                 )
                 from main import init_index
                 from utils.run_mode_utils import (
+                    get_run_mode,
                     is_run_mode_on_prem,
-                    is_run_mode_oss,
                     is_run_mode_saas,
                 )
 
                 # Choose the admin identity for index/security setup, by run mode:
-                #   saas    -> platform service token (JWT); admin from its claim
-                #   on_prem -> OpenSearch basic auth; OpenSearch username as admin
-                #   oss     -> OpenSearch basic auth; OpenSearch username as admin
+                #   saas/on_prem -> platform service token (JWT); admin from its claim
+                #   oss          -> OpenSearch basic auth; OpenSearch username as admin
                 # The matching client comes from the shared run-mode-aware helper.
                 admin_username = None
-                if is_run_mode_saas():
+                if is_run_mode_saas() or is_run_mode_on_prem():
                     service_token = get_openrag_service_token()
-                    if service_token:
-                        # Prefer the platform service token so onboarding pins the
-                        # same admin identity as the startup security bootstrap
-                        # (see app/lifespan.py).
-                        from auth.ibm_auth import admin_username_from_service_jwt
+                    if not service_token:
+                        raise RuntimeError(
+                            "OPENRAG_SERVICE_TOKEN is required to determine the "
+                            "OpenSearch admin identity during onboarding in "
+                            f"{get_run_mode()} mode."
+                        )
+                    # Prefer the platform service token so onboarding pins the
+                    # same admin identity as the startup security bootstrap
+                    # (see app/lifespan.py).
+                    from auth.ibm_auth import admin_username_from_service_jwt
 
-                        admin_username = admin_username_from_service_jwt(service_token)
-                        if not admin_username:
-                            raise RuntimeError(
-                                "OPENRAG_SERVICE_TOKEN has no 'username' or 'sub' claim; "
-                                "cannot determine OpenSearch admin during onboarding"
-                            )
-                    elif user:
-                        # TODO: backward-compatibility fallback for saas deployments
-                        # without OPENRAG_SERVICE_TOKEN — pins the onboarding user as
-                        # admin instead of the platform service identity. Remove once
-                        # the service token is always provided.
-                        admin_username = user.user_id
-                elif is_run_mode_on_prem() or is_run_mode_oss():
+                    admin_username = admin_username_from_service_jwt(service_token)
+                    if not admin_username:
+                        raise RuntimeError(
+                            "OPENRAG_SERVICE_TOKEN has no 'username' or 'sub' claim; "
+                            "cannot determine OpenSearch admin during onboarding"
+                        )
+                else:
                     admin_username = get_opensearch_username()
 
                 opensearch_client = app_clients.create_index_admin_opensearch_client(

--- a/src/app/lifespan.py
+++ b/src/app/lifespan.py
@@ -261,27 +261,17 @@ async def run_startup(app: FastAPI):
         from utils.opensearch_init import wait_for_opensearch
         from utils.opensearch_utils import setup_opensearch_security
         from utils.run_mode_utils import (
+            get_run_mode,
             is_run_mode_on_prem,
-            is_run_mode_oss,
+            is_run_mode_saas,
         )
 
         # Choose the OpenSearch client + admin identity, by run mode:
-        #   saas    -> platform service token (JWT); admin from its claim
-        #   on_prem -> OpenSearch basic auth; OpenSearch username as admin
-        #   oss     -> OpenSearch basic auth; OpenSearch username as admin
+        #   saas/on_prem -> platform service token (JWT); admin from its claim
+        #   oss          -> OpenSearch basic auth; OpenSearch username as admin
         admin_username = None
         opensearch_client = None
-        if is_run_mode_on_prem() or is_run_mode_oss():
-            admin_username = get_opensearch_username()
-            opensearch_client = clients.create_basic_opensearch_client(
-                admin_username, get_opensearch_password()
-            )
-            logger.info(
-                "OpenSearch startup client: %s mode, using OpenSearch basic auth"
-                % ("on_prem" if is_run_mode_on_prem() else "oss"),
-                admin_username=admin_username,
-            )
-        else:
+        if is_run_mode_saas() or is_run_mode_on_prem():
             service_token = get_openrag_service_token()
             if not service_token:
                 # A missing service token is fatal only when security bootstrap
@@ -293,8 +283,9 @@ async def run_startup(app: FastAPI):
                         "OPENRAG_SERVICE_TOKEN is not set"
                     )
                 logger.warning(
-                    "Skipping startup OpenSearch replica reconciliation: saas mode "
-                    "requires OPENRAG_SERVICE_TOKEN, which is not set"
+                    "Skipping startup OpenSearch replica reconciliation: "
+                    f"{get_run_mode()} mode requires OPENRAG_SERVICE_TOKEN, "
+                    "which is not set"
                 )
             else:
                 from auth.ibm_auth import admin_username_from_service_jwt
@@ -307,9 +298,19 @@ async def run_startup(app: FastAPI):
                     )
                 opensearch_client = clients.create_opensearch_client_from_jwt(service_token)
                 logger.info(
-                    "OpenSearch startup client: saas mode, using platform service token",
+                    "OpenSearch startup client: %s mode, using platform service token"
+                    % get_run_mode(),
                     admin_username=admin_username,
                 )
+        else:
+            admin_username = get_opensearch_username()
+            opensearch_client = clients.create_basic_opensearch_client(
+                admin_username, get_opensearch_password()
+            )
+            logger.info(
+                "OpenSearch startup client: oss mode, using OpenSearch basic auth",
+                admin_username=admin_username,
+            )
 
         if opensearch_client is not None:
             try:

--- a/src/app/lifespan.py
+++ b/src/app/lifespan.py
@@ -298,8 +298,8 @@ async def run_startup(app: FastAPI):
                     )
                 opensearch_client = clients.create_opensearch_client_from_jwt(service_token)
                 logger.info(
-                    "OpenSearch startup client: %s mode, using platform service token"
-                    % get_run_mode(),
+                    f"OpenSearch startup client: {get_run_mode()} mode, "
+                    "using platform service token",
                     admin_username=admin_username,
                 )
         else:

--- a/src/auth/request_identity.py
+++ b/src/auth/request_identity.py
@@ -289,14 +289,14 @@ async def _get_ibm_user(request: Request, required: bool) -> Optional["User"]:
                 # existing DB roles untouched). RBAC on -> extract + 401 if none.
                 _stage_jwt_roles(request, claims, user_id)
 
-    from utils.run_mode_utils import is_run_mode_saas
+    from utils.run_mode_utils import get_run_mode, is_run_mode_on_prem, is_run_mode_saas
 
-    saas_rbac = is_run_mode_saas() and jwt_roles_enabled()
+    platform_rbac = (is_run_mode_saas() or is_run_mode_on_prem()) and jwt_roles_enabled()
 
     # The forwarded end-user JWT is the OpenSearch credential — OpenSearch's
     # openid_auth_domain validates it via the backend JWKS. Build it once; it's
-    # used both as the saas+rbac authoritative credential and as the header-less
-    # fallback in other modes.
+    # used both as the platform+rbac authoritative credential and as the
+    # header-less fallback in other modes.
     jwt_user = None
     if ibm_token and user_id:
         jwt_user = User(
@@ -310,37 +310,41 @@ async def _get_ibm_user(request: Request, required: bool) -> Optional["User"]:
             opensearch_credentials=None,
         )
 
-    # In SaaS + RBAC the JWT is authoritative: the lakehouse `X-IBM-LH-Credentials`
-    # Basic credential must NOT override it (when the gateway began injecting that
-    # header, OpenSearch rejected the Basic cred with 401 and every data-plane call
-    # surfaced as a misleading 403 "insufficient permissions"). Return before
-    # `_resolve_lakehouse_credentials` so its connections-store upsert side effect
-    # is also skipped. Mirrors the /v1 surface, which already treats the JWT as
-    # primary.
-    if saas_rbac:
+    # In SaaS/on-prem + RBAC the JWT is authoritative: the lakehouse
+    # `X-IBM-LH-Credentials` Basic credential must NOT override it (when the
+    # gateway began injecting that header, OpenSearch rejected the Basic cred
+    # with 401 and every data-plane call surfaced as a misleading 403
+    # "insufficient permissions"). Return before `_resolve_lakehouse_credentials`
+    # so its connections-store upsert side effect is also skipped. Mirrors the
+    # /v1 surface, which already treats the JWT as primary.
+    if platform_rbac:
         if jwt_user:
             logger.debug(
-                "[AUTH] User created from forwarded JWT (saas+rbac; lakehouse creds bypassed)"
+                "[AUTH] User created from forwarded JWT (platform+rbac; lakehouse creds bypassed)",
+                run_mode=get_run_mode(),
             )
             request.state.user = jwt_user
             return jwt_user
-        # saas + RBAC but no valid forwarded JWT (missing header, undecodable, or no
-        # `sub`). Do NOT degrade to lakehouse Basic creds or the debug cookie — that
-        # would authenticate (and write DB user/role rows) under a roles-less
-        # identity. Fail loud, mirroring resolve_api_key_user's saas_rbac branch.
+        # SaaS/on-prem + RBAC but no valid forwarded JWT (missing header,
+        # undecodable, or no `sub`). Do NOT degrade to lakehouse Basic creds or
+        # the debug cookie — that would authenticate (and write DB user/role
+        # rows) under a roles-less identity. Fail loud, mirroring
+        # resolve_api_key_user's platform_rbac branch.
         request.state.user = None
         if required:
             logger.error(
-                "[AUTH] No valid forwarded JWT under saas+RBAC; refusing lakehouse/basic fallback",
+                "[AUTH] No valid forwarded JWT under platform+RBAC; refusing lakehouse/basic fallback",
                 jwt_present=bool(ibm_token),
+                run_mode=get_run_mode(),
             )
             raise HTTPException(
                 status_code=401,
                 detail={
                     "error": "invalid_jwt" if ibm_token else "missing_user_jwt",
                     "message": (
-                        "No valid user JWT was forwarded by the gateway. In SaaS/RBAC "
-                        "mode the gateway must forward the end-user JWT on every request."
+                        "No valid user JWT was forwarded by the gateway. In "
+                        "SaaS/on-prem RBAC mode the gateway must forward the "
+                        "end-user JWT on every request."
                     ),
                 },
             )
@@ -492,14 +496,15 @@ async def resolve_api_key_user(request: Request, api_key_service, session_manage
         get_jwt_auth_header,
     )
     from config.utils import resolve_jwt_claims
-    from utils.run_mode_utils import is_run_mode_saas
+    from utils.run_mode_utils import get_run_mode, is_run_mode_on_prem, is_run_mode_saas
 
-    # SaaS/RBAC: the gateway MUST forward the end-user JWT on every /v1 request.
-    # When it doesn't, we must NOT silently degrade to lakehouse Basic creds —
-    # that path does DB user writes under a degraded identity and can clobber the
-    # shared users row the same person sees on UI login. Fail loud (401) with no
-    # DB side effects instead; explicit orag_ API-key auth still works.
-    saas_rbac = is_run_mode_saas() and jwt_roles_enabled()
+    # SaaS/on-prem + RBAC: the gateway MUST forward the end-user JWT on every
+    # /v1 request. When it doesn't, we must NOT silently degrade to lakehouse
+    # Basic creds — that path does DB user writes under a degraded identity and
+    # can clobber the shared users row the same person sees on UI login. Fail
+    # loud (401) with no DB side effects instead; explicit orag_ API-key auth
+    # still works.
+    platform_rbac = (is_run_mode_saas() or is_run_mode_on_prem()) and jwt_roles_enabled()
 
     # Primary: the gateway-forwarded JWT header (default Authorization).
     # Fallback: the API/MCP add-on header — FastMCP strips Authorization before
@@ -571,15 +576,15 @@ async def resolve_api_key_user(request: Request, api_key_service, session_manage
             )
         # RBAC off + missing/invalid JWT -> fall through to the API-key path.
     else:
-        if saas_rbac:
-            # In saas the gateway is responsible for forwarding the end-user
-            # JWT on every API/MCP request; its absence is a gateway
+        if platform_rbac:
+            # In SaaS/on-prem the gateway is responsible for forwarding the
+            # end-user JWT on every API/MCP request; its absence is a gateway
             # misconfiguration, not a normal client state. Fail fast here —
             # before any lakehouse / X-Username / API-key fallback — so no DB
             # user/role write ever runs under a degraded (roles-less) identity.
             logger.error(
-                "[AUTH] JWT not found in request header — run_mode=saas with "
-                "RBAC enabled requires the gateway to forward the user JWT",
+                f"[AUTH] JWT not found in request header — run_mode={get_run_mode()} "
+                "with RBAC enabled requires the gateway to forward the user JWT",
                 header_name=jwt_header,
                 authorization_present=bool(request.headers.get("authorization")),
                 api_jwt_present=bool(request.headers.get(get_api_jwt_header())),
@@ -594,9 +599,9 @@ async def resolve_api_key_user(request: Request, api_key_service, session_manage
                 detail={
                     "error": "missing_user_jwt",
                     "message": (
-                        "No user JWT was forwarded by the gateway. In SaaS/RBAC "
-                        "mode the gateway must forward the end-user JWT on every "
-                        "/v1 request."
+                        "No user JWT was forwarded by the gateway. In "
+                        "SaaS/on-prem RBAC mode the gateway must forward the "
+                        "end-user JWT on every /v1 request."
                     ),
                 },
             )
@@ -656,9 +661,9 @@ async def resolve_api_key_user(request: Request, api_key_service, session_manage
                 api_key = token
 
     if not api_key:
-        # saas_rbac is already handled by the fail-fast 401 above (no JWT ->
-        # missing_user_jwt), so reaching here means non-saas_rbac: prompt for
-        # an API key as before.
+        # platform_rbac is already handled by the fail-fast 401 above (no JWT
+        # -> missing_user_jwt), so reaching here means non-platform_rbac:
+        # prompt for an API key as before.
         raise HTTPException(
             status_code=401,
             detail={

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -893,36 +893,32 @@ class AppClients:
 
     async def initialize(self):
         from utils.run_mode_utils import (
+            get_run_mode,
             is_run_mode_on_prem,
-            is_run_mode_oss,
             is_run_mode_saas,
         )
 
         # Credentials for the global (backend-owned) writer client, by run mode:
-        #   saas    -> platform service token (JWT) when available, else unauthenticated
-        #   on_prem -> OpenSearch basic auth
-        #   oss     -> OpenSearch basic auth
-        service_token = get_openrag_service_token() if is_run_mode_saas() else None
-        if service_token:
+        #   saas/on_prem -> platform service token (JWT); required, raises if unset
+        #   oss          -> OpenSearch basic auth
+        if is_run_mode_saas() or is_run_mode_on_prem():
+            service_token = get_openrag_service_token()
+            if not service_token:
+                raise RuntimeError(
+                    "OPENRAG_SERVICE_TOKEN is required to initialize the global "
+                    f"OpenSearch writer client in {get_run_mode()} mode."
+                )
             logger.info(
-                "Initializing global OpenSearch writer client: saas mode, "
-                "using platform service token"
+                "Initializing global OpenSearch writer client: %s mode, "
+                "using platform service token" % get_run_mode()
             )
             self.opensearch = self.create_opensearch_client_from_jwt(service_token)
         else:
-            if is_run_mode_on_prem() or is_run_mode_oss():
-                os_auth = (get_opensearch_username(), get_opensearch_password())
-                logger.info(
-                    "Initializing global OpenSearch writer client: %s mode, "
-                    "using OpenSearch basic auth" % ("on_prem" if is_run_mode_on_prem() else "oss")
-                )
-            else:
-                os_auth = None
-                logger.info(
-                    "Initializing global OpenSearch writer client: saas mode without "
-                    "service token, using the unauthenticated client"
-                )
-
+            os_auth = (get_opensearch_username(), get_opensearch_password())
+            logger.info(
+                "Initializing global OpenSearch writer client: oss mode, "
+                "using OpenSearch basic auth"
+            )
             self.opensearch = AsyncOpenSearch(
                 hosts=[{"host": OPENSEARCH_HOST, "port": OPENSEARCH_PORT}],
                 connection_class=AIOHttpConnection,
@@ -1566,49 +1562,34 @@ class AppClients:
         """Create the OpenSearch client used for index administration
         (init_index: index creation, mapping/settings updates), by run mode:
 
-          saas    -> platform service token — the end-user JWT identity can
-                     search/write documents but lacks index-admin privileges on
-                     managed OpenSearch, so admin calls (e.g. HEAD /<index>)
-                     fail. Falls back to the user's token for legacy
-                     deployments without OPENRAG_SERVICE_TOKEN.
-          on_prem -> OpenSearch basic auth
-          oss     -> OpenSearch basic auth
+          saas/on_prem -> platform service token (JWT); required, raises if
+                          unset. The end-user JWT (``user_jwt_token``, kept
+                          for call-site compatibility but no longer consulted)
+                          lacks index-admin privileges on managed OpenSearch,
+                          so admin calls (e.g. HEAD /<index>) would fail.
+          oss          -> OpenSearch basic auth
 
-        Returns None when no suitable credentials exist; callers should then
-        use the global writer client (clients.opensearch).
+        Raises RuntimeError when saas/on_prem is missing OPENRAG_SERVICE_TOKEN.
         """
-        from utils.run_mode_utils import (
-            is_run_mode_on_prem,
-            is_run_mode_oss,
-            is_run_mode_saas,
-        )
+        from utils.run_mode_utils import get_run_mode, is_run_mode_on_prem, is_run_mode_saas
 
-        if is_run_mode_saas():
+        if is_run_mode_saas() or is_run_mode_on_prem():
             service_token = get_openrag_service_token()
-            if service_token:
-                logger.info(
-                    "Index admin OpenSearch client: saas mode, using platform service token"
+            if not service_token:
+                raise RuntimeError(
+                    "OPENRAG_SERVICE_TOKEN is required for the index-admin "
+                    f"OpenSearch client in {get_run_mode()} mode."
                 )
-                return self.create_opensearch_client_from_jwt(service_token)
-            if user_jwt_token:
-                logger.warning(
-                    "Index admin OpenSearch client: saas mode without "
-                    "OPENRAG_SERVICE_TOKEN; falling back to the requesting "
-                    "user's token (backward-compatibility path)"
-                )
-                return self.create_opensearch_client_from_jwt(user_jwt_token)
             logger.info(
-                "Index admin OpenSearch client: saas mode with no service or "
-                "user token; using the global writer client"
+                "Index admin OpenSearch client: %s mode, using platform service token"
+                % get_run_mode()
             )
-            return None
-        if is_run_mode_on_prem() or is_run_mode_oss():
-            # Build a fresh basic-auth client so credentials updated after
-            # startup (e.g. during onboarding) take effect immediately.
-            return self.create_basic_opensearch_client(
-                get_opensearch_username(), get_opensearch_password()
-            )
-        return None
+            return self.create_opensearch_client_from_jwt(service_token)
+        # oss: build a fresh basic-auth client so credentials updated after
+        # startup (e.g. during onboarding) take effect immediately.
+        return self.create_basic_opensearch_client(
+            get_opensearch_username(), get_opensearch_password()
+        )
 
 
 # Component template paths — derived from the centralized flows directory

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -922,8 +922,8 @@ class AppClients:
                     f"OpenSearch writer client in {get_run_mode()} mode."
                 )
             logger.info(
-                "Initializing global OpenSearch writer client: %s mode, "
-                "using platform service token" % get_run_mode()
+                f"Initializing global OpenSearch writer client: {get_run_mode()} mode, "
+                "using platform service token"
             )
             self.opensearch = self.create_opensearch_client_from_jwt(service_token)
         else:
@@ -1594,8 +1594,8 @@ class AppClients:
                     f"OpenSearch client in {get_run_mode()} mode."
                 )
             logger.info(
-                "Index admin OpenSearch client: %s mode, using platform service token"
-                % get_run_mode()
+                f"Index admin OpenSearch client: {get_run_mode()} mode, "
+                "using platform service token"
             )
             return self.create_opensearch_client_from_jwt(service_token)
         # oss: build a fresh basic-auth client so credentials updated after

--- a/src/services/dls_principal_service.py
+++ b/src/services/dls_principal_service.py
@@ -272,8 +272,7 @@ class DLSPrincipalService:
                     service_token
                 )
                 logger.info(
-                    f"DLS principal service: {get_run_mode()} mode, "
-                    "using platform service token"
+                    f"DLS principal service: {get_run_mode()} mode, using platform service token"
                 )
             else:
                 username = get_opensearch_username()

--- a/src/services/dls_principal_service.py
+++ b/src/services/dls_principal_service.py
@@ -241,8 +241,8 @@ class DLSPrincipalService:
         # An explicitly injected client wins; otherwise build (once) an
         # admin-identity client using the same run-mode switching as the
         # startup security bootstrap (app/lifespan.py) and onboarding
-        # (api/settings/endpoints.py): SaaS -> platform service-token JWT;
-        # on-prem/OSS -> OpenSearch basic auth.
+        # (api/settings/endpoints.py): SaaS/on-prem -> platform service-token
+        # JWT (required); OSS -> OpenSearch basic auth.
         if self.opensearch_client is not None:
             return self.opensearch_client
         if self._admin_opensearch_client is not None:
@@ -256,30 +256,32 @@ class DLSPrincipalService:
                 get_opensearch_username,
             )
             from utils.run_mode_utils import (
+                get_run_mode,
                 is_run_mode_on_prem,
                 is_run_mode_saas,
             )
 
-            if is_run_mode_saas():
+            if is_run_mode_saas() or is_run_mode_on_prem():
                 service_token = get_openrag_service_token()
                 if not service_token:
-                    logger.warning(
-                        "DLS principal OpenSearch client unavailable: saas mode "
-                        "but OPENRAG_SERVICE_TOKEN is not set"
+                    raise RuntimeError(
+                        "OPENRAG_SERVICE_TOKEN is required for the DLS principal "
+                        f"OpenSearch client in {get_run_mode()} mode."
                     )
-                    return None
                 self._admin_opensearch_client = clients.create_opensearch_client_from_jwt(
                     service_token
                 )
-                logger.info("DLS principal service: saas mode, using platform service token")
+                logger.info(
+                    "DLS principal service: %s mode, using platform service token"
+                    % get_run_mode()
+                )
             else:
-                mode = "on_prem" if is_run_mode_on_prem() else "oss"
                 username = get_opensearch_username()
                 password = get_opensearch_password()
                 if not password:
                     logger.warning(
-                        "DLS principal OpenSearch client unavailable: "
-                        f"{mode} mode but OpenSearch password is not set"
+                        "DLS principal OpenSearch client unavailable: oss mode "
+                        "but OpenSearch password is not set"
                     )
                     return None
                 self._admin_opensearch_client = clients.create_basic_opensearch_client(
@@ -287,7 +289,7 @@ class DLSPrincipalService:
                     password,
                 )
                 logger.info(
-                    f"DLS principal service: {mode} mode, using OpenSearch basic auth",
+                    "DLS principal service: oss mode, using OpenSearch basic auth",
                     admin_username=username,
                 )
 

--- a/src/services/dls_principal_service.py
+++ b/src/services/dls_principal_service.py
@@ -272,8 +272,7 @@ class DLSPrincipalService:
                     service_token
                 )
                 logger.info(
-                    "DLS principal service: %s mode, using platform service token"
-                    % get_run_mode()
+                    "DLS principal service: %s mode, using platform service token" % get_run_mode()
                 )
             else:
                 username = get_opensearch_username()

--- a/src/services/dls_principal_service.py
+++ b/src/services/dls_principal_service.py
@@ -294,6 +294,8 @@ class DLSPrincipalService:
                 )
 
             return self._admin_opensearch_client
+        except RuntimeError:
+            raise
         except Exception as e:
             logger.warning(
                 "Failed to build DLS principal OpenSearch client",

--- a/src/services/dls_principal_service.py
+++ b/src/services/dls_principal_service.py
@@ -272,7 +272,8 @@ class DLSPrincipalService:
                     service_token
                 )
                 logger.info(
-                    "DLS principal service: %s mode, using platform service token" % get_run_mode()
+                    f"DLS principal service: {get_run_mode()} mode, "
+                    "using platform service token"
                 )
             else:
                 username = get_opensearch_username()

--- a/tests/unit/config/test_index_admin_client_selection.py
+++ b/tests/unit/config/test_index_admin_client_selection.py
@@ -1,18 +1,21 @@
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parents[3]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
 
 
-def test_saas_prefers_service_token_over_user_jwt(monkeypatch):
+def test_saas_uses_service_token(monkeypatch):
     from config import settings
     from utils import run_mode_utils
 
     sentinel = object()
     monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: True)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: False)
     monkeypatch.setattr(settings, "get_openrag_service_token", lambda: "svc-jwt-token")
     captured = {}
 
@@ -28,13 +31,26 @@ def test_saas_prefers_service_token_over_user_jwt(monkeypatch):
     assert captured["token"] == "svc-jwt-token"
 
 
-def test_saas_without_service_token_falls_back_to_user_jwt(monkeypatch):
+def test_saas_without_service_token_raises(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: True)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: False)
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
+
+    with pytest.raises(RuntimeError, match="OPENRAG_SERVICE_TOKEN"):
+        settings.clients.create_index_admin_opensearch_client("Bearer user-jwt")
+
+
+def test_on_prem_uses_service_token(monkeypatch):
     from config import settings
     from utils import run_mode_utils
 
     sentinel = object()
-    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: True)
-    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: False)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: True)
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: "svc-jwt-token")
     captured = {}
 
     def fake_from_jwt(token):
@@ -43,43 +59,22 @@ def test_saas_without_service_token_falls_back_to_user_jwt(monkeypatch):
 
     monkeypatch.setattr(settings.clients, "create_opensearch_client_from_jwt", fake_from_jwt)
 
-    client = settings.clients.create_index_admin_opensearch_client("Bearer user-jwt")
+    client = settings.clients.create_index_admin_opensearch_client(None)
 
     assert client is sentinel
-    assert captured["token"] == "Bearer user-jwt"
+    assert captured["token"] == "svc-jwt-token"
 
 
-def test_saas_without_any_token_returns_none(monkeypatch):
+def test_on_prem_without_service_token_raises(monkeypatch):
     from config import settings
     from utils import run_mode_utils
 
-    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: True)
-    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
-
-    assert settings.clients.create_index_admin_opensearch_client(None) is None
-
-
-def test_on_prem_uses_basic_auth(monkeypatch):
-    from config import settings
-    from utils import run_mode_utils
-
-    sentinel = object()
     monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: False)
     monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: True)
-    monkeypatch.setattr(settings, "get_opensearch_username", lambda: "admin")
-    monkeypatch.setattr(settings, "get_opensearch_password", lambda: "secret")
-    captured = {}
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
 
-    def fake_basic(username, password):
-        captured["creds"] = (username, password)
-        return sentinel
-
-    monkeypatch.setattr(settings.clients, "create_basic_opensearch_client", fake_basic)
-
-    client = settings.clients.create_index_admin_opensearch_client("Bearer user-jwt")
-
-    assert client is sentinel
-    assert captured["creds"] == ("admin", "secret")
+    with pytest.raises(RuntimeError, match="OPENRAG_SERVICE_TOKEN"):
+        settings.clients.create_index_admin_opensearch_client("Bearer user-jwt")
 
 
 def test_oss_uses_basic_auth(monkeypatch):

--- a/tests/unit/dependencies/test_ibm_header_auth.py
+++ b/tests/unit/dependencies/test_ibm_header_auth.py
@@ -151,3 +151,56 @@ async def test_saas_rbac_jwt_wins_over_lakehouse_header(monkeypatch):
     assert user is not None
     assert user.jwt_token == "Bearer tok"  # Bearer JWT, never "Basic ..."
     assert user.opensearch_credentials is None
+
+
+# --- on_prem mirrors: on-prem must behave exactly like saas here -----------
+
+
+@pytest.mark.asyncio
+async def test_on_prem_rbac_no_jwt_does_not_degrade_to_lakehouse(monkeypatch):
+    """on_prem+RBAC with no forwarded JWT must fail loud, even when the
+    lakehouse credentials header is present — it must NOT build a Basic
+    lakehouse user (matches saas)."""
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    monkeypatch.setattr(
+        ibm_auth,
+        "decode_ibm_jwt",
+        lambda tok: (_ for _ in ()).throw(AssertionError("decode must not run without a JWT")),
+    )
+    req = _FakeRequest(headers={LH_HEADER: "dGVzdDp0ZXN0"})
+
+    with pytest.raises(HTTPException) as exc:
+        await _get_ibm_user(req, required=True)
+    assert exc.value.status_code == 401
+    assert exc.value.detail["error"] == "missing_user_jwt"
+
+
+@pytest.mark.asyncio
+async def test_on_prem_rbac_no_jwt_optional_returns_none(monkeypatch):
+    """on_prem+RBAC with no forwarded JWT on an optional endpoint returns None
+    (anonymous), not a 401."""
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    req = _FakeRequest(headers={LH_HEADER: "dGVzdDp0ZXN0"})
+
+    user = await _get_ibm_user(req, required=False)
+
+    assert user is None
+
+
+@pytest.mark.asyncio
+async def test_on_prem_rbac_jwt_wins_over_lakehouse_header(monkeypatch):
+    """on_prem+RBAC: a valid forwarded JWT is authoritative — the lakehouse
+    header must never override it into a Basic credential."""
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "true")
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    claims = {"sub": "s1", "username": "alice", "display_name": "Alice", "openrag_roles": ["admin"]}
+    monkeypatch.setattr(ibm_auth, "decode_ibm_jwt", lambda tok: claims if tok == "tok" else None)
+    req = _FakeRequest(headers={"X-OpenRAG-JWT": "Bearer tok", LH_HEADER: "dGVzdDp0ZXN0"})
+
+    user = await _get_ibm_user(req, required=True)
+
+    assert user is not None
+    assert user.jwt_token == "Bearer tok"  # Bearer JWT, never "Basic ..."
+    assert user.opensearch_credentials is None

--- a/tests/unit/dependencies/test_jwt_header_auth.py
+++ b/tests/unit/dependencies/test_jwt_header_auth.py
@@ -379,6 +379,72 @@ async def test_no_jwt_saas_rbac_off_no_error_log(monkeypatch):
     assert errors == []
 
 
+# --- on_prem mirrors: on-prem must behave exactly like saas here -----------
+
+
+@pytest.mark.asyncio
+async def test_no_jwt_on_prem_rbac_on_fails_loud_no_db_write(monkeypatch, _patch_attach):
+    """on_prem + RBAC + no gateway JWT -> fail loud with 401 missing_user_jwt
+    and do NOT silently fall back to lakehouse creds (matches saas)."""
+    manager, services = _ibm_setup(monkeypatch)
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    errors: list[str] = []
+    monkeypatch.setattr(deps.logger, "error", lambda msg, **kw: errors.append(msg))
+    # Even with a valid LH-credentials header present, platform_rbac must not use it.
+    req = _FakeRequest({"X-IBM-LH-Credentials": _B64}, services=services)
+
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_user_async(req, api_key_service=None, session_manager=None)
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail["error"] == "missing_user_jwt"
+    assert any("JWT not found" in m for m in errors)
+    assert "user" not in _patch_attach
+    assert manager.upserts == []
+
+
+@pytest.mark.asyncio
+async def test_no_jwt_on_prem_rbac_on_rejects_api_key_fail_fast(monkeypatch, _patch_attach):
+    """on_prem + RBAC + no gateway JWT -> fail fast even when a valid orag_ API
+    key is present (matches saas)."""
+    _ibm_setup(monkeypatch)
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+
+    calls: list[str] = []
+
+    class _KeySvc:
+        async def validate_key(self, key):
+            calls.append(key)
+            return {"user_id": "svc-user", "user_email": "svc@example.com", "key_id": "k1"}
+
+    req = _FakeRequest({"X-API-Key": "orag_live_key"})
+
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_user_async(req, api_key_service=_KeySvc(), session_manager=None)
+
+    assert exc.value.status_code == 401
+    assert exc.value.detail["error"] == "missing_user_jwt"
+    assert calls == []  # API key never validated under platform_rbac
+    assert "user" not in _patch_attach  # no _attach_request_user / DB write
+
+
+@pytest.mark.asyncio
+async def test_no_jwt_on_prem_rbac_off_no_error_log(monkeypatch):
+    """on_prem + RBAC off + no JWT -> no error log (legacy API-key behavior),
+    exactly as when RBAC is off today."""
+    monkeypatch.setenv("OPENRAG_RBAC_ENFORCE", "false")
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    monkeypatch.setattr(app_settings, "IBM_AUTH_ENABLED", False)
+    errors: list[str] = []
+    monkeypatch.setattr(deps.logger, "error", lambda msg, **kw: errors.append(msg))
+    req = _FakeRequest({})
+
+    with pytest.raises(HTTPException) as exc:
+        await get_api_key_user_async(req, api_key_service=None, session_manager=None)
+    assert exc.value.status_code == 401  # API key required
+    assert errors == []
+
+
 @pytest.mark.asyncio
 async def test_invalid_jwt_rbac_on_logs_error(monkeypatch, _patch_attach):
     """Header present but unverifiable under RBAC -> 401 plus a clear

--- a/tests/unit/services/test_dls_principal_client_selection.py
+++ b/tests/unit/services/test_dls_principal_client_selection.py
@@ -51,7 +51,8 @@ def test_saas_uses_service_token(monkeypatch):
     assert service._get_opensearch_client() is sentinel
 
 
-def test_saas_without_service_token_returns_none(monkeypatch):
+def test_saas_without_service_token_raises(monkeypatch):
+    import pytest
     from config import settings
     from utils import run_mode_utils
 
@@ -59,7 +60,8 @@ def test_saas_without_service_token_returns_none(monkeypatch):
     monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
 
     service = _make_service()
-    assert service._get_opensearch_client() is None
+    with pytest.raises(RuntimeError):
+        service._get_opensearch_client()
 
 
 def test_on_prem_uses_service_token(monkeypatch):
@@ -85,7 +87,8 @@ def test_on_prem_uses_service_token(monkeypatch):
     assert captured["token"] == "svc-jwt-token"
 
 
-def test_on_prem_without_service_token_returns_none(monkeypatch):
+def test_on_prem_without_service_token_raises(monkeypatch):
+    import pytest
     from config import settings
     from utils import run_mode_utils
 
@@ -94,7 +97,8 @@ def test_on_prem_without_service_token_returns_none(monkeypatch):
     monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
 
     service = _make_service()
-    assert service._get_opensearch_client() is None
+    with pytest.raises(RuntimeError):
+        service._get_opensearch_client()
 
 
 def test_oss_uses_basic_auth(monkeypatch):

--- a/tests/unit/services/test_dls_principal_client_selection.py
+++ b/tests/unit/services/test_dls_principal_client_selection.py
@@ -62,6 +62,41 @@ def test_saas_without_service_token_returns_none(monkeypatch):
     assert service._get_opensearch_client() is None
 
 
+def test_on_prem_uses_service_token(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    sentinel = object()
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: False)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: True)
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: "svc-jwt-token")
+    captured = {}
+
+    def fake_from_jwt(token):
+        captured["token"] = token
+        return sentinel
+
+    monkeypatch.setattr(settings.clients, "create_opensearch_client_from_jwt", fake_from_jwt)
+
+    service = _make_service()
+    client = service._get_opensearch_client()
+
+    assert client is sentinel
+    assert captured["token"] == "svc-jwt-token"
+
+
+def test_on_prem_without_service_token_returns_none(monkeypatch):
+    from config import settings
+    from utils import run_mode_utils
+
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: False)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: True)
+    monkeypatch.setattr(settings, "get_openrag_service_token", lambda: None)
+
+    service = _make_service()
+    assert service._get_opensearch_client() is None
+
+
 def test_oss_uses_basic_auth(monkeypatch):
     from config import settings
     from utils import run_mode_utils
@@ -86,12 +121,12 @@ def test_oss_uses_basic_auth(monkeypatch):
     assert captured["creds"] == ("admin", "secret")
 
 
-def test_on_prem_without_password_returns_none(monkeypatch):
+def test_oss_without_password_returns_none(monkeypatch):
     from config import settings
     from utils import run_mode_utils
 
     monkeypatch.setattr(run_mode_utils, "is_run_mode_saas", lambda: False)
-    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: True)
+    monkeypatch.setattr(run_mode_utils, "is_run_mode_on_prem", lambda: False)
     monkeypatch.setattr(settings, "get_opensearch_username", lambda: "admin")
     monkeypatch.setattr(settings, "get_opensearch_password", lambda: None)
 

--- a/tests/unit/services/test_dls_principal_client_selection.py
+++ b/tests/unit/services/test_dls_principal_client_selection.py
@@ -53,6 +53,7 @@ def test_saas_uses_service_token(monkeypatch):
 
 def test_saas_without_service_token_raises(monkeypatch):
     import pytest
+
     from config import settings
     from utils import run_mode_utils
 
@@ -89,6 +90,7 @@ def test_on_prem_uses_service_token(monkeypatch):
 
 def test_on_prem_without_service_token_raises(monkeypatch):
     import pytest
+
     from config import settings
     from utils import run_mode_utils
 


### PR DESCRIPTION
This pull request refactors the handling of OpenSearch credentials and RBAC enforcement across SaaS, on-prem, and OSS deployment modes. The main change is to treat both SaaS and on-prem modes as requiring a platform service token (JWT) for OpenSearch administration and RBAC, removing prior fallback logic and clarifying error handling and logging. OSS mode continues to use OpenSearch basic authentication. This unifies and simplifies the authentication model, making requirements stricter and more predictable.

**OpenSearch client and credential handling:**
- Both SaaS and on-prem now require `OPENRAG_SERVICE_TOKEN` for OpenSearch admin and writer clients; missing the token raises a `RuntimeError` and logs a clear error message. OSS continues to use basic auth. [[1]](diffhunk://#diff-4d75b7c1443c4f51a4fa22fb59df90c20bf2ccf2c76a4f76fc66e17bb1f35dccR1105-R1122) [[2]](diffhunk://#diff-7256a966ec47d12af4482369f083f68d5a08f112439093b0d54f0864722d962fR264-R274) [[3]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690R896-L925) [[4]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690L1569-L1611)
- The logic for creating OpenSearch clients is updated throughout the codebase to consistently treat SaaS/on-prem as requiring the service token, and OSS as using basic auth. [[1]](diffhunk://#diff-4d75b7c1443c4f51a4fa22fb59df90c20bf2ccf2c76a4f76fc66e17bb1f35dccR1105-R1122) [[2]](diffhunk://#diff-7256a966ec47d12af4482369f083f68d5a08f112439093b0d54f0864722d962fR264-R274) [[3]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690L1569-L1611) [[4]](diffhunk://#diff-6a7ded7417c902e8e0d51d5008a58e007373b8f09a340320bc09ff3646fa4167L244-R245)

**RBAC enforcement and authentication:**
- RBAC enforcement is unified for SaaS and on-prem: in either mode, with RBAC enabled, the gateway must forward the end-user JWT on every request. If missing, the API fails fast with a 401 error and descriptive message, and does not fall back to basic credentials. [[1]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL292-R299) [[2]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL313-R347) [[3]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL495-R507) [[4]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL574-R587) [[5]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL597-R604) [[6]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL659-R666)
- All logging and error messages are updated to refer to "platform" (SaaS/on-prem) modes and to include the current run mode for clarity. [[1]](diffhunk://#diff-7256a966ec47d12af4482369f083f68d5a08f112439093b0d54f0864722d962fL296-R288) [[2]](diffhunk://#diff-7256a966ec47d12af4482369f083f68d5a08f112439093b0d54f0864722d962fL310-R311) [[3]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL313-R347) [[4]](diffhunk://#diff-1365801e155896d9da186ce9f0261ece6a9fdbbf11fd4fa69cdcab07b5c8a06dL574-R587)

**Code and documentation cleanup:**
- Removes legacy or backward-compatibility paths that allowed user JWTs or unauthenticated clients in SaaS/on-prem; these modes now always require the service token. [[1]](diffhunk://#diff-4d75b7c1443c4f51a4fa22fb59df90c20bf2ccf2c76a4f76fc66e17bb1f35dccL1130-R1134) [[2]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690L1569-L1611)
- Updates docstrings and comments to reflect the new, unified platform authentication model. [[1]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690L1569-L1611) [[2]](diffhunk://#diff-6a7ded7417c902e8e0d51d5008a58e007373b8f09a340320bc09ff3646fa4167L244-R245)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Authentication**
  * Platform RBAC now applies to both **SaaS** and **on-prem** with **fail-fast 401** responses when the forwarded user JWT is missing or invalid.
  * When RBAC is enabled, the gateway JWT path takes precedence and skips other credential fallback behavior.

* **Configuration**
  * **SaaS** and **on-prem** OpenSearch admin setup/index bootstrap now require **`OPENRAG_SERVICE_TOKEN`** and use a JWT-derived admin identity.
  * **OSS** continues to use OpenSearch basic authentication.

* **Bug Fixes**
  * Startup/security reconciliation warning messaging now reflects the active run mode.

* **Tests**
  * Updated and expanded unit coverage for RBAC and OpenSearch client selection across run modes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->