### PR TITLE
fix: removed invalid docker/podman exec flag causing make health to not work for backend container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1208,9 +1208,9 @@ health: ## Check health of all services
 	@printf "$(CYAN)Backend:$(NC)     "
 	@if curl -s -k --fail http://127.0.0.1:$${OPENRAG_BACKEND_PORT:-8000}/health >/dev/null 2>&1; then \
 		printf "$(GREEN)Healthy$(NC)\n"; \
-	elif command -v podman >/dev/null 2>&1 && podman ps --format "{{.Names}}" | grep -q "^openrag-backend$$" && podman exec -T openrag-backend curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then \
+	elif command -v podman >/dev/null 2>&1 && podman ps --format "{{.Names}}" | grep -q "^openrag-backend$$" && podman exec openrag-backend curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then \
 		printf "$(GREEN)Healthy$(NC)\n"; \
-	elif command -v docker >/dev/null 2>&1 && docker ps --format "{{.Names}}" | grep -q "^openrag-backend$$" && docker exec -T openrag-backend curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then \
+	elif command -v docker >/dev/null 2>&1 && docker ps --format "{{.Names}}" | grep -q "^openrag-backend$$" && docker exec openrag-backend curl -s -k --fail http://127.0.0.1:8000/health >/dev/null 2>&1; then \
 		printf "$(GREEN)Healthy$(NC)\n"; \
 	else \
 		printf "$(RED)Not responding$(NC)\n"; \


### PR DESCRIPTION
## Summary
This pr fixes an issue with make health incorrectly showing backend as `not responding`. This was caused by an invalid `-T` flag in the docker/podman exec commands used to check the backend container health that was silently failing and causing backend to show up as `Not responding`

## Before
```
Health check:
Frontend:   Healthy
Backend:     Not responding
Langflow:   Healthy
OpenSearch: green
Docling:    Healthy
```

## After
```
Health check:
Frontend:   Healthy
Backend:     Healthy
Langflow:   Healthy
OpenSearch: green
Docling:    Healthy
```

## Changes
- `makefile`: removed invalid -T flag for the backend health podman/docker exec commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved backend health checks to run more reliably in containerized environments.
  - Health status requests and success or failure reporting remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->