### PR TITLE
fix: pass index name at runtime to langflow

### DIFF
--- a/src/utils/langflow_headers.py
+++ b/src/utils/langflow_headers.py
@@ -97,13 +97,17 @@ async def add_provider_credentials_to_headers(
             ollama_endpoint = transform_localhost_url(config.providers.ollama.endpoint)
         headers["X-LANGFLOW-GLOBAL-VAR-OLLAMA_BASE_URL"] = str(ollama_endpoint)
 
-    # Inject OpenSearch URL so Langflow flows always use the correct endpoint
-    from config.settings import LANGFLOW_OPENSEARCH_HOST, LANGFLOW_OPENSEARCH_PORT
+    # Inject OpenSearch URL and index name so Langflow flows always use the correct endpoint
+    from config.settings import LANGFLOW_OPENSEARCH_HOST, LANGFLOW_OPENSEARCH_PORT, get_index_name
 
     if LANGFLOW_OPENSEARCH_HOST and LANGFLOW_OPENSEARCH_PORT:
         headers["X-LANGFLOW-GLOBAL-VAR-OPENSEARCH_URL"] = (
             f"https://{LANGFLOW_OPENSEARCH_HOST}:{LANGFLOW_OPENSEARCH_PORT}"
         )
+
+    index_name = get_index_name()
+    if index_name:
+        headers["X-LANGFLOW-GLOBAL-VAR-OPENSEARCH_INDEX_NAME"] = index_name
 
     # IBM mode: inject OpenSearch Basic credentials as separate global vars
     from config.settings import IBM_AUTH_ENABLED


### PR DESCRIPTION
This pull request updates the way OpenSearch configuration is injected into Langflow headers to ensure flows always use the correct endpoint and index name. The most important changes are:

**OpenSearch Configuration Injection:**

* The OpenSearch index name is now included in the headers by importing and using the `get_index_name` function from `config.settings`, and setting the `X-LANGFLOW-GLOBAL-VAR-OPENSEARCH_INDEX_NAME` header if an index name is available.
* The import statement for OpenSearch settings now includes `get_index_name` in addition to `LANGFLOW_OPENSEARCH_HOST` and `LANGFLOW_OPENSEARCH_PORT`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenSearch requests now include the configured index name when available.
  * Preserved support for setting the OpenSearch connection URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->