### PR TITLE
feat: make functional and up to date models available in the list

### DIFF
--- a/frontend/app/settings/_helpers/model-helpers.tsx
+++ b/frontend/app/settings/_helpers/model-helpers.tsx
@@ -102,8 +102,18 @@ export function getFallbackModels(provider: ModelProvider) {
     case "openai":
       return {
         language: [
+          // GPT-5.6 family (current frontier)
+          { value: "gpt-5.6", label: "GPT-5.6" },
+          { value: "gpt-5.6-sol", label: "GPT-5.6 Sol" },
+          { value: "gpt-5.6-terra", label: "GPT-5.6 Terra" },
+          { value: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
+          // GPT-5.5
+          { value: "gpt-5.5", label: "GPT-5.5" },
+          { value: "gpt-5.5-pro", label: "GPT-5.5 Pro" },
+          // GPT-5.4 and earlier (still functional)
           { value: "gpt-5.4", label: "GPT-5.4" },
           { value: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
+          { value: "gpt-5.4-nano", label: "GPT-5.4 Nano" },
           { value: "gpt-5.4-pro", label: "GPT-5.4 Pro" },
           { value: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
           { value: "gpt-5.2", label: "GPT-5.2" },
@@ -129,6 +139,13 @@ export function getFallbackModels(provider: ModelProvider) {
     case "anthropic":
       return {
         language: [
+          // Claude 5 family (current)
+          { value: "claude-fable-5", label: "Claude Fable 5" },
+          { value: "claude-opus-5", label: "Claude Opus 5" },
+          { value: "claude-sonnet-5", label: "Claude Sonnet 5" },
+          // Claude 4.x (still functional)
+          { value: "claude-opus-4-8", label: "Claude Opus 4.8" },
+          { value: "claude-opus-4-7", label: "Claude Opus 4.7" },
           { value: "claude-opus-4-6", label: "Claude Opus 4.6" },
           { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
           { value: "claude-opus-4-5-20251101", label: "Claude Opus 4.5" },
@@ -142,6 +159,8 @@ export function getFallbackModels(provider: ModelProvider) {
         language: [
           { value: "gpt-oss", label: "gpt-oss" },
           { value: "mistral-nemo", label: "mistral-nemo" },
+          { value: "llama3.1", label: "Llama 3.1" },
+          { value: "qwen2.5", label: "Qwen 2.5" },
         ],
         embedding: [
           { value: "nomic-embed-text", label: "Nomic Embed Text" },
@@ -154,6 +173,7 @@ export function getFallbackModels(provider: ModelProvider) {
     default:
       return {
         language: [
+          { value: "gpt-5.6-luna", label: "GPT-5.6 Luna" },
           { value: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
           { value: "gpt-4o", label: "GPT-4o" },
           { value: "gpt-4o-mini", label: "GPT-4o Mini" },

--- a/frontend/app/settings/_helpers/model-helpers.tsx
+++ b/frontend/app/settings/_helpers/model-helpers.tsx
@@ -94,7 +94,9 @@ export function getModelLogo(modelValue: string, provider?: ModelProvider) {
   return <OpenAILogo className="w-4 h-4" />; // Default to OpenAI logo
 }
 
-// Helper function to get fallback models by provider
+// Offline fallbacks when live /api/models/* returns empty.
+// Include current preferred defaults AND older models that are still functional.
+// Live provider lists remain the real catalog when the API is reachable.
 export function getFallbackModels(provider: ModelProvider) {
   switch (provider) {
     case "openai":
@@ -109,18 +111,19 @@ export function getFallbackModels(provider: ModelProvider) {
           { value: "gpt-5", label: "GPT-5" },
           { value: "gpt-5-mini", label: "GPT-5 Mini" },
           { value: "gpt-5-nano", label: "GPT-5 Nano" },
-          { value: "gpt-4o-mini", label: "GPT-4o Mini" },
-          { value: "gpt-4o", label: "GPT-4o" },
           { value: "gpt-4.1", label: "GPT-4.1" },
           { value: "gpt-4.1-mini", label: "GPT-4.1 Mini" },
+          { value: "gpt-4o", label: "GPT-4o" },
+          { value: "gpt-4o-mini", label: "GPT-4o Mini" },
           { value: "o3", label: "o3" },
           { value: "o3-pro", label: "o3 Pro" },
+          { value: "o4-mini", label: "o4 Mini" },
           { value: "o4-mini-high", label: "o4 Mini High" },
         ],
         embedding: [
-          { value: "text-embedding-ada-002", label: "text-embedding-ada-002" },
-          { value: "text-embedding-3-small", label: "text-embedding-3-small" },
           { value: "text-embedding-3-large", label: "text-embedding-3-large" },
+          { value: "text-embedding-3-small", label: "text-embedding-3-small" },
+          { value: "text-embedding-ada-002", label: "text-embedding-ada-002" },
         ],
       };
     case "anthropic":
@@ -128,59 +131,34 @@ export function getFallbackModels(provider: ModelProvider) {
         language: [
           { value: "claude-opus-4-6", label: "Claude Opus 4.6" },
           { value: "claude-sonnet-4-6", label: "Claude Sonnet 4.6" },
+          { value: "claude-opus-4-5-20251101", label: "Claude Opus 4.5" },
           { value: "claude-sonnet-4-5-20250929", label: "Claude Sonnet 4.5" },
+          { value: "claude-haiku-4-5-20251001", label: "Claude Haiku 4.5" },
         ],
       };
     case "ollama":
       return {
+        // Tool-calling capable recommendations only (agent requires tools)
         language: [
-          { value: "llama2", label: "Llama 2" },
-          { value: "llama2:13b", label: "Llama 2 13B" },
-          { value: "codellama", label: "Code Llama" },
+          { value: "gpt-oss", label: "gpt-oss" },
+          { value: "mistral-nemo", label: "mistral-nemo" },
         ],
         embedding: [
-          { value: "mxbai-embed-large", label: "MxBai Embed Large" },
           { value: "nomic-embed-text", label: "Nomic Embed Text" },
+          { value: "mxbai-embed-large", label: "MxBai Embed Large" },
         ],
       };
     case "watsonx":
-      return {
-        language: [
-          {
-            value: "meta-llama/llama-3-1-70b-instruct",
-            label: "Llama 3.1 70B Instruct",
-          },
-          { value: "ibm/granite-13b-chat-v2", label: "Granite 13B Chat v2" },
-        ],
-        embedding: [
-          {
-            value: "ibm/slate-125m-english-rtrvr",
-            label: "Slate 125M English Retriever",
-          },
-        ],
-      };
+      // No stable static IDs — live list is required for watsonx.
+      return { language: [], embedding: [] };
     default:
       return {
         language: [
-          { value: "gpt-5.4", label: "GPT-5.4" },
           { value: "gpt-5.4-mini", label: "GPT-5.4 Mini" },
-          { value: "gpt-5.4-pro", label: "GPT-5.4 Pro" },
-          { value: "gpt-5.3-codex", label: "GPT-5.3 Codex" },
-          { value: "gpt-5.2", label: "GPT-5.2" },
-          { value: "gpt-5.1", label: "GPT-5.1" },
-          { value: "gpt-5", label: "GPT-5" },
-          { value: "gpt-5-mini", label: "GPT-5 Mini" },
-          { value: "gpt-5-nano", label: "GPT-5 Nano" },
-          { value: "gpt-4o-mini", label: "GPT-4o Mini" },
           { value: "gpt-4o", label: "GPT-4o" },
-          { value: "gpt-4.1", label: "GPT-4.1" },
-          { value: "gpt-4.1-mini", label: "GPT-4.1 Mini" },
-          { value: "o3", label: "o3" },
-          { value: "o3-pro", label: "o3 Pro" },
-          { value: "o4-mini-high", label: "o4 Mini High" },
+          { value: "gpt-4o-mini", label: "GPT-4o Mini" },
         ],
         embedding: [
-          { value: "text-embedding-ada-002", label: "text-embedding-ada-002" },
           { value: "text-embedding-3-small", label: "text-embedding-3-small" },
           { value: "text-embedding-3-large", label: "text-embedding-3-large" },
         ],

--- a/src/api/settings/helpers.py
+++ b/src/api/settings/helpers.py
@@ -47,7 +47,12 @@ def _first_configured_embedding_provider(config, excluding: str) -> str:
 
 
 def _default_llm_model(provider: str) -> str:
-    """Return the default LLM model for a provider."""
+    """Return the static preferred LLM model for a provider.
+
+    OpenAI/Anthropic have stable preferred defaults. Ollama/watsonx model IDs are
+    dynamic from the live provider list — return empty so the frontend picks from
+    the live list (default flag or first available).
+    """
     from config.model_constants import (
         ANTHROPIC_DEFAULT_LANGUAGE_MODEL,
         OPENAI_DEFAULT_LANGUAGE_MODEL,
@@ -56,8 +61,8 @@ def _default_llm_model(provider: str) -> str:
     return {
         "openai": OPENAI_DEFAULT_LANGUAGE_MODEL,
         "anthropic": ANTHROPIC_DEFAULT_LANGUAGE_MODEL,
-        "watsonx": "ibm/granite-4-h-small",
-        "ollama": "llama3",
+        "watsonx": "",
+        "ollama": "",
     }.get(provider, "")
 
 

--- a/src/config/model_constants.py
+++ b/src/config/model_constants.py
@@ -1,31 +1,9 @@
-"""Shared model constants used across provider/model validation flows."""
+"""Preferred default model IDs used when a live provider list is available.
 
-ANTHROPIC_VALIDATION_MODELS = [
-    "claude-opus-4-6",
-    "claude-sonnet-4-6",
-    "claude-haiku-4-5-20251001",
-    "claude-opus-4-5-20251101",
-    "claude-sonnet-4-5-20250929",
-]
-
-OPENAI_VALIDATION_MODELS = [
-    "gpt-5.4",
-    "gpt-5.4-mini",
-    "gpt-5.4-pro",
-    "gpt-5.3-codex",
-    "gpt-5.2",
-    "gpt-5.1",
-    "gpt-5",
-    "gpt-5-mini",
-    "gpt-5-nano",
-    "gpt-4o-mini",
-    "gpt-4o",
-    "gpt-4.1",
-    "gpt-4.1-mini",
-    "o3",
-    "o3-pro",
-    "o4-mini-high",
-]
+Live provider APIs are the source of truth for which models appear in pickers.
+These constants are soft preferences: used when present in the live list, and
+as thin offline fallbacks when a live fetch is unavailable.
+"""
 
 OPENAI_DEFAULT_LANGUAGE_MODEL = "gpt-5.4-mini"
 

--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -48,6 +48,10 @@ def is_openai_non_chat_model(model_id: str) -> bool:
     lower = model_id.lower()
     if "-moderation" in lower:
         return True
+    # Mid-string modality markers (e.g. gpt-4o-realtime-preview, gpt-4o-mini-tts)
+    # that prefix checks alone miss.
+    if any(marker in lower for marker in ("-realtime", "-transcribe", "-tts")):
+        return True
     return any(lower.startswith(prefix) for prefix in _OPENAI_NON_CHAT_PREFIXES)
 
 
@@ -55,12 +59,12 @@ def is_openai_language_model(model_id: str) -> bool:
     """True if the OpenAI model ID is usable as a chat/agent language model.
 
     Classifies the live /v1/models inventory: embeddings and non-chat junk are
-    excluded; gpt-*, chatgpt-*, and o<digit>* reasoning models are included so
-    new chat families appear without a curated allowlist.
+    excluded; gpt-*, chatgpt-*, ft:gpt-* fine-tunes, and o<digit>* reasoning
+    models are included so new chat families appear without a curated allowlist.
     """
     if not model_id or is_openai_embedding_model(model_id) or is_openai_non_chat_model(model_id):
         return False
-    if model_id.startswith(("gpt-", "chatgpt-")):
+    if model_id.startswith(("gpt-", "chatgpt-", "ft:gpt-")):
         return True
     return bool(_OPENAI_REASONING_MODEL_RE.match(model_id))
 

--- a/src/services/models_service.py
+++ b/src/services/models_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import re
 
 import httpx
 
@@ -15,6 +16,71 @@ from utils.logging_config import get_logger
 logger = get_logger(__name__)
 
 KNOWN_PREFIXES = ["openai", "ollama", "watsonx", "anthropic"]
+
+# OpenAI /v1/models is a flat inventory. These IDs are real products but not
+# usable as OpenRAG agent LLMs (wrong modality / API surface).
+_OPENAI_NON_CHAT_PREFIXES = (
+    "whisper",
+    "dall-e",
+    "tts-",
+    "davinci",
+    "babbage",
+    "curie",
+    "sora-",
+    "computer-use",
+    "omni-moderation",
+    "text-moderation",
+    "gpt-image",
+    "gpt-audio",
+    "gpt-realtime",
+    "chatgpt-image",
+)
+_OPENAI_REASONING_MODEL_RE = re.compile(r"^o\d")
+
+
+def is_openai_embedding_model(model_id: str) -> bool:
+    """True if the OpenAI model ID is an embedding model."""
+    return OPENAI_EMBEDDING_MODEL_PREFIX in model_id or "text-similarity-" in model_id
+
+
+def is_openai_non_chat_model(model_id: str) -> bool:
+    """True if the ID is a known non-chat OpenAI product (junk for LLM/embedding pickers)."""
+    lower = model_id.lower()
+    if "-moderation" in lower:
+        return True
+    return any(lower.startswith(prefix) for prefix in _OPENAI_NON_CHAT_PREFIXES)
+
+
+def is_openai_language_model(model_id: str) -> bool:
+    """True if the OpenAI model ID is usable as a chat/agent language model.
+
+    Classifies the live /v1/models inventory: embeddings and non-chat junk are
+    excluded; gpt-*, chatgpt-*, and o<digit>* reasoning models are included so
+    new chat families appear without a curated allowlist.
+    """
+    if not model_id or is_openai_embedding_model(model_id) or is_openai_non_chat_model(model_id):
+        return False
+    if model_id.startswith(("gpt-", "chatgpt-")):
+        return True
+    return bool(_OPENAI_REASONING_MODEL_RE.match(model_id))
+
+
+def resolve_preferred_model(preferred: str, live_models: list[dict]) -> str:
+    """Pick a model from a live provider list.
+
+    Prefer ``preferred`` when it appears in the live list; otherwise the entry
+    marked ``default``, otherwise the first live model. If the live list is
+    empty, return ``preferred`` (may be empty).
+    """
+    if not live_models:
+        return preferred or ""
+    values = {m.get("value") for m in live_models}
+    if preferred and preferred in values:
+        return preferred
+    for model in live_models:
+        if model.get("default"):
+            return model.get("value") or preferred or ""
+    return live_models[0].get("value") or preferred or ""
 
 
 class UnknownEmbeddingProvider(Exception):
@@ -230,35 +296,44 @@ class ModelsService:
                 data = response.json()
                 models = data.get("data", [])
 
-                # Filter for relevant models
+                # Classify live inventory into embedding vs chat; drop non-chat junk.
                 language_models = []
                 embedding_models = []
 
                 for model in models:
                     model_id = model.get("id", "")
+                    if not model_id:
+                        continue
 
-                    # Embedding models
-                    if OPENAI_EMBEDDING_MODEL_PREFIX in model_id or "text-similarity-" in model_id:
+                    if is_openai_embedding_model(model_id):
                         embedding_models.append(
                             {
                                 "value": model_id,
                                 "label": model_id,
-                                "default": model_id == OPENAI_DEFAULT_EMBEDDING_MODEL,
+                                "default": False,
                             }
                         )
-                    # Language models (GPT and o1/o3/chatgpt models)
-                    elif (
-                        model_id.startswith(("gpt-", "o1-", "o3-", "chatgpt-"))
-                        and "-moderation" not in model_id
-                    ):
+                    elif is_openai_language_model(model_id):
                         language_models.append(
                             {
                                 "value": model_id,
                                 "label": model_id,
-                                "default": model_id == OPENAI_DEFAULT_LANGUAGE_MODEL,
+                                "default": False,
                                 "supports_images": self._openai_supports_images(model_id),
                             }
                         )
+
+                chosen_language = resolve_preferred_model(
+                    OPENAI_DEFAULT_LANGUAGE_MODEL, language_models
+                )
+                for entry in language_models:
+                    entry["default"] = entry["value"] == chosen_language
+
+                chosen_embedding = resolve_preferred_model(
+                    OPENAI_DEFAULT_EMBEDDING_MODEL, embedding_models
+                )
+                for entry in embedding_models:
+                    entry["default"] = entry["value"] == chosen_embedding
 
                 # Sort by name and ensure defaults are first
                 language_models.sort(key=lambda x: (not x.get("default", False), x["value"]))
@@ -302,7 +377,7 @@ class ModelsService:
                 "Content-Type": "application/json",
             }
 
-            # Validate API key with lightweight models endpoint and return curated models
+            # Validate API key and return all models from Anthropic's chat-oriented list API
             async with httpx.AsyncClient() as client:
                 response = await client.get(
                     "https://api.anthropic.com/v1/models",
@@ -314,19 +389,27 @@ class ModelsService:
                 data = response.json()
                 models = data.get("data", [])
 
-                # Filter for curated Anthropic models (same pattern as OpenAI validation list)
+                # Anthropic /v1/models is already chat-oriented; pass through live list.
                 language_models = []
 
                 for model in models:
                     model_id = model.get("id", "")
+                    if not model_id:
+                        continue
                     language_models.append(
                         {
                             "value": model_id,
                             "label": model.get("display_name", model_id),
-                            "default": model_id == ANTHROPIC_DEFAULT_LANGUAGE_MODEL,
+                            "default": False,
                             "supports_images": self._anthropic_supports_images(model),
                         }
                     )
+
+                chosen_language = resolve_preferred_model(
+                    ANTHROPIC_DEFAULT_LANGUAGE_MODEL, language_models
+                )
+                for entry in language_models:
+                    entry["default"] = entry["value"] == chosen_language
 
                 # Sort by default first, then by name
                 language_models.sort(key=lambda x: (not x.get("default", False), x["value"]))

--- a/tests/unit/services/test_models_service_classification.py
+++ b/tests/unit/services/test_models_service_classification.py
@@ -1,0 +1,117 @@
+"""Unit tests for OpenAI model classification and preferred-model resolution."""
+
+from config.embedding_constants import OPENAI_DEFAULT_EMBEDDING_MODEL
+from config.model_constants import OPENAI_DEFAULT_LANGUAGE_MODEL
+from services.models_service import (
+    is_openai_embedding_model,
+    is_openai_language_model,
+    is_openai_non_chat_model,
+    resolve_preferred_model,
+)
+
+
+class TestOpenAIEmbeddingClassification:
+    def test_text_embedding_models(self):
+        assert is_openai_embedding_model("text-embedding-3-small")
+        assert is_openai_embedding_model("text-embedding-3-large")
+        assert is_openai_embedding_model("text-embedding-ada-002")
+
+    def test_text_similarity_models(self):
+        assert is_openai_embedding_model("text-similarity-davinci-001")
+
+    def test_chat_models_are_not_embeddings(self):
+        assert not is_openai_embedding_model("gpt-5.4-mini")
+        assert not is_openai_embedding_model("o4-mini")
+
+
+class TestOpenAINonChatClassification:
+    def test_whisper_dalle_tts_moderation(self):
+        assert is_openai_non_chat_model("whisper-1")
+        assert is_openai_non_chat_model("dall-e-3")
+        assert is_openai_non_chat_model("tts-1")
+        assert is_openai_non_chat_model("tts-1-hd")
+        assert is_openai_non_chat_model("omni-moderation-latest")
+        assert is_openai_non_chat_model("text-moderation-latest")
+        assert is_openai_non_chat_model("gpt-4o-moderation")
+
+    def test_image_audio_realtime_variants(self):
+        assert is_openai_non_chat_model("gpt-image-1")
+        assert is_openai_non_chat_model("gpt-audio-1")
+        assert is_openai_non_chat_model("gpt-realtime")
+
+    def test_chat_models_are_not_junk(self):
+        assert not is_openai_non_chat_model("gpt-5.4-mini")
+        assert not is_openai_non_chat_model("o4-mini")
+        assert not is_openai_non_chat_model("chatgpt-4o-latest")
+
+
+class TestOpenAILanguageClassification:
+    def test_gpt_and_chatgpt_families(self):
+        assert is_openai_language_model("gpt-5.4-mini")
+        assert is_openai_language_model("gpt-4o")
+        assert is_openai_language_model("gpt-4.1")
+        assert is_openai_language_model("chatgpt-4o-latest")
+
+    def test_reasoning_o_families_including_o4(self):
+        assert is_openai_language_model("o1")
+        assert is_openai_language_model("o1-mini")
+        assert is_openai_language_model("o3")
+        assert is_openai_language_model("o3-pro")
+        assert is_openai_language_model("o4-mini")
+        assert is_openai_language_model("o4-mini-high")
+
+    def test_excludes_embeddings_and_junk(self):
+        assert not is_openai_language_model("text-embedding-3-small")
+        assert not is_openai_language_model("whisper-1")
+        assert not is_openai_language_model("dall-e-3")
+        assert not is_openai_language_model("gpt-image-1")
+        assert not is_openai_language_model("omni-moderation-latest")
+
+    def test_excludes_unknown_non_chat_ids(self):
+        assert not is_openai_language_model("")
+        assert not is_openai_language_model("ft:gpt-4o:org:custom")
+        # ft: prefix is not gpt-/chatgpt-/oN — intentionally not classified as chat
+        # (fine-tunes may still work if named gpt-*; ft: ids stay excluded)
+
+
+class TestResolvePreferredModel:
+    def test_uses_preferred_when_present(self):
+        live = [
+            {"value": "gpt-4o", "default": False},
+            {"value": OPENAI_DEFAULT_LANGUAGE_MODEL, "default": False},
+        ]
+        assert (
+            resolve_preferred_model(OPENAI_DEFAULT_LANGUAGE_MODEL, live)
+            == OPENAI_DEFAULT_LANGUAGE_MODEL
+        )
+
+    def test_uses_live_default_when_preferred_missing(self):
+        live = [
+            {"value": "gpt-4o", "default": False},
+            {"value": "o4-mini", "default": True},
+        ]
+        assert resolve_preferred_model("gpt-missing", live) == "o4-mini"
+
+    def test_uses_first_when_preferred_and_default_missing(self):
+        live = [
+            {"value": "o4-mini", "default": False},
+            {"value": "gpt-4o", "default": False},
+        ]
+        assert resolve_preferred_model("gpt-missing", live) == "o4-mini"
+
+    def test_empty_live_list_returns_preferred(self):
+        assert (
+            resolve_preferred_model(OPENAI_DEFAULT_LANGUAGE_MODEL, [])
+            == OPENAI_DEFAULT_LANGUAGE_MODEL
+        )
+        assert resolve_preferred_model("", []) == ""
+
+    def test_embedding_preferred(self):
+        live = [
+            {"value": "text-embedding-3-large", "default": False},
+            {"value": OPENAI_DEFAULT_EMBEDDING_MODEL, "default": False},
+        ]
+        assert (
+            resolve_preferred_model(OPENAI_DEFAULT_EMBEDDING_MODEL, live)
+            == OPENAI_DEFAULT_EMBEDDING_MODEL
+        )

--- a/tests/unit/services/test_models_service_classification.py
+++ b/tests/unit/services/test_models_service_classification.py
@@ -38,6 +38,9 @@ class TestOpenAINonChatClassification:
         assert is_openai_non_chat_model("gpt-image-1")
         assert is_openai_non_chat_model("gpt-audio-1")
         assert is_openai_non_chat_model("gpt-realtime")
+        assert is_openai_non_chat_model("gpt-4o-realtime-preview")
+        assert is_openai_non_chat_model("gpt-4o-transcribe")
+        assert is_openai_non_chat_model("gpt-4o-mini-tts")
 
     def test_chat_models_are_not_junk(self):
         assert not is_openai_non_chat_model("gpt-5.4-mini")
@@ -66,12 +69,16 @@ class TestOpenAILanguageClassification:
         assert not is_openai_language_model("dall-e-3")
         assert not is_openai_language_model("gpt-image-1")
         assert not is_openai_language_model("omni-moderation-latest")
+        assert not is_openai_language_model("gpt-4o-realtime-preview")
+        assert not is_openai_language_model("gpt-4o-transcribe")
+        assert not is_openai_language_model("gpt-4o-mini-tts")
 
-    def test_excludes_unknown_non_chat_ids(self):
+    def test_excludes_empty_id(self):
         assert not is_openai_language_model("")
-        assert not is_openai_language_model("ft:gpt-4o:org:custom")
-        # ft: prefix is not gpt-/chatgpt-/oN — intentionally not classified as chat
-        # (fine-tunes may still work if named gpt-*; ft: ids stay excluded)
+
+    def test_fine_tuned_gpt_models(self):
+        assert is_openai_language_model("ft:gpt-4o:org:custom")
+        assert is_openai_language_model("ft:gpt-4.1-mini:acme:my-tune:abc123")
 
 
 class TestResolvePreferredModel:


### PR DESCRIPTION
issue: https://github.ibm.com/lakehouse/tracker/issues/71218

**Summary**

Prefer live provider model lists: classify OpenAI inventory into chat vs embedding vs junk (include o4-* and other oN* reasoning models; exclude whisper/dall-e/tts/moderation/etc.) instead of a curated chat-prefix allowlist.
Resolve preferred defaults from the live list when present; leave watsonx/Ollama static defaults empty so the UI picks from the live catalog (avoids stale IDs that 404).
Remove dead *_VALIDATION_MODELS; keep Anthropic pass-through, watsonx lifecycle filtering, and the Ollama tools gate for the agent.
Expand offline getFallbackModels to current + older still-functional models (not only the latest preferred default).

Test plan
Automated

uv run pytest tests/unit/services/test_models_service_classification.py \
  tests/unit/test_settings_provider_removal_defaults.py -q
Manual

With OpenAI configured: Settings → Agent LLM list includes both the current/updated chat models (e.g. the gpt-5.* family such as the default gpt-5.4-mini) and older functional chat models (e.g. gpt-4o, gpt-4.1), plus any chatgpt-*, ft:gpt-* fine-tunes, and o-series reasoning models (o1/o3/o4-*) that your account exposes; it does not list embeddings or non-chat products (whisper, dall-e, tts, image/audio/realtime/transcribe, moderation).
Select an older model (e.g. gpt-4o) and confirm chat works.
Anthropic / watsonx / Ollama pickers still load from their live APIs; the Ollama language list stays tools-only (models must report both completion and tools capabilities), and Ollama embeddings come from models reporting the embedding capability.
Remove OpenAI while Ollama (or watsonx) remains: the LLM/embedding provider falls back to the remaining provider and the model is left blank (no hardcoded/stale model ID is persisted); the UI then picks from the live list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved automatic model discovery across OpenAI and Anthropic.
  * Filters out unsupported model types and identifies language, embedding, and image-capable models.
  * Selects preferred models when available, with sensible live-catalog and offline fallback options.
  * Updated fallback catalogs with newer provider models, including tool-capable Ollama models.

* **Bug Fixes**
  * Prevents invalid or unavailable models from being selected.
  * Supports dynamic model selection for Watsonx and Ollama instead of relying on outdated defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->