### PR TITLE
fix: Unable to access Frontend app on Ubuntu Linux (x86_64)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -736,11 +736,11 @@ frontend: ## Run frontend locally
 		echo "$(YELLOW)Detected Power architecture ($$ARCH) — using Webpack fallback$(NC)"; \
 		npx next dev --webpack \
 			--port $$PORT \
-			--hostname $$(hostname); \
+			--hostname $(hostname); \
 	else \
 		npx next dev \
 			--port $$PORT \
-			--hostname $$(hostname); \
+			--hostname $(hostname); \
 	fi
 
 docling: ## Start docling-serve for document processing


### PR DESCRIPTION
Issue

- #2140

Summary

- Use Make variable reference `$(hostname)` instead of shell command substitution `$$(hostname)`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved frontend development server accessibility by consistently binding it to the configured hostname across supported build modes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->