### PR TITLE
fix: Fetch latest documentation and apply style fixes

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -968,7 +968,8 @@ function SearchPage() {
                   });
                   try {
                     toast.info("Refreshing OpenRAG docs...");
-                    const result = await refreshOpenragDocsMutation.mutateAsync();
+                    const result =
+                      await refreshOpenragDocsMutation.mutateAsync();
                     toast.success(result.message);
                   } catch (error) {
                     toast.error(

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -34,6 +34,7 @@ import { KnowledgeActionsDropdown } from "@/components/knowledge-actions-dropdow
 import { KnowledgeBatchActionsBar } from "@/components/knowledge-batch-actions-bar";
 import { KnowledgeSearchBar } from "@/components/knowledge-search-bar";
 import { KnowledgeSearchInput } from "@/components/knowledge-search-input";
+import { RequirePermission } from "@/components/require-permission";
 import { StatusBadge } from "@/components/ui/status-badge";
 import {
   Tooltip,
@@ -953,36 +954,38 @@ function SearchPage() {
                 </>
               )}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="rounded-lg flex-shrink-0"
-              disabled={refreshOpenragDocsMutation.isPending}
-              onClick={async () => {
-                trackButton({
-                  CTA: "Fetch Latest Docs",
-                  elementId: "fetch-latest-docs-button",
-                  namespace: "knowledge",
-                });
-                try {
-                  toast.info("Refreshing OpenRAG docs...");
-                  const result = await refreshOpenragDocsMutation.mutateAsync();
-                  toast.success(result.message);
-                } catch (error) {
-                  toast.error(
-                    error instanceof Error
-                      ? error.message
-                      : "Failed to refresh OpenRAG docs",
-                  );
-                }
-              }}
-            >
-              {refreshOpenragDocsMutation.isPending ? (
-                <>Refreshing docs...</>
-              ) : (
-                <>Fetch latest docs</>
-              )}
-            </Button>
+            <RequirePermission perm="config:write">
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-lg flex-shrink-0"
+                disabled={refreshOpenragDocsMutation.isPending}
+                onClick={async () => {
+                  trackButton({
+                    CTA: "Fetch Latest Docs",
+                    elementId: "fetch-latest-docs-button",
+                    namespace: "knowledge",
+                  });
+                  try {
+                    toast.info("Refreshing OpenRAG docs...");
+                    const result = await refreshOpenragDocsMutation.mutateAsync();
+                    toast.success(result.message);
+                  } catch (error) {
+                    toast.error(
+                      error instanceof Error
+                        ? error.message
+                        : "Failed to refresh OpenRAG docs",
+                    );
+                  }
+                }}
+              >
+                {refreshOpenragDocsMutation.isPending ? (
+                  <>Refreshing docs...</>
+                ) : (
+                  <>Fetch latest docs</>
+                )}
+              </Button>
+            </RequirePermission>
             {selectedRows.length > 0 && (
               <Button
                 type="button"

--- a/frontend/components/knowledge-search-bar.tsx
+++ b/frontend/components/knowledge-search-bar.tsx
@@ -7,6 +7,7 @@ import {
   useSyncAllConnectors,
   useSyncAllConnectorsPreview,
 } from "@/app/api/mutations/useSyncConnector";
+import { RequirePermission } from "@/components/require-permission";
 import { Button } from "@/components/ui/button";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { cn } from "@/lib/utils";
@@ -166,29 +167,31 @@ export const KnowledgeSearchBar = () => {
         >
           <RefreshCw className="h-4 w-4 m-4 text-[var(--icon-primary)]" />
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={refreshOpenragDocsMutation.isPending}
-          className="h-auto flex-shrink-0 rounded-none px-3 text-sm hover:bg-accent hover:text-foreground"
-          onClick={async () => {
-            try {
-              toast.info("Refreshing OpenRAG docs...");
-              const result = await refreshOpenragDocsMutation.mutateAsync();
-              toast.success(result.message);
-            } catch (error) {
-              toast.error(
-                error instanceof Error
-                  ? error.message
-                  : "Failed to refresh OpenRAG docs",
-              );
-            }
-          }}
-        >
-          {refreshOpenragDocsMutation.isPending
-            ? "Refreshing docs..."
-            : "Fetch latest docs"}
-        </Button>
+        <RequirePermission perm="config:write">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={refreshOpenragDocsMutation.isPending}
+            className="h-auto flex-shrink-0 rounded-none px-3 text-sm hover:bg-accent hover:text-foreground"
+            onClick={async () => {
+              try {
+                toast.info("Refreshing OpenRAG docs...");
+                const result = await refreshOpenragDocsMutation.mutateAsync();
+                toast.success(result.message);
+              } catch (error) {
+                toast.error(
+                  error instanceof Error
+                    ? error.message
+                    : "Failed to refresh OpenRAG docs",
+                );
+              }
+            }}
+          >
+            {refreshOpenragDocsMutation.isPending
+              ? "Refreshing docs..."
+              : "Fetch latest docs"}
+          </Button>
+        </RequirePermission>
         <div className="ml-auto">
           <KnowledgeDropdown />
         </div>


### PR DESCRIPTION
This pull request introduces permission-based access control for actions related to refreshing documentation in the knowledge management UI. By wrapping the "Fetch latest docs" buttons with the `RequirePermission` component and specifying the `config:write` permission, only authorized users can trigger these actions. Minor formatting improvements were also made for consistency.

**Permission Enforcement for Refresh Actions:**

* Wrapped the "Fetch latest docs" button in `frontend/app/knowledge/page.tsx` with the `RequirePermission` component, restricting access to users with `config:write` permission. [[1]](diffhunk://#diff-60146564fb7979730b4a32d5e921417e85149f7cd99bccceddbfe042345b505fR37) [[2]](diffhunk://#diff-60146564fb7979730b4a32d5e921417e85149f7cd99bccceddbfe042345b505fR957) [[3]](diffhunk://#diff-60146564fb7979730b4a32d5e921417e85149f7cd99bccceddbfe042345b505fR989)
* Applied the same permission check to the corresponding button in `frontend/components/knowledge-search-bar.tsx`. [[1]](diffhunk://#diff-229892fad705143238b083dbf547db55ae8a9983a0d1ae91c1d95918d8e50244R10) [[2]](diffhunk://#diff-229892fad705143238b083dbf547db55ae8a9983a0d1ae91c1d95918d8e50244R170) [[3]](diffhunk://#diff-229892fad705143238b083dbf547db55ae8a9983a0d1ae91c1d95918d8e50244R194)

**Code Formatting:**

* Improved formatting for the async mutation call in the refresh handler for better readability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted the “Fetch latest docs” and “Refreshing docs…” actions to users with the required configuration permission.
  * Users without permission can no longer view or use the documentation refresh controls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->