### PR TITLE
fix: pin fastapi-pagination version

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -18,6 +18,7 @@ RUN pip install --no-cache-dir \
     torch==2.10.0 \
     torchvision==0.25.0 \
     "fastapi<0.140.5" \
+    "fastapi-pagination<0.15.16" \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
     "ibm-watsonx-ai>=1.3.1,<2.0.0" \
     "langchain-ibm~=1.1.0" \

--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -17,8 +17,8 @@ RUN pip install --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
     torch==2.10.0 \
     torchvision==0.25.0 \
-    "fastapi<0.140.5" \
-    "fastapi-pagination<0.15.16" \
+    fastapi-pagination>=0.15.16 \
+    fastapi>=0.140.5 \
     "langflow-base[docling,openai,anthropic,google,ollama,opensearch,langfuse]==0.9.6" \
     "ibm-watsonx-ai>=1.3.1,<2.0.0" \
     "langchain-ibm~=1.1.0" \


### PR DESCRIPTION
`fastapi-pagination` released a new version yesterday and is not compatible with `fastapi<0.140.5` so we have to pin `fastapi-pagination` as well

The error:

```
  Error: get_body_field() got an unexpected keyword argument 'body_params'
2026-07-29T16:03:20.407839Z [error    ] get_body_field() got an unexpected keyword argument 'body_params'
Traceback (most recent call last):
  File "/opt/app-root/lib64/python3.14/site-packages/langflow/__main__.py", line 988, in <module>
    main()
    ~~~~^^
  File "/opt/app-root/lib64/python3.14/site-packages/langflow/__main__.py", line 983, in main
    app()
    ~~~^^
  File "/opt/app-root/lib64/python3.14/site-packages/typer/main.py", line 1152, in __call__
    raise e
  File "/opt/app-root/lib64/python3.14/site-packages/typer/main.py", line 1135, in __call__
    return get_command(self)(*args, **kwargs)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 1569, in __call__
    return self.main(*args, **kwargs)
           ~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/typer/core.py", line 794, in main
    return _main(
        self,
    ...<6 lines>...
        **extra,
    )
  File "/opt/app-root/lib64/python3.14/site-packages/typer/core.py", line 188, in _main
    rv = self.invoke(ctx)
  File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 1970, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
                           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 1353, in invoke
    return ctx.invoke(self.callback, **ctx.params)
           ~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/click/core.py", line 907, in invoke
    return callback(*args, **kwargs)
  File "/opt/app-root/lib64/python3.14/site-packages/typer/main.py", line 1514, in wrapper
    return callback(**use_params)
  File "/opt/app-root/lib64/python3.14/site-packages/langflow/__main__.py", line 342, in run
    app = setup_app(static_files_dir=static_files_dir, backend_only=bool(backend_only))
  File "/opt/app-root/lib64/python3.14/site-packages/langflow/main.py", line 656, in setup_app
    app = create_app()
  File "/opt/app-root/lib64/python3.14/site-packages/langflow/main.py", line 590, in create_app
    add_pagination(app)
    ~~~~~~~~~~~~~~^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/fastapi_pagination/api.py", line 430, in add_pagination
    _add_pagination(parent)
    ~~~~~~~~~~~~~~~^^^^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/fastapi_pagination/api.py", line 420, in _add_pagination
    _update_route(route)
    ~~~~~~~~~~~~~^^^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/fastapi_pagination/api.py", line 395, in _update_route
    route.body_field = _bet_body_field(route)
                       ~~~~~~~~~~~~~~~^^^^^^^
  File "/opt/app-root/lib64/python3.14/site-packages/fastapi_pagination/api.py", line 352, in _bet_body_field
    return get_body_field(
        body_params=get_flat_body_params(route.dependant),
        name=route.unique_id,
        embed_body_fields=route._embed_body_fields,
    )
TypeError: get_body_field() got an unexpected keyword argument 'body_params'

The above exception was the direct cause of the following exception:

Traceback (most recent call last):
  File "<frozen runpy>", line 203, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/app-root/lib64/python3.14/site-packages/langflow/__main__.py", line 991, in <module>
    raise typer.Exit(1) from e
click.exceptions.Exit: 1
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime compatibility by updating the FastAPI version constraint and adding the required pagination dependency to the application environment.  
  * Pagination support now installs reliably, reducing the risk of startup or runtime issues related to mismatched package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->