### PR TITLE
feat: added option to disable StorageClass creation in Helm chart

### DIFF
--- a/kubernetes/helm/openrag/templates/storage/backend-sc.yaml
+++ b/kubernetes/helm/openrag/templates/storage/backend-sc.yaml
@@ -1,4 +1,4 @@
-{{- if or (.Values.backend.persistence.data.enabled) (.Values.backend.persistence.shared.enabled) }}
+{{- if and (or (.Values.backend.persistence.data.enabled) (.Values.backend.persistence.shared.enabled)) (ne .Values.backend.createStorageClass false) }}
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:

--- a/kubernetes/helm/openrag/values.yaml
+++ b/kubernetes/helm/openrag/values.yaml
@@ -218,6 +218,7 @@ backend:
   enabled: true
 
   # StorageClass templating fields
+  createStorageClass: true                # Optional skip storageClass creation
   storageClassName: ""
   storageClassAnnotations: {}
   storageClassLabels: {}


### PR DESCRIPTION
## Summary

Added createStorageClass value to openrag helm chart values.yaml. If explicitly set to false, default behavior is overridden and no attempt to create a storageClass is made during deployment. This is helpful in clusters with prohibitive RBAC. Adjusted the backend-sc template accordingly.

## Changes

- added createStorageClass, default true, to openrag helm chart values.yaml
- adjusted backend-sc template with according predicate
- defaults behavior remains unchanged, unless createStorageClass is set to false explicitly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to control whether the backend StorageClass is created.
  * StorageClass creation is enabled by default and can be disabled through configuration.

* **Bug Fixes**
  * Prevented unintended StorageClass creation when explicitly disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->