### PR TITLE
fix: replaced deprecated regex with pattern in Query field

### DIFF
--- a/src/api/files.py
+++ b/src/api/files.py
@@ -25,7 +25,7 @@ async def list_files(
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(25, ge=1, le=100, description="Items per page"),
     sort_by: str = Query("filename", description="Sort field"),
-    sort_order: str = Query("asc", regex="^(asc|desc)$", description="Sort order"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
     connector_type: str | None = Query(None, description="Filter by connector type"),
     mimetype: str | None = Query(None, description="Filter by MIME type"),
     owner: str | None = Query(None, description="Filter by owner"),


### PR DESCRIPTION
## Summary
This PR replaces the deprecated `regex` field with the updated `pattern` field. The current version of Fastapi (>=0.115) uses Pydantic v2 which deprecated the `regex` in favor of `pattern`. The old code works but lead to deprecation warnings in backend logs like:
```
/app/src/api/files.py:28: FastAPIDeprecationWarning: `regex` has been deprecated, please use `pattern` instead
sort_order: str = Query("asc", regex="^(asc|desc)$", description="Sort order"),"
```

## Changes
- `src/api/files.py`: changed the `regex` kwarg to `pattern` kwarg for sort_order

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated file-list sorting parameter validation while preserving support for ascending and descending sort orders.
  * No changes to endpoint behavior or error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->