### PR TITLE
fix: remove tenant id from docling component

### DIFF
--- a/flows/ingestion_flow.json
+++ b/flows/ingestion_flow.json
@@ -660,13 +660,6 @@
                     },
                     "key": "Authorization",
                     "value": "JWT"
-                  },
-                  {
-                    "__load_from_db_fields": {
-                      "value": true
-                    },
-                    "key": "X-Tenant-Id",
-                    "value": ""
                   }
                 ]
               },


### PR DESCRIPTION
This pull request makes a small change to the `flows/ingestion_flow.json` file by removing the `X-Tenant-Id` header from the configuration. This simplifies the request headers and may reflect a change in authentication or multi-tenancy handling.

Closes #2124 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default authentication header used when connecting to Docling Serve.
  * Connections now send an `Authorization: JWT` header by default instead of the previous tenant identifier header.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->