### PR TITLE
feat: delete failed ingestion documents

### DIFF
--- a/frontend/app/api/mutations/useDismissTaskFilesMutation.ts
+++ b/frontend/app/api/mutations/useDismissTaskFilesMutation.ts
@@ -1,0 +1,81 @@
+import {
+  type UseMutationOptions,
+  useMutation,
+  useQueryClient,
+} from "@tanstack/react-query";
+import { taskDetailQueryKey } from "@/app/api/queries/useGetTaskQuery";
+import { TASKS_QUERY_KEY } from "@/app/api/queries/useGetTasksQuery";
+
+export interface DismissTaskFilesRequest {
+  taskId: string;
+  /** Task file paths of terminal failed files to remove from the task. */
+  filePaths: string[];
+}
+
+export interface DismissTaskFilesSkippedFile {
+  file_path: string;
+  filename?: string;
+  reason: "file_not_in_task" | "not_failed" | string;
+}
+
+export interface DismissTaskFilesResponse {
+  task_id: string;
+  dismissed: number;
+  skipped: DismissTaskFilesSkippedFile[];
+  status: string;
+  message?: string;
+  error?: string;
+}
+
+async function dismissTaskFiles(
+  variables: DismissTaskFilesRequest,
+): Promise<DismissTaskFilesResponse> {
+  const response = await fetch(`/api/tasks/${variables.taskId}/files/dismiss`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ file_paths: variables.filePaths }),
+  });
+
+  const payload = (await response
+    .json()
+    .catch(() => ({}))) as DismissTaskFilesResponse;
+
+  if (!response.ok) {
+    throw new Error(
+      payload.message || payload.error || "Failed to dismiss task files",
+    );
+  }
+
+  return payload;
+}
+
+export const useDismissTaskFilesMutation = (
+  options?: Omit<
+    UseMutationOptions<
+      DismissTaskFilesResponse,
+      Error,
+      DismissTaskFilesRequest
+    >,
+    "mutationFn"
+  >,
+) => {
+  const queryClient = useQueryClient();
+
+  const { onSuccess, onError, onSettled, ...restOptions } = options ?? {};
+
+  return useMutation({
+    mutationFn: dismissTaskFiles,
+    ...restOptions,
+    onSuccess: (data, variables, onMutateResult, context) => {
+      queryClient.invalidateQueries({ queryKey: [...TASKS_QUERY_KEY] });
+      queryClient.invalidateQueries({
+        queryKey: taskDetailQueryKey(variables.taskId),
+      });
+      queryClient.invalidateQueries({ queryKey: ["listFiles"] });
+      queryClient.invalidateQueries({ queryKey: ["search"] });
+      onSuccess?.(data, variables, onMutateResult, context);
+    },
+    onError,
+    onSettled,
+  });
+};

--- a/frontend/app/knowledge/page.tsx
+++ b/frontend/app/knowledge/page.tsx
@@ -32,6 +32,7 @@ import "@/components/AgGrid/agGridStyles.css";
 import { toast } from "sonner";
 import { KnowledgeActionsDropdown } from "@/components/knowledge-actions-dropdown";
 import { KnowledgeBatchActionsBar } from "@/components/knowledge-batch-actions-bar";
+import { KnowledgeRowActions } from "@/components/knowledge-row-actions";
 import { KnowledgeSearchBar } from "@/components/knowledge-search-bar";
 import { KnowledgeSearchInput } from "@/components/knowledge-search-input";
 import { StatusBadge } from "@/components/ui/status-badge";
@@ -752,13 +753,20 @@ function SearchPage() {
       suppressMovable: true,
       cellRenderer: ({ data }: CustomCellRendererProps<File>) => {
         const status = data?.status || "active";
-        if (status !== "active") return null;
-        return (
-          <KnowledgeActionsDropdown
-            filename={data?.filename || ""}
-            connectorType={data?.connector_type}
-          />
-        );
+        if (status === "active") {
+          return (
+            <KnowledgeActionsDropdown
+              filename={data?.filename || ""}
+              connectorType={data?.connector_type}
+            />
+          );
+        }
+        if (data && status === "failed") {
+          return (
+            <KnowledgeRowActions file={data} taskId={getTaskIdForRow(data)} />
+          );
+        }
+        return null;
       },
       cellStyle: {
         display: "flex",

--- a/frontend/components/knowledge-row-actions.tsx
+++ b/frontend/components/knowledge-row-actions.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Trash2 } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
+import { useDeleteDocument } from "@/app/api/mutations/useDeleteDocument";
+import { useDismissTaskFilesMutation } from "@/app/api/mutations/useDismissTaskFilesMutation";
+import type { File } from "@/app/api/queries/useGetSearchQuery";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { useTask } from "@/contexts/task-context";
+import { trackButton } from "@/lib/analytics";
+import { cn } from "@/lib/utils";
+import { RequirePermission } from "./require-permission";
+import { Button } from "./ui/button";
+
+interface KnowledgeRowActionsProps {
+  file: File;
+  /** Task that owns this failed row, resolved by the caller. */
+  taskId: string | null;
+}
+
+/**
+ * Delete action for failed knowledge rows: clears any indexed chunks and dismisses
+ * the failed task entry so the row leaves the list. Active rows use
+ * KnowledgeActionsDropdown; other statuses have no row action.
+ */
+export const KnowledgeRowActions = ({
+  file,
+  taskId,
+}: KnowledgeRowActionsProps) => {
+  const { refreshTasks } = useTask();
+  const dismissMutation = useDismissTaskFilesMutation();
+  const deleteDocumentMutation = useDeleteDocument();
+  const [isRemoving, setIsRemoving] = useState(false);
+
+  if ((file.status ?? "active") !== "failed") {
+    return null;
+  }
+
+  const sourceUrl = file.source_url?.trim();
+
+  const handleDelete = async () => {
+    trackButton({
+      CTA: "Delete Failed Document",
+      elementId: "knowledge-delete-failed-button",
+      namespace: "knowledge",
+    });
+    setIsRemoving(true);
+    try {
+      // A partially-indexed failure may have chunks; a never-indexed one 404s.
+      // Best-effort cleanup so the row does not reappear as "active".
+      try {
+        await deleteDocumentMutation.mutateAsync({ filename: file.filename });
+      } catch {
+        // Expected when the failed document never produced any chunks.
+      }
+      if (taskId && sourceUrl) {
+        await dismissMutation.mutateAsync({ taskId, filePaths: [sourceUrl] });
+      }
+      await refreshTasks();
+      toast.success("Removed from list");
+    } catch (error) {
+      toast.error("Failed to remove document", {
+        description: error instanceof Error ? error.message : undefined,
+      });
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return (
+    <RequirePermission
+      anyOf={["knowledge:delete:own", "knowledge:delete:anonymous"]}
+    >
+      <TooltipProvider>
+        <Tooltip delayDuration={0}>
+          <TooltipTrigger asChild>
+            <Button
+              variant="ghost"
+              className={cn(
+                "h-8 w-8 p-0 hover:bg-muted hover:text-destructive",
+              )}
+              aria-label="Delete from list"
+              data-testid="knowledge-row-delete"
+              disabled={isRemoving}
+              onClick={handleDelete}
+            >
+              <Trash2 className="h-4 w-4 text-muted-foreground" />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent side="left">Delete from list</TooltipContent>
+        </Tooltip>
+      </TooltipProvider>
+    </RequirePermission>
+  );
+};

--- a/frontend/contexts/task-context.tsx
+++ b/frontend/contexts/task-context.tsx
@@ -279,10 +279,14 @@ export function TaskProvider({ children }: { children: React.ReactNode }) {
       // 1. Task is in progress (always process to keep files list updated)
       // 2. Status has changed
       // 3. New task appeared (not on initial load)
+      // 4. Task is terminal but still has failed files — rebuild the overlay even
+      //    on initial load so failed rows (and their retry/delete actions) survive
+      //    a page refresh instead of silently disappearing.
       const shouldProcessFiles =
         isTaskInProgress ||
         (previousTask && previousTask.status !== currentTask.status) ||
-        (!previousTask && !isInitialLoad);
+        (!previousTask && !isInitialLoad) ||
+        hasFailedFileEntries(currentTask);
 
       // Only show toasts if we have previous data and status has changed
       const shouldShowToast =

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -100,9 +100,7 @@ async def dismiss_files(
     user: User = Depends(get_current_user),
 ):
     """Remove terminal FAILED file entries from a task so they leave the list."""
-    result = await task_service.dismiss_files(
-        user.user_id, task_id, file_paths=body.file_paths
-    )
+    result = await task_service.dismiss_files(user.user_id, task_id, file_paths=body.file_paths)
     if result is None:
         return JSONResponse({"error": "Task not found"}, status_code=404)
 

--- a/src/api/tasks.py
+++ b/src/api/tasks.py
@@ -86,6 +86,32 @@ async def retry_task(
     return JSONResponse(result, status_code=202)
 
 
+class DismissFilesBody(BaseModel):
+    file_paths: list[str] = Field(
+        ...,
+        description="Task file paths of terminal FAILED files to remove from the task.",
+    )
+
+
+async def dismiss_files(
+    task_id: str,
+    body: DismissFilesBody,
+    task_service=Depends(get_task_service),
+    user: User = Depends(get_current_user),
+):
+    """Remove terminal FAILED file entries from a task so they leave the list."""
+    result = await task_service.dismiss_files(
+        user.user_id, task_id, file_paths=body.file_paths
+    )
+    if result is None:
+        return JSONResponse({"error": "Task not found"}, status_code=404)
+
+    if result.get("status") == "no_op":
+        return JSONResponse(result, status_code=400)
+
+    return JSONResponse(result, status_code=200)
+
+
 async def cancel_task(
     task_id: str,
     task_service=Depends(get_task_service),

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -117,6 +117,12 @@ def register_internal_routes(app: FastAPI):
         methods=["POST"],
         tags=["internal"],
     )
+    app.add_api_route(
+        "/tasks/{task_id}/files/dismiss",
+        tasks.dismiss_files,
+        methods=["POST"],
+        tags=["internal"],
+    )
 
     # Search endpoint
     app.add_api_route("/search", search.search, methods=["POST"], tags=["internal"])

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -929,6 +929,77 @@ class TaskService:
             "status": "accepted",
         }
 
+    async def dismiss_files(
+        self,
+        user_id: str,
+        task_id: str,
+        *,
+        file_paths: list[str],
+    ) -> dict | None:
+        """Remove terminal FAILED file entries from a task so they leave the UI.
+
+        Only files in a FAILED state can be dismissed; a still-running file must be
+        cancelled first. Paths missing from the task or not in a failed state are
+        reported in *skipped*. When the last file is removed, the whole task record
+        is dropped from the store. This mutates only the in-memory task store — it
+        does not delete indexed OpenSearch chunks (the caller handles that).
+        """
+        resolved = self._resolve_upload_task_store(user_id, task_id)
+        if resolved is None:
+            return None
+
+        store_user_id, upload_task = resolved
+
+        dismissed: list[str] = []
+        skipped: list[dict] = []
+
+        async with self._get_task_lock(task_id):
+            for path in file_paths:
+                file_task = upload_task.file_tasks.get(path)
+                if file_task is None:
+                    skipped.append({"file_path": path, "reason": "file_not_in_task"})
+                    continue
+                if file_task.status != TaskStatus.FAILED:
+                    skipped.append(
+                        {
+                            "file_path": path,
+                            "filename": file_task.filename,
+                            "reason": "not_failed",
+                        }
+                    )
+                    continue
+
+                del upload_task.file_tasks[path]
+                upload_task.total_files = max(0, upload_task.total_files - 1)
+                if upload_task.failed_files > 0:
+                    upload_task.failed_files -= 1
+                if upload_task.processed_files > 0:
+                    upload_task.processed_files -= 1
+                dismissed.append(path)
+
+            if dismissed:
+                upload_task.updated_at = time.time()
+
+            # Drop the task entirely once nothing is left to show.
+            if not upload_task.file_tasks:
+                self.task_store.get(store_user_id, {}).pop(task_id, None)
+
+        if not dismissed:
+            return {
+                "task_id": task_id,
+                "dismissed": 0,
+                "skipped": skipped,
+                "status": "no_op",
+                "message": "No dismissible failed files",
+            }
+
+        return {
+            "task_id": task_id,
+            "dismissed": len(dismissed),
+            "skipped": skipped,
+            "status": "accepted",
+        }
+
     def _serialize_file_task(self, file_task: FileTask) -> dict:
         """Serialize a FileTask to the standard dict shape."""
         return {

--- a/tests/unit/test_task_service_dismiss_files.py
+++ b/tests/unit/test_task_service_dismiss_files.py
@@ -1,0 +1,100 @@
+"""Unit tests for TaskService.dismiss_files."""
+
+from unittest.mock import Mock
+
+import pytest
+
+from models.tasks import FileTask, TaskStatus, UploadTask
+from services.task_service import TaskService
+
+
+@pytest.fixture
+def task_service():
+    return TaskService(document_service=Mock(), ingestion_timeout=2)
+
+
+def _failed_file(file_path: str, filename: str) -> FileTask:
+    ft = FileTask(file_path=file_path, filename=filename)
+    ft.status = TaskStatus.FAILED
+    ft.error = "boom"
+    return ft
+
+
+def _store_task(task_service: TaskService, user_id: str, upload_task: UploadTask) -> None:
+    task_service.task_store.setdefault(user_id, {})[upload_task.task_id] = upload_task
+
+
+@pytest.mark.asyncio
+async def test_dismiss_removes_failed_file_and_drops_empty_task(task_service):
+    ft = _failed_file("/data/a.pdf", "a.pdf")
+    task = UploadTask(
+        task_id="task-1",
+        total_files=1,
+        file_tasks={"/data/a.pdf": ft},
+        status=TaskStatus.FAILED,
+        failed_files=1,
+        processed_files=1,
+    )
+    _store_task(task_service, "user1", task)
+
+    result = await task_service.dismiss_files("user1", "task-1", file_paths=["/data/a.pdf"])
+
+    assert result["dismissed"] == 1
+    assert result["status"] == "accepted"
+    assert result["skipped"] == []
+    # The task had a single file, so the whole record is dropped.
+    assert "task-1" not in task_service.task_store.get("user1", {})
+
+
+@pytest.mark.asyncio
+async def test_dismiss_keeps_task_with_remaining_files_and_adjusts_counters(task_service):
+    ft_a = _failed_file("/data/a.pdf", "a.pdf")
+    ft_b = _failed_file("/data/b.pdf", "b.pdf")
+    task = UploadTask(
+        task_id="task-2",
+        total_files=2,
+        file_tasks={"/data/a.pdf": ft_a, "/data/b.pdf": ft_b},
+        status=TaskStatus.FAILED,
+        failed_files=2,
+        processed_files=2,
+    )
+    _store_task(task_service, "user1", task)
+
+    result = await task_service.dismiss_files("user1", "task-2", file_paths=["/data/a.pdf"])
+
+    assert result["dismissed"] == 1
+    remaining = task_service.task_store["user1"]["task-2"]
+    assert set(remaining.file_tasks.keys()) == {"/data/b.pdf"}
+    assert remaining.total_files == 1
+    assert remaining.failed_files == 1
+    assert remaining.processed_files == 1
+
+
+@pytest.mark.asyncio
+async def test_dismiss_skips_non_failed_and_unknown_files(task_service):
+    running = FileTask(file_path="/data/live.pdf", filename="live.pdf")
+    running.status = TaskStatus.RUNNING
+    task = UploadTask(
+        task_id="task-3",
+        total_files=1,
+        file_tasks={"/data/live.pdf": running},
+        status=TaskStatus.RUNNING,
+    )
+    _store_task(task_service, "user1", task)
+
+    result = await task_service.dismiss_files(
+        "user1", "task-3", file_paths=["/data/live.pdf", "/data/ghost.pdf"]
+    )
+
+    assert result["dismissed"] == 0
+    assert result["status"] == "no_op"
+    reasons = {entry["reason"] for entry in result["skipped"]}
+    assert reasons == {"not_failed", "file_not_in_task"}
+    # Nothing removed; the task and its file survive.
+    assert "/data/live.pdf" in task_service.task_store["user1"]["task-3"].file_tasks
+
+
+@pytest.mark.asyncio
+async def test_dismiss_returns_none_for_unknown_task(task_service):
+    result = await task_service.dismiss_files("user1", "nope", file_paths=["/data/a.pdf"])
+    assert result is None


### PR DESCRIPTION
## Summary

Previously, a document that failed to ingest was a dead end in the Knowledge table: only `active` rows had any actions, so a `failed` row couldn't be removed. It also disappeared from the UI on refresh even though the backend still held the failed task entry in memory (~1h), so the failure silently lingered with no way to clear it.

This PR adds a **delete (trash) action on failed rows** that removes the document from the list for good, and makes failed rows persist across refresh so the action is reliably reachable.

## Changes

**Backend — dismiss a failed task file**
- `src/services/task_service.py`: new `dismiss_files()` that removes terminal `FAILED` file entries from the in-memory task store (adjusting counters, and dropping the whole task record once it has no files left). Only `FAILED` entries are dismissible.
- `src/api/tasks.py`: `DismissFilesBody` + `dismiss_files` handler (404 unknown task, 400 no-op, 200 on success).
- `src/app/routes/internal.py`: registers `POST /tasks/{task_id}/files/dismiss`.
- `tests/unit/test_task_service_dismiss_files.py`: unit tests (remove + drop empty task, keep task with remaining files + counter adjustment, skip non-failed/unknown paths, unknown-task → None).

**Frontend — delete action on failed rows**
- `frontend/app/api/mutations/useDismissTaskFilesMutation.ts`: new hook wrapping the dismiss endpoint; invalidates `tasks` / `listFiles` / `search`.
- `frontend/components/knowledge-row-actions.tsx`: new cell component rendering a trash icon for failed rows. Delete best-effort clears any indexed chunks (`delete-by-filename`, which 404s harmlessly for never-indexed docs) then dismisses the failed task entry. Gated behind the existing `knowledge:delete` permission.
- `frontend/app/knowledge/page.tsx`: renders the delete action for `failed` rows (active rows keep the existing three-dot menu; other statuses have no action).
- `frontend/contexts/task-context.tsx`: rebuild `failed` overlays on initial load so failed rows survive a page refresh instead of vanishing while the backend still holds them.

## Before

https://github.com/user-attachments/assets/457fc70b-5e03-4a09-a0cb-6577bbffc26c

## After


https://github.com/user-attachments/assets/de6b695b-2e75-43d5-a3c4-37c62f6113f6


## Testing
- New backend unit tests pass; existing `task_service` tests unaffected.
- Frontend typecheck/lint clean on changed files.
- Manual: ingest a failing file → failed row shows a trash icon → delete removes it and it does not reappear on the next poll or after a page refresh.