### PR TITLE
refactor: update design for vlm advanced settings

### DIFF
--- a/frontend/app/settings/_components/ingest-settings-section.tsx
+++ b/frontend/app/settings/_components/ingest-settings-section.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ArrowUpRight, Loader2, Minus, Plus } from "lucide-react";
+import { ArrowUpRight, ChevronDown, Loader2, Minus, Plus } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { toast } from "sonner";
 import {
@@ -13,12 +13,6 @@ import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import { ConfirmationDialog } from "@/components/confirmation-dialog";
 import { LabelWrapper } from "@/components/label-wrapper";
 import { RequirePermission } from "@/components/require-permission";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { Button } from "@/components/ui/button";
 import {
   Card,
@@ -27,6 +21,11 @@ import {
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible";
 import { Input } from "@/components/ui/input";
 import { NumberInput } from "@/components/ui/inputs/number-input";
 import { Label } from "@/components/ui/label";
@@ -338,7 +337,7 @@ export function IngestSettingsSection() {
       setVlmWatsonxApiVersion(k.vlm_watsonx_api_version);
   }, [settings.knowledge]);
 
-  const [vlmAccordionValue, setVlmAccordionValue] = useState<string>("");
+  const [vlmOpen, setVlmOpen] = useState(false);
 
   const autoSelectedVlm = useRef(false);
   useEffect(() => {
@@ -825,161 +824,164 @@ export function IngestSettingsSection() {
               />
             </div>
             {showVlmSettings && (
-              <div
-                className={cn(
-                  "mt-4 border border-border rounded-lg bg-muted/5 overflow-hidden transition-all duration-200",
-                  !pictureDescriptions &&
-                    "opacity-50 cursor-not-allowed select-none",
-                )}
-              >
-                <Accordion
-                  type="single"
-                  collapsible
-                  disabled={!pictureDescriptions}
-                  value={pictureDescriptions ? vlmAccordionValue : ""}
-                  onValueChange={setVlmAccordionValue}
+              <>
+                <hr className="mt-4 border-border" />
+                <Collapsible
+                  open={vlmOpen}
+                  onOpenChange={setVlmOpen}
+                  className={cn(
+                    "mt-4 px-4 transition-all duration-200",
+                    !pictureDescriptions && "opacity-50",
+                  )}
                 >
-                  <AccordionItem value="vlm-settings" className="border-none">
-                    <AccordionTrigger
+                  <CollapsibleTrigger className="flex w-full items-center justify-between py-2 text-sm font-medium text-foreground hover:text-foreground/80">
+                    Advanced Vision Model (VLM) Settings
+                    <ChevronDown
                       className={cn(
-                        "hover:no-underline font-medium text-foreground px-4 py-3 bg-muted/10 border-b border-border",
-                        !pictureDescriptions && "pointer-events-none",
+                        "h-4 w-4 text-muted-foreground transition-transform duration-200",
+                        vlmOpen && "rotate-180",
                       )}
-                    >
-                      Advanced Vision Model (VLM) Settings
-                    </AccordionTrigger>
-                    <AccordionContent className="p-4 space-y-6">
-                      <div className="space-y-2">
-                        <LabelWrapper
-                          id="vlm-model"
-                          label="Vision model"
-                          helperText="Pick a vision-capable model; the provider is set from your selection"
-                          required={pictureDescriptions}
-                        >
-                          <ModelSelector
-                            groupedOptions={groupedVlmModels}
-                            noOptionsPlaceholder={
-                              isLoadingAnyVlmModels
-                                ? "Loading models..."
-                                : "No models detected. Configure OpenAI, Anthropic, Ollama, or IBM watsonx.ai first."
-                            }
-                            value={vlmModel}
-                            onValueChange={handleVlmModelChange}
-                            hasError={!!validationError}
-                          />
-                        </LabelWrapper>
-                        {providerWarning && (
-                          <p className="text-sm text-destructive" role="alert">
-                            {providerLabel} is not configured. Configure it in
-                            Settings &gt; Providers first.
-                          </p>
-                        )}
-                      </div>
-
-                      {vlmProvider === "watsonx" && (
-                        <div className="space-y-2">
-                          <LabelWrapper
-                            id="vlm-watsonx-api-version"
-                            label="watsonx API version"
-                            helperText="API version date sent to watsonx.ai"
-                          >
-                            <Input
-                              id="vlm-watsonx-api-version"
-                              type="text"
-                              placeholder={DEFAULT_WATSONX_API_VERSION}
-                              value={vlmWatsonxApiVersion}
-                              onChange={(e) =>
-                                setVlmWatsonxApiVersion(e.target.value)
-                              }
-                            />
-                          </LabelWrapper>
-                        </div>
-                      )}
-
-                      <div className="space-y-2">
-                        <LabelWrapper
-                          id="vlm-prompt"
-                          label="Prompt"
-                          helperText="Sent to the VLM for every page"
-                        >
-                          <Textarea
-                            id="vlm-prompt"
-                            rows={3}
-                            value={vlmPrompt}
-                            onChange={(e) => setVlmPrompt(e.target.value)}
-                          />
-                        </LabelWrapper>
-                      </div>
-
-                      <div className="space-y-2">
-                        <LabelWrapper
-                          id="vlm-response-format"
-                          label="Response format"
-                          helperText="Per-page VLM output. Markdown is compatible with the existing pipeline; the final document is always Docling JSON."
-                        >
-                          <Select
-                            value={vlmResponseFormat}
-                            onValueChange={setVlmResponseFormat}
-                          >
-                            <SelectTrigger id="vlm-response-format">
-                              <SelectValue placeholder="Select a format" />
-                            </SelectTrigger>
-                            <SelectContent>
-                              {RESPONSE_FORMATS.map((format) => (
-                                <SelectItem
-                                  key={format.value}
-                                  value={format.value}
-                                >
-                                  {format.label}
-                                </SelectItem>
-                              ))}
-                            </SelectContent>
-                          </Select>
-                        </LabelWrapper>
-                      </div>
-
-                      <div className="grid grid-cols-3 gap-4">
-                        <NumberInput
-                          id="vlm-max-tokens"
-                          label="Max tokens per page"
-                          value={vlmMaxTokens}
-                          onChange={(value) =>
-                            setVlmMaxTokens(Math.max(1, value))
+                    />
+                  </CollapsibleTrigger>
+                  <CollapsibleContent className="pt-4 space-y-6">
+                    <div className="space-y-2">
+                      <LabelWrapper
+                        id="vlm-model"
+                        label="Vision model"
+                        helperText="Pick a vision-capable model; the provider is set from your selection"
+                        required={pictureDescriptions}
+                      >
+                        <ModelSelector
+                          groupedOptions={groupedVlmModels}
+                          noOptionsPlaceholder={
+                            isLoadingAnyVlmModels
+                              ? "Loading models..."
+                              : "No models detected. Configure OpenAI, Anthropic, Ollama, or IBM watsonx.ai first."
                           }
-                          unit="tokens"
-                          min={1}
+                          value={vlmModel}
+                          onValueChange={handleVlmModelChange}
+                          hasError={!!validationError}
+                          disabled={!pictureDescriptions}
                         />
-                        <NumberInput
-                          id="vlm-concurrency"
-                          label="Concurrency"
-                          value={vlmConcurrency}
-                          onChange={(value) =>
-                            setVlmConcurrency(Math.max(1, value))
-                          }
-                          unit="requests"
-                          min={1}
-                        />
-                        <NumberInput
-                          id="vlm-timeout"
-                          label="API timeout"
-                          value={vlmTimeout}
-                          onChange={(value) =>
-                            setVlmTimeout(Math.max(1, value))
-                          }
-                          unit="seconds"
-                          min={1}
-                        />
-                      </div>
-
-                      {validationError && (
+                      </LabelWrapper>
+                      {providerWarning && (
                         <p className="text-sm text-destructive" role="alert">
-                          {validationError}
+                          {providerLabel} is not configured. Configure it in
+                          Settings &gt; Providers first.
                         </p>
                       )}
-                    </AccordionContent>
-                  </AccordionItem>
-                </Accordion>
-              </div>
+                    </div>
+
+                    {vlmProvider === "watsonx" && (
+                      <div className="space-y-2">
+                        <LabelWrapper
+                          id="vlm-watsonx-api-version"
+                          label="watsonx API version"
+                          helperText="API version date sent to watsonx.ai"
+                        >
+                          <Input
+                            id="vlm-watsonx-api-version"
+                            type="text"
+                            placeholder={DEFAULT_WATSONX_API_VERSION}
+                            value={vlmWatsonxApiVersion}
+                            onChange={(e) =>
+                              setVlmWatsonxApiVersion(e.target.value)
+                            }
+                            disabled={!pictureDescriptions}
+                          />
+                        </LabelWrapper>
+                      </div>
+                    )}
+
+                    <div className="space-y-2">
+                      <LabelWrapper
+                        id="vlm-prompt"
+                        label="Prompt"
+                        helperText="Sent to the VLM for every page"
+                      >
+                        <Textarea
+                          id="vlm-prompt"
+                          rows={3}
+                          value={vlmPrompt}
+                          onChange={(e) => setVlmPrompt(e.target.value)}
+                          disabled={!pictureDescriptions}
+                        />
+                      </LabelWrapper>
+                    </div>
+
+                    <div className="space-y-2">
+                      <LabelWrapper
+                        id="vlm-response-format"
+                        label="Response format"
+                        helperText="Per-page VLM output. Markdown is compatible with the existing pipeline; the final document is always Docling JSON."
+                      >
+                        <Select
+                          value={vlmResponseFormat}
+                          onValueChange={setVlmResponseFormat}
+                          disabled={!pictureDescriptions}
+                        >
+                          <SelectTrigger
+                            id="vlm-response-format"
+                            disabled={!pictureDescriptions}
+                          >
+                            <SelectValue placeholder="Select a format" />
+                          </SelectTrigger>
+                          <SelectContent>
+                            {RESPONSE_FORMATS.map((format) => (
+                              <SelectItem
+                                key={format.value}
+                                value={format.value}
+                              >
+                                {format.label}
+                              </SelectItem>
+                            ))}
+                          </SelectContent>
+                        </Select>
+                      </LabelWrapper>
+                    </div>
+
+                    <div className="grid grid-cols-3 gap-4">
+                      <NumberInput
+                        id="vlm-max-tokens"
+                        label="Max tokens per page"
+                        value={vlmMaxTokens}
+                        onChange={(value) =>
+                          setVlmMaxTokens(Math.max(1, value))
+                        }
+                        unit="tokens"
+                        min={1}
+                        disabled={!pictureDescriptions}
+                      />
+                      <NumberInput
+                        id="vlm-concurrency"
+                        label="Concurrency"
+                        value={vlmConcurrency}
+                        onChange={(value) =>
+                          setVlmConcurrency(Math.max(1, value))
+                        }
+                        unit="requests"
+                        min={1}
+                        disabled={!pictureDescriptions}
+                      />
+                      <NumberInput
+                        id="vlm-timeout"
+                        label="API timeout"
+                        value={vlmTimeout}
+                        onChange={(value) => setVlmTimeout(Math.max(1, value))}
+                        unit="seconds"
+                        min={1}
+                        disabled={!pictureDescriptions}
+                      />
+                    </div>
+
+                    {validationError && (
+                      <p className="text-sm text-destructive" role="alert">
+                        {validationError}
+                      </p>
+                    )}
+                  </CollapsibleContent>
+                </Collapsible>
+              </>
             )}
           </div>
           <div className="flex justify-end pt-2">

--- a/frontend/app/settings/_components/ingest-settings-section.tsx
+++ b/frontend/app/settings/_components/ingest-settings-section.tsx
@@ -866,7 +866,7 @@ export function IngestSettingsSection() {
                       </LabelWrapper>
                       {providerWarning && (
                         <p className="text-sm text-destructive" role="alert">
-                          {providerLabel} is not configured. Configure it in
+                          Configure a provider with vision-capable models in
                           Settings &gt; Providers first.
                         </p>
                       )}

--- a/frontend/components/ui/inputs/number-input.tsx
+++ b/frontend/components/ui/inputs/number-input.tsx
@@ -35,39 +35,45 @@ export const NumberInput = ({
           min={min}
           value={value}
           onChange={(e) => onChange(parseInt(e.target.value) || 0)}
-          className="w-full pr-20 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          className={
+            disabled
+              ? "w-full pr-8 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+              : "w-full pr-20 [appearance:textfield] [&::-webkit-outer-spin-button]:appearance-none [&::-webkit-inner-spin-button]:appearance-none"
+          }
         />
-        <div className="absolute inset-y-0 right-0 top-0 p-[1px] py-[1.5px] flex items-center ">
-          <span className="text-sm text-placeholder-foreground mr-4 pointer-events-none">
-            {unit}
-          </span>
-          <div className="flex flex-col mt-[2px] mb-[2px]">
-            <Button
-              aria-label={`Increase ${label} value`}
-              className="h-5 rounded-l-none rounded-br-none border-input border-t-transparent border-r-transparent border-b-[0.5px] hover:border-t-[.5px] hover:border-foreground"
-              variant="outline"
-              size="iconSm"
-              onClick={() => onChange(value + 1)}
-            >
-              <Plus
-                className="text-muted-foreground hover:text-foreground"
-                size={8}
-              />
-            </Button>
-            <Button
-              aria-label={`Decrease ${label} value`}
-              className="h-5 rounded-l-none rounded-tr-none border-input border-b-transparent border-r-transparent hover:border-b-1 hover:border-b-[.5px] hover:border-foreground"
-              variant="outline"
-              size="iconSm"
-              onClick={() => onChange(value - 1)}
-            >
-              <Minus
-                className="text-muted-foreground hover:text-foreground"
-                size={8}
-              />
-            </Button>
+        {!disabled && (
+          <div className="absolute inset-y-0 right-0 top-0 p-[1px] py-[1.5px] flex items-center ">
+            <span className="text-sm text-placeholder-foreground mr-4 pointer-events-none">
+              {unit}
+            </span>
+            <div className="flex flex-col mt-[2px] mb-[2px]">
+              <Button
+                aria-label={`Increase ${label} value`}
+                className="h-5 rounded-l-none rounded-br-none border-input border-t-transparent border-r-transparent border-b-[0.5px] hover:border-t-[.5px] hover:border-foreground"
+                variant="outline"
+                size="iconSm"
+                onClick={() => onChange(value + 1)}
+              >
+                <Plus
+                  className="text-muted-foreground hover:text-foreground"
+                  size={8}
+                />
+              </Button>
+              <Button
+                aria-label={`Decrease ${label} value`}
+                className="h-5 rounded-l-none rounded-tr-none border-input border-b-transparent border-r-transparent hover:border-b-1 hover:border-b-[.5px] hover:border-foreground"
+                variant="outline"
+                size="iconSm"
+                onClick={() => onChange(value - 1)}
+              >
+                <Minus
+                  className="text-muted-foreground hover:text-foreground"
+                  size={8}
+                />
+              </Button>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     </LabelWrapper>
   );


### PR DESCRIPTION
Makes it so it can be opened before picture descriptions is enabled as well
<img width="1108" height="655" alt="Screenshot 2026-07-27 at 4 25 39 PM" src="https://github.com/user-attachments/assets/31091d30-8a26-47b4-83fd-1e4d6c1ead92" />

also improve error messaging
<img width="1017" height="338" alt="Screenshot 2026-07-27 at 4 35 56 PM" src="https://github.com/user-attachments/assets/dc8f58dc-aa3b-45dd-a925-1fcbaf88252d" />




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary of updates

* **UI Improvements**
  * Reworked Advanced Vision Model settings to use a Collapsible section with a rotating chevron to clearly show open/close state.
  * When picture descriptions are off, all VLM configuration controls are now disabled to prevent unintended input.
  * Improved disabled NumberInput presentation by adjusting spacing and hiding unit labels and increment/decrement controls while disabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->