### PR TITLE
fix: upgrade go version

### DIFF
--- a/kubernetes/operator/Dockerfile
+++ b/kubernetes/operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/kubernetes/operator/go.mod
+++ b/kubernetes/operator/go.mod
@@ -1,6 +1,6 @@
 module github.com/langflow-ai/openrag-operator
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/stretchr/testify v1.11.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Kubernetes operator’s build environment to Go 1.26.5.
  * No user-facing functionality or dependency behavior changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->