### PR TITLE
fix: preserve connector icon after source sync

### DIFF
--- a/frontend/app/api/queries/useGetTasksQuery.ts
+++ b/frontend/app/api/queries/useGetTasksQuery.ts
@@ -40,6 +40,7 @@ export interface TaskFileEntry {
   updated_at?: string;
   duration_seconds?: number;
   filename?: string;
+  connector_type?: string;
   embedding_model?: string;
   embedding_dimensions?: number;
   phase?: "docling" | "langflow" | "complete" | string;

--- a/frontend/contexts/task-context.tsx
+++ b/frontend/contexts/task-context.tsx
@@ -351,10 +351,13 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
                 const connectorType = inferTaskFileConnectorType(
                   filePath,
                   fileName,
-                  existingFile?.connector_type &&
-                    existingFile.connector_type !== "local"
-                    ? existingFile.connector_type
-                    : taskConnectorTypesRef.current.get(currentTask.task_id),
+                  fileInfoEntry.connector_type &&
+                    fileInfoEntry.connector_type !== "local"
+                    ? fileInfoEntry.connector_type
+                    : existingFile?.connector_type &&
+                        existingFile.connector_type !== "local"
+                      ? existingFile.connector_type
+                      : taskConnectorTypesRef.current.get(currentTask.task_id),
                 );
 
                 const fileEntry: TaskFile = {

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -946,6 +946,7 @@ class ConnectorFileProcessor(TaskProcessor):
                 raise ValueError(f"Connection '{self.connection_id}' not found")
 
             connector_type = self.connector_type or connection.connector_type
+            file_task.connector_type = connector_type
 
             # Validate file extension early if filename is available
             VALID_EXTENSIONS = {

--- a/src/models/tasks.py
+++ b/src/models/tasks.py
@@ -53,6 +53,7 @@ class FileTask:
     created_at: float = field(default_factory=time.time)
     updated_at: float = field(default_factory=time.time)
     filename: str | None = None  # Original filename for display
+    connector_type: str | None = None
     # Two-phase ingestion fields. Only meaningful for processors that submit
     # files to Docling Serve and then trigger Langflow (i.e. LangflowFileProcessor).
     docling_task_id: str | None = None

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -940,6 +940,7 @@ class TaskService:
             "updated_at": file_task.updated_at,
             "duration_seconds": file_task.duration_seconds,
             "filename": file_task.filename,
+            "connector_type": file_task.connector_type,
             "phase": file_task.phase.value,
             "docling_status": file_task.docling_status.value,
             "docling_task_id": file_task.docling_task_id,


### PR DESCRIPTION
Fixes #2146 

## Summary

Fixes connector file icons temporarily reverting to the generic icon after syncing an updated source document.

When a document from a connector source was modified in the source and then synced in OpenRAG, the Knowledge page temporarily showed the generic file icon. The correct connector icon only returned after refreshing the page or navigating away and back.

This change preserves connector metadata through the task/file update flow so the frontend can keep showing the correct connector icon immediately after sync.

## Changes

- Adds `connector_type` to task file metadata
- Sets `connector_type` on connector file tasks during connector processing
- Includes `connector_type` in task file API responses
- Adds `connector_type` to the frontend task file entry type
- Updates task context icon resolution to prefer file-level connector metadata when available

After, Synced connector files keep the correct connector icon:

<img width="978" height="352" alt="Screenshot 2026-07-27 at 1 30 34 PM" src="https://github.com/user-attachments/assets/310f22bc-ddb9-43b1-a2e9-464c9f769229" />
