### PR TITLE
fix: upgrade nodejs packages to solve cves in frontend

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -8,6 +8,8 @@ FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS deps
 WORKDIR /opt/app-root/src
 USER 0
 
+RUN microdnf update -y --nodocs && microdnf clean all
+
 COPY frontend/package.json frontend/package-lock.json ./
 # Copy local stub packages referenced via file: in package.json (e.g. sharp stub
 # that keeps LGPL libvips binaries out of the tree). npm ci needs these present.
@@ -22,6 +24,8 @@ FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS builder
 
 WORKDIR /opt/app-root/src
 USER 0
+
+RUN microdnf update -y --nodocs && microdnf clean all
 
 COPY --from=deps /opt/app-root/src/node_modules ./node_modules
 COPY --from=deps /opt/app-root/src/stubs ./stubs
@@ -38,6 +42,8 @@ FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS runtime
 
 WORKDIR /opt/app-root/src
 USER 0
+
+RUN microdnf update -y --nodocs && microdnf clean all
 
 
 ENV NODE_ENV=production \


### PR DESCRIPTION
This pull request updates the `Dockerfile.frontend` to improve the security and reliability of the frontend build process by ensuring that the base images are updated with the latest security patches and unnecessary package metadata is removed in each build stage.

**Docker image security and maintenance:**

* Added `microdnf update -y --nodocs && microdnf clean all` to the `deps`, `builder`, and `runtime` stages to ensure all packages are updated and unnecessary files are cleaned up, reducing potential vulnerabilities and image size. [[1]](diffhunk://#diff-4444de7e0285ace98379daf14b0a12432671267023fecaa9ce0bc69fb670f8fbR11-R12) [[2]](diffhunk://#diff-4444de7e0285ace98379daf14b0a12432671267023fecaa9ce0bc69fb670f8fbR28-R29) [[3]](diffhunk://#diff-4444de7e0285ace98379daf14b0a12432671267023fecaa9ce0bc69fb670f8fbR46-R47)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend container’s operating system packages during each build stage.
  * Added cleanup steps to remove package manager metadata and reduce leftover build artifacts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->