### PR TITLE
fix: keep default docs title the same for every type of ingestion

### DIFF
--- a/frontend/tests/core/fetch_latest_docs.spec.ts
+++ b/frontend/tests/core/fetch_latest_docs.spec.ts
@@ -8,7 +8,7 @@ test.describe("Fetch Latest Docs Functionality", () => {
     knowledge,
     settings,
   }) => {
-    test.setTimeout(180000); // 3 minutes timeout
+    test.setTimeout(360000); // 6 minutes timeout
 
     logger.info("Starting Fetch Latest Docs E2E test");
     const expectedDocName = "What is OpenRAG? | OpenRAG";

--- a/frontend/tests/core/fetch_latest_docs.spec.ts
+++ b/frontend/tests/core/fetch_latest_docs.spec.ts
@@ -3,29 +3,50 @@ import logger from "../utils/logger";
 import { navigateToKnowledge } from "../utils/navigation";
 
 test.describe("Fetch Latest Docs Functionality", () => {
-  test("Verify Fetch Latest Docs works and refreshes the document list @33219240", async ({
+  test("Verify Fetch Latest Docs works and refreshes the document list with and without Langflow @33219240", async ({
     page,
     knowledge,
+    settings,
   }) => {
     test.setTimeout(180000); // 3 minutes timeout
 
     logger.info("Starting Fetch Latest Docs E2E test");
+    const expectedDocName = "What is OpenRAG? | OpenRAG";
 
-    // 1. Navigate to the Knowledge page
+    // Navigate initially to load the app UI (sidebar with Settings link)
+    await navigateToKnowledge(page);
+    logger.info("Successfully loaded the app UI");
+
+    // --- Phase 1: Test with Langflow Ingestion DISABLED (Traditional OpenRAG processing) ---
+    logger.info("PHASE 1: Testing with Langflow Ingestion DISABLED");
+    await settings.setDisableLangflowIngestion(true);
+
     await navigateToKnowledge(page);
     logger.info("Successfully navigated to Knowledge page");
 
-    // 2. Click the "Fetch latest docs" button and verify success toast is shown
     logger.info("Triggering fetchLatestDocs()...");
     await knowledge.fetchLatestDocs();
     logger.info("fetchLatestDocs() execution completed successfully");
 
-    // 3. Verify that the OpenRAG docs URL document appears and becomes active
-    const expectedDocName =
-      process.env.DEFAULT_DOCS_URL || "https://docs.openr.ag/";
     logger.info(`Verifying default document '${expectedDocName}' is active`);
     await knowledge.verifyDocumentActive(expectedDocName);
 
-    logger.info("Fetch Latest Docs E2E test passed successfully!");
+    // --- Phase 2: Test with Langflow Ingestion ENABLED (Langflow processing) ---
+    logger.info("PHASE 2: Testing with Langflow Ingestion ENABLED");
+    await settings.setDisableLangflowIngestion(false);
+
+    await navigateToKnowledge(page);
+    logger.info("Successfully navigated to Knowledge page");
+
+    logger.info("Triggering fetchLatestDocs()...");
+    await knowledge.fetchLatestDocs();
+    logger.info("fetchLatestDocs() execution completed successfully");
+
+    logger.info(`Verifying default document '${expectedDocName}' is active`);
+    await knowledge.verifyDocumentActive(expectedDocName);
+
+    logger.info(
+      "Fetch Latest Docs E2E test passed successfully for both modes!",
+    );
   });
 });

--- a/frontend/tests/pages/Settings.ts
+++ b/frontend/tests/pages/Settings.ts
@@ -29,6 +29,8 @@ export class Settings {
   private readonly chunkSizeInput = () => this.page.getByLabel(/chunk size/i);
   private readonly chunkOverlapInput = () =>
     this.page.getByLabel(/chunk overlap/i);
+  private readonly disableLangflowIngestionToggle = () =>
+    this.page.getByRole("switch", { name: /disable langflow ingestion/i });
   private readonly watsonxProjectIDInput = () =>
     this.page.locator("#project-id");
   private readonly apiKeyInput = () => this.page.locator("#api-key");
@@ -227,6 +229,18 @@ export class Settings {
   async setOCR(enabled: boolean) {
     await this.open();
     const toggle = this.ocrToggle();
+    await toggle.scrollIntoViewIfNeeded();
+    const state = await toggle.getAttribute("data-state");
+    const isChecked = state === "checked";
+    if (isChecked !== enabled) {
+      await toggle.click();
+      await this.saveIngestSettings();
+    }
+  }
+
+  async setDisableLangflowIngestion(enabled: boolean) {
+    await this.clickTab("Langflow");
+    const toggle = this.disableLangflowIngestionToggle();
     await toggle.scrollIntoViewIfNeeded();
     const state = await toggle.getAttribute("data-state");
     const isChecked = state === "checked";

--- a/src/services/default_docs_service.py
+++ b/src/services/default_docs_service.py
@@ -316,7 +316,7 @@ async def _ingest_default_documents_url(
         docs_url=docs_url,
         crawl_depth=crawl_depth,
     )
-    temp_file_path = await materialize_url_as_text_file(
+    temp_file_path, title = await materialize_url_as_text_file(
         docs_url=docs_url,
         crawl_depth=crawl_depth,
     )
@@ -341,7 +341,7 @@ async def _ingest_default_documents_url(
             file_path=temp_file_path,
             file_hash=hash_id(temp_file_path),
             owner_user_id=None,
-            original_filename="openrag-url-default.txt",
+            original_filename=title,
             jwt_token=jwt_token,
             owner_name=anonymous_user.name,
             owner_email=anonymous_user.email,

--- a/src/services/document_index_writer.py
+++ b/src/services/document_index_writer.py
@@ -24,9 +24,9 @@ logger = get_logger(__name__)
 @dataclass
 class DocumentIndexContext:
     document_id: str
-    filename: str
     mimetype: str
     embedding_model: str
+    filename: str | None = None
     owner: str | None = None
     owner_name: str | None = None
     owner_email: str | None = None

--- a/src/services/langflow_file_service.py
+++ b/src/services/langflow_file_service.py
@@ -192,10 +192,10 @@ class LangflowFileService:
         self,
         *,
         document_id: str,
-        filename: str,
         mimetype: str,
         file_size: int,
         embedding_model: str,
+        filename: str | None = None,
         owner: str | None,
         owner_name: str | None,
         owner_email: str | None,
@@ -651,7 +651,6 @@ class LangflowFileService:
         }
         ingest_token, ingest_run_id = self._configure_ingest_callback(
             document_id=resolved_document_id,
-            filename=docs_url,
             mimetype="text/html",
             file_size=0,
             embedding_model=embedding_model,

--- a/src/utils/url_content_fetcher.py
+++ b/src/utils/url_content_fetcher.py
@@ -48,7 +48,8 @@ async def materialize_url_as_text_file(docs_url: str, crawl_depth: int) -> tuple
         raw_html,
         flags=re.IGNORECASE | re.DOTALL,
     )
-    title = html.unescape(title_match.group(1).strip()) if title_match else "OpenRAG"
+    title = html.unescape(title_match.group(1).strip()) if title_match else ""
+    title = title or "OpenRAG"
 
     text_parser = _VisibleTextHTMLParser()
     text_parser.feed(raw_html)

--- a/src/utils/url_content_fetcher.py
+++ b/src/utils/url_content_fetcher.py
@@ -36,8 +36,8 @@ class _VisibleTextHTMLParser(HTMLParser):
         return " ".join(self._chunks)
 
 
-async def materialize_url_as_text_file(docs_url: str, crawl_depth: int) -> str:
-    """Fetch URL content and write a temporary text file for OpenRAG ingestion."""
+async def materialize_url_as_text_file(docs_url: str, crawl_depth: int) -> tuple[str, str]:
+    """Fetch URL content and write a temporary text file for OpenRAG ingestion, returning path and title."""
     async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
         response = await client.get(docs_url)
         response.raise_for_status()
@@ -68,4 +68,4 @@ async def materialize_url_as_text_file(docs_url: str, crawl_depth: int) -> str:
     )
     with temp_file:
         temp_file.write(content)
-    return temp_file.name
+    return temp_file.name, title


### PR DESCRIPTION
This pull request enhances the "Fetch Latest Docs" feature by improving end-to-end test coverage for both Langflow-enabled and traditional ingestion modes, and refactors backend ingestion logic to better handle document metadata. The main changes include updating tests to toggle Langflow ingestion, modifying ingestion services to use document titles from URLs, and improving type safety for optional filenames throughout the codebase.

**Testing improvements:**

* The E2E test in `fetch_latest_docs.spec.ts` now verifies "Fetch Latest Docs" works both with Langflow ingestion enabled and disabled, toggling the setting and validating the active document in each mode.
* The `Settings` test page object adds a method to toggle Langflow ingestion and locates the relevant UI element for the test. [[1]](diffhunk://#diff-ef53de3490f9b9215a31fa873b46cbf6be04ef9bfe1f2fa7a3b32497eafdb642R32-R33) [[2]](diffhunk://#diff-ef53de3490f9b9215a31fa873b46cbf6be04ef9bfe1f2fa7a3b32497eafdb642R241-R252)

**Backend ingestion and metadata handling:**

* `materialize_url_as_text_file` now returns both the temporary file path and the document title, allowing ingestion services to use the actual title as the `original_filename` instead of a hardcoded value. [[1]](diffhunk://#diff-2fd9d85a26b4928d22cd2dce268767e8e59ce3af9baf4e14cc2508bb9293ec7dL39-R40) [[2]](diffhunk://#diff-2fd9d85a26b4928d22cd2dce268767e8e59ce3af9baf4e14cc2508bb9293ec7dL71-R71) [[3]](diffhunk://#diff-a9b854b0c9d74d5bc43f38d0113bcd7a4860eb5ae52856f3c50ba33db819095eL319-R319) [[4]](diffhunk://#diff-a9b854b0c9d74d5bc43f38d0113bcd7a4860eb5ae52856f3c50ba33db819095eL344-R344)
* The `filename` parameter in document ingestion contexts and callbacks is now optional (`str | None`), improving type safety and flexibility for documents without explicit filenames. [[1]](diffhunk://#diff-d131634fa6bbaeccb67906110fcbe7368a3e9ad5720a8afe1ce014b8bbfb8db6L27-R29) [[2]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958L195-R198) [[3]](diffhunk://#diff-8878811cc1efd5dd9d2c815ce131fcaf5ba0e43ee8cf3e20512a53a8511e3958L654)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Default documents now use the source page title, making them easier to identify.
  - URL-based document ingestion now handles missing filenames more reliably.

- **Bug Fixes**
  - Fetching the latest default documentation is now consistent whether Langflow ingestion is enabled or disabled.
  - Default documentation verification recognizes the correct document title.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->