### PR TITLE
fix: remove tenant id and also move to run mode utils

### DIFF
--- a/src/services/docling_service.py
+++ b/src/services/docling_service.py
@@ -16,7 +16,7 @@ from config.settings import (
     get_openrag_config,
 )
 from utils.logging_config import get_logger
-from utils.run_mode_utils import is_run_mode_saas
+from utils.run_mode_utils import is_run_mode_on_prem, is_run_mode_saas
 
 logger = get_logger(__name__)
 
@@ -178,7 +178,7 @@ class DoclingService:
     ) -> dict[str, str]:
         """Build authentication headers for Docling Serve in saas run mode."""
         headers = {}
-        if is_run_mode_saas() and auth_header:
+        if (is_run_mode_saas() or is_run_mode_on_prem()) and auth_header:
             headers["Authorization"] = auth_header
         return headers
 

--- a/src/services/docling_service.py
+++ b/src/services/docling_service.py
@@ -13,10 +13,10 @@ from config.settings import (
     DOCLING_ERROR_DETAIL_MAX_LENGTH,
     DOCLING_SERVE_URL,
     DOCLING_SERVE_VERIFY_SSL,
-    IBM_AUTH_ENABLED,
     get_openrag_config,
 )
 from utils.logging_config import get_logger
+from utils.run_mode_utils import is_run_mode_saas
 
 logger = get_logger(__name__)
 
@@ -176,14 +176,10 @@ class DoclingService:
     def _get_auth_headers(
         self, user_id: str | None = None, auth_header: str | None = None
     ) -> dict[str, str]:
-        """Build authentication headers for Docling Serve if IBM auth is enabled."""
+        """Build authentication headers for Docling Serve in saas run mode."""
         headers = {}
-        if IBM_AUTH_ENABLED:
-            if auth_header:
-                headers["Authorization"] = auth_header
-
-            if user_id:
-                headers["X-Tenant-Id"] = user_id
+        if is_run_mode_saas() and auth_header:
+            headers["Authorization"] = auth_header
         return headers
 
     async def upload_to_docling_direct_async(


### PR DESCRIPTION
This pull request updates the authentication logic for Docling Serve integration to better align with the application's run mode. The main change is to replace the use of the `IBM_AUTH_ENABLED` flag with checks for whether the application is running in SaaS or on-premises mode.

**Authentication logic update:**

* Replaced the `IBM_AUTH_ENABLED` flag with `is_run_mode_saas()` and `is_run_mode_on_prem()` checks to determine when to include authentication headers in requests to Docling Serve. (`src/services/docling_service.py`) [[1]](diffhunk://#diff-732675f677994bc2bd488b70a6884c8713d268c0ec5141128657d36e18bf7c41L16-R19) [[2]](diffhunk://#diff-732675f677994bc2bd488b70a6884c8713d268c0ec5141128657d36e18bf7c41L179-L186)
* Updated the `_get_auth_headers` method docstring to clarify that authentication headers are now built for SaaS run mode.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Docling Serve request authentication to no longer rely on the previous environment-based toggle.
  * Authorization headers are now included only when an auth header is available, improving authenticated SaaS requests.
  * Removed the prior tenant-header behavior from these Docling Serve requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->