### PR TITLE
fix: pin fastapi to version without errors

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -17,7 +17,7 @@ RUN pip install --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
     torch==2.10.0 \
     torchvision==0.25.0 \
-    "fastapi<0.140.0" \
+    "fastapi<0.140.5" \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
     "ibm-watsonx-ai>=1.3.1,<2.0.0" \
     "langchain-ibm~=1.1.0" \

--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -17,6 +17,7 @@ RUN pip install --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
     torch==2.10.0 \
     torchvision==0.25.0 \
+    "fastapi<0.140.0" \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
     "ibm-watsonx-ai>=1.3.1,<2.0.0" \
     "langchain-ibm~=1.1.0" \


### PR DESCRIPTION
This pull request makes a dependency update to the `Dockerfile.langflow`, adding a version constraint for the `fastapi` package to ensure compatibility.

Dependency updates:

* Added `fastapi` with a version constraint (`<0.140.0`) to the list of installed packages in `Dockerfile.langflow` to prevent compatibility issues with newer releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility and stability by constraining the FastAPI package version used in the container build (now pins `fastapi<0.140.5`).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->