### PR TITLE
fix: add clickable citations in onboarding

### DIFF
--- a/frontend/app/chat/_components/assistant-message.tsx
+++ b/frontend/app/chat/_components/assistant-message.tsx
@@ -66,7 +66,7 @@ interface AssistantMessageProps {
   usage?: TokenUsageType;
   timestamp?: Date;
   showFeedback?: boolean;
-  interactiveCitations?: boolean;
+  showViewDocument?: boolean;
   showFunctionCalls?: boolean;
   unstyledMessageContent?: boolean;
 }
@@ -88,7 +88,7 @@ export function AssistantMessage({
   usage,
   timestamp,
   showFeedback = true,
-  interactiveCitations = true,
+  showViewDocument = true,
   showFunctionCalls = true,
   unstyledMessageContent = false,
 }: AssistantMessageProps) {
@@ -270,9 +270,7 @@ export function AssistantMessage({
                     : "text-foreground",
                 )}
                 chatMessage={displayMessageText}
-                onCitationClick={
-                  interactiveCitations ? openChunkPopoverFromText : undefined
-                }
+                onCitationClick={openChunkPopoverFromText}
               />
 
               {/* Citation Cards */}
@@ -280,13 +278,8 @@ export function AssistantMessage({
                 <CitationCards
                   citedSources={citedSources}
                   activeCardIndex={activeChunkIndex}
-                  onCardClick={
-                    interactiveCitations ? openChunkPopover : undefined
-                  }
-                  onCardRef={
-                    interactiveCitations ? setCitationCardRef : undefined
-                  }
-                  interactive={interactiveCitations}
+                  onCardClick={openChunkPopover}
+                  onCardRef={setCitationCardRef}
                 />
               )}
 
@@ -307,7 +300,7 @@ export function AssistantMessage({
         </Message>
 
         {/* Chunk Details Popup Modal */}
-        {interactiveCitations && activeCitedSource && (
+        {activeCitedSource && (
           <ChunkPopup
             onClose={closeChunkPopover}
             chunkNumber={activeCitedSource.index}
@@ -327,6 +320,7 @@ export function AssistantMessage({
               ""
             }
             item={activeCitedSource.item}
+            showViewDocument={showViewDocument}
           />
         )}
       </Popover>

--- a/frontend/app/chat/_components/chunk-popup.tsx
+++ b/frontend/app/chat/_components/chunk-popup.tsx
@@ -14,6 +14,7 @@ interface ChunkPopupProps {
   score: number | string;
   sourceText: string;
   item: ToolCallResult;
+  showViewDocument?: boolean;
 }
 
 const getMetadataValue = (
@@ -103,11 +104,12 @@ export function ChunkPopup({
   score,
   sourceText,
   item,
+  showViewDocument = true,
 }: ChunkPopupProps) {
   const { data: settings } = useGetSettingsQuery();
   const closeButtonRef = useRef<HTMLButtonElement>(null);
 
-  const hasUrl = !!item.source_url;
+  const hasUrl = showViewDocument && !!item.source_url;
   const parser = formatParser(item, filename);
   const scoreLabel = formatScore(item, score);
   const pageLabel = formatPage(item);

--- a/frontend/app/onboarding/_components/onboarding-content.tsx
+++ b/frontend/app/onboarding/_components/onboarding-content.tsx
@@ -364,7 +364,7 @@ export function OnboardingContent({
                 isStreaming={!!streamingMessage}
                 isCompleted={currentStep > 3}
                 showFeedback={false}
-                interactiveCitations={true}
+                showViewDocument={false}
                 showFunctionCalls={false}
                 unstyledMessageContent
               />

--- a/frontend/app/onboarding/_components/onboarding-content.tsx
+++ b/frontend/app/onboarding/_components/onboarding-content.tsx
@@ -39,6 +39,12 @@ const sanitizeCitationResult = (item: ToolCallResult): ToolCallResult => {
       file_path: item.data.file_path,
       page: item.data.page,
       score: item.data.score,
+      text: item.data.text,
+      embedding_model: item.data.embedding_model,
+      parser: item.data.parser,
+      chunk_size: item.data.chunk_size,
+      chunk_overlap: item.data.chunk_overlap,
+      metadata: item.data.metadata,
     };
 
     return Object.values(sanitizedData).some((value) => value !== undefined)
@@ -53,6 +59,13 @@ const sanitizeCitationResult = (item: ToolCallResult): ToolCallResult => {
     filename: item.filename,
     page: item.page ?? item.data?.page,
     score: item.score ?? item.data?.score,
+    text: item.text ?? item.data?.text,
+    embedding_model: item.embedding_model ?? item.data?.embedding_model,
+    parser: item.parser ?? item.data?.parser,
+    chunk_size: item.chunk_size ?? item.data?.chunk_size,
+    chunk_overlap: item.chunk_overlap ?? item.data?.chunk_overlap,
+    source_url: item.source_url,
+    metadata: item.metadata ?? item.data?.metadata,
   };
 };
 
@@ -351,7 +364,7 @@ export function OnboardingContent({
                 isStreaming={!!streamingMessage}
                 isCompleted={currentStep > 3}
                 showFeedback={false}
-                interactiveCitations={false}
+                interactiveCitations={true}
                 showFunctionCalls={false}
                 unstyledMessageContent
               />

--- a/src/api/settings/models.py
+++ b/src/api/settings/models.py
@@ -67,6 +67,12 @@ class CitationDisplayData(BaseModel):
     file_path: str | None = None
     page: int | str | None = None
     score: float | str | None = None
+    text: str | None = None
+    embedding_model: str | None = None
+    parser: str | None = None
+    chunk_size: int | float | str | None = None
+    chunk_overlap: int | float | str | None = None
+    metadata: dict[str, Any] | None = None
 
 
 class CitationDisplayResult(BaseModel):
@@ -76,6 +82,13 @@ class CitationDisplayResult(BaseModel):
     filename: str | None = None
     page: int | str | None = None
     score: float | str | None = None
+    text: str | None = None
+    embedding_model: str | None = None
+    parser: str | None = None
+    chunk_size: int | float | str | None = None
+    chunk_overlap: int | float | str | None = None
+    source_url: str | None = None
+    metadata: dict[str, Any] | None = None
 
 
 class CitationDisplayResultGroup(BaseModel):

--- a/tests/unit/api/test_settings_endpoints.py
+++ b/tests/unit/api/test_settings_endpoints.py
@@ -93,5 +93,3 @@ def test_assistant_message_citation_serialization():
     assert result.metadata == {"custom_key": "val"}
     assert result.data is not None
     assert result.data.text == "Extracted chunk text"
-
-

--- a/tests/unit/api/test_settings_endpoints.py
+++ b/tests/unit/api/test_settings_endpoints.py
@@ -9,6 +9,7 @@ import pytest
 from fastapi import HTTPException
 
 from api.settings import DoclingPresetBody, update_docling_preset
+from api.settings.models import AssistantMessage, OnboardingFunctionCall
 from session_manager import User
 
 
@@ -35,3 +36,62 @@ async def test_update_docling_preset_invalid_preset_returns_400():
     assert exc_info.value.status_code == 400
     assert "Invalid preset" in exc_info.value.detail
     assert "nonexistent_preset" in exc_info.value.detail
+
+
+def test_assistant_message_citation_serialization():
+    """Test AssistantMessage model citation parsing with text and metadata."""
+    payload = {
+        "role": "assistant",
+        "content": "Here is the response [1]",
+        "timestamp": "2026-07-27T00:00:00.000Z",
+        "functionCalls": [
+            {
+                "name": "search_docs",
+                "status": "completed",
+                "result": [
+                    {
+                        "chunk_id": "chunk-123",
+                        "filename": "doc.pdf",
+                        "page": 2,
+                        "score": 0.95,
+                        "text": "Extracted chunk text",
+                        "embedding_model": "text-embedding-3-small",
+                        "parser": "Docling",
+                        "chunk_size": 512,
+                        "chunk_overlap": 64,
+                        "source_url": "https://example.com/doc.pdf",
+                        "metadata": {"custom_key": "val"},
+                        "data": {
+                            "file_path": "/path/to/doc.pdf",
+                            "page": 2,
+                            "score": 0.95,
+                            "text": "Extracted chunk text",
+                            "embedding_model": "text-embedding-3-small",
+                            "parser": "Docling",
+                            "chunk_size": 512,
+                            "chunk_overlap": 64,
+                        },
+                    }
+                ],
+            }
+        ],
+    }
+
+    msg = AssistantMessage(**payload)
+    assert msg.functionCalls is not None
+    assert len(msg.functionCalls) == 1
+    fc = msg.functionCalls[0]
+    assert isinstance(fc, OnboardingFunctionCall)
+    assert fc.result is not None
+    result = fc.result[0]
+    assert result.text == "Extracted chunk text"
+    assert result.embedding_model == "text-embedding-3-small"
+    assert result.parser == "Docling"
+    assert result.chunk_size == 512
+    assert result.chunk_overlap == 64
+    assert result.source_url == "https://example.com/doc.pdf"
+    assert result.metadata == {"custom_key": "val"}
+    assert result.data is not None
+    assert result.data.text == "Extracted chunk text"
+
+


### PR DESCRIPTION
This pull request enhances the citation data model and its handling across the backend, frontend, and tests. The main focus is on expanding citation metadata fields, ensuring proper serialization/deserialization, and enabling interactive citations in the onboarding UI.

**Citation Data Model and Serialization Enhancements:**

* Expanded the citation data models (`CitationDisplayData`, `CitationDisplayResult`) in `src/api/settings/models.py` to include new fields: `text`, `embedding_model`, `parser`, `chunk_size`, `chunk_overlap`, `metadata`, and `source_url`. [[1]](diffhunk://#diff-90fbed4b1dfef5c5110115bded743376ee82c6d485c1a07289954ae1bf39c876R70-R75) [[2]](diffhunk://#diff-90fbed4b1dfef5c5110115bded743376ee82c6d485c1a07289954ae1bf39c876R85-R91)
* Updated the citation result sanitization in `frontend/app/onboarding/_components/onboarding-content.tsx` to handle the new fields, ensuring these are passed through and available in the frontend. [[1]](diffhunk://#diff-7b086e20299003a2825f84cf5f0737ff240182bc6a1b15f57e343cb9f85e3e5dR42-R47) [[2]](diffhunk://#diff-7b086e20299003a2825f84cf5f0737ff240182bc6a1b15f57e343cb9f85e3e5dR62-R68)

**Frontend Feature Improvements:**

* Enabled `interactiveCitations` in the onboarding content component, allowing users to interact with citation elements during onboarding.

**Testing and Validation:**

* Added a new unit test in `tests/unit/api/test_settings_endpoints.py` to validate the serialization and parsing of the expanded citation fields in the `AssistantMessage` model. This ensures all new fields are correctly handled in API payloads. [[1]](diffhunk://#diff-1104958d9701187aca9013a0c6e3a43e1ab9daef0fdaae990c61ed72b09ed0b6R12) [[2]](diffhunk://#diff-1104958d9701187aca9013a0c6e3a43e1ab9daef0fdaae990c61ed72b09ed0b6R39-R97)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Citation details now show richer information, including source text, embedding model, parser, chunking parameters, source URLs, and custom metadata.
  * “View document” visibility is now controlled via a dedicated toggle for citation-related UI.

* **Bug Fixes**
  * Improved citation payload sanitization and rendering when citation fields are provided in alternate locations.
  * Invalid document presets now return a clear validation error (400) with the submitted preset.

* **Tests**
  * Added/updated unit tests for citation field parsing/serialization and invalid preset validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->