### PR TITLE
feat: refactored api key service to use the sql database instead of opensearch

### DIFF
--- a/src/api/keys.py
+++ b/src/api/keys.py
@@ -29,11 +29,7 @@ async def list_keys_endpoint(
 
     GET /keys
     """
-    result = await api_key_service.list_keys(
-        user.db_user_id, 
-        user.user_id,
-        user.jwt_token
-    )
+    result = await api_key_service.list_keys(user.db_user_id, user.user_id, user.jwt_token)
     return JSONResponse(result)
 
 

--- a/src/api/keys.py
+++ b/src/api/keys.py
@@ -28,7 +28,7 @@ async def list_keys_endpoint(
 
     GET /keys
     """
-    result = await api_key_service.list_keys(user.user_id, user.jwt_token)
+    result = await api_key_service.list_keys(user.db_user_id, user.jwt_token)
     return JSONResponse(result)
 
 
@@ -52,10 +52,8 @@ async def create_key_endpoint(
             )
 
         result = await api_key_service.create_key(
-            user_id=user.user_id,
-            user_email=user.email,
+            user_id=user.db_user_id,
             name=name,
-            jwt_token=user.jwt_token,
         )
 
         if result.get("success"):
@@ -64,7 +62,7 @@ async def create_key_endpoint(
             return JSONResponse(result, status_code=500)
 
     except Exception as e:
-        logger.error("Failed to create API key", error=str(e), user_id=user.user_id)
+        logger.error("Failed to create API key", error=str(e), user_id=user.db_user_id)
         return JSONResponse(
             {"success": False, "error": str(e)},
             status_code=500,
@@ -82,9 +80,8 @@ async def revoke_key_endpoint(
     DELETE /keys/{key_id}
     """
     result = await api_key_service.revoke_key(
-        user_id=user.user_id,
+        user_id=user.db_user_id,
         key_id=key_id,
-        jwt_token=user.jwt_token,
     )
 
     if result.get("success"):
@@ -108,9 +105,8 @@ async def delete_key_endpoint(
     DELETE /keys/{key_id}/permanent
     """
     result = await api_key_service.delete_key(
-        user_id=user.user_id,
+        user_id=user.db_user_id,
         key_id=key_id,
-        jwt_token=user.jwt_token,
     )
 
     if result.get("success"):

--- a/src/api/keys.py
+++ b/src/api/keys.py
@@ -29,7 +29,11 @@ async def list_keys_endpoint(
 
     GET /keys
     """
-    result = await api_key_service.list_keys(user.db_user_id, user.jwt_token)
+    result = await api_key_service.list_keys(
+        user.db_user_id, 
+        user.user_id,
+        user.jwt_token
+    )
     return JSONResponse(result)
 
 

--- a/src/api/keys.py
+++ b/src/api/keys.py
@@ -4,13 +4,14 @@ API Key management endpoints.
 These endpoints use JWT cookie authentication (for the UI) and allow users
 to create, list, and revoke their API keys for use with the public API.
 """
+
 from fastapi import Depends
-from pydantic import BaseModel, Field
 from fastapi.responses import JSONResponse
-from utils.logging_config import get_logger
+from pydantic import BaseModel, Field
 
 from dependencies import get_api_key_service, get_current_user, require_permission
 from session_manager import User
+from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 

--- a/src/app/container.py
+++ b/src/app/container.py
@@ -169,13 +169,11 @@ async def initialize_services():
         Category.SERVICE_INITIALIZATION, MessageId.ORB_SVC_INIT_SUCCESS
     )
 
-    api_key_service = APIKeyService(session_manager)
-
-    # ===== RBAC service =====
+    # ===== SQL-backed services (shared lazy session factory) =====
     # We do NOT open the SQL engine here. `create_app()` runs inside an
     # `asyncio.run(...)` whose loop is closed BEFORE uvicorn starts its
     # own loop — any AsyncEngine bound to this loop would be dead by
-    # then. Instead, RBACService takes a *lazy* session-factory getter
+    # then. Instead, these services take a *lazy* session-factory getter
     # that resolves `db.engine.SessionLocal` at call time — that
     # attribute is filled in by the lifespan startup event running on
     # uvicorn's loop. Alembic upgrade is run synchronously from __main__
@@ -189,11 +187,12 @@ async def initialize_services():
         sl = _db_engine_mod.SessionLocal
         if sl is None:
             raise RuntimeError(
-                "DB engine not yet initialized. RBACService called before lifespan startup."
+                "DB engine not yet initialized. A SQL-backed service called before lifespan startup"
             )
         return sl()
 
     rbac_service = RBACService(_lazy_session_factory)
+    api_key_service = APIKeyService(session_manager, session_factory=_lazy_session_factory)
 
     # WorkspaceConfigService — DB-first reads of what config.yaml holds,
     # with the legacy ConfigManager kept as the yaml fallback during

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -41,7 +41,7 @@ JSON_TO_DB_V1 = "json_to_db_v1"
 # SQLite, so there's no longer dirty data to sweep.
 CONFIG_YAML_TO_DB_V1 = "config_yaml_to_db_v1"
 CHAT_HISTORY_JSON_TO_DB_V1 = "chat_history_json_to_db_v1"
-
+API_KEYS_OS_TO_DB_V1 = "api_keys_os_to_db_v1"
 
 class RuntimeMigrationError(RuntimeError):
     """Raised when a required startup data migration fails."""
@@ -266,6 +266,67 @@ async def migrate_chat_history_json_to_db(session: AsyncSession) -> dict[str, in
     return stats
 
 
+async def migrate_api_keys_os_to_sql_db(session: AsyncSession) -> int:
+    """Copy API keys from OpenSearch `api_keys` index into SQL DB
+    
+    Resolves each key's OpenSearch ``user_id`` (an OAuth subject) to the
+    internal ``users.id`` — by id, then by the denormalized ``user_email``.
+    Keys whose user can't be resolved are skipped; they stay valid via the
+    service's read-only OpenSearch fallback. Returns rows inserted.
+    """
+    from config.settings import API_KEYS_INDEX_NAME, clients
+    from db.models import ApiKey
+    from db.repositories import UserRepo
+
+    client = getattr(clients, "opensearch", None)
+    if client is None:
+        return 0
+    
+    try:
+        result = await client.search(
+            index=API_KEYS_INDEX_NAME,
+            body={"query": {"match_all": {}}, "size": 10000},
+        )
+    except Exception as exc: # noqa: BLE001 — index may be absent / OS down
+        logger.warning("api_keys_os_to_db_v1: OpenSearch read failed; skipping", error=str(exc))
+        return 0
+    
+    user_repo = UserRepo(session)
+    inserted = 0
+    for hit in result.get("hits", {}).get("hits", []):
+        doc = hit.get("_source", {})
+        key_id = doc.get("key_id")
+        key_hash = doc.get("key_hash")
+        key_prefix = doc.get("key_prefix")
+        name = doc.get("name")
+        created_at = _parse_legacy_dt(doc.get("created_at"))
+        if not (key_id and key_hash and key_prefix and name and created_at):
+            continue
+
+        os_user_id = doc.get("user_id")
+        db_user = await user_repo.get_by_id(os_user_id) if os_user_id else None
+        if db_user is None and doc.get("user_email"):
+            db_user = await user_repo.get_by_email(doc["user_email"])
+        if db_user is None: 
+            continue
+
+        session.add(
+            ApiKey(
+                id=key_id,
+                user_id=db_user.id,
+                name=name,
+                key_hash=key_hash,
+                key_prefix=key_prefix,
+                last_used_at=_parse_legacy_dt(doc.get("last_used_at")),
+                created_at=created_at,
+                revoked=bool(doc.get("revoked", False)),
+            )
+        )
+        inserted += 1
+    
+    await session.flush()
+    return inserted
+
 async def run(session: AsyncSession) -> None:
     """Top-level entry. Caller is responsible for committing."""
     if not await _already_done(session, JSON_TO_DB_V1):
@@ -301,6 +362,18 @@ async def run(session: AsyncSession) -> None:
         )
         await _mark_done(session, CHAT_HISTORY_JSON_TO_DB_V1, notes=notes)
         logger.info("chat_history_json_to_db_v1 completed", **stats)
+    
+    if not await _already_done(session, API_KEYS_OS_TO_DB_V1):
+        try:
+            migrated = await migrate_api_keys_os_to_sql_db(session)
+        except Exception as exc: # noqa: BLE001
+            logger.error(
+                "api_keys_os_to_db_v1 failed: aborting startup",
+                error=str(exc)
+            )
+            raise RuntimeMigrationError(f"{API_KEYS_OS_TO_DB_V1} failed") from exc
+        await _mark_done(session, API_KEYS_OS_TO_DB_V1, notes=f"api_keys_migrated={migrated}")
+        logger.info("api_keys_os_to_db_v1 completed", migrated=migrated)
 
     try:
         from db.seed import seed_roles_and_permissions

--- a/src/db/migrations_runtime.py
+++ b/src/db/migrations_runtime.py
@@ -43,6 +43,7 @@ CONFIG_YAML_TO_DB_V1 = "config_yaml_to_db_v1"
 CHAT_HISTORY_JSON_TO_DB_V1 = "chat_history_json_to_db_v1"
 API_KEYS_OS_TO_DB_V1 = "api_keys_os_to_db_v1"
 
+
 class RuntimeMigrationError(RuntimeError):
     """Raised when a required startup data migration fails."""
 
@@ -268,7 +269,7 @@ async def migrate_chat_history_json_to_db(session: AsyncSession) -> dict[str, in
 
 async def migrate_api_keys_os_to_sql_db(session: AsyncSession) -> int:
     """Copy API keys from OpenSearch `api_keys` index into SQL DB
-    
+
     Resolves each key's OpenSearch ``user_id`` (an OAuth subject) to the
     internal ``users.id`` — by id, then by the denormalized ``user_email``.
     Keys whose user can't be resolved are skipped; they stay valid via the
@@ -281,16 +282,16 @@ async def migrate_api_keys_os_to_sql_db(session: AsyncSession) -> int:
     client = getattr(clients, "opensearch", None)
     if client is None:
         return 0
-    
+
     try:
         result = await client.search(
             index=API_KEYS_INDEX_NAME,
             body={"query": {"match_all": {}}, "size": 10000},
         )
-    except Exception as exc: # noqa: BLE001 — index may be absent / OS down
+    except Exception as exc:  # noqa: BLE001 — index may be absent / OS down
         logger.warning("api_keys_os_to_db_v1: OpenSearch read failed; skipping", error=str(exc))
         return 0
-    
+
     user_repo = UserRepo(session)
     inserted = 0
     for hit in result.get("hits", {}).get("hits", []):
@@ -307,7 +308,7 @@ async def migrate_api_keys_os_to_sql_db(session: AsyncSession) -> int:
         db_user = await user_repo.get_by_id(os_user_id) if os_user_id else None
         if db_user is None and doc.get("user_email"):
             db_user = await user_repo.get_by_email(doc["user_email"])
-        if db_user is None: 
+        if db_user is None:
             continue
 
         session.add(
@@ -323,9 +324,10 @@ async def migrate_api_keys_os_to_sql_db(session: AsyncSession) -> int:
             )
         )
         inserted += 1
-    
+
     await session.flush()
     return inserted
+
 
 async def run(session: AsyncSession) -> None:
     """Top-level entry. Caller is responsible for committing."""
@@ -362,15 +364,12 @@ async def run(session: AsyncSession) -> None:
         )
         await _mark_done(session, CHAT_HISTORY_JSON_TO_DB_V1, notes=notes)
         logger.info("chat_history_json_to_db_v1 completed", **stats)
-    
+
     if not await _already_done(session, API_KEYS_OS_TO_DB_V1):
         try:
             migrated = await migrate_api_keys_os_to_sql_db(session)
-        except Exception as exc: # noqa: BLE001
-            logger.error(
-                "api_keys_os_to_db_v1 failed: aborting startup",
-                error=str(exc)
-            )
+        except Exception as exc:  # noqa: BLE001
+            logger.error("api_keys_os_to_db_v1 failed: aborting startup", error=str(exc))
             raise RuntimeMigrationError(f"{API_KEYS_OS_TO_DB_V1} failed") from exc
         await _mark_done(session, API_KEYS_OS_TO_DB_V1, notes=f"api_keys_migrated={migrated}")
         logger.info("api_keys_os_to_db_v1 completed", migrated=migrated)

--- a/src/db/repositories/api_key_repo.py
+++ b/src/db/repositories/api_key_repo.py
@@ -17,12 +17,10 @@ class ApiKeyRepo:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    # TODO: once we remove opensearch fallback for reads, we can revert this to 
+    # TODO: once we remove opensearch fallback for reads, we can revert this to
     # get_by_hash to only return non revoked keys
     async def get_by_hash_any_state(self, key_hash: str) -> ApiKey | None:
-        result = await self.session.execute(
-            select(ApiKey).where(col(ApiKey.key_hash) == key_hash)
-        )
+        result = await self.session.execute(select(ApiKey).where(col(ApiKey.key_hash) == key_hash))
         return result.scalar_one_or_none()
 
     async def get_by_id(self, key_id: str) -> ApiKey | None:

--- a/src/db/repositories/api_key_repo.py
+++ b/src/db/repositories/api_key_repo.py
@@ -22,7 +22,7 @@ class ApiKeyRepo:
             select(ApiKey).where(col(ApiKey.key_hash) == key_hash, col(ApiKey.revoked).is_(False))
         )
         return result.scalar_one_or_none()
-    
+
     async def get_by_id(self, key_id: str) -> ApiKey | None:
         return await self.session.get(ApiKey, key_id)
 
@@ -34,7 +34,7 @@ class ApiKeyRepo:
         self.session.add(api_key)
         await self.session.flush()
         return api_key
-    
+
     async def mark_used(self, key_id: str) -> None:
         """Update last_used_at on a successful validation"""
         from datetime import UTC, datetime
@@ -42,7 +42,7 @@ class ApiKeyRepo:
         row = await self.session.get(ApiKey, key_id)
         if row is None:
             return
-        
+
         row.last_used_at = datetime.now(UTC)
         self.session.add(row)
         await self.session.flush()

--- a/src/db/repositories/api_key_repo.py
+++ b/src/db/repositories/api_key_repo.py
@@ -22,6 +22,9 @@ class ApiKeyRepo:
             select(ApiKey).where(col(ApiKey.key_hash) == key_hash, col(ApiKey.revoked).is_(False))
         )
         return result.scalar_one_or_none()
+    
+    async def get_by_id(self, key_id: str) -> ApiKey | None:
+        return await self.session.get(ApiKey, key_id)
 
     async def list_for_user(self, user_id: str) -> list[ApiKey]:
         result = await self.session.execute(select(ApiKey).where(col(ApiKey.user_id) == user_id))
@@ -31,6 +34,18 @@ class ApiKeyRepo:
         self.session.add(api_key)
         await self.session.flush()
         return api_key
+    
+    async def mark_used(self, key_id: str) -> None:
+        """Update last_used_at on a successful validation"""
+        from datetime import UTC, datetime
+
+        row = await self.session.get(ApiKey, key_id)
+        if row is None:
+            return
+        
+        row.last_used_at = datetime.now(UTC)
+        self.session.add(row)
+        await self.session.flush()
 
     async def revoke(self, key_id: str) -> None:
         from datetime import datetime
@@ -40,4 +55,10 @@ class ApiKeyRepo:
             row.revoked = True
             row.revoked_at = datetime.now(UTC)
             self.session.add(row)
+            await self.session.flush()
+
+    async def delete(self, key_id: str) -> None:
+        row = await self.session.get(ApiKey, key_id)
+        if row is not None:
+            await self.session.delete(row)
             await self.session.flush()

--- a/src/db/repositories/api_key_repo.py
+++ b/src/db/repositories/api_key_repo.py
@@ -17,9 +17,11 @@ class ApiKeyRepo:
     def __init__(self, session: AsyncSession):
         self.session = session
 
-    async def get_by_hash(self, key_hash: str) -> ApiKey | None:
+    # TODO: once we remove opensearch fallback for reads, we can revert this to 
+    # get_by_hash to only return non revoked keys
+    async def get_by_hash_any_state(self, key_hash: str) -> ApiKey | None:
         result = await self.session.execute(
-            select(ApiKey).where(col(ApiKey.key_hash) == key_hash, col(ApiKey.revoked).is_(False))
+            select(ApiKey).where(col(ApiKey.key_hash) == key_hash)
         )
         return result.scalar_one_or_none()
 
@@ -57,8 +59,4 @@ class ApiKeyRepo:
             self.session.add(row)
             await self.session.flush()
 
-    async def delete(self, key_id: str) -> None:
-        row = await self.session.get(ApiKey, key_id)
-        if row is not None:
-            await self.session.delete(row)
-            await self.session.flush()
+    # TODO: once we remove opensearch fallback for reads, add a hard delete sql method

--- a/src/services/api_key_service.py
+++ b/src/services/api_key_service.py
@@ -230,7 +230,7 @@ class APIKeyService:
 
                 # Keyed-HMAC digest first, then the pre-HMAC legacy digest
                 # so old keys migrated with a legacy hash still validate.
-                # Look up in *any* state: a SQL row is authoritative, so a 
+                # Look up in *any* state: a SQL row is authoritative, so a
                 # revoked/tombstoned key must be found and rejected here rather
                 # than slipping through to OpenSearch fallback (whose copy
                 # is never updated on revoke/delete) and re-authenticating.
@@ -266,12 +266,9 @@ class APIKeyService:
         except Exception as e:
             logger.error("Failed to validate API key", error=str(e))
             return None
-            
+
     async def list_keys(
-        self, 
-        user_id: str,
-        oauth_subject: str,
-        jwt_token: str | None = None
+        self, user_id: str, oauth_subject: str, jwt_token: str | None = None
     ) -> dict[str, Any]:
         """
         List all active (non-revoked) API keys for a user (without the actual keys).
@@ -415,11 +412,11 @@ class APIKeyService:
                     return {"success": False, "error": "Key not found"}
                 if row.user_id != user_id:
                     return {"success": False, "error": "Not authorized to delete this key"}
-                
+
                 # since a migrated key still has a live OpenSearch doc and we never write to
-                # OpenSearch on delete we should Tombstone instead of hard-deleting. 
+                # OpenSearch on delete we should Tombstone instead of hard-deleting.
                 # Dropping the sql row would let validate_key's OpenSearch fallback re-auth the key.
-                # TODO: once we complete migration to sql (remove opensearch read fallback), 
+                # TODO: once we complete migration to sql (remove opensearch read fallback),
                 # we should update this to use a proper sql delete instead of soft delete
                 await repo.revoke(key_id)
                 await session.commit()

--- a/src/services/api_key_service.py
+++ b/src/services/api_key_service.py
@@ -6,13 +6,14 @@ import hashlib
 import hmac
 import secrets
 from datetime import UTC, datetime
-from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Any
 
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from config.settings import API_KEYS_INDEX_NAME
-from utils.logging_config import get_logger
 from db.models import ApiKey
 from db.repositories import ApiKeyRepo, UserRepo
+from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 API_KEY_HASH_PREFIX = "hmac-sha256:"
@@ -96,7 +97,7 @@ class APIKeyService:
         keyed_hash = self._hash_key(api_key)
         legacy_hash = self._legacy_hash_key(api_key)
         return [keyed_hash, legacy_hash]
-    
+
     async def _validate_key_opensearch(self, api_key: str) -> dict[str, Any] | None:
         """Read-only OpenSearch fallback for keys not yet copied into SQL DB."""
         try:
@@ -129,7 +130,7 @@ class APIKeyService:
             key_doc = hits[0]["_source"]
 
             matched_hash = key_doc.get("key_hash")
-            
+
             # Update last_used_at and opportunistically migrate legacy hashes.
             try:
                 write_client = self._get_write_opensearch_client()
@@ -155,11 +156,7 @@ class APIKeyService:
             logger.error("Failed to validate API key", error=str(e))
             return None
 
-    async def create_key(
-        self, 
-        user_id: str, 
-        name: str
-    ) -> dict[str, Any]:
+    async def create_key(self, user_id: str, name: str) -> dict[str, Any]:
         """
         Create a new API key for a user.
 
@@ -244,7 +241,7 @@ class APIKeyService:
                         "key_id": row.id,
                         "user_id": row.user_id,
                         "user_email": user.email if user else None,
-                        "name": row.name
+                        "name": row.name,
                     }
 
                     try:
@@ -253,19 +250,15 @@ class APIKeyService:
                     except Exception:
                         await session.rollback()
                     return result
-                
+
             # Not in SQL db yet, read-only fallback to OpenSearch
             return await self._validate_key_opensearch(api_key)
 
         except Exception as e:
             logger.error("Failed to validate API key", error=str(e))
             return None
-            
-    async def list_keys(
-        self, 
-        user_id: str,
-        jwt_token: str | None = None
-    ) -> dict[str, Any]:
+
+    async def list_keys(self, user_id: str, jwt_token: str | None = None) -> dict[str, Any]:
         """
         List all active (non-revoked) API keys for a user (without the actual keys).
 
@@ -295,7 +288,7 @@ class APIKeyService:
                     for r in active
                 ]
                 return {"success": True, "keys": keys}
-            
+
             # No SQL db keys for this user, read-only fallback to OpenSearch
             opensearch_client = self._get_opensearch_client(jwt_token)
 
@@ -331,7 +324,7 @@ class APIKeyService:
                 keys.append(hit["_source"])
 
             return {"success": True, "keys": keys}
-        
+
         except Exception as e:
             logger.error("Failed to list API keys", error=str(e), user_id=user_id)
             return {"success": False, "error": str(e), "keys": []}
@@ -361,7 +354,7 @@ class APIKeyService:
                     return {"success": False, "error": "Key not found"}
                 if row.user_id != user_id:
                     return {"success": False, "error": "Not authorized to revoke this key"}
-                
+
                 await repo.revoke(key_id)
                 await session.commit()
 
@@ -371,7 +364,7 @@ class APIKeyService:
                 key_id=key_id,
             )
             return {"success": True}
-        
+
         except Exception as e:
             logger.error(
                 "Failed to revoke API key",
@@ -406,7 +399,7 @@ class APIKeyService:
                     return {"success": False, "error": "Key not found"}
                 if row.user_id != user_id:
                     return {"success": False, "error": "Not authorized to delete this key"}
-                
+
                 await repo.delete(key_id)
                 await session.commit()
 

--- a/src/services/api_key_service.py
+++ b/src/services/api_key_service.py
@@ -230,11 +230,20 @@ class APIKeyService:
 
                 # Keyed-HMAC digest first, then the pre-HMAC legacy digest
                 # so old keys migrated with a legacy hash still validate.
-                row = await repo.get_by_hash(key_hash)
+                # Look up in *any* state: a SQL row is authoritative, so a 
+                # revoked/tombstoned key must be found and rejected here rather
+                # than slipping through to OpenSearch fallback (whose copy
+                # is never updated on revoke/delete) and re-authenticating.
+                row = await repo.get_by_hash_any_state(key_hash)
                 if row is None:
-                    row = await repo.get_by_hash(self._legacy_hash_key(api_key))
+                    row = await repo.get_by_hash_any_state(self._legacy_hash_key(api_key))
 
                 if row is not None:
+                    # sql row exists. If its revoked (tombstone applies to both revoke and delete)
+                    # the key is invalid and we shouldnt fall back to OpenSearch
+                    if row.revoked:
+                        return None
+
                     user = await UserRepo(session).get_by_id(row.user_id)
 
                     result = {
@@ -257,13 +266,20 @@ class APIKeyService:
         except Exception as e:
             logger.error("Failed to validate API key", error=str(e))
             return None
-
-    async def list_keys(self, user_id: str, jwt_token: str | None = None) -> dict[str, Any]:
+            
+    async def list_keys(
+        self, 
+        user_id: str,
+        oauth_subject: str,
+        jwt_token: str | None = None
+    ) -> dict[str, Any]:
         """
         List all active (non-revoked) API keys for a user (without the actual keys).
 
         Args:
             user_id: The user's ID
+            oauth_subject: The user's OAuth subject, used only for the OpenSearch
+                read fallback (OpenSearch documents key on the subject, not users.id)
             jwt_token: JWT token for OpenSearch authentication (used only for OpenSearch read fallback)
 
         Returns:
@@ -273,8 +289,8 @@ class APIKeyService:
             async with self._db_session() as session:
                 rows = await ApiKeyRepo(session).list_for_user(user_id)
 
-            active = [r for r in rows if not r.revoked]
-            if active:
+            if rows:
+                active = [r for r in rows if not r.revoked]
                 active.sort(key=lambda r: r.created_at, reverse=True)
                 keys = [
                     {
@@ -297,7 +313,7 @@ class APIKeyService:
                 "query": {
                     "bool": {
                         "must": [
-                            {"term": {"user_id": user_id}},
+                            {"term": {"user_id": oauth_subject}},
                             {"term": {"revoked": False}},
                         ]
                     }
@@ -380,7 +396,7 @@ class APIKeyService:
         key_id: str,
     ) -> dict[str, Any]:
         """
-        Permanently delete an API key.
+        Delete an API key (tombstone).
 
         Args:
             user_id: The user's ID (for authorization)
@@ -399,8 +415,13 @@ class APIKeyService:
                     return {"success": False, "error": "Key not found"}
                 if row.user_id != user_id:
                     return {"success": False, "error": "Not authorized to delete this key"}
-
-                await repo.delete(key_id)
+                
+                # since a migrated key still has a live OpenSearch doc and we never write to
+                # OpenSearch on delete we should Tombstone instead of hard-deleting. 
+                # Dropping the sql row would let validate_key's OpenSearch fallback re-auth the key.
+                # TODO: once we complete migration to sql (remove opensearch read fallback), 
+                # we should update this to use a proper sql delete instead of soft delete
+                await repo.revoke(key_id)
                 await session.commit()
 
             logger.info(

--- a/src/services/api_key_service.py
+++ b/src/services/api_key_service.py
@@ -6,10 +6,13 @@ import hashlib
 import hmac
 import secrets
 from datetime import UTC, datetime
+from sqlalchemy.ext.asyncio import AsyncSession
 from typing import Any
 
 from config.settings import API_KEYS_INDEX_NAME
 from utils.logging_config import get_logger
+from db.models import ApiKey
+from db.repositories import ApiKeyRepo, UserRepo
 
 logger = get_logger(__name__)
 API_KEY_HASH_PREFIX = "hmac-sha256:"
@@ -18,8 +21,9 @@ API_KEY_HASH_PREFIX = "hmac-sha256:"
 class APIKeyService:
     """Service for managing user API keys for public API authentication."""
 
-    def __init__(self, session_manager=None):
+    def __init__(self, session_manager=None, session_factory=None):
         self.session_manager = session_manager
+        self._session_factory = session_factory
 
     def _generate_api_key(self) -> tuple[str, str, str]:
         """
@@ -43,6 +47,12 @@ class APIKeyService:
         key_prefix = f"orag_{random_bytes[:8]}"
 
         return full_key, key_hash, key_prefix
+
+    def _db_session(self) -> AsyncSession:
+        """Open a DB session, failing if the factory wasn't wired"""
+        if self._session_factory is None:
+            raise RuntimeError("APIKeyService requires a DB session factory")
+        return self._session_factory()
 
     def _get_opensearch_client(self, jwt_token: str = None):
         """Get the appropriate OpenSearch client.
@@ -86,106 +96,21 @@ class APIKeyService:
         keyed_hash = self._hash_key(api_key)
         legacy_hash = self._legacy_hash_key(api_key)
         return [keyed_hash, legacy_hash]
-
-    async def create_key(
-        self,
-        user_id: str,
-        user_email: str,
-        name: str,
-        jwt_token: str = None,
-    ) -> dict[str, Any]:
-        """
-        Create a new API key for a user.
-
-        Args:
-            user_id: The user's ID
-            user_email: The user's email
-            name: A friendly name for the key
-            jwt_token: JWT token for OpenSearch authentication
-
-        Returns:
-            Dict with success status, key info, and the full key (only shown once)
-        """
+    
+    async def _validate_key_opensearch(self, api_key: str) -> dict[str, Any] | None:
+        """Read-only OpenSearch fallback for keys not yet copied into SQL DB."""
         try:
-            # Generate the key
-            full_key, key_hash, key_prefix = self._generate_api_key()
-
-            # Create a unique key_id
-            key_id = secrets.token_urlsafe(16)
-
-            now = datetime.now(UTC).isoformat()
-
-            # Create the document to store
-            key_doc = {
-                "key_id": key_id,
-                "key_hash": key_hash,
-                "key_prefix": key_prefix,
-                "user_id": user_id,
-                "user_email": user_email,
-                "name": name,
-                "created_at": now,
-                "last_used_at": None,
-                "revoked": False,
-            }
-
-            opensearch_client = self._get_write_opensearch_client()
-
-            # Index the key document
-            result = await opensearch_client.index(
-                index=API_KEYS_INDEX_NAME,
-                id=key_id,
-                body=key_doc,
-                refresh="wait_for",
-            )
-
-            if result.get("result") in ("created", "updated"):
-                logger.info(
-                    "Created API key",
-                    user_id=user_id,
-                    key_id=key_id,
-                    key_prefix=key_prefix,
-                )
-                return {
-                    "success": True,
-                    "key_id": key_id,
-                    "key_prefix": key_prefix,
-                    "name": name,
-                    "created_at": now,
-                    "api_key": full_key,  # Only returned once!
-                }
-            else:
-                return {"success": False, "error": "Failed to create API key"}
-
-        except Exception as e:
-            logger.error("Failed to create API key", error=str(e), user_id=user_id)
-            return {"success": False, "error": str(e)}
-
-    async def validate_key(self, api_key: str) -> dict[str, Any] | None:
-        """
-        Validate an API key and return user info if valid.
-
-        Args:
-            api_key: The full API key to validate
-
-        Returns:
-            Dict with user info if valid, None if invalid
-        """
-        try:
-            # Check key format
-            if not api_key or not api_key.startswith("orag_"):
-                return None
-
             key_hash = self._hash_key(api_key)
-            candidate_hashes = self._candidate_hashes(api_key)
-
             opensearch_client = self._get_opensearch_client()
+            if opensearch_client is None:
+                return None
 
             # Search for the key by hash
             search_body = {
                 "query": {
                     "bool": {
                         "must": [
-                            {"terms": {"key_hash": candidate_hashes}},
+                            {"terms": {"key_hash": self._candidate_hashes(api_key)}},
                             {"term": {"revoked": False}},
                         ]
                     }
@@ -197,7 +122,6 @@ class APIKeyService:
                 index=API_KEYS_INDEX_NAME,
                 body=search_body,
             )
-
             hits = result.get("hits", {}).get("hits", [])
             if not hits:
                 return None
@@ -205,7 +129,7 @@ class APIKeyService:
             key_doc = hits[0]["_source"]
 
             matched_hash = key_doc.get("key_hash")
-
+            
             # Update last_used_at and opportunistically migrate legacy hashes.
             try:
                 write_client = self._get_write_opensearch_client()
@@ -231,22 +155,148 @@ class APIKeyService:
             logger.error("Failed to validate API key", error=str(e))
             return None
 
+    async def create_key(
+        self, 
+        user_id: str, 
+        name: str
+    ) -> dict[str, Any]:
+        """
+        Create a new API key for a user.
+
+        Args:
+            user_id: The user's ID
+            name: A friendly name for the key
+
+        Returns:
+            Dict with success status, key info, and the full key (only shown once)
+        """
+        try:
+            # Generate the key
+            full_key, key_hash, key_prefix = self._generate_api_key()
+
+            # Create a unique key_id
+            key_id = secrets.token_urlsafe(16)
+
+            now = datetime.now(UTC)
+
+            # Create the row to store
+            row = ApiKey(
+                id=key_id,
+                user_id=user_id,
+                name=name,
+                key_hash=key_hash,
+                key_prefix=key_prefix,
+                created_at=now,
+            )
+
+            async with self._db_session() as session:
+                await ApiKeyRepo(session).add(row)
+                await session.commit()
+
+            logger.info(
+                "Created API key",
+                user_id=user_id,
+                key_id=key_id,
+                key_prefix=key_prefix,
+            )
+            return {
+                "success": True,
+                "key_id": key_id,
+                "key_prefix": key_prefix,
+                "name": name,
+                "created_at": now.isoformat(),
+                "api_key": full_key,  # Only returned once!
+            }
+        except Exception as e:
+            logger.error("Failed to create API key", error=str(e), user_id=user_id)
+            return {"success": False, "error": str(e)}
+
+    async def validate_key(self, api_key: str) -> dict[str, Any] | None:
+        """
+        Validate an API key and return user info if valid.
+
+        Args:
+            api_key: The full API key to validate
+
+        Returns:
+            Dict with user info if valid, None if invalid
+        """
+        try:
+            # Check key format
+            if not api_key or not api_key.startswith("orag_"):
+                return None
+
+            key_hash = self._hash_key(api_key)
+
+            async with self._db_session() as session:
+                repo = ApiKeyRepo(session)
+
+                # Keyed-HMAC digest first, then the pre-HMAC legacy digest
+                # so old keys migrated with a legacy hash still validate.
+                row = await repo.get_by_hash(key_hash)
+                if row is None:
+                    row = await repo.get_by_hash(self._legacy_hash_key(api_key))
+
+                if row is not None:
+                    user = await UserRepo(session).get_by_id(row.user_id)
+
+                    result = {
+                        "key_id": row.id,
+                        "user_id": row.user_id,
+                        "user_email": user.email if user else None,
+                        "name": row.name
+                    }
+
+                    try:
+                        await repo.mark_used(row.id)
+                        await session.commit()
+                    except Exception:
+                        await session.rollback()
+                    return result
+                
+            # Not in SQL db yet, read-only fallback to OpenSearch
+            return await self._validate_key_opensearch(api_key)
+
+        except Exception as e:
+            logger.error("Failed to validate API key", error=str(e))
+            return None
+            
     async def list_keys(
-        self,
+        self, 
         user_id: str,
-        jwt_token: str = None,
+        jwt_token: str | None = None
     ) -> dict[str, Any]:
         """
         List all active (non-revoked) API keys for a user (without the actual keys).
 
         Args:
             user_id: The user's ID
-            jwt_token: JWT token for OpenSearch authentication
+            jwt_token: JWT token for OpenSearch authentication (used only for OpenSearch read fallback)
 
         Returns:
             Dict with list of key metadata
         """
         try:
+            async with self._db_session() as session:
+                rows = await ApiKeyRepo(session).list_for_user(user_id)
+
+            active = [r for r in rows if not r.revoked]
+            if active:
+                active.sort(key=lambda r: r.created_at, reverse=True)
+                keys = [
+                    {
+                        "key_id": r.id,
+                        "key_prefix": r.key_prefix,
+                        "name": r.name,
+                        "created_at": r.created_at.isoformat() if r.created_at else None,
+                        "last_used_at": r.last_used_at.isoformat() if r.last_used_at else None,
+                        "revoked": r.revoked,
+                    }
+                    for r in active
+                ]
+                return {"success": True, "keys": keys}
+            
+            # No SQL db keys for this user, read-only fallback to OpenSearch
             opensearch_client = self._get_opensearch_client(jwt_token)
 
             # Search for user's keys
@@ -281,7 +331,7 @@ class APIKeyService:
                 keys.append(hit["_source"])
 
             return {"success": True, "keys": keys}
-
+        
         except Exception as e:
             logger.error("Failed to list API keys", error=str(e), user_id=user_id)
             return {"success": False, "error": str(e), "keys": []}
@@ -290,7 +340,6 @@ class APIKeyService:
         self,
         user_id: str,
         key_id: str,
-        jwt_token: str = None,
     ) -> dict[str, Any]:
         """
         Revoke an API key.
@@ -298,46 +347,31 @@ class APIKeyService:
         Args:
             user_id: The user's ID (for authorization)
             key_id: The key ID to revoke
-            jwt_token: JWT token for OpenSearch authentication
 
         Returns:
             Dict with success status
         """
         try:
-            opensearch_client = self._get_opensearch_client(jwt_token)
+            async with self._db_session() as session:
+                repo = ApiKeyRepo(session)
 
-            # First, verify the key belongs to this user
-            try:
-                doc = await opensearch_client.get(
-                    index=API_KEYS_INDEX_NAME,
-                    id=key_id,
-                )
-
-                if doc["_source"]["user_id"] != user_id:
+                # First, verify the key belongs to this user
+                row = await repo.get_by_id(key_id)
+                if row is None:
+                    return {"success": False, "error": "Key not found"}
+                if row.user_id != user_id:
                     return {"success": False, "error": "Not authorized to revoke this key"}
+                
+                await repo.revoke(key_id)
+                await session.commit()
 
-            except Exception:
-                return {"success": False, "error": "Key not found"}
-
-            # Update the key to mark as revoked with the trusted backend client.
-            write_client = self._get_write_opensearch_client()
-            result = await write_client.update(
-                index=API_KEYS_INDEX_NAME,
-                id=key_id,
-                body={"doc": {"revoked": True}},
-                refresh="wait_for",
+            logger.info(
+                "Revoked API key",
+                user_id=user_id,
+                key_id=key_id,
             )
-
-            if result.get("result") == "updated":
-                logger.info(
-                    "Revoked API key",
-                    user_id=user_id,
-                    key_id=key_id,
-                )
-                return {"success": True}
-            else:
-                return {"success": False, "error": "Failed to revoke key"}
-
+            return {"success": True}
+        
         except Exception as e:
             logger.error(
                 "Failed to revoke API key",
@@ -351,7 +385,6 @@ class APIKeyService:
         self,
         user_id: str,
         key_id: str,
-        jwt_token: str = None,
     ) -> dict[str, Any]:
         """
         Permanently delete an API key.
@@ -359,44 +392,30 @@ class APIKeyService:
         Args:
             user_id: The user's ID (for authorization)
             key_id: The key ID to delete
-            jwt_token: JWT token for OpenSearch authentication
 
         Returns:
             Dict with success status
         """
         try:
-            opensearch_client = self._get_opensearch_client(jwt_token)
+            async with self._db_session() as session:
+                repo = ApiKeyRepo(session)
 
-            # First, verify the key belongs to this user
-            try:
-                doc = await opensearch_client.get(
-                    index=API_KEYS_INDEX_NAME,
-                    id=key_id,
-                )
-
-                if doc["_source"]["user_id"] != user_id:
+                # First, verify the key belongs to this user
+                row = await repo.get_by_id(key_id)
+                if row is None:
+                    return {"success": False, "error": "Key not found"}
+                if row.user_id != user_id:
                     return {"success": False, "error": "Not authorized to delete this key"}
+                
+                await repo.delete(key_id)
+                await session.commit()
 
-            except Exception:
-                return {"success": False, "error": "Key not found"}
-
-            # Delete the key with the trusted backend client.
-            write_client = self._get_write_opensearch_client()
-            result = await write_client.delete(
-                index=API_KEYS_INDEX_NAME,
-                id=key_id,
-                refresh="wait_for",
+            logger.info(
+                "Deleted API key",
+                user_id=user_id,
+                key_id=key_id,
             )
-
-            if result.get("result") == "deleted":
-                logger.info(
-                    "Deleted API key",
-                    user_id=user_id,
-                    key_id=key_id,
-                )
-                return {"success": True}
-            else:
-                return {"success": False, "error": "Failed to delete key"}
+            return {"success": True}
 
         except Exception as e:
             logger.error(

--- a/tests/unit/test_api_key_service.py
+++ b/tests/unit/test_api_key_service.py
@@ -1,12 +1,12 @@
 import sys
 from pathlib import Path
-from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
-from sqlalchemy.pool import StaticPool
-from sqlmodel import SQLModel
 from unittest.mock import AsyncMock
 
 import pytest
 import pytest_asyncio
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel
 
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
@@ -19,7 +19,7 @@ async def session_factory():
     engine = create_async_engine(
         "sqlite+aiosqlite:///:memory:",
         connect_args={"check_same_thread": False},
-        poolclass=StaticPool
+        poolclass=StaticPool,
     )
     async with engine.begin() as conn:
         await conn.run_sync(SQLModel.metadata.create_all)
@@ -55,10 +55,15 @@ async def test_create_then_validate_roundtrip_stamps_last_used(session_factory, 
     service = APIKeyService(session_factory=session_factory)
 
     async with session_factory() as session:
-        session.add(User(
-            id="user-1", oauth_provider="google", oauth_subject="user-1",
-            email="user@example.com", email_lookup_hash=email_lookup_hash("user@example.com"),
-        ))
+        session.add(
+            User(
+                id="user-1",
+                oauth_provider="google",
+                oauth_subject="user-1",
+                email="user@example.com",
+                email_lookup_hash=email_lookup_hash("user@example.com"),
+            )
+        )
         await session.commit()
 
     created = await service.create_key(user_id="user-1", name="my key")
@@ -73,7 +78,7 @@ async def test_create_then_validate_roundtrip_stamps_last_used(session_factory, 
     # mark_used ran (parity with the OpenSearch last_used_at update)
     async with session_factory() as session:
         row = await ApiKeyRepo(session).get_by_id(created["key_id"])
-    
+
     assert row is not None
     assert row.last_used_at is not None
 
@@ -110,14 +115,24 @@ async def test_validate_key_accepts_and_migrates_legacy_hash(session_factory, mo
     api_key = "orag_legacy_key"
 
     async with session_factory() as session:
-        session.add(User(
-            id="user-1", oauth_provider="google", oauth_subject="user-1",
-            email="user@example.com", email_lookup_hash=email_lookup_hash("user@example.com"),
-        ))
-        session.add(ApiKey(
-            id="key-1", user_id="user-1", name="legacy key",
-            key_hash=service._legacy_hash_key(api_key), key_prefix="orag_legacy1",
-        ))
+        session.add(
+            User(
+                id="user-1",
+                oauth_provider="google",
+                oauth_subject="user-1",
+                email="user@example.com",
+                email_lookup_hash=email_lookup_hash("user@example.com"),
+            )
+        )
+        session.add(
+            ApiKey(
+                id="key-1",
+                user_id="user-1",
+                name="legacy key",
+                key_hash=service._legacy_hash_key(api_key),
+                key_prefix="orag_legacy1",
+            )
+        )
         await session.commit()
 
     user_info = await service.validate_key(api_key)
@@ -128,8 +143,11 @@ async def test_validate_key_accepts_and_migrates_legacy_hash(session_factory, mo
         "name": "legacy key",
     }
 
+
 @pytest.mark.asyncio
-async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(session_factory, monkeypatch) -> None:
+async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(
+    session_factory, monkeypatch
+) -> None:
     from services.api_key_service import APIKeyService
 
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
@@ -182,25 +200,41 @@ async def test_list_keys_returns_only_non_revoked_api_keys(session_factory, monk
 
     service = APIKeyService(session_factory=session_factory)
     async with session_factory() as session:
-        session.add(ApiKey(id="k1", user_id="user-1", name="active",
-                           key_hash="h1", key_prefix="orag_a"))
-        session.add(ApiKey(id="k2", user_id="user-1", name="revoked",
-                           key_hash="h2", key_prefix="orag_b", revoked=True))
+        session.add(
+            ApiKey(id="k1", user_id="user-1", name="active", key_hash="h1", key_prefix="orag_a")
+        )
+        session.add(
+            ApiKey(
+                id="k2",
+                user_id="user-1",
+                name="revoked",
+                key_hash="h2",
+                key_prefix="orag_b",
+                revoked=True,
+            )
+        )
         await session.commit()
 
     result = await service.list_keys("user-1")
     assert [k["key_id"] for k in result["keys"]] == ["k1"]
     assert set(result["keys"][0]) == {
-        "key_id", "key_prefix", "name", "created_at", "last_used_at", "revoked",
+        "key_id",
+        "key_prefix",
+        "name",
+        "created_at",
+        "last_used_at",
+        "revoked",
     }
 
 
 @pytest.mark.asyncio
-async def test_list_keys_opensearch_fallback_when_sqlite_empty(session_factory, monkeypatch) -> None:
+async def test_list_keys_opensearch_fallback_when_sqlite_empty(
+    session_factory, monkeypatch
+) -> None:
     from services.api_key_service import APIKeyService
 
     service = APIKeyService(session_factory=session_factory)
-    
+
     opensearch_client = AsyncMock()
     opensearch_client.search.return_value = {
         "hits": {

--- a/tests/unit/test_api_key_service.py
+++ b/tests/unit/test_api_key_service.py
@@ -1,14 +1,14 @@
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
-from services.api_key_service import APIKeyService
-
 
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 from sqlalchemy.pool import StaticPool
 from sqlmodel import SQLModel
+
+from services.api_key_service import APIKeyService
 
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
@@ -145,7 +145,9 @@ async def test_validate_key_accepts_and_migrates_legacy_hash(session_factory, mo
 
 
 @pytest.mark.asyncio
-async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(session_factory, monkeypatch) -> None:
+async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(
+    session_factory, monkeypatch
+) -> None:
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
 
     service = APIKeyService(session_factory=session_factory)
@@ -223,7 +225,9 @@ async def test_list_keys_returns_only_non_revoked_api_keys(session_factory, monk
 
 
 @pytest.mark.asyncio
-async def test_list_keys_opensearch_fallback_when_sqlite_empty(session_factory, monkeypatch) -> None:
+async def test_list_keys_opensearch_fallback_when_sqlite_empty(
+    session_factory, monkeypatch
+) -> None:
     service = APIKeyService(session_factory=session_factory)
 
     opensearch_client = AsyncMock()
@@ -265,13 +269,23 @@ async def test_list_keys_opensearch_fallback_when_sqlite_empty(session_factory, 
 
 
 @pytest.mark.asyncio
-async def test_list_keys_all_revoked_returns_empty_without_fallback(session_factory, monkeypatch) -> None:
+async def test_list_keys_all_revoked_returns_empty_without_fallback(
+    session_factory, monkeypatch
+) -> None:
     from db.models import ApiKey
 
     service = APIKeyService(session_factory=session_factory)
     async with session_factory() as session:
-        session.add(ApiKey(id="k1", user_id="user-1", name="revoked",
-                           key_hash="h1", key_prefix="orag_a", revoked=True))
+        session.add(
+            ApiKey(
+                id="k1",
+                user_id="user-1",
+                name="revoked",
+                key_hash="h1",
+                key_prefix="orag_a",
+                revoked=True,
+            )
+        )
         await session.commit()
 
     opensearch_client = AsyncMock()

--- a/tests/unit/test_api_key_service.py
+++ b/tests/unit/test_api_key_service.py
@@ -1,13 +1,33 @@
 import sys
 from pathlib import Path
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+from sqlalchemy.pool import StaticPool
+from sqlmodel import SQLModel
 from unittest.mock import AsyncMock
 
 import pytest
+import pytest_asyncio
 
 ROOT = Path(__file__).resolve().parents[2]
 SRC = ROOT / "src"
 if str(SRC) not in sys.path:
     sys.path.insert(0, str(SRC))
+
+
+@pytest_asyncio.fixture
+async def session_factory():
+    engine = create_async_engine(
+        "sqlite+aiosqlite:///:memory:",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(SQLModel.metadata.create_all)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    yield factory
+
+    await engine.dispose()
 
 
 def test_api_key_hash_uses_keyed_digest(monkeypatch):
@@ -23,37 +43,98 @@ def test_api_key_hash_uses_keyed_digest(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_create_key_stores_hmac_hash(monkeypatch):
-    from services.api_key_service import API_KEY_HASH_PREFIX, APIKeyService
+async def test_create_then_validate_roundtrip_stamps_last_used(session_factory, monkeypatch):
+    """Primary path: a created key validates, resolves its owner's email via
+    the users join, and gets last_used_at stamped."""
+    from db.models import User
+    from db.repositories import ApiKeyRepo
+    from db.repositories._helpers import email_lookup_hash
+    from services.api_key_service import APIKeyService
 
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
-    monkeypatch.setattr("secrets.token_urlsafe", lambda n: "deterministic-token")
+    service = APIKeyService(session_factory=session_factory)
 
-    opensearch_client = AsyncMock()
-    opensearch_client.index.return_value = {"result": "created"}
-    monkeypatch.setattr("config.settings.clients.opensearch", opensearch_client)
+    async with session_factory() as session:
+        session.add(User(
+            id="user-1", oauth_provider="google", oauth_subject="user-1",
+            email="user@example.com", email_lookup_hash=email_lookup_hash("user@example.com"),
+        ))
+        await session.commit()
 
-    service = APIKeyService()
-    result = await service.create_key(
-        user_id="user-1",
-        user_email="user@example.com",
-        name="test key",
-    )
+    created = await service.create_key(user_id="user-1", name="my key")
+    info = await service.validate_key(created["api_key"])
 
-    assert result["success"] is True
-    stored_doc = opensearch_client.index.await_args.kwargs["body"]
-    assert stored_doc["key_hash"].startswith(API_KEY_HASH_PREFIX)
-    assert stored_doc["key_hash"] == service._hash_key(result["api_key"])
-    assert stored_doc["key_hash"] != result["api_key"]
+    assert info == {
+        "key_id": created["key_id"],
+        "user_id": "user-1",
+        "user_email": "user@example.com",
+        "name": "my key",
+    }
+    # mark_used ran (parity with the OpenSearch last_used_at update)
+    async with session_factory() as session:
+        row = await ApiKeyRepo(session).get_by_id(created["key_id"])
+    
+    assert row is not None
+    assert row.last_used_at is not None
 
 
 @pytest.mark.asyncio
-async def test_validate_key_accepts_and_migrates_legacy_hash(monkeypatch):
+async def test_create_key_stores_hmac_hash(session_factory, monkeypatch):
+    from db.repositories import ApiKeyRepo
+    from services.api_key_service import API_KEY_HASH_PREFIX, APIKeyService
+
+    monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
+    service = APIKeyService(session_factory=session_factory)
+    result = await service.create_key(user_id="user-1", name="test key")
+
+    assert result["success"] is True
+    assert result["api_key"].startswith("orag_")
+
+    async with session_factory() as session:
+        row = await ApiKeyRepo(session).get_by_id(result["key_id"])
+
+    assert row is not None
+    assert row.key_hash.startswith(API_KEY_HASH_PREFIX)
+    assert row.key_hash == service._hash_key(result["api_key"])
+    assert row.key_hash != result["api_key"]
+
+
+@pytest.mark.asyncio
+async def test_validate_key_accepts_and_migrates_legacy_hash(session_factory, monkeypatch):
+    from db.models import ApiKey, User
+    from db.repositories._helpers import email_lookup_hash
+    from services.api_key_service import APIKeyService
+
+    monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
+    service = APIKeyService(session_factory=session_factory)
+    api_key = "orag_legacy_key"
+
+    async with session_factory() as session:
+        session.add(User(
+            id="user-1", oauth_provider="google", oauth_subject="user-1",
+            email="user@example.com", email_lookup_hash=email_lookup_hash("user@example.com"),
+        ))
+        session.add(ApiKey(
+            id="key-1", user_id="user-1", name="legacy key",
+            key_hash=service._legacy_hash_key(api_key), key_prefix="orag_legacy1",
+        ))
+        await session.commit()
+
+    user_info = await service.validate_key(api_key)
+    assert user_info == {
+        "key_id": "key-1",
+        "user_id": "user-1",
+        "user_email": "user@example.com",
+        "name": "legacy key",
+    }
+
+@pytest.mark.asyncio
+async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(session_factory, monkeypatch) -> None:
     from services.api_key_service import APIKeyService
 
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
 
-    service = APIKeyService()
+    service = APIKeyService(session_factory=session_factory)
     api_key = "orag_legacy_key"
     legacy_hash = service._legacy_hash_key(api_key)
     keyed_hash = service._hash_key(api_key)
@@ -95,11 +176,31 @@ async def test_validate_key_accepts_and_migrates_legacy_hash(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_list_keys_returns_only_non_revoked_api_keys(monkeypatch) -> None:
+async def test_list_keys_returns_only_non_revoked_api_keys(session_factory, monkeypatch) -> None:
+    from db.models import ApiKey
     from services.api_key_service import APIKeyService
 
-    service = APIKeyService()
+    service = APIKeyService(session_factory=session_factory)
+    async with session_factory() as session:
+        session.add(ApiKey(id="k1", user_id="user-1", name="active",
+                           key_hash="h1", key_prefix="orag_a"))
+        session.add(ApiKey(id="k2", user_id="user-1", name="revoked",
+                           key_hash="h2", key_prefix="orag_b", revoked=True))
+        await session.commit()
 
+    result = await service.list_keys("user-1")
+    assert [k["key_id"] for k in result["keys"]] == ["k1"]
+    assert set(result["keys"][0]) == {
+        "key_id", "key_prefix", "name", "created_at", "last_used_at", "revoked",
+    }
+
+
+@pytest.mark.asyncio
+async def test_list_keys_opensearch_fallback_when_sqlite_empty(session_factory, monkeypatch) -> None:
+    from services.api_key_service import APIKeyService
+
+    service = APIKeyService(session_factory=session_factory)
+    
     opensearch_client = AsyncMock()
     opensearch_client.search.return_value = {
         "hits": {

--- a/tests/unit/test_api_key_service.py
+++ b/tests/unit/test_api_key_service.py
@@ -1,6 +1,8 @@
 import sys
 from pathlib import Path
 from unittest.mock import AsyncMock
+from services.api_key_service import APIKeyService
+
 
 import pytest
 import pytest_asyncio
@@ -31,7 +33,7 @@ async def session_factory():
 
 
 def test_api_key_hash_uses_keyed_digest(monkeypatch):
-    from services.api_key_service import API_KEY_HASH_PREFIX, APIKeyService
+    from services.api_key_service import API_KEY_HASH_PREFIX
 
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
 
@@ -49,7 +51,6 @@ async def test_create_then_validate_roundtrip_stamps_last_used(session_factory, 
     from db.models import User
     from db.repositories import ApiKeyRepo
     from db.repositories._helpers import email_lookup_hash
-    from services.api_key_service import APIKeyService
 
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
     service = APIKeyService(session_factory=session_factory)
@@ -86,7 +87,7 @@ async def test_create_then_validate_roundtrip_stamps_last_used(session_factory, 
 @pytest.mark.asyncio
 async def test_create_key_stores_hmac_hash(session_factory, monkeypatch):
     from db.repositories import ApiKeyRepo
-    from services.api_key_service import API_KEY_HASH_PREFIX, APIKeyService
+    from services.api_key_service import API_KEY_HASH_PREFIX
 
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
     service = APIKeyService(session_factory=session_factory)
@@ -108,7 +109,6 @@ async def test_create_key_stores_hmac_hash(session_factory, monkeypatch):
 async def test_validate_key_accepts_and_migrates_legacy_hash(session_factory, monkeypatch):
     from db.models import ApiKey, User
     from db.repositories._helpers import email_lookup_hash
-    from services.api_key_service import APIKeyService
 
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
     service = APIKeyService(session_factory=session_factory)
@@ -145,11 +145,7 @@ async def test_validate_key_accepts_and_migrates_legacy_hash(session_factory, mo
 
 
 @pytest.mark.asyncio
-async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(
-    session_factory, monkeypatch
-) -> None:
-    from services.api_key_service import APIKeyService
-
+async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(session_factory, monkeypatch) -> None:
     monkeypatch.setattr("config.settings.SESSION_SECRET", "unit-test-session-secret")
 
     service = APIKeyService(session_factory=session_factory)
@@ -196,7 +192,6 @@ async def test_validate_key_opensearch_fallback_accepts_and_migrates_legacy_has(
 @pytest.mark.asyncio
 async def test_list_keys_returns_only_non_revoked_api_keys(session_factory, monkeypatch) -> None:
     from db.models import ApiKey
-    from services.api_key_service import APIKeyService
 
     service = APIKeyService(session_factory=session_factory)
     async with session_factory() as session:
@@ -215,7 +210,7 @@ async def test_list_keys_returns_only_non_revoked_api_keys(session_factory, monk
         )
         await session.commit()
 
-    result = await service.list_keys("user-1")
+    result = await service.list_keys("user-1", oauth_subject="subject-1")
     assert [k["key_id"] for k in result["keys"]] == ["k1"]
     assert set(result["keys"][0]) == {
         "key_id",
@@ -228,11 +223,7 @@ async def test_list_keys_returns_only_non_revoked_api_keys(session_factory, monk
 
 
 @pytest.mark.asyncio
-async def test_list_keys_opensearch_fallback_when_sqlite_empty(
-    session_factory, monkeypatch
-) -> None:
-    from services.api_key_service import APIKeyService
-
+async def test_list_keys_opensearch_fallback_when_sqlite_empty(session_factory, monkeypatch) -> None:
     service = APIKeyService(session_factory=session_factory)
 
     opensearch_client = AsyncMock()
@@ -254,7 +245,7 @@ async def test_list_keys_opensearch_fallback_when_sqlite_empty(
     }
     monkeypatch.setattr("config.settings.clients.opensearch", opensearch_client)
 
-    result = await service.list_keys(user_id="user-1")
+    result = await service.list_keys(user_id="user-1", oauth_subject="oauth-subject-1")
 
     assert result["success"] is True
     assert result["keys"] == [
@@ -269,5 +260,23 @@ async def test_list_keys_opensearch_fallback_when_sqlite_empty(
     ]
 
     query_must = opensearch_client.search.await_args.kwargs["body"]["query"]["bool"]["must"]
-    assert {"term": {"user_id": "user-1"}} in query_must
+    assert {"term": {"user_id": "oauth-subject-1"}} in query_must
     assert {"term": {"revoked": False}} in query_must
+
+
+@pytest.mark.asyncio
+async def test_list_keys_all_revoked_returns_empty_without_fallback(session_factory, monkeypatch) -> None:
+    from db.models import ApiKey
+
+    service = APIKeyService(session_factory=session_factory)
+    async with session_factory() as session:
+        session.add(ApiKey(id="k1", user_id="user-1", name="revoked",
+                           key_hash="h1", key_prefix="orag_a", revoked=True))
+        await session.commit()
+
+    opensearch_client = AsyncMock()
+    monkeypatch.setattr("config.settings.clients.opensearch", opensearch_client)
+
+    result = await service.list_keys("user-1", oauth_subject="subject-1")
+    assert result == {"success": True, "keys": []}
+    opensearch_client.search.assert_not_awaited()


### PR DESCRIPTION
## Summary
This pr updates the `api_key_service` to use the sql database instead of opensearch for operations like validate_key, create_key, list_key, revoke_key, and delete_key. For read operations like list_key and validate_key, it keeps opensearch as a fallback in case the api key doesn't exist in the sql database. Also added a migration method to read api keys in opensearch on startup and transfer it into the sql database on startup.

## Changes
- **`src/services/api_key_service.py`** — Reworked create/validate/list/revoke/delete to use SQL via `ApiKeyRepo`, with read-only OpenSearch fallback for un-migrated keys.
- **`src/db/repositories/api_key_repo.py`** — Added `get_by_id` and `mark_used` methods.
- **`src/db/migrations_runtime.py`** — Added `api_keys_os_to_db_v1` startup migration copying API keys from OpenSearch into SQL.
- **`src/api/keys.py`** — Pass `user.db_user_id` and drop the removed `user_email`/`jwt_token` args.
- **`src/app/container.py`** — Wire `APIKeyService` with the lazy DB session factory.
- **`tests/unit/test_api_key_service.py`** — Updated tests for new signatures and added SQL/fallback coverage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * API keys are now managed primarily via the application database, including active-key listing and last-used tracking.
  * API keys are migrated automatically from the prior storage during startup.
  * Legacy keys (including older hash formats) are supported for validation and compatibility.

* **Bug Fixes**
  * Key existence/revocation/delete behavior is now driven by database ownership checks for more reliable results.
  * Safer fallback behavior remains when legacy key storage is unavailable.

* **Tests**
  * Expanded async unit test coverage for DB persistence, legacy validation, usage stamping, listing behavior, and migration/fallback paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->