### PR TITLE
refactor: Clear up VLM settings limitations

### DIFF
--- a/frontend/app/settings/_components/ingest-settings-section.tsx
+++ b/frontend/app/settings/_components/ingest-settings-section.tsx
@@ -38,10 +38,16 @@ import {
 } from "@/components/ui/select";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { useAuth } from "@/contexts/auth-context";
 import { useIsCloudBrand } from "@/contexts/brand-context";
 import { trackButton } from "@/lib/analytics";
-import { DEFAULT_KNOWLEDGE_SETTINGS } from "@/lib/constants";
+import { DEFAULT_KNOWLEDGE_SETTINGS, RUN_MODE } from "@/lib/constants";
 import { resolveLangflowEditUrl } from "@/lib/url-utils";
 import { cn } from "@/lib/utils";
 import { useUpdateSettingsMutation } from "../../api/mutations/useUpdateSettingsMutation";
@@ -60,6 +66,12 @@ const RESPONSE_FORMATS = [
 export function IngestSettingsSection() {
   const isCloudBrand = useIsCloudBrand();
   const { isAuthenticated, isNoAuthMode, isIbmAuthMode, runMode } = useAuth();
+
+  // In SaaS, the managed Docling-Serve runs without the custom-VLM flags, so
+  // picture descriptions can't work on the non-Langflow ingestion path. Treat
+  // the two as mutually exclusive: enabling one forces the other off. Only the
+  // currently-off toggle is disabled, so a legacy both-on config stays escapable.
+  const isSaas = runMode === RUN_MODE.SAAS;
 
   const [isRestoringFlow, setIsRestoringFlow] = useState<boolean>(false);
 
@@ -767,11 +779,32 @@ export function IngestSettingsSection() {
                   processing.
                 </div>
               </div>
-              <Switch
-                id="disable-ingest-with-langflow"
-                checked={disableIngestWithLangflow}
-                onCheckedChange={setDisableIngestWithLangflow}
-              />
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <Switch
+                        id="disable-ingest-with-langflow"
+                        checked={disableIngestWithLangflow}
+                        disabled={
+                          isSaas && pictureDescriptions && !disableIngestWithLangflow
+                        }
+                        onCheckedChange={(checked) => {
+                          setDisableIngestWithLangflow(checked);
+                          if (isSaas && checked) setPictureDescriptions(false);
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {isSaas &&
+                    pictureDescriptions &&
+                    !disableIngestWithLangflow && (
+                      <TooltipContent>
+                        <p>Unavailable while Picture Descriptions is on.</p>
+                      </TooltipContent>
+                    )}
+                </Tooltip>
+              </TooltipProvider>
             </div>
             <div className="flex items-center justify-between py-3 border-b border-border">
               <div className="flex-1">
@@ -817,11 +850,32 @@ export function IngestSettingsSection() {
                   Adds captions for images. Ingest is slower when enabled.
                 </div>
               </div>
-              <Switch
-                id="picture-descriptions"
-                checked={pictureDescriptions}
-                onCheckedChange={setPictureDescriptions}
-              />
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <Switch
+                        id="picture-descriptions"
+                        checked={pictureDescriptions}
+                        disabled={
+                          isSaas && disableIngestWithLangflow && !pictureDescriptions
+                        }
+                        onCheckedChange={(checked) => {
+                          setPictureDescriptions(checked);
+                          if (isSaas && checked) setDisableIngestWithLangflow(false);
+                        }}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {isSaas &&
+                    disableIngestWithLangflow &&
+                    !pictureDescriptions && (
+                      <TooltipContent>
+                        <p>Unavailable while Disable Langflow Ingestion is on.</p>
+                      </TooltipContent>
+                    )}
+                </Tooltip>
+              </TooltipProvider>
             </div>
             {showVlmSettings && (
               <>

--- a/frontend/app/settings/_components/ingest-settings-section.tsx
+++ b/frontend/app/settings/_components/ingest-settings-section.tsx
@@ -787,7 +787,9 @@ export function IngestSettingsSection() {
                         id="disable-ingest-with-langflow"
                         checked={disableIngestWithLangflow}
                         disabled={
-                          isSaas && pictureDescriptions && !disableIngestWithLangflow
+                          isSaas &&
+                          pictureDescriptions &&
+                          !disableIngestWithLangflow
                         }
                         onCheckedChange={(checked) => {
                           setDisableIngestWithLangflow(checked);
@@ -858,11 +860,14 @@ export function IngestSettingsSection() {
                         id="picture-descriptions"
                         checked={pictureDescriptions}
                         disabled={
-                          isSaas && disableIngestWithLangflow && !pictureDescriptions
+                          isSaas &&
+                          disableIngestWithLangflow &&
+                          !pictureDescriptions
                         }
                         onCheckedChange={(checked) => {
                           setPictureDescriptions(checked);
-                          if (isSaas && checked) setDisableIngestWithLangflow(false);
+                          if (isSaas && checked)
+                            setDisableIngestWithLangflow(false);
                         }}
                       />
                     </div>
@@ -871,7 +876,9 @@ export function IngestSettingsSection() {
                     disableIngestWithLangflow &&
                     !pictureDescriptions && (
                       <TooltipContent>
-                        <p>Unavailable while Disable Langflow Ingestion is on.</p>
+                        <p>
+                          Unavailable while Disable Langflow Ingestion is on.
+                        </p>
                       </TooltipContent>
                     )}
                 </Tooltip>

--- a/frontend/contexts/auth-context.tsx
+++ b/frontend/contexts/auth-context.tsx
@@ -9,6 +9,7 @@ import React, {
   useState,
 } from "react";
 import { hasRbacPermission } from "@/lib/brand";
+import { RUN_MODE, type RunMode } from "@/lib/constants";
 import { encodeBase64 } from "@/lib/utils";
 
 interface User {
@@ -28,7 +29,7 @@ interface AuthContextType {
   isAuthenticated: boolean;
   isNoAuthMode: boolean;
   isIbmAuthMode: boolean;
-  runMode: string | null;
+  runMode: RunMode | null;
   version: string | null;
   permissions: Set<string>;
   roles: string[];
@@ -78,7 +79,7 @@ export function AuthProvider({ children }: AuthProviderProps) {
   const [isNoAuthMode, setIsNoAuthMode] = useState(false);
   const [isIbmAuthMode, setIsIbmAuthMode] = useState(false);
   const [version, setVersion] = useState<string | null>(null);
-  const [runMode, setRunMode] = useState<string | null>(null);
+  const [runMode, setRunMode] = useState<RunMode | null>(null);
 
   const checkAuth = useCallback(async () => {
     setIsLoading(true);

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -1,4 +1,15 @@
 /**
+ * Run mode constants
+ */
+export const RUN_MODE = {
+  OSS: "oss",
+  SAAS: "saas",
+  ON_PREM: "on_prem",
+} as const;
+
+export type RunMode = (typeof RUN_MODE)[keyof typeof RUN_MODE];
+
+/**
  * Default agent settings
  */
 export const DEFAULT_AGENT_SETTINGS = {

--- a/frontend/lib/url-utils.ts
+++ b/frontend/lib/url-utils.ts
@@ -1,3 +1,5 @@
+import { RUN_MODE, type RunMode } from "@/lib/constants";
+
 export interface LangflowEditUrlParams {
   /** Flow ID to open directly (e.g. settings.ingest_flow_id). */
   flowId?: string | null;
@@ -9,8 +11,8 @@ export interface LangflowEditUrlParams {
   langflowPort?: number | string | null;
   /** Whether the deployment is in IBM auth mode. */
   isIbmAuthMode: boolean;
-  /** Backend run mode ("oss" | "saas" | "on_prem"), used to pick the IBM URL derivation. */
-  runMode: string | null;
+  /** Backend run mode, used to pick the IBM URL derivation. */
+  runMode: RunMode | null;
   /** Current origin; defaults to window.location.origin in the browser. */
   locationOrigin?: string;
 }
@@ -35,7 +37,7 @@ export function resolveLangflowEditUrl({
 }: LangflowEditUrlParams): string {
   const ibmLangflowUrl =
     isIbmAuthMode && locationOrigin
-      ? runMode === "on_prem"
+      ? runMode === RUN_MODE.ON_PREM
         ? deriveOnPremLangflowUrl(locationOrigin)
         : deriveCloudLangflowUrl(locationOrigin)
       : null;


### PR DESCRIPTION
in SaaS disabling langflow ingestion does not work w/ picture descriptions this change clarifies that relationship for the users

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer guidance for SaaS ingestion settings with tooltips.
  * Prevented incompatible ingestion options from being enabled simultaneously.
  * Enabling one mutually exclusive option now automatically turns off the other.

* **Bug Fixes**
  * Improved handling of ingestion preferences across supported deployment modes.
  * Ensured on-premises configuration links and behavior use the correct run mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->