### PR TITLE
fix: backwards compatibility

### DIFF
--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -229,6 +229,7 @@ async def get_settings(
                 user_doc_filter_id=openrag_config.onboarding.user_doc_filter_id,
                 openrag_docs_ingested_version=openrag_config.onboarding.openrag_docs_ingested_version,
                 openrag_docs_remote_signature=openrag_config.onboarding.openrag_docs_remote_signature,
+                openrag_flows_synced_version=openrag_config.onboarding.openrag_flows_synced_version,
             ),
             providers=ProvidersConfig(
                 openai=OpenAIProviderConfig(
@@ -1610,6 +1611,7 @@ async def rollback_onboarding(
         current_config.knowledge.embedding_model = ""
         current_config.onboarding.openrag_docs_ingested_version = None
         current_config.onboarding.openrag_docs_remote_signature = None
+        current_config.onboarding.openrag_flows_synced_version = None
         current_config.onboarding.assistant_message = None
         current_config.onboarding.selected_nudge = None
         current_config.onboarding.card_steps = None

--- a/src/api/settings/models.py
+++ b/src/api/settings/models.py
@@ -112,6 +112,7 @@ class OnboardingStateBody(BaseModel):
     user_doc_filter_id: str | None = None
     openrag_docs_ingested_version: str | None = None
     openrag_docs_remote_signature: str | None = None
+    openrag_flows_synced_version: str | None = None
 
 
 class DoclingPresetBody(BaseModel):
@@ -131,6 +132,7 @@ class OnboardingStateConfig(BaseModel):
     user_doc_filter_id: str | None
     openrag_docs_ingested_version: str | None
     openrag_docs_remote_signature: str | None
+    openrag_flows_synced_version: str | None = None
 
 
 class OpenAIProviderConfig(BaseModel):

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -218,6 +218,10 @@ class OnboardingState:
     user_doc_filter_id: str | None = field(default=None)
     openrag_docs_ingested_version: str | None = field(default=None)
     openrag_docs_remote_signature: str | None = field(default=None)
+    # Last OpenRAG version for which stock Langflow flows were synced from
+    # bundled JSON. Used on OSS upgrades so two-phase Docling (DOCLING_TASK_ID)
+    # wiring replaces stale 0.5.x ingest graphs without overwriting locked flows.
+    openrag_flows_synced_version: str | None = field(default=None)
 
 
 @dataclass

--- a/src/services/flows_service.py
+++ b/src/services/flows_service.py
@@ -1021,7 +1021,9 @@ class FlowsService:
                     )
 
         config.onboarding.openrag_flows_synced_version = current_version
-        if not config_manager.save_config_file(config):
+        # Internal stamp only — do not mark onboarding as user-edited (fresh
+        # installs / explicit rollback stay unedited).
+        if not config_manager.save_config_file(config, preserve_edited=True):
             logger.warning(
                 "Stock flows sync completed but failed to persist openrag_flows_synced_version",
                 current_version=current_version,

--- a/src/services/flows_service.py
+++ b/src/services/flows_service.py
@@ -20,6 +20,7 @@ from config.settings import (
 )
 from utils.logging_config import get_logger
 from utils.telemetry import Category, MessageId, TelemetryClient
+from utils.version_utils import OPENRAG_VERSION
 
 logger = get_logger(__name__)
 
@@ -952,6 +953,154 @@ class FlowsService:
         results = await asyncio.gather(*tasks)
         created_flow_types = {r for r in results if r is not None}
         return created_flow_types
+
+    async def refresh_stock_flows_on_upgrade_if_needed(
+        self, newly_created: set[str] | None = None
+    ) -> set[str]:
+        """On OSS upgrades, PATCH unlocked stock flows from bundled JSON.
+
+        0.5.1→0.6 changed ingest to two-phase Docling (backend passes
+        ``DOCLING_TASK_ID``, empty file paths). Create-only
+        ``ensure_flows_exist`` leaves the old graph at the same UUID in
+        preserved ``langflow-data``. This refreshes unlocked stock flows
+        once per OpenRAG version bump.
+
+        Locked flows are skipped with a warning. Fresh installs that just
+        created flows are stamped without an extra PATCH.
+
+        Returns the set of flow type names that were refreshed.
+        """
+        from config.config_manager import config_manager
+        from utils.run_mode_utils import is_run_mode_oss
+
+        if not is_run_mode_oss():
+            return set()
+
+        newly_created = newly_created or set()
+        config = get_openrag_config()
+        previous_version = config.onboarding.openrag_flows_synced_version
+        current_version = OPENRAG_VERSION
+
+        if previous_version == current_version:
+            return set()
+
+        # Fresh install: ensure_flows_exist just seeded from current JSON —
+        # stamp only. Upgrade / pre-stamp installs: ingest already existed.
+        should_patch = (previous_version is not None and previous_version != current_version) or (
+            previous_version is None and "ingest" not in newly_created
+        )
+
+        refreshed: set[str] = set()
+        if should_patch:
+            logger.info(
+                "Detected OpenRAG upgrade; refreshing unlocked stock Langflow flows",
+                previous_version=previous_version,
+                current_version=current_version,
+            )
+            flow_configs = [
+                ("nudges", NUDGES_FLOW_ID),
+                ("retrieval", LANGFLOW_CHAT_FLOW_ID),
+                ("ingest", LANGFLOW_INGEST_FLOW_ID),
+                ("url_ingest", LANGFLOW_URL_INGEST_FLOW_ID),
+            ]
+            for flow_type, flow_id in flow_configs:
+                if not flow_id:
+                    continue
+                if flow_type in newly_created:
+                    continue
+                try:
+                    result = await self._refresh_unlocked_stock_flow(flow_type, flow_id)
+                    if result == "refreshed":
+                        refreshed.add(flow_type)
+                except Exception as e:
+                    logger.error(
+                        "Failed to refresh stock flow on upgrade",
+                        flow_type=flow_type,
+                        flow_id=flow_id,
+                        error=str(e),
+                    )
+
+        config.onboarding.openrag_flows_synced_version = current_version
+        if not config_manager.save_config_file(config):
+            logger.warning(
+                "Stock flows sync completed but failed to persist openrag_flows_synced_version",
+                current_version=current_version,
+                refreshed=sorted(refreshed),
+            )
+        else:
+            logger.info(
+                "Recorded stock flows synced version",
+                current_version=current_version,
+                refreshed=sorted(refreshed),
+                patched=should_patch,
+            )
+        return refreshed
+
+    async def _refresh_unlocked_stock_flow(self, flow_type: str, flow_id: str) -> str:
+        """PATCH one stock flow from bundled JSON if it exists and is unlocked.
+
+        Returns one of: ``refreshed``, ``skipped_missing``, ``skipped_locked``,
+        ``skipped_no_file``, ``failed``.
+        """
+        response = await clients.langflow_request("GET", f"/api/v1/flows/{flow_id}")
+        if response.status_code == 404:
+            logger.info(
+                "Stock flow missing during upgrade refresh; relying on ensure_flows_exist",
+                flow_type=flow_type,
+                flow_id=flow_id,
+            )
+            return "skipped_missing"
+        if response.status_code != 200:
+            logger.warning(
+                "Unexpected status checking stock flow during upgrade refresh",
+                flow_type=flow_type,
+                flow_id=flow_id,
+                status_code=response.status_code,
+            )
+            return "failed"
+
+        current_flow = response.json()
+        if current_flow.get("locked", False):
+            logger.warning(
+                "Skipping upgrade refresh for locked stock flow — "
+                "manual reset may be required for Docling/two-phase ingest compatibility",
+                flow_type=flow_type,
+                flow_id=flow_id,
+            )
+            return "skipped_locked"
+
+        flow_path = self._find_flow_file_by_id(flow_id)
+        if not flow_path:
+            logger.warning(
+                "No bundled flow file found for upgrade refresh",
+                flow_type=flow_type,
+                flow_id=flow_id,
+            )
+            return "skipped_no_file"
+
+        with open(flow_path) as f:
+            flow_data = json.load(f)
+
+        patch_resp = await clients.langflow_request(
+            "PATCH", f"/api/v1/flows/{flow_id}", json=flow_data
+        )
+        if patch_resp.status_code != 200:
+            logger.warning(
+                "Failed to PATCH stock flow during upgrade refresh",
+                flow_type=flow_type,
+                flow_id=flow_id,
+                status_code=patch_resp.status_code,
+                body_preview=patch_resp.text[:300],
+            )
+            return "failed"
+
+        logger.info(
+            "Refreshed unlocked stock flow from bundled JSON on upgrade",
+            flow_type=flow_type,
+            flow_id=flow_id,
+            flow_file=os.path.basename(flow_path),
+        )
+        return "refreshed"
 
     async def check_flows_reset(self):
         """

--- a/src/services/startup_orchestrator.py
+++ b/src/services/startup_orchestrator.py
@@ -184,6 +184,31 @@ async def startup_tasks(services):
             error=str(e),
         )
 
+    # OSS upgrades: refresh unlocked stock flows when OpenRAG version changes
+    # so two-phase Docling (DOCLING_TASK_ID) replaces stale 0.5.x ingest graphs.
+    upgraded_flows: set[str] = set()
+    try:
+        flows_service = services["flows_service"]
+        upgraded_flows = await flows_service.refresh_stock_flows_on_upgrade_if_needed(
+            newly_created=newly_created
+        )
+        if upgraded_flows:
+            config = get_openrag_config()
+            if config.edited:
+                logger.info(
+                    "Reapplying settings after stock flow upgrade refresh",
+                    refreshed=sorted(upgraded_flows),
+                )
+                from api.settings import reapply_all_settings
+
+                await reapply_all_settings(session_manager=services["session_manager"])
+    except Exception as e:
+        logger.error(
+            "Failed to refresh stock Langflow flows on upgrade — "
+            "ingest may still use a stale Docling flow until manual reset",
+            error=str(e),
+        )
+
     # Check if flows were reset and reapply settings if config is edited
     try:
         config = get_openrag_config()
@@ -191,9 +216,11 @@ async def startup_tasks(services):
             logger.info("Checking if Langflow flows were reset")
             flows_service = services["flows_service"]
             reset_flows = await flows_service.check_flows_reset()
-            # Exclude flows that were just seeded — they match the JSON by design,
-            # not because they were externally reset.
-            reset_flows = [f for f in reset_flows if f not in newly_created]
+            # Exclude flows that were just seeded or upgrade-refreshed — they
+            # match the JSON by design, not because they were externally reset.
+            reset_flows = [
+                f for f in reset_flows if f not in newly_created and f not in upgraded_flows
+            ]
 
             if reset_flows:
                 logger.info(

--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -363,13 +363,12 @@ def _start_services_cli(
         else:
             console.print("  [yellow]No container runtime available[/yellow]")
 
-        # Start docling
-        if not docling_manager.is_running():
-            success, message = await docling_manager.start()
-            if success:
-                console.print(f"  {message}")
-            else:
-                console.print(f"  [yellow]{message}[/yellow]")
+        # Start docling (restart if recovered PID is on an older pin)
+        success, message = await docling_manager.ensure_running()
+        if success:
+            console.print(f"  {message}")
+        else:
+            console.print(f"  [yellow]{message}[/yellow]")
 
     try:
         asyncio.run(_inner())

--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -99,6 +99,7 @@ def _get_service_states(
 
     Returns (container_services, docling_status, all_running).
     """
+
     async def _inner():
         if container_manager.is_available():
             return await container_manager.get_service_status(force_refresh=True)
@@ -114,8 +115,7 @@ def _get_service_states(
     # Determine if everything is up
     expected = set(container_manager.expected_services)
     running = {
-        name for name, info in container_services.items()
-        if info.status == ServiceStatus.RUNNING
+        name for name, info in container_services.items() if info.status == ServiceStatus.RUNNING
     }
     containers_up = running == expected and len(expected) > 0
     docling_up = docling_status.get("status") == "running"
@@ -204,7 +204,9 @@ def _setup_walkthrough(
     _collect_config(env_manager, advanced=False)
 
     try:
-        configure_advanced = input("Configure cloud connectors & advanced settings? [y/N]: ").strip().lower()
+        configure_advanced = (
+            input("Configure cloud connectors & advanced settings? [y/N]: ").strip().lower()
+        )
     except (EOFError, KeyboardInterrupt):
         console.print()
         configure_advanced = "n"

--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -6,7 +6,6 @@ import os
 import signal
 import sys
 import webbrowser
-from pathlib import Path
 
 from rich.console import Console
 from rich.rule import Rule
@@ -17,7 +16,6 @@ from .config_fields import CONFIG_SECTIONS
 from .managers.container_manager import ContainerManager, ServiceStatus
 from .managers.docling_manager import DoclingManager
 from .managers.env_manager import EnvManager
-from .utils.platform import PlatformDetector
 
 console = Console()
 
@@ -390,7 +388,7 @@ def _stop_services_cli(
     async def _inner():
         # Stop container services
         if container_manager.is_available():
-            async for success, message, *rest in container_manager.stop_services():
+            async for _success, message, *_rest in container_manager.stop_services():
                 console.print(f"  {message}")
         # Stop docling
         if docling_manager.is_running():

--- a/src/tui/managers/docling_manager.py
+++ b/src/tui/managers/docling_manager.py
@@ -565,6 +565,7 @@ class DoclingManager:
         if "already running" in message.lower() and self.started_for_current_openrag_version():
             return True, message
         return False, message
+
     async def stop(self) -> tuple[bool, str]:
         """Stop docling serve."""
         if not self.is_running():

--- a/src/tui/managers/docling_manager.py
+++ b/src/tui/managers/docling_manager.py
@@ -11,6 +11,7 @@ from collections.abc import AsyncIterator
 from typing import Any
 
 from utils.logging_config import get_logger
+from utils.version_utils import OPENRAG_VERSION
 
 logger = get_logger(__name__)
 
@@ -46,6 +47,10 @@ class DoclingManager:
 
         self._tui_dir = get_tui_dir()
         self._pid_file = self._tui_dir / ".docling.pid"
+        # Records which OpenRAG package version started the long-lived
+        # docling-serve PID. On OSS OpenRAG upgrades the stamp mismatches and
+        # ensure_running()/start() recycle the process so a new uvx pin applies.
+        self._openrag_version_file = self._tui_dir / ".docling.openrag_version"
         self._log_file_path = self._tui_dir / "docling-serve.log"
 
         # Log storage - simplified, no queue
@@ -92,6 +97,38 @@ class DoclingManager:
                 self._add_log_entry("Cleared PID file")
         except Exception as e:
             self._add_log_entry(f"Failed to clear PID file: {e}")
+
+    def _read_started_openrag_version(self) -> str | None:
+        """Read the OpenRAG version that started the recovered docling process."""
+        try:
+            if self._openrag_version_file.exists():
+                value = self._openrag_version_file.read_text().strip()
+                return value or None
+        except Exception as e:
+            self._add_log_entry(f"Failed to read docling OpenRAG version stamp: {e}")
+        return None
+
+    def _write_started_openrag_version(self) -> None:
+        """Persist the current OpenRAG version next to the PID file."""
+        try:
+            self._openrag_version_file.parent.mkdir(parents=True, exist_ok=True)
+            self._openrag_version_file.write_text(OPENRAG_VERSION)
+            self._add_log_entry(f"Saved docling OpenRAG version stamp {OPENRAG_VERSION}")
+        except Exception as e:
+            self._add_log_entry(f"Failed to write docling OpenRAG version stamp: {e}")
+
+    def _clear_started_openrag_version(self) -> None:
+        """Remove the OpenRAG version stamp file."""
+        try:
+            if self._openrag_version_file.exists():
+                self._openrag_version_file.unlink()
+                self._add_log_entry("Cleared docling OpenRAG version stamp")
+        except Exception as e:
+            self._add_log_entry(f"Failed to clear docling OpenRAG version stamp: {e}")
+
+    def started_for_current_openrag_version(self) -> bool:
+        """True when the running process was started under this OpenRAG version."""
+        return self._read_started_openrag_version() == OPENRAG_VERSION
 
     def _is_process_running(self, pid: int) -> bool:
         """Check if a process with the given PID is running."""
@@ -242,7 +279,16 @@ class DoclingManager:
             timeout: Seconds to wait for the service to start listening (default: 120)
         """
         if self.is_running():
-            return False, "Docling serve is already running"
+            if self.started_for_current_openrag_version():
+                return False, "Docling serve is already running"
+            self._add_log_entry(
+                f"Docling serve OpenRAG version mismatch "
+                f"(running={self._read_started_openrag_version()!r}, "
+                f"expected={OPENRAG_VERSION!r}); restarting for upgrade"
+            )
+            stop_ok, stop_msg = await self.stop()
+            if not stop_ok:
+                return False, f"Failed to stop outdated docling-serve for upgrade: {stop_msg}"
 
         self._port = port
         # Use provided host or keep default from __init__
@@ -435,6 +481,7 @@ class DoclingManager:
             if self._process.poll() is None:
                 self._starting = False
 
+            self._write_started_openrag_version()
             display_host = "localhost" if self._host == "0.0.0.0" else self._host
             return True, f"Docling serve starting on http://{display_host}:{port}"
 
@@ -489,6 +536,35 @@ class DoclingManager:
 
         self._add_log_entry("Log file capture thread started")
 
+    async def ensure_running(
+        self,
+        port: int = 5001,
+        host: str | None = None,
+        enable_ui: bool = False,
+        workers: int | None = None,
+        timeout: int = 10,
+    ) -> tuple[bool, str]:
+        """Ensure docling-serve is running for the current OpenRAG version.
+
+        Unlike ``start()``, returns success when a process started under this
+        OpenRAG version is already running. Restarts when a recovered PID was
+        started under an older OpenRAG version (OSS upgrade path).
+        """
+        if self.is_running() and self.started_for_current_openrag_version():
+            return True, "Docling serve is already running"
+
+        success, message = await self.start(
+            port=port,
+            host=host,
+            enable_ui=enable_ui,
+            workers=workers,
+            timeout=timeout,
+        )
+        if success:
+            return True, message
+        if "already running" in message.lower() and self.started_for_current_openrag_version():
+            return True, message
+        return False, message
     async def stop(self) -> tuple[bool, str]:
         """Stop docling serve."""
         if not self.is_running():
@@ -542,6 +618,7 @@ class DoclingManager:
 
             # Clear the PID file since we intentionally stopped the service
             self._clear_pid_file()
+            self._clear_started_openrag_version()
 
             self._add_log_entry("Docling serve stopped successfully")
             return True, "Docling serve stopped successfully"

--- a/src/tui/screens/monitor.py
+++ b/src/tui/screens/monitor.py
@@ -644,22 +644,23 @@ class MonitorScreen(Screen):
         """Start docling serve."""
         self.operation_in_progress = True
         try:
-            # Check for port conflicts before attempting to start
-            port_available, error_msg = self.docling_manager.check_port_available()
-            if not port_available:
-                self.notify(
-                    f"Cannot start docling serve: {error_msg}. "
-                    f"Please stop the conflicting service first.",
-                    severity="error",
-                    timeout=10,
-                )
-                # Refresh to show current state
-                await self._refresh_services()
-                return
+            # Port conflict check only when we don't already own a docling process
+            # (pin-upgrade restarts stop first inside ensure_running/start).
+            if not self.docling_manager.is_running():
+                port_available, error_msg = self.docling_manager.check_port_available()
+                if not port_available:
+                    self.notify(
+                        f"Cannot start docling serve: {error_msg}. "
+                        f"Please stop the conflicting service first.",
+                        severity="error",
+                        timeout=10,
+                    )
+                    # Refresh to show current state
+                    await self._refresh_services()
+                    return
 
-            # Start the service (this sets _starting = True internally at the start)
-            # Create task and let it begin executing (which sets the flag)
-            start_task = asyncio.create_task(self.docling_manager.start())
+            # Start (or pin-upgrade restart) the service
+            start_task = asyncio.create_task(self.docling_manager.ensure_running())
             # Give it a tiny moment to set the _starting flag
             await asyncio.sleep(0.1)
             # Refresh immediately to show "Starting" status

--- a/src/tui/screens/monitor.py
+++ b/src/tui/screens/monitor.py
@@ -374,7 +374,9 @@ class MonitorScreen(Screen):
             command_generator = self.container_manager.start_services(cpu_mode)
             modal = CommandOutputModal(
                 "Starting Services",
-                command_generator,
+                # start_services yields an optional replace_last flag; the modal
+                # accepts both 2- and 3-tuples at runtime.
+                cast(AsyncIterator[tuple[bool, str]], command_generator),
                 on_complete=self._on_start_complete,  # Refresh after completion
             )
             self.app.push_screen(modal)

--- a/src/tui/screens/welcome.py
+++ b/src/tui/screens/welcome.py
@@ -2,18 +2,23 @@
 
 import os
 from pathlib import Path
-from textual.app import ComposeResult
-from textual.containers import Container, Vertical, Horizontal
-from textual.screen import Screen
-from textual.widgets import Header, Footer, Static, Button
-from rich.text import Text
-from rich.align import Align
+
 from dotenv import load_dotenv
+from rich.align import Align
+from rich.text import Text
+from textual.app import ComposeResult
+from textual.containers import Container, Horizontal, Vertical
+from textual.screen import Screen
+from textual.widgets import Button, Footer, Header, Static
 
 from .. import __version__
-from ..managers.container_manager import ContainerManager, ServiceStatus, format_port_conflict_message
-from ..managers.env_manager import EnvManager
+from ..managers.container_manager import (
+    ContainerManager,
+    ServiceStatus,
+    format_port_conflict_message,
+)
 from ..managers.docling_manager import DoclingManager
+from ..managers.env_manager import EnvManager
 from ..widgets.command_modal import CommandOutputModal
 from ..widgets.version_mismatch_warning_modal import VersionMismatchWarningModal
 
@@ -37,7 +42,7 @@ class WelcomeScreen(Screen):
         self.default_button_id = "basic-setup-btn"
         self._state_checked = False
         self.has_flow_backups = False
-        
+
         # Check if .env file exists
         self.has_env_file = self.env_manager.env_file.exists()
 
@@ -49,7 +54,7 @@ class WelcomeScreen(Screen):
         self.has_oauth_config = bool(os.getenv("GOOGLE_OAUTH_CLIENT_ID")) or bool(
             os.getenv("MICROSOFT_GRAPH_OAUTH_CLIENT_ID")
         )
-        
+
         # Check for flow backups
         self.has_flow_backups = self._check_flow_backups()
 
@@ -75,7 +80,9 @@ class WelcomeScreen(Screen):
         # Get flows path from env config
         env_manager = EnvManager()
         env_manager.load_existing_env()
-        flows_path = Path(env_manager.config.openrag_flows_path.replace("$HOME", str(Path.home()))).expanduser()
+        flows_path = Path(
+            env_manager.config.openrag_flows_path.replace("$HOME", str(Path.home()))
+        ).expanduser()
         backup_dir = flows_path / "backup"
         if not backup_dir.exists():
             return False
@@ -97,19 +104,19 @@ class WelcomeScreen(Screen):
         try:
             # Use detected runtime command to check services
             import subprocess
+
             compose_cmd = self.container_manager.runtime_info.compose_command + [
-                "-f", str(self.container_manager.compose_file),
-                "ps", "--format", "json"
+                "-f",
+                str(self.container_manager.compose_file),
+                "ps",
+                "--format",
+                "json",
             ]
-            result = subprocess.run(
-                compose_cmd,
-                capture_output=True,
-                text=True,
-                timeout=5
-            )
+            result = subprocess.run(compose_cmd, capture_output=True, text=True, timeout=5)
 
             if result.returncode == 0:
                 import json
+
                 services = []
 
                 # Try parsing as a single JSON array first (podman format)
@@ -121,7 +128,7 @@ class WelcomeScreen(Screen):
                         services = [parsed] if isinstance(parsed, dict) else []
                 except json.JSONDecodeError:
                     # Fallback: try parsing line-by-line (docker format)
-                    for line in result.stdout.strip().split('\n'):
+                    for line in result.stdout.strip().split("\n"):
                         if line.strip():
                             try:
                                 service = json.loads(line)
@@ -141,13 +148,13 @@ class WelcomeScreen(Screen):
                     if not isinstance(s, dict):
                         continue
                     # Get service name - try compose label first (most reliable for Podman)
-                    labels = s.get('Labels', {}) or {}
-                    service_name = labels.get('com.docker.compose.service', '')
+                    labels = s.get("Labels", {}) or {}
+                    service_name = labels.get("com.docker.compose.service", "")
                     if not service_name:
                         # Fall back to container name mapping
-                        container_name = s.get('Name') or s.get('Service', '')
+                        container_name = s.get("Name") or s.get("Service", "")
                         if not container_name:
-                            names = s.get('Names', [])
+                            names = s.get("Names", [])
                             if names and isinstance(names, list):
                                 container_name = names[0]
                         # Map container name to service name using container_name_map
@@ -155,15 +162,17 @@ class WelcomeScreen(Screen):
                     # Skip if not an expected service
                     if service_name not in expected:
                         continue
-                    state = str(s.get('State', '')).lower()
-                    if state == 'running':
+                    state = str(s.get("State", "")).lower()
+                    if state == "running":
                         running_services.add(service_name)
-                    elif 'starting' in state or 'created' in state:
+                    elif "starting" in state or "created" in state:
                         starting_services.add(service_name)
 
                 # Services are running if all expected services are in running state
                 # (i.e., we have all expected services running and none are still starting)
-                self.services_running = len(running_services) == len(expected) and len(starting_services) == 0
+                self.services_running = (
+                    len(running_services) == len(expected) and len(starting_services) == 0
+                )
             else:
                 self.services_running = False
         except Exception:
@@ -192,13 +201,9 @@ class WelcomeScreen(Screen):
         all_services_running = self.services_running and self.docling_running
 
         if all_services_running:
-            welcome_text.append(
-                "✓ All services are running\n\n", style="bold green"
-            )
+            welcome_text.append("✓ All services are running\n\n", style="bold green")
         elif self.services_running or self.docling_running:
-            welcome_text.append(
-                "⚠ Some services are running\n\n", style="bold yellow"
-            )
+            welcome_text.append("⚠ Some services are running\n\n", style="bold yellow")
         elif self.has_oauth_config:
             welcome_text.append(
                 "OAuth credentials detected — Advanced Setup recommended\n\n",
@@ -221,17 +226,11 @@ class WelcomeScreen(Screen):
         if not self.has_env_file:
             if has_oauth:
                 # If OAuth is configured, only show advanced setup
-                buttons.append(
-                    Button("Advanced Setup", variant="success", id="advanced-setup-btn")
-                )
+                buttons.append(Button("Advanced Setup", variant="success", id="advanced-setup-btn"))
             else:
                 # If no OAuth, show both options with basic as primary
-                buttons.append(
-                    Button("Basic Setup", variant="success", id="basic-setup-btn")
-                )
-                buttons.append(
-                    Button("Advanced Setup", variant="default", id="advanced-setup-btn")
-                )
+                buttons.append(Button("Basic Setup", variant="success", id="basic-setup-btn"))
+                buttons.append(Button("Advanced Setup", variant="default", id="advanced-setup-btn"))
             return Horizontal(*buttons, classes="button-row")
 
         # Check if all services (native + container) are running
@@ -239,36 +238,22 @@ class WelcomeScreen(Screen):
 
         if all_services_running:
             # All services running - show app link first, then stop all
-            buttons.append(
-                Button("Launch OpenRAG", variant="success", id="open-app-btn")
-            )
-            buttons.append(
-                Button("Stop All Services", variant="error", id="stop-all-services-btn")
-            )
+            buttons.append(Button("Launch OpenRAG", variant="success", id="open-app-btn"))
+            buttons.append(Button("Stop All Services", variant="error", id="stop-all-services-btn"))
         else:
             # Some or no services running - show setup options and start all
             if has_oauth:
                 # If OAuth is configured, only show advanced setup
-                buttons.append(
-                    Button("Advanced Setup", variant="success", id="advanced-setup-btn")
-                )
+                buttons.append(Button("Advanced Setup", variant="success", id="advanced-setup-btn"))
             else:
                 # If no OAuth, show both options with basic as primary
-                buttons.append(
-                    Button("Basic Setup", variant="success", id="basic-setup-btn")
-                )
-                buttons.append(
-                    Button("Advanced Setup", variant="default", id="advanced-setup-btn")
-                )
+                buttons.append(Button("Basic Setup", variant="success", id="basic-setup-btn"))
+                buttons.append(Button("Advanced Setup", variant="default", id="advanced-setup-btn"))
 
-            buttons.append(
-                Button("Start OpenRAG", variant="primary", id="start-all-services-btn")
-            )
+            buttons.append(Button("Start OpenRAG", variant="primary", id="start-all-services-btn"))
 
         # Always show status option
-        buttons.append(
-            Button("Status", variant="default", id="status-btn")
-        )
+        buttons.append(Button("Status", variant="default", id="status-btn"))
 
         return Horizontal(*buttons, classes="button-row")
 
@@ -285,13 +270,14 @@ class WelcomeScreen(Screen):
                 s.name for s in services.values() if s.status == ServiceStatus.STARTING
             ]
             # Services are running if all expected services are in running state
-            self.services_running = len(running_services) == len(expected) and len(starting_services) == 0
+            self.services_running = (
+                len(running_services) == len(expected) and len(starting_services) == 0
+            )
         else:
             self.services_running = False
 
         # Check native service state
         self.docling_running = self.docling_manager.is_running()
-
 
         # Check for OAuth configuration
         self.has_oauth_config = bool(os.getenv("GOOGLE_OAUTH_CLIENT_ID")) or bool(
@@ -327,7 +313,7 @@ class WelcomeScreen(Screen):
         """Called when returning from another screen (e.g., config screen)."""
         # Check if .env file exists (may have been created)
         self.has_env_file = self.env_manager.env_file.exists()
-        
+
         # Reload environment variables
         load_dotenv(override=True)
 
@@ -346,7 +332,9 @@ class WelcomeScreen(Screen):
             starting_services = [
                 s.name for s in services.values() if s.status == ServiceStatus.STARTING
             ]
-            self.services_running = len(running_services) == len(expected) and len(starting_services) == 0
+            self.services_running = (
+                len(running_services) == len(expected) and len(starting_services) == 0
+            )
         else:
             self.services_running = False
 
@@ -422,7 +410,9 @@ class WelcomeScreen(Screen):
             starting_services = [
                 s.name for s in services.values() if s.status == ServiceStatus.STARTING
             ]
-            self.services_running = len(running_services) == len(expected) and len(starting_services) == 0
+            self.services_running = (
+                len(running_services) == len(expected) and len(starting_services) == 0
+            )
         else:
             self.services_running = False
 
@@ -503,21 +493,27 @@ class WelcomeScreen(Screen):
         if not self.docling_manager.is_running():
             port_available, error_msg = self.docling_manager.check_port_available()
             if not port_available:
-                conflicts.append(("docling", self.docling_manager._port, error_msg or f"Port {self.docling_manager._port} is already in use"))
+                conflicts.append(
+                    (
+                        "docling",
+                        self.docling_manager._port,
+                        error_msg or f"Port {self.docling_manager._port} is already in use",
+                    )
+                )
 
         # If there are any conflicts, show error and return
         if conflicts:
-            self.notify(
-                format_port_conflict_message(conflicts),
-                severity="error",
-                timeout=15
-            )
+            self.notify(format_port_conflict_message(conflicts), severity="error", timeout=15)
             return
 
         # Step 1: Start container services first (to create the network)
         if self.container_manager.is_available() and not self.services_running:
             # Check for version mismatch before starting
-            has_mismatch, container_version, tui_version = await self.container_manager.check_version_mismatch()
+            (
+                has_mismatch,
+                container_version,
+                tui_version,
+            ) = await self.container_manager.check_version_mismatch()
             if has_mismatch and container_version:
                 # Show warning modal and wait for user decision
                 should_continue = await self.app.push_screen_wait(
@@ -530,14 +526,16 @@ class WelcomeScreen(Screen):
                 # This ensures docker compose reads the correct version
                 try:
                     from ..managers.env_manager import EnvManager
+
                     env_manager = EnvManager()
                     env_manager.ensure_openrag_version()
                     # Small delay to ensure .env file is written and flushed
                     import asyncio
+
                     await asyncio.sleep(0.5)
                 except Exception:
                     pass  # Continue even if version setting fails
-            
+
             command_generator = self.container_manager.start_services()
             modal = CommandOutputModal(
                 "Starting Container Services",
@@ -580,7 +578,7 @@ class WelcomeScreen(Screen):
                         f"Cannot start native services: {error_msg}. "
                         f"Please stop the conflicting service first.",
                         severity="error",
-                        timeout=10
+                        timeout=10,
                     )
                     # Update state and return
                     self.docling_running = False
@@ -642,6 +640,7 @@ class WelcomeScreen(Screen):
     def action_open_app(self) -> None:
         """Open the OpenRAG app in the default browser."""
         import webbrowser
+
         try:
             # Get the frontend port from environment variable, defaulting to 3000
             frontend_port = os.getenv("FRONTEND_PORT", "3000")

--- a/src/tui/screens/welcome.py
+++ b/src/tui/screens/welcome.py
@@ -565,23 +565,30 @@ class WelcomeScreen(Screen):
 
     async def _start_native_services_after_containers(self) -> None:
         """Start native services after containers have been started."""
-        if not self.docling_manager.is_running():
-            # Check for port conflicts before attempting to start
-            port_available, error_msg = self.docling_manager.check_port_available()
-            if not port_available:
-                self.notify(
-                    f"Cannot start native services: {error_msg}. "
-                    f"Please stop the conflicting service first.",
-                    severity="error",
-                    timeout=10
-                )
-                # Update state and return
-                self.docling_running = False
-                await self._refresh_welcome_content()
-                return
+        # Restart if a recovered PID is still on an older docling-serve pin.
+        needs_start = (
+            not self.docling_manager.is_running()
+            or not self.docling_manager.started_for_current_openrag_version()
+        )
+        if needs_start:
+            # Check for port conflicts before attempting to start (skip when
+            # we own the port and are about to restart for a pin upgrade).
+            if not self.docling_manager.is_running():
+                port_available, error_msg = self.docling_manager.check_port_available()
+                if not port_available:
+                    self.notify(
+                        f"Cannot start native services: {error_msg}. "
+                        f"Please stop the conflicting service first.",
+                        severity="error",
+                        timeout=10
+                    )
+                    # Update state and return
+                    self.docling_running = False
+                    await self._refresh_welcome_content()
+                    return
 
             self.notify("Starting native services...", severity="information")
-            success, message = await self.docling_manager.start()
+            success, message = await self.docling_manager.ensure_running()
             if success:
                 self.notify(message, severity="information")
             else:

--- a/src/tui/screens/welcome.py
+++ b/src/tui/screens/welcome.py
@@ -4,12 +4,11 @@ import os
 from pathlib import Path
 
 from dotenv import load_dotenv
-from rich.align import Align
 from rich.text import Text
 from textual.app import ComposeResult
 from textual.containers import Container, Horizontal, Vertical
 from textual.screen import Screen
-from textual.widgets import Button, Footer, Header, Static
+from textual.widgets import Button, Footer, Static
 
 from .. import __version__
 from ..managers.container_manager import (
@@ -306,7 +305,7 @@ class WelcomeScreen(Screen):
                 self.query_one("#advanced-setup-btn").focus()
             else:
                 self.query_one("#basic-setup-btn").focus()
-        except:
+        except Exception:
             pass  # Button might not exist
 
     async def on_screen_resume(self) -> None:

--- a/tests/unit/services/test_flows_upgrade_refresh.py
+++ b/tests/unit/services/test_flows_upgrade_refresh.py
@@ -72,7 +72,8 @@ async def test_fresh_install_stamps_without_patch(monkeypatch):
     assert refreshed == set()
     refresh.assert_not_called()
     assert config.onboarding.openrag_flows_synced_version == "0.6.0"
-    save.assert_called_once()
+    save.assert_called_once_with(config, preserve_edited=True)
+    assert config.edited is False
 
 
 @pytest.mark.asyncio
@@ -102,7 +103,7 @@ async def test_upgrade_refreshes_unlocked_ingest(monkeypatch):
     assert refreshed == {"ingest"}
     assert refresh.await_count == 4
     assert config.onboarding.openrag_flows_synced_version == "0.6.0"
-    save.assert_called_once()
+    save.assert_called_once_with(config, preserve_edited=True)
 
 
 @pytest.mark.asyncio
@@ -132,6 +133,7 @@ async def test_pre_stamp_upgrade_when_ingest_already_existed(monkeypatch):
 
     assert refreshed == {"ingest"}
     refresh.assert_awaited_once()
+    save.assert_called_once_with(config, preserve_edited=True)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/services/test_flows_upgrade_refresh.py
+++ b/tests/unit/services/test_flows_upgrade_refresh.py
@@ -1,0 +1,181 @@
+"""Tests for OSS stock-flow refresh on OpenRAG version upgrade."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from services.flows_service import FlowsService
+
+
+def _config(*, flows_synced_version: str | None = None, edited: bool = False):
+    return SimpleNamespace(
+        edited=edited,
+        onboarding=SimpleNamespace(openrag_flows_synced_version=flows_synced_version),
+    )
+
+
+@pytest.mark.asyncio
+async def test_refresh_noop_when_version_matches(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    service = FlowsService()
+    config = _config(flows_synced_version="0.6.0")
+
+    with (
+        patch("services.flows_service.get_openrag_config", return_value=config),
+        patch("services.flows_service.OPENRAG_VERSION", "0.6.0"),
+        patch.object(service, "_refresh_unlocked_stock_flow", new_callable=AsyncMock) as refresh,
+    ):
+        refreshed = await service.refresh_stock_flows_on_upgrade_if_needed(newly_created=set())
+
+    assert refreshed == set()
+    refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_refresh_skips_non_oss(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    service = FlowsService()
+    config = _config(flows_synced_version="0.5.1")
+
+    with (
+        patch("services.flows_service.get_openrag_config", return_value=config),
+        patch("services.flows_service.OPENRAG_VERSION", "0.6.0"),
+        patch.object(service, "_refresh_unlocked_stock_flow", new_callable=AsyncMock) as refresh,
+    ):
+        refreshed = await service.refresh_stock_flows_on_upgrade_if_needed(newly_created=set())
+
+    assert refreshed == set()
+    refresh.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_fresh_install_stamps_without_patch(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    service = FlowsService()
+    config = _config(flows_synced_version=None)
+    save = MagicMock(return_value=True)
+
+    with (
+        patch("services.flows_service.get_openrag_config", return_value=config),
+        patch("services.flows_service.OPENRAG_VERSION", "0.6.0"),
+        patch("config.config_manager.config_manager.save_config_file", save),
+        patch.object(service, "_refresh_unlocked_stock_flow", new_callable=AsyncMock) as refresh,
+    ):
+        refreshed = await service.refresh_stock_flows_on_upgrade_if_needed(
+            newly_created={"ingest", "retrieval", "nudges", "url_ingest"}
+        )
+
+    assert refreshed == set()
+    refresh.assert_not_called()
+    assert config.onboarding.openrag_flows_synced_version == "0.6.0"
+    save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upgrade_refreshes_unlocked_ingest(monkeypatch):
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    service = FlowsService()
+    config = _config(flows_synced_version="0.5.1")
+    save = MagicMock(return_value=True)
+
+    async def _refresh(flow_type, flow_id):
+        return "refreshed" if flow_type == "ingest" else "skipped_locked"
+
+    with (
+        patch("services.flows_service.get_openrag_config", return_value=config),
+        patch("services.flows_service.OPENRAG_VERSION", "0.6.0"),
+        patch("config.config_manager.config_manager.save_config_file", save),
+        patch.object(
+            service, "_refresh_unlocked_stock_flow", new_callable=AsyncMock, side_effect=_refresh
+        ) as refresh,
+        patch("services.flows_service.LANGFLOW_INGEST_FLOW_ID", "ingest-id"),
+        patch("services.flows_service.LANGFLOW_CHAT_FLOW_ID", "chat-id"),
+        patch("services.flows_service.NUDGES_FLOW_ID", "nudges-id"),
+        patch("services.flows_service.LANGFLOW_URL_INGEST_FLOW_ID", "url-id"),
+    ):
+        refreshed = await service.refresh_stock_flows_on_upgrade_if_needed(newly_created=set())
+
+    assert refreshed == {"ingest"}
+    assert refresh.await_count == 4
+    assert config.onboarding.openrag_flows_synced_version == "0.6.0"
+    save.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_pre_stamp_upgrade_when_ingest_already_existed(monkeypatch):
+    """0.5.1 installs have no stamp; existing ingest means upgrade, not fresh create."""
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    service = FlowsService()
+    config = _config(flows_synced_version=None)
+    save = MagicMock(return_value=True)
+
+    with (
+        patch("services.flows_service.get_openrag_config", return_value=config),
+        patch("services.flows_service.OPENRAG_VERSION", "0.6.0"),
+        patch("config.config_manager.config_manager.save_config_file", save),
+        patch.object(
+            service,
+            "_refresh_unlocked_stock_flow",
+            new_callable=AsyncMock,
+            return_value="refreshed",
+        ) as refresh,
+        patch("services.flows_service.LANGFLOW_INGEST_FLOW_ID", "ingest-id"),
+        patch("services.flows_service.LANGFLOW_CHAT_FLOW_ID", None),
+        patch("services.flows_service.NUDGES_FLOW_ID", None),
+        patch("services.flows_service.LANGFLOW_URL_INGEST_FLOW_ID", None),
+    ):
+        refreshed = await service.refresh_stock_flows_on_upgrade_if_needed(newly_created=set())
+
+    assert refreshed == {"ingest"}
+    refresh.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_unlocked_skips_locked_flow():
+    service = FlowsService()
+    mock_resp = MagicMock(status_code=200)
+    mock_resp.json.return_value = {"id": "ingest-id", "locked": True}
+
+    with patch(
+        "services.flows_service.clients.langflow_request",
+        new_callable=AsyncMock,
+        return_value=mock_resp,
+    ) as request:
+        result = await service._refresh_unlocked_stock_flow("ingest", "ingest-id")
+
+    assert result == "skipped_locked"
+    request.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_refresh_unlocked_patches_from_bundle(tmp_path):
+    service = FlowsService()
+    flow_id = "5488df7c-b93f-4f87-a446-b67028bc0813"
+    flow_file = tmp_path / "ingestion_flow.json"
+    flow_payload = {"id": flow_id, "name": "OpenSearch Ingestion Flow", "data": {}}
+    flow_file.write_text(json.dumps(flow_payload))
+
+    get_resp = MagicMock(status_code=200)
+    get_resp.json.return_value = {"id": flow_id, "locked": False}
+    patch_resp = MagicMock(status_code=200, text="ok")
+
+    async def _request(method, path, **kwargs):
+        if method == "GET":
+            return get_resp
+        return patch_resp
+
+    with (
+        patch(
+            "services.flows_service.clients.langflow_request",
+            new_callable=AsyncMock,
+            side_effect=_request,
+        ),
+        patch.object(service, "_find_flow_file_by_id", return_value=str(flow_file)),
+    ):
+        result = await service._refresh_unlocked_stock_flow("ingest", flow_id)
+
+    assert result == "refreshed"

--- a/tests/unit/test_docling_manager_openrag_version_upgrade.py
+++ b/tests/unit/test_docling_manager_openrag_version_upgrade.py
@@ -1,0 +1,83 @@
+"""Tests for Docling restart keyed to OpenRAG version upgrades."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from tui.managers.docling_manager import DoclingManager
+
+
+@pytest.fixture
+def docling_manager(tmp_path, monkeypatch):
+    # Reset singleton so each test gets a fresh instance bound to tmp_path.
+    DoclingManager._instance = None
+    DoclingManager._initialized = False
+    monkeypatch.setattr("utils.paths.get_tui_dir", lambda: Path(tmp_path))
+    monkeypatch.setattr("tui.managers.docling_manager.OPENRAG_VERSION", "0.6.0")
+    manager = DoclingManager()
+    yield manager
+    DoclingManager._instance = None
+    DoclingManager._initialized = False
+
+
+def test_stamp_matches_current_when_file_written(docling_manager):
+    docling_manager._write_started_openrag_version()
+    assert docling_manager._read_started_openrag_version() == "0.6.0"
+    assert docling_manager.started_for_current_openrag_version() is True
+
+
+def test_stamp_mismatch_when_missing_or_stale(docling_manager):
+    assert docling_manager.started_for_current_openrag_version() is False
+    docling_manager._openrag_version_file.write_text("0.5.1")
+    assert docling_manager.started_for_current_openrag_version() is False
+
+
+@pytest.mark.asyncio
+async def test_start_restarts_when_openrag_version_mismatches(docling_manager, monkeypatch):
+    docling_manager._openrag_version_file.write_text("0.5.1")
+    stop = AsyncMock(return_value=(True, "stopped"))
+    calls = {"n": 0}
+
+    def _is_running():
+        calls["n"] += 1
+        # First check in start() → True (triggers upgrade stop)
+        return calls["n"] == 1
+
+    monkeypatch.setattr(docling_manager, "is_running", _is_running)
+    monkeypatch.setattr(docling_manager, "stop", stop)
+
+    # Avoid actually spawning uvx: fail early after stop by claiming port in use
+    import socket
+
+    class _Sock:
+        def settimeout(self, *_a, **_k):
+            return None
+
+        def connect_ex(self, *_a, **_k):
+            return 0
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(socket, "socket", lambda *a, **k: _Sock())
+
+    success, message = await docling_manager.start()
+    stop.assert_awaited_once()
+    assert success is False
+    assert "already in use" in message.lower()
+
+
+@pytest.mark.asyncio
+async def test_ensure_running_returns_success_when_up_to_date(docling_manager, monkeypatch):
+    docling_manager._write_started_openrag_version()
+    monkeypatch.setattr(docling_manager, "is_running", lambda: True)
+    start = AsyncMock()
+    monkeypatch.setattr(docling_manager, "start", start)
+
+    success, message = await docling_manager.ensure_running()
+    assert success is True
+    assert "already running" in message.lower()
+    start.assert_not_awaited()


### PR DESCRIPTION
refresh stock Langflow flows and Docling on OSS OpenRAG upgrades
Preserved langflow-data kept stale 0.5.x ingest graphs after 0.6's two-phase Docling change (DOCLING_TASK_ID). On version bump, OSS now PATCHes unlocked stock flows from bundled JSON and restarts Docling when OPENRAG_VERSION changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stock Langflow flows refresh automatically during eligible OSS OpenRAG upgrades.
  * Onboarding now tracks `openrag_flows_synced_version`, included in settings and reset on onboarding rollback.
  * Docling serve now records the OpenRAG version it started with and provides version-aware start/reuse.
* **Bug Fixes**
  * Upgrade-refreshed flows are no longer treated as reset candidates.
  * Improved handling of port conflicts when starting native services.
* **Tests**
  * Added unit tests for flow refresh/version stamping, locked-flow refresh behavior, and docling restart/reuse.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->