### PR TITLE
fix: overflows setup apiKey in settings

### DIFF
--- a/frontend/app/settings/_components/anthropic-settings-dialog.tsx
+++ b/frontend/app/settings/_components/anthropic-settings-dialog.tsx
@@ -173,7 +173,7 @@ const AnthropicSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4 break-all">
+                  <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -185,7 +185,7 @@ const AnthropicSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4 break-all">
+                  <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                     {removeMutation.error?.message}
                   </p>
                 </motion.div>

--- a/frontend/app/settings/_components/anthropic-settings-dialog.tsx
+++ b/frontend/app/settings/_components/anthropic-settings-dialog.tsx
@@ -145,9 +145,12 @@ const AnthropicSettingsDialog = ({
         setOpen(o);
       }}
     >
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl overflow-hidden">
         <FormProvider {...methods}>
-          <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="grid min-w-0 gap-4"
+          >
             <DialogHeader className="mb-2">
               <DialogTitle className="flex items-center gap-3">
                 <div className="w-8 h-8 rounded flex items-center justify-center bg-white border">
@@ -170,7 +173,7 @@ const AnthropicSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4">
+                  <p className="rounded-lg border border-destructive p-4 break-all">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -182,7 +185,7 @@ const AnthropicSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4">
+                  <p className="rounded-lg border border-destructive p-4 break-all">
                     {removeMutation.error?.message}
                   </p>
                 </motion.div>

--- a/frontend/app/settings/_components/anthropic-settings-form.tsx
+++ b/frontend/app/settings/_components/anthropic-settings-form.tsx
@@ -41,7 +41,7 @@ export function AnthropicSettingsForm({
           />
         </LabelWrapper>
         {apiKeyError && (
-          <p className="text-sm text-destructive">{apiKeyError}</p>
+          <p className="text-sm text-destructive break-all">{apiKeyError}</p>
         )}
         {isLoadingModels && (
           <p className="text-sm text-muted-foreground">Validating API key...</p>

--- a/frontend/app/settings/_components/anthropic-settings-form.tsx
+++ b/frontend/app/settings/_components/anthropic-settings-form.tsx
@@ -21,8 +21,8 @@ export function AnthropicSettingsForm({
   const apiKeyError = modelsError?.message || errors.apiKey?.message;
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
+    <div className="min-w-0 space-y-4">
+      <div className="min-w-0 space-y-2">
         <LabelWrapper
           label="Anthropic API key"
           helperText="The API key for your Anthropic account"
@@ -41,7 +41,9 @@ export function AnthropicSettingsForm({
           />
         </LabelWrapper>
         {apiKeyError && (
-          <p className="text-sm text-destructive break-all">{apiKeyError}</p>
+          <p className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]">
+            {apiKeyError}
+          </p>
         )}
         {isLoadingModels && (
           <p className="text-sm text-muted-foreground">Validating API key...</p>

--- a/frontend/app/settings/_components/ollama-settings-dialog.tsx
+++ b/frontend/app/settings/_components/ollama-settings-dialog.tsx
@@ -180,7 +180,7 @@ const OllamaSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4 break-all">
+                  <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -193,7 +193,7 @@ const OllamaSettingsDialog = ({
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -10 }}
                   >
-                    <p className="rounded-lg border border-destructive p-4 break-all">
+                    <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                       {removeMutation.error?.message}
                     </p>
                   </motion.div>

--- a/frontend/app/settings/_components/ollama-settings-dialog.tsx
+++ b/frontend/app/settings/_components/ollama-settings-dialog.tsx
@@ -152,9 +152,12 @@ const OllamaSettingsDialog = ({
         setOpen(o);
       }}
     >
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl overflow-hidden">
         <FormProvider {...methods}>
-          <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="grid min-w-0 gap-4"
+          >
             <DialogHeader className="mb-2">
               <DialogTitle className="flex items-center gap-3">
                 <div className="w-8 h-8 rounded flex items-center justify-center bg-white border">
@@ -177,7 +180,7 @@ const OllamaSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4">
+                  <p className="rounded-lg border border-destructive p-4 break-all">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -190,7 +193,7 @@ const OllamaSettingsDialog = ({
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -10 }}
                   >
-                    <p className="rounded-lg border border-destructive p-4">
+                    <p className="rounded-lg border border-destructive p-4 break-all">
                       {removeMutation.error?.message}
                     </p>
                   </motion.div>

--- a/frontend/app/settings/_components/ollama-settings-form.tsx
+++ b/frontend/app/settings/_components/ollama-settings-form.tsx
@@ -40,7 +40,7 @@ export function OllamaSettingsForm({
           />
         </LabelWrapper>
         {endpointError && (
-          <p className="text-sm text-destructive">{endpointError}</p>
+          <p className="text-sm text-destructive break-all">{endpointError}</p>
         )}
         {isLoadingModels && (
           <p className="text-sm text-muted-foreground">

--- a/frontend/app/settings/_components/ollama-settings-form.tsx
+++ b/frontend/app/settings/_components/ollama-settings-form.tsx
@@ -21,8 +21,8 @@ export function OllamaSettingsForm({
   const endpointError = modelsError?.message || errors.endpoint?.message;
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
+    <div className="min-w-0 space-y-4">
+      <div className="min-w-0 space-y-2">
         <LabelWrapper
           label="Ollama Base URL"
           helperText="Base URL of your Ollama server"
@@ -40,7 +40,9 @@ export function OllamaSettingsForm({
           />
         </LabelWrapper>
         {endpointError && (
-          <p className="text-sm text-destructive break-all">{endpointError}</p>
+          <p className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]">
+            {endpointError}
+          </p>
         )}
         {isLoadingModels && (
           <p className="text-sm text-muted-foreground">

--- a/frontend/app/settings/_components/openai-settings-dialog.tsx
+++ b/frontend/app/settings/_components/openai-settings-dialog.tsx
@@ -159,9 +159,12 @@ const OpenAISettingsDialog = ({
         setOpen(o);
       }}
     >
-      <DialogContent className="max-w-2xl">
+      <DialogContent className="max-w-2xl overflow-hidden">
         <FormProvider {...methods}>
-          <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="grid min-w-0 gap-4"
+          >
             <DialogHeader className="mb-2">
               <DialogTitle className="flex items-center gap-3">
                 <div className="w-8 h-8 rounded flex items-center justify-center bg-white border">
@@ -184,7 +187,7 @@ const OpenAISettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4">
+                  <p className="rounded-lg border border-destructive p-4 break-all">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -197,7 +200,7 @@ const OpenAISettingsDialog = ({
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -10 }}
                   >
-                    <p className="rounded-lg border border-destructive p-4">
+                    <p className="rounded-lg border border-destructive p-4 break-all">
                       {removeMutation.error?.message}
                     </p>
                   </motion.div>

--- a/frontend/app/settings/_components/openai-settings-dialog.tsx
+++ b/frontend/app/settings/_components/openai-settings-dialog.tsx
@@ -187,7 +187,7 @@ const OpenAISettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4 break-all">
+                  <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -200,7 +200,7 @@ const OpenAISettingsDialog = ({
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -10 }}
                   >
-                    <p className="rounded-lg border border-destructive p-4 break-all">
+                    <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                       {removeMutation.error?.message}
                     </p>
                   </motion.div>

--- a/frontend/app/settings/_components/openai-settings-form.tsx
+++ b/frontend/app/settings/_components/openai-settings-form.tsx
@@ -41,7 +41,7 @@ export function OpenAISettingsForm({
           />
         </LabelWrapper>
         {apiKeyError && (
-          <p className="text-sm text-destructive">{apiKeyError}</p>
+          <p className="text-sm text-destructive break-all">{apiKeyError}</p>
         )}
         {isLoadingModels && (
           <p className="text-sm text-muted-foreground">Validating API key...</p>

--- a/frontend/app/settings/_components/openai-settings-form.tsx
+++ b/frontend/app/settings/_components/openai-settings-form.tsx
@@ -21,8 +21,8 @@ export function OpenAISettingsForm({
   const apiKeyError = modelsError?.message || errors.apiKey?.message;
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
+    <div className="min-w-0 space-y-4">
+      <div className="min-w-0 space-y-2">
         <LabelWrapper
           label="OpenAI API key"
           helperText="The API key for your OpenAI account"
@@ -41,7 +41,9 @@ export function OpenAISettingsForm({
           />
         </LabelWrapper>
         {apiKeyError && (
-          <p className="text-sm text-destructive break-all">{apiKeyError}</p>
+          <p className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]">
+            {apiKeyError}
+          </p>
         )}
         {isLoadingModels && (
           <p className="text-sm text-muted-foreground">Validating API key...</p>

--- a/frontend/app/settings/_components/watsonx-settings-dialog.tsx
+++ b/frontend/app/settings/_components/watsonx-settings-dialog.tsx
@@ -196,7 +196,7 @@ const WatsonxSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4 break-all">
+                  <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -209,7 +209,7 @@ const WatsonxSettingsDialog = ({
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -10 }}
                   >
-                    <p className="rounded-lg border border-destructive p-4 break-all">
+                    <p className="rounded-lg border border-destructive p-4 min-w-0 [overflow-wrap:anywhere]">
                       {removeMutation.error?.message}
                     </p>
                   </motion.div>

--- a/frontend/app/settings/_components/watsonx-settings-dialog.tsx
+++ b/frontend/app/settings/_components/watsonx-settings-dialog.tsx
@@ -168,9 +168,12 @@ const WatsonxSettingsDialog = ({
         setOpen(o);
       }}
     >
-      <DialogContent autoFocus={false} className="max-w-2xl">
+      <DialogContent autoFocus={false} className="max-w-2xl overflow-hidden">
         <FormProvider {...methods}>
-          <form onSubmit={handleSubmit(onSubmit)} className="grid gap-4">
+          <form
+            onSubmit={handleSubmit(onSubmit)}
+            className="grid min-w-0 gap-4"
+          >
             <DialogHeader className="mb-2">
               <DialogTitle className="flex items-center gap-3">
                 <div className="w-8 h-8 rounded flex items-center justify-center bg-white border">
@@ -193,7 +196,7 @@ const WatsonxSettingsDialog = ({
                   animate={{ opacity: 1, y: 0 }}
                   exit={{ opacity: 0, y: -10 }}
                 >
-                  <p className="rounded-lg border border-destructive p-4">
+                  <p className="rounded-lg border border-destructive p-4 break-all">
                     {settingsMutation.error?.message}
                   </p>
                 </motion.div>
@@ -206,7 +209,7 @@ const WatsonxSettingsDialog = ({
                     animate={{ opacity: 1, y: 0 }}
                     exit={{ opacity: 0, y: -10 }}
                   >
-                    <p className="rounded-lg border border-destructive p-4">
+                    <p className="rounded-lg border border-destructive p-4 break-all">
                       {removeMutation.error?.message}
                     </p>
                   </motion.div>

--- a/frontend/app/settings/_components/watsonx-settings-form.tsx
+++ b/frontend/app/settings/_components/watsonx-settings-form.tsx
@@ -80,7 +80,9 @@ export function WatsonxSettingsForm({
           />
         </LabelWrapper>
         {errors.endpoint && (
-          <p className="text-sm text-destructive">{errors.endpoint.message}</p>
+          <p className="text-sm text-destructive break-all">
+            {errors.endpoint.message}
+          </p>
         )}
       </div>
       <div className="space-y-2">
@@ -103,7 +105,9 @@ export function WatsonxSettingsForm({
           />
         </LabelWrapper>
         {errors.projectId && (
-          <p className="text-sm text-destructive">{errors.projectId.message}</p>
+          <p className="text-sm text-destructive break-all">
+            {errors.projectId.message}
+          </p>
         )}
       </div>
       <div className="space-y-2">
@@ -127,7 +131,9 @@ export function WatsonxSettingsForm({
           />
         </LabelWrapper>
         {errors.apiKey && (
-          <p className="text-sm text-destructive">{errors.apiKey.message}</p>
+          <p className="text-sm text-destructive break-all">
+            {errors.apiKey.message}
+          </p>
         )}
         {isLoadingModels && (
           <p className="text-sm text-muted-foreground">
@@ -135,7 +141,9 @@ export function WatsonxSettingsForm({
           </p>
         )}
         {modelsError && (
-          <p className="text-sm text-destructive">{modelsError.message}</p>
+          <p className="text-sm text-destructive break-all">
+            {modelsError.message}
+          </p>
         )}
       </div>
       <p className="text-sm text-muted-foreground">

--- a/frontend/app/settings/_components/watsonx-settings-form.tsx
+++ b/frontend/app/settings/_components/watsonx-settings-form.tsx
@@ -50,8 +50,8 @@ export function WatsonxSettingsForm({
   } = useFormContext<WatsonxSettingsFormData>();
 
   return (
-    <div className="space-y-4">
-      <div className="space-y-2">
+    <div className="min-w-0 space-y-4">
+      <div className="min-w-0 space-y-2">
         <LabelWrapper
           label="watsonx.ai API Endpoint"
           helperText="Base URL of the API"
@@ -80,7 +80,7 @@ export function WatsonxSettingsForm({
           />
         </LabelWrapper>
         {errors.endpoint && (
-          <p className="text-sm text-destructive break-all">
+          <p className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]">
             {errors.endpoint.message}
           </p>
         )}
@@ -105,7 +105,7 @@ export function WatsonxSettingsForm({
           />
         </LabelWrapper>
         {errors.projectId && (
-          <p className="text-sm text-destructive break-all">
+          <p className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]">
             {errors.projectId.message}
           </p>
         )}
@@ -131,7 +131,7 @@ export function WatsonxSettingsForm({
           />
         </LabelWrapper>
         {errors.apiKey && (
-          <p className="text-sm text-destructive break-all">
+          <p className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]">
             {errors.apiKey.message}
           </p>
         )}
@@ -141,7 +141,7 @@ export function WatsonxSettingsForm({
           </p>
         )}
         {modelsError && (
-          <p className="text-sm text-destructive break-all">
+          <p className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]">
             {modelsError.message}
           </p>
         )}


### PR DESCRIPTION
issue: [](https://github.ibm.com/lakehouse/tracker/issues/78890)
**Summary**
- Prevent long provider validation/error messages (e.g. OpenAI echoing a masked invalid key as an unbroken string) from expanding the Setup dialog past "max-w-2xl.
- Add "break-all" on validation and mutation error text in OpenAI, Anthropic, watsonx, and Ollama settings forms/dialogs.
- Clamp dialog layout with "overflow-hidden" on "DialogContent" and "min-w-0" on the form grid so the input and Cancel/Save footer stay inside the modal.

**Before**
<img width="897" height="435" alt="Screenshot 2026-07-30 at 8 22 01 AM" src="https://github.com/user-attachments/assets/efadf155-b06f-4a26-9e04-01806426d2ce" />

**After**
<img width="706" height="381" alt="Screenshot 2026-07-30 at 8 18 59 AM" src="https://github.com/user-attachments/assets/c59ea903-0b3e-410e-af82-f317a649baf5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved settings dialogs for Anthropic, Ollama, OpenAI, and Watsonx to prevent long error messages from overflowing in narrow dialog windows.
  * Updated error text wrapping for API key, endpoint, project/model, and configuration/removal failures to wrap reliably instead of using prior overflow-prone styling.
  * Refined dialog/form layout constraints so content fits cleanly (including better sizing inside the dialog grid).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->