### PR TITLE
fix: removed duplicate key for backend.loglevel in helm values.yaml

### DIFF
--- a/kubernetes/helm/openrag/values.yaml
+++ b/kubernetes/helm/openrag/values.yaml
@@ -281,6 +281,8 @@ backend:
   logFormat: "json"                       # json or text
   logLevel: "INFO"                        # DEBUG, INFO, WARNING, ERROR
   serviceName: "openrag"
+  noColor: false                          # Set true to disable ANSI color codes in log output
+  accessLog: true                         # Set false to disable HTTP access log events
 
   # Persistence consolidated into two main volumes:
   # 1. /data: internal application state (data, backups, config, keys)
@@ -317,12 +319,6 @@ backend:
           - ibm_anthropic.pdf
           - openrag-documentation.pdf
           - warmup_ocr.pdf
-
-
-  # Logging
-  logLevel: "INFO"                        # DEBUG, INFO, WARNING, ERROR, CRITICAL
-  noColor: false                          # Set true to disable ANSI color codes in log output
-  accessLog: true                         # Set false to disable HTTP access log events
 
   # Timeouts
   langflowTimeout: 2400                   # seconds; total timeout for Langflow HTTP calls (default: 40 min)


### PR DESCRIPTION
## Summary

Removes a duplicate key in `kubernetes/helm/openrag/values.yaml` under the `backend` configuration block.

## Changes

- Removed duplicate key in `values.yaml` backend section
- Refactor, minor: Put all backend log related configs closer together

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Consolidated backend logging configuration for more consistent application behavior.
  - Removed duplicate logging settings while preserving existing log format, level, and service name options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->