### PR TITLE
fix: gate fetch latest docs by permission

### DIFF
--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -973,7 +973,8 @@ function SearchPage() {
                   });
                   try {
                     toast.info("Refreshing OpenRAG docs...");
-                    const result = await refreshOpenragDocsMutation.mutateAsync();
+                    const result =
+                      await refreshOpenragDocsMutation.mutateAsync();
                     toast.success(result.message);
                   } catch (error) {
                     toast.error(

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -34,6 +34,7 @@ import { KnowledgeActionsDropdown } from "@/components/knowledge-actions-dropdow
 import { KnowledgeBatchActionsBar } from "@/components/knowledge-batch-actions-bar";
 import { KnowledgeSearchBar } from "@/components/knowledge-search-bar";
 import { KnowledgeSearchInput } from "@/components/knowledge-search-input";
+import { RequirePermission } from "@/components/require-permission";
 import { StatusBadge } from "@/components/ui/status-badge";
 import {
   Tooltip,
@@ -958,36 +959,38 @@ function SearchPage() {
                 </>
               )}
             </Button>
-            <Button
-              type="button"
-              variant="outline"
-              className="rounded-lg flex-shrink-0"
-              disabled={refreshOpenragDocsMutation.isPending}
-              onClick={async () => {
-                trackButton({
-                  CTA: "Fetch Latest Docs",
-                  elementId: "fetch-latest-docs-button",
-                  namespace: "knowledge",
-                });
-                try {
-                  toast.info("Refreshing OpenRAG docs...");
-                  const result = await refreshOpenragDocsMutation.mutateAsync();
-                  toast.success(result.message);
-                } catch (error) {
-                  toast.error(
-                    error instanceof Error
-                      ? error.message
-                      : "Failed to refresh OpenRAG docs",
-                  );
-                }
-              }}
-            >
-              {refreshOpenragDocsMutation.isPending ? (
-                <>Refreshing docs...</>
-              ) : (
-                <>Fetch latest docs</>
-              )}
-            </Button>
+            <RequirePermission perm="config:write">
+              <Button
+                type="button"
+                variant="outline"
+                className="rounded-lg flex-shrink-0"
+                disabled={refreshOpenragDocsMutation.isPending}
+                onClick={async () => {
+                  trackButton({
+                    CTA: "Fetch Latest Docs",
+                    elementId: "fetch-latest-docs-button",
+                    namespace: "knowledge",
+                  });
+                  try {
+                    toast.info("Refreshing OpenRAG docs...");
+                    const result = await refreshOpenragDocsMutation.mutateAsync();
+                    toast.success(result.message);
+                  } catch (error) {
+                    toast.error(
+                      error instanceof Error
+                        ? error.message
+                        : "Failed to refresh OpenRAG docs",
+                    );
+                  }
+                }}
+              >
+                {refreshOpenragDocsMutation.isPending ? (
+                  <>Refreshing docs...</>
+                ) : (
+                  <>Fetch latest docs</>
+                )}
+              </Button>
+            </RequirePermission>
             {selectedRows.length > 0 && (
               <Button
                 type="button"

--- a/frontend/components/knowledge-search-bar.tsx
+++ b/frontend/components/knowledge-search-bar.tsx
@@ -7,6 +7,7 @@ import {
   useSyncAllConnectors,
   useSyncAllConnectorsPreview,
 } from "@/app/api/mutations/useSyncConnector";
+import { RequirePermission } from "@/components/require-permission";
 import { Button } from "@/components/ui/button";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { cn } from "@/lib/utils";
@@ -166,29 +167,31 @@ export const KnowledgeSearchBar = () => {
         >
           <RefreshCw className="h-4 w-4 m-4 text-[var(--icon-primary)]" />
         </Button>
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={refreshOpenragDocsMutation.isPending}
-          className="h-auto flex-shrink-0 rounded-none px-3 text-sm hover:bg-accent hover:text-foreground"
-          onClick={async () => {
-            try {
-              toast.info("Refreshing OpenRAG docs...");
-              const result = await refreshOpenragDocsMutation.mutateAsync();
-              toast.success(result.message);
-            } catch (error) {
-              toast.error(
-                error instanceof Error
-                  ? error.message
-                  : "Failed to refresh OpenRAG docs",
-              );
-            }
-          }}
-        >
-          {refreshOpenragDocsMutation.isPending
-            ? "Refreshing docs..."
-            : "Fetch latest docs"}
-        </Button>
+        <RequirePermission perm="config:write">
+          <Button
+            type="button"
+            variant="ghost"
+            disabled={refreshOpenragDocsMutation.isPending}
+            className="h-auto flex-shrink-0 rounded-none px-3 text-sm hover:bg-accent hover:text-foreground"
+            onClick={async () => {
+              try {
+                toast.info("Refreshing OpenRAG docs...");
+                const result = await refreshOpenragDocsMutation.mutateAsync();
+                toast.success(result.message);
+              } catch (error) {
+                toast.error(
+                  error instanceof Error
+                    ? error.message
+                    : "Failed to refresh OpenRAG docs",
+                );
+              }
+            }}
+          >
+            {refreshOpenragDocsMutation.isPending
+              ? "Refreshing docs..."
+              : "Fetch latest docs"}
+          </Button>
+        </RequirePermission>
         <div className="ml-auto">
           <KnowledgeDropdown />
         </div>


### PR DESCRIPTION
## Summary
- backport the UI permission gating from #2184 to `main`
- hide **Fetch latest docs** unless the user has `config:write`
- apply the gate to both standard and cloud knowledge-page layouts
- exclude release-only Docker changes

## Test plan
- [x] Confirm the diff against `main` contains only the two knowledge UI files
- [x] Run editor lint diagnostics on both modified files
- [ ] Verify an admin can see and use **Fetch latest docs**
- [ ] Verify developer, user, and viewer roles cannot see the action
- [ ] Verify RBAC-disabled/no-auth behavior remains unchanged



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Access Control**
  * Restricted the “Fetch latest docs” action to users with the required configuration permission.
  * Users without permission no longer see or can trigger the document refresh action.
  * Kept the existing refresh behavior, notifications, and loading states unchanged for authorized users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->