### PR TITLE
fix: add limit for max tokens in a batch for watsonx

### DIFF
--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -437,8 +437,14 @@ class TaskProcessor:
         # Use provided embedding model or configured model.
         # get_embedding_model() returns empty string when Langflow ingest is enabled,
         # but OpenRAG processors still need a concrete embedding model.
-        configured_embedding_model = get_openrag_config().knowledge.embedding_model
+        config = get_openrag_config()
+        configured_embedding_model = config.knowledge.embedding_model
         embedding_model = embedding_model or configured_embedding_model or get_embedding_model()
+
+        if chunk_size is None:
+            chunk_size = config.knowledge.chunk_size
+        if chunk_overlap is None:
+            chunk_overlap = config.knowledge.chunk_overlap
 
         # Get user's OpenSearch client with JWT for OIDC auth
         opensearch_client = self.document_service.session_manager.get_user_opensearch_client(

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -516,7 +516,7 @@ class TaskProcessor:
 
         litellm_model_lower = litellm_embedding_model.lower() if litellm_embedding_model else ""
         if "watsonx" in litellm_model_lower:
-            max_tokens = 350
+            max_tokens = 500
         elif "ollama" in litellm_model_lower:
             max_tokens = 2000
         else:

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -510,7 +510,7 @@ class TaskProcessor:
 
         litellm_model_lower = litellm_embedding_model.lower() if litellm_embedding_model else ""
         if "watsonx" in litellm_model_lower:
-            max_tokens = 500
+            max_tokens = 350
         elif "ollama" in litellm_model_lower:
             max_tokens = 2000
         else:

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -508,12 +508,13 @@ class TaskProcessor:
             else embedding_model
         )
 
-        # Split into batches to avoid token limits (8191 limit, use 8000 with buffer or 2000 if it's ollama)
-        max_tokens = (
-            2000
-            if litellm_embedding_model and "ollama" in litellm_embedding_model.lower()
-            else 8000
-        )
+        litellm_model_lower = litellm_embedding_model.lower() if litellm_embedding_model else ""
+        if "watsonx" in litellm_model_lower:
+            max_tokens = 500
+        elif "ollama" in litellm_model_lower:
+            max_tokens = 2000
+        else:
+            max_tokens = 8000
 
         # Split any chunks that exceed max_tokens before embedding, ensuring chunks and embeddings align 1-to-1.
         slim_doc["chunks"] = split_chunks_by_max_tokens(

--- a/tests/integration/core/test_non_langflow_ingestion.py
+++ b/tests/integration/core/test_non_langflow_ingestion.py
@@ -87,7 +87,7 @@ async def test_non_langflow_csv_ingestion_with_splitting(tmp_path: Path):
     os.environ["DISABLE_STARTUP_INGEST"] = "true"
     os.environ["EMBEDDING_MODEL"] = "text-embedding-3-small"
     os.environ["EMBEDDING_PROVIDER"] = "openai"
-    os.environ["CHUNK_SIZE"] = "8000"
+    os.environ["CHUNK_SIZE"] = "0"
     os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
     os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
 

--- a/tests/integration/core/test_non_langflow_ingestion.py
+++ b/tests/integration/core/test_non_langflow_ingestion.py
@@ -87,7 +87,6 @@ async def test_non_langflow_csv_ingestion_with_splitting(tmp_path: Path):
     os.environ["DISABLE_STARTUP_INGEST"] = "true"
     os.environ["EMBEDDING_MODEL"] = "text-embedding-3-small"
     os.environ["EMBEDDING_PROVIDER"] = "openai"
-    os.environ["CHUNK_SIZE"] = "0"
     os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
     os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
 
@@ -194,9 +193,9 @@ async def test_non_langflow_csv_ingestion_with_splitting(tmp_path: Path):
             )
             hits = opensearch_resp.get("hits", {}).get("hits", [])
 
-            # Since the text is ~12,000 tokens, and max_tokens=8000,
-            # it should be split into 2 chunks, resulting in 2 documents in OpenSearch.
-            assert len(hits) == 2, f"Expected 2 indexed chunks, but got {len(hits)}"
+            # Since the text is ~12,000 tokens, and max_tokens=1000,
+            # it should be split into 10 chunks, resulting in 10 documents in OpenSearch.
+            assert len(hits) == 10, f"Expected 10 indexed chunks, but got {len(hits)}"
             for hit in hits:
                 source = hit.get("_source", {})
                 assert source.get("document_id") == expected_document_id

--- a/tests/integration/core/test_non_langflow_ingestion.py
+++ b/tests/integration/core/test_non_langflow_ingestion.py
@@ -87,6 +87,7 @@ async def test_non_langflow_csv_ingestion_with_splitting(tmp_path: Path):
     os.environ["DISABLE_STARTUP_INGEST"] = "true"
     os.environ["EMBEDDING_MODEL"] = "text-embedding-3-small"
     os.environ["EMBEDDING_PROVIDER"] = "openai"
+    os.environ["CHUNK_SIZE"] = "8000"
     os.environ["GOOGLE_OAUTH_CLIENT_ID"] = ""
     os.environ["GOOGLE_OAUTH_CLIENT_SECRET"] = ""
 


### PR DESCRIPTION
This pull request updates the document processing logic to improve how chunking and token limits are handled based on the selected embedding model. The main changes ensure that the chunk size and overlap default to configuration values when not provided, and that the maximum token limit is set appropriately for different embedding models, including special handling for "watsonx".

**Configuration handling improvements:**

* The `chunk_size` and `chunk_overlap` parameters now default to values from the configuration (`config.knowledge.chunk_size` and `config.knowledge.chunk_overlap`) if not explicitly provided.

**Model-specific token limit logic:**

* The logic for determining `max_tokens` has been updated to set a lower limit (500) for the "watsonx" embedding model, 2000 for "ollama", and 8000 for other models, improving compatibility and preventing token overflow issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved document processing by applying configured embedding model, chunk size, and chunk overlap defaults when values aren’t provided.
  * Updated embedding batching limits to choose token caps based on the resolved embedding provider/model (Watsonx, Ollama, and a default for others).
* **Tests**
  * Updated the CSV ingestion integration test to expect increased indexing results (more chunks) for large inputs, reflecting the updated batching/chunking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->