### PR TITLE
fix: tenant ID and remove unused components

### DIFF
--- a/flows/ingestion_flow.json
+++ b/flows/ingestion_flow.json
@@ -666,7 +666,7 @@
                       "value": true
                     },
                     "key": "X-Tenant-Id",
-                    "value": "OWNER"
+                    "value": ""
                   }
                 ]
               },

--- a/src/api/docling.py
+++ b/src/api/docling.py
@@ -8,11 +8,11 @@ from config.settings import (
     DOCLING_HOST_IP,
     DOCLING_SERVE_URL,
     DOCLING_SERVE_VERIFY_SSL,
-    IBM_AUTH_ENABLED,
 )
 from dependencies import get_optional_user
 from session_manager import User
 from utils.logging_config import get_logger
+from utils.run_mode_utils import is_run_mode_on_prem, is_run_mode_saas
 
 logger = get_logger(__name__)
 
@@ -31,11 +31,9 @@ async def health(
     """
     health_url = f"{DOCLING_SERVICE_URL}/health"
     headers = {}
-    if IBM_AUTH_ENABLED and user:
+    if (is_run_mode_saas() or is_run_mode_on_prem()) and user:
         if user.jwt_token:
             headers["Authorization"] = user.jwt_token
-        if user.user_id:
-            headers["X-Tenant-Id"] = user.user_id
 
     try:
         async with httpx.AsyncClient(verify=DOCLING_SERVE_VERIFY_SSL) as client:


### PR DESCRIPTION
This pull request updates authentication handling for the Docling service and makes a small change to the ingestion flow configuration. The main focus is on improving how authentication headers are set based on the deployment mode, making the logic more robust and less dependent on a single environment variable.

Authentication logic improvements:
* Replaced the use of `IBM_AUTH_ENABLED` with checks for `is_run_mode_saas()` and `is_run_mode_on_prem()` to determine when to add authentication headers in `src/api/docling.py`. [[1]](diffhunk://#diff-9b2e0d4eecb17971a285069e8086cf8c710711e7d67bbcab7ba4cd1a77e3c0adL11-R15) [[2]](diffhunk://#diff-9b2e0d4eecb17971a285069e8086cf8c710711e7d67bbcab7ba4cd1a77e3c0adL34-L38)
* Removed the addition of the `X-Tenant-Id` header in the health check endpoint, streamlining the headers sent to the Docling service.

Configuration change:
* Set the `X-Tenant-Id` value to an empty string in the `flows/ingestion_flow.json` configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Docling service health checks across supported runtime modes.
  * Authorization headers are now forwarded only when a valid token is available.
  * Removed unnecessary tenant header forwarding from health-check requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->