### PR TITLE
feat: added new status backend with new /v1/status route

### DIFF
--- a/src/api/schemas/status.py
+++ b/src/api/schemas/status.py
@@ -1,0 +1,32 @@
+from enum import StrEnum
+from pydantic import BaseModel, Field
+from typing import Any
+
+
+class ComponentState(StrEnum):
+    HEALTHY = "healthy"
+    DEGRADED = "degraded"
+    UNHEALTHY = "unhealthy"
+    UNKNOWN = "unknown"
+
+class ComponentBuild(BaseModel):
+    git_sha: str | None = None
+    build_time: str | None = None
+    image: str | None = None
+    image_digest: str | None = None
+
+class ComponentStatus(BaseModel):
+    name: str
+    display_name: str
+    status: ComponentState
+    required: bool
+    latency_ms: int | None = None
+    message: str | None = None
+    version: str | None = None
+    build: ComponentBuild = Field(default_factory=ComponentBuild)
+    metadata: dict[str, Any] = Field(default_factory=dict)
+
+class StatusResponse(BaseModel):
+    overall_status: ComponentState
+    checked_at: str # ISO 8601 UTC
+    components: list[ComponentStatus] = Field(default_factory=list)

--- a/src/api/schemas/status.py
+++ b/src/api/schemas/status.py
@@ -1,6 +1,7 @@
 from enum import StrEnum
-from pydantic import BaseModel, Field
 from typing import Any
+
+from pydantic import BaseModel, Field
 
 
 class ComponentState(StrEnum):
@@ -9,11 +10,13 @@ class ComponentState(StrEnum):
     UNHEALTHY = "unhealthy"
     UNKNOWN = "unknown"
 
+
 class ComponentBuild(BaseModel):
     git_sha: str | None = None
     build_time: str | None = None
     image: str | None = None
     image_digest: str | None = None
+
 
 class ComponentStatus(BaseModel):
     name: str
@@ -26,7 +29,8 @@ class ComponentStatus(BaseModel):
     build: ComponentBuild = Field(default_factory=ComponentBuild)
     metadata: dict[str, Any] = Field(default_factory=dict)
 
+
 class StatusResponse(BaseModel):
     overall_status: ComponentState
-    checked_at: str # ISO 8601 UTC
+    checked_at: str  # ISO 8601 UTC
     components: list[ComponentStatus] = Field(default_factory=list)

--- a/src/api/v1/status.py
+++ b/src/api/v1/status.py
@@ -9,8 +9,9 @@ from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
+
 async def get_status_endpoint(
-    user: User = Depends(require_api_key_permission("providers:read"))
+    user: User = Depends(require_api_key_permission("providers:read")),
 ) -> StatusResponse:
     """Aggregate component readiness. GET /v1/status"""
     try:
@@ -19,4 +20,3 @@ async def get_status_endpoint(
         logger.error("Failed to get status", error=str(e))
 
         return JSONResponse({"error": "Failed to get status"}, status_code=500)
-    

--- a/src/api/v1/status.py
+++ b/src/api/v1/status.py
@@ -18,4 +18,4 @@ async def get_status_endpoint(
     except Exception as e:
         logger.error("Failed to get status", error=str(e))
 
-        raise HTTPException(status_code=500, detail="Failed to get status")
+        raise HTTPException(status_code=500, detail="Failed to get status") from e

--- a/src/api/v1/status.py
+++ b/src/api/v1/status.py
@@ -1,5 +1,4 @@
-from fastapi import Depends
-from fastapi.responses import JSONResponse
+from fastapi import Depends, HTTPException
 
 from api.schemas.status import StatusResponse
 from dependencies import require_api_key_permission
@@ -19,4 +18,4 @@ async def get_status_endpoint(
     except Exception as e:
         logger.error("Failed to get status", error=str(e))
 
-        return JSONResponse({"error": "Failed to get status"}, status_code=500)
+        raise HTTPException(status_code=500, detail="Failed to get status")

--- a/src/api/v1/status.py
+++ b/src/api/v1/status.py
@@ -1,0 +1,22 @@
+from fastapi import Depends
+from fastapi.responses import JSONResponse
+
+from api.schemas.status import StatusResponse
+from dependencies import require_api_key_permission
+from services.status_service import aggregate_status
+from session_manager import User
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+async def get_status_endpoint(
+    user: User = Depends(require_api_key_permission("providers:read"))
+) -> StatusResponse:
+    """Aggregate component readiness. GET /v1/status"""
+    try:
+        return await aggregate_status()
+    except Exception as e:
+        logger.error("Failed to get status", error=str(e))
+
+        return JSONResponse({"error": "Failed to get status"}, status_code=500)
+    

--- a/src/app/routes/public_v1.py
+++ b/src/app/routes/public_v1.py
@@ -20,6 +20,9 @@ from api.v1 import (
 from api.v1 import (
     settings as v1_settings,
 )
+from api.v1 import (
+    status as v1_status
+)
 
 
 def register_public_v1_routes(app: FastAPI):
@@ -128,5 +131,13 @@ def register_public_v1_routes(app: FastAPI):
         "/v1/knowledge-filters/{filter_id}",
         v1_knowledge_filters.delete_endpoint,
         methods=["DELETE"],
+        tags=["public"],
+    )
+
+    # Status endpoint
+    app.add_api_route(
+        "/v1/status",
+        v1_status.get_status_endpoint,
+        methods=["GET"],
         tags=["public"],
     )

--- a/src/app/routes/public_v1.py
+++ b/src/app/routes/public_v1.py
@@ -20,9 +20,7 @@ from api.v1 import (
 from api.v1 import (
     settings as v1_settings,
 )
-from api.v1 import (
-    status as v1_status
-)
+from api.v1 import status as v1_status
 
 
 def register_public_v1_routes(app: FastAPI):

--- a/src/services/status_checks.py
+++ b/src/services/status_checks.py
@@ -1,13 +1,14 @@
 from time import perf_counter
 
 from api.schemas.status import ComponentBuild, ComponentState, ComponentStatus
-from config.settings import clients, DOCLING_SERVE_URL, get_openrag_config
+from config.settings import DOCLING_SERVE_URL, clients, get_openrag_config
 from utils.logging_config import get_logger
 from utils.version_utils import OPENRAG_VERSION
 
 logger = get_logger(__name__)
 
 _CHECK_TIMEOUT_S = 3.0
+
 
 async def check_openrag_backend() -> ComponentStatus:
     start = perf_counter()
@@ -23,9 +24,9 @@ async def check_openrag_backend() -> ComponentStatus:
             required=True,
             latency_ms=int((perf_counter() - start) * 1000),
             message="OpenRAG configuration is not loaded",
-            version=None, 
-            build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-            metadata={}
+            version=None,
+            build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+            metadata={},
         )
 
     missing = []
@@ -50,9 +51,10 @@ async def check_openrag_backend() -> ComponentStatus:
         latency_ms=int((perf_counter() - start) * 1000),
         message=message,
         version=OPENRAG_VERSION,
-        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-        metadata={}
+        build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+        metadata={},
     )
+
 
 async def check_docling() -> ComponentStatus:
     start = perf_counter()
@@ -69,10 +71,10 @@ async def check_docling() -> ComponentStatus:
                 latency_ms=int((perf_counter() - start) * 1000),
                 message="Docling client is not initialized",
                 version=version,
-                build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-                metadata={}
+                build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+                metadata={},
             )
-        
+
         resp = await docling_client.get(f"{DOCLING_SERVE_URL}/version", timeout=_CHECK_TIMEOUT_S)
         if resp.status_code == 200:
             status, message = ComponentState.HEALTHY, "Docling Serve reachable"
@@ -91,9 +93,10 @@ async def check_docling() -> ComponentStatus:
         latency_ms=int((perf_counter() - start) * 1000),
         message=message,
         version=version,
-        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-        metadata={}
+        build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+        metadata={},
     )
+
 
 async def check_langflow() -> ComponentStatus:
     start = perf_counter()
@@ -110,8 +113,8 @@ async def check_langflow() -> ComponentStatus:
                 latency_ms=int((perf_counter() - start) * 1000),
                 message="Langflow client is not initialized",
                 version=version,
-                build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-                metadata={}
+                build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+                metadata={},
             )
 
         resp = await langflow_client.get("/api/v1/version", timeout=_CHECK_TIMEOUT_S)
@@ -133,9 +136,10 @@ async def check_langflow() -> ComponentStatus:
         latency_ms=int((perf_counter() - start) * 1000),
         message=message,
         version=version,
-        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-        metadata={}
+        build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+        metadata={},
     )
+
 
 async def check_opensearch() -> ComponentStatus:
     start = perf_counter()
@@ -153,8 +157,8 @@ async def check_opensearch() -> ComponentStatus:
                 latency_ms=int((perf_counter() - start) * 1000),
                 message="OpenSearch client is not initialized",
                 version=version,
-                build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-                metadata={}
+                build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+                metadata={},
             )
 
         health = await opensearch.cluster.health()
@@ -166,13 +170,13 @@ async def check_opensearch() -> ComponentStatus:
         status = {
             "green": ComponentState.HEALTHY,
             "yellow": ComponentState.DEGRADED,
-            "red": ComponentState.UNHEALTHY
+            "red": ComponentState.UNHEALTHY,
         }.get(cluster_status, ComponentState.UNKNOWN)
         message = f"Cluster Health is {cluster_status}"
-        metadata={
+        metadata = {
             "cluster_name": health.get("cluster_name"),
             "cluster_health": cluster_status,
-            "distribution": distribution
+            "distribution": distribution,
         }
 
     except Exception as e:
@@ -189,6 +193,6 @@ async def check_opensearch() -> ComponentStatus:
         latency_ms=int((perf_counter() - start) * 1000),
         message=message,
         version=os_version,
-        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
-        metadata=metadata
+        build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
+        metadata=metadata,
     )

--- a/src/services/status_checks.py
+++ b/src/services/status_checks.py
@@ -1,0 +1,187 @@
+from time import perf_counter
+
+from api.schemas.status import ComponentBuild, ComponentState, ComponentStatus
+from config.settings import clients, DOCLING_SERVE_URL, get_openrag_config
+from utils.logging_config import get_logger
+from utils.version_utils import OPENRAG_VERSION
+
+logger = get_logger(__name__)
+
+_CHECK_TIMEOUT_S = 3.0
+
+async def check_openrag_backend() -> ComponentStatus:
+    start = perf_counter()
+    try:
+        get_openrag_config()
+    except Exception as e:
+        logger.warning("OpenRAG config not loaded", error=str(e))
+
+        return ComponentStatus(
+            name="openrag",
+            display_name="OpenRAG Backend",
+            status=ComponentState.UNHEALTHY,
+            required=True,
+            latency_ms=int((perf_counter() - start) * 1000),
+            message="OpenRAG configuration is not loaded",
+            version="UNKNOWN_VERSION", 
+            build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+            metadata={}
+        )
+
+    missing = []
+    if clients.opensearch is None:
+        missing.append("opensearch client")
+    if clients.langflow_http_client is None:
+        missing.append("langflow client")
+    if clients.docling_http_client is None:
+        missing.append("docling client")
+
+    if missing:
+        status = ComponentState.DEGRADED
+        message = "Backend serving but not fully initialized: " + ", ".join(missing)
+    else:
+        status, message = ComponentState.HEALTHY, "OpenRAG backend is ready"
+
+    return ComponentStatus(
+        name="openrag",
+        display_name="OpenRAG Backend",
+        status=status,
+        required=True,
+        latency_ms=int((perf_counter() - start) * 1000),
+        message=message,
+        version=OPENRAG_VERSION,
+        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+        metadata={}
+    )
+
+async def check_docling() -> ComponentStatus:
+    start = perf_counter()
+    try:
+        docling_client = clients.docling_http_client
+        if not docling_client:
+            return ComponentStatus(
+                name="docling",
+                display_name="Docling",
+                status=ComponentState.UNKNOWN,
+                required=True,
+                latency_ms=int((perf_counter() - start) * 1000),
+                message="Docling client is not initialized",
+                version="UNKNOWN_VERSION",
+                build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+                metadata={}
+            )
+        
+        resp = await docling_client.get(f"{DOCLING_SERVE_URL}/version", timeout=_CHECK_TIMEOUT_S)
+        if resp.status_code == 200:
+            status, message = ComponentState.HEALTHY, "Docling Serve reachable"
+            version = resp.json().get("docling-serve")
+        else:
+            status, message = ComponentState.UNHEALTHY, f"Docling returned HTTP {resp.status_code}"
+    except Exception as e:
+        logger.warning("Docling status check failed", error=str(e))
+        status, message = ComponentState.UNHEALTHY, "Docling Serve unreachable"
+
+    return ComponentStatus(
+        name="docling",
+        display_name="Docling",
+        status=status,
+        required=True,
+        latency_ms=int((perf_counter() - start) * 1000),
+        message=message,
+        version=version,
+        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+        metadata={}
+    )
+
+async def check_langflow() -> ComponentStatus:
+    start = perf_counter()
+    try:
+        langflow_client = clients.langflow_http_client
+        if not langflow_client:
+            return ComponentStatus(
+                name="langflow",
+                display_name="Langflow",
+                status=ComponentState.UNKNOWN,
+                required=True,
+                latency_ms=int((perf_counter() - start) * 1000),
+                message="Langflow client is not initialized",
+                version="UNKNOWN_VERSION",
+                build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+                metadata={}
+            )
+
+        resp = await langflow_client.get("/api/v1/version", timeout=_CHECK_TIMEOUT_S)
+        if resp.status_code == 200:
+            status, message = ComponentState.HEALTHY, "Langflow API reachable"
+            version = resp.json().get("version")
+        else:
+            status, message = ComponentState.UNHEALTHY, f"Langflow returned HTTP {resp.status_code}"
+    except Exception as e:
+        logger.warning("Langflow status check failed", error=str(e))
+
+        status, message = ComponentState.UNHEALTHY, "Langflow is unreachable"
+
+    return ComponentStatus(
+        name="langflow",
+        display_name="Langflow",
+        status=status,
+        required=True,
+        latency_ms=int((perf_counter() - start) * 1000),
+        message=message,
+        version=version,
+        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+        metadata={}
+    )
+
+async def check_opensearch() -> ComponentStatus:
+    start = perf_counter()
+    try:
+        opensearch = clients.opensearch
+        if opensearch is None:
+            return ComponentStatus(
+                name="opensearch",
+                display_name="OpenSearch",
+                status=ComponentState.UNKNOWN,
+                required=True,
+                latency_ms=int((perf_counter() - start) * 1000),
+                message="OpenSearch client is not initialized",
+                version="UNKNOWN_VERSION",
+                build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+                metadata={}
+            )
+
+        health = await opensearch.cluster.health()
+        info = await opensearch.info()
+        cluster_status = health.get("status")
+        os_version = (info.get("version") or {}).get("number")
+        distribution = (info.get("version") or {}).get("distribution")
+
+        status = {
+            "green": ComponentState.HEALTHY,
+            "yellow": ComponentState.DEGRADED,
+            "red": ComponentState.UNHEALTHY
+        }.get(cluster_status, ComponentState.UNKNOWN)
+        message = f"Cluster Health is {cluster_status}"
+        metadata={
+            "cluster_name": health.get("cluster_name"),
+            "cluster_health": cluster_status,
+            "distribution": distribution
+        }
+
+    except Exception as e:
+        logger.warning("OpenSearch status check failed", error=str(e))
+
+        status, message = ComponentState.UNHEALTHY, "OpenSearch is unreachable"
+        build, metadata = ComponentBuild(), {}
+
+    return ComponentStatus(
+        name="opensearch",
+        display_name="OpenSearch",
+        status=status,
+        required=True,
+        latency_ms=int((perf_counter() - start) * 1000),
+        message=message,
+        version=os_version,
+        build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
+        metadata=metadata
+    )

--- a/src/services/status_checks.py
+++ b/src/services/status_checks.py
@@ -23,7 +23,7 @@ async def check_openrag_backend() -> ComponentStatus:
             required=True,
             latency_ms=int((perf_counter() - start) * 1000),
             message="OpenRAG configuration is not loaded",
-            version="UNKNOWN_VERSION", 
+            version=None, 
             build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
             metadata={}
         )
@@ -56,6 +56,8 @@ async def check_openrag_backend() -> ComponentStatus:
 
 async def check_docling() -> ComponentStatus:
     start = perf_counter()
+    version = None
+
     try:
         docling_client = clients.docling_http_client
         if not docling_client:
@@ -66,7 +68,7 @@ async def check_docling() -> ComponentStatus:
                 required=True,
                 latency_ms=int((perf_counter() - start) * 1000),
                 message="Docling client is not initialized",
-                version="UNKNOWN_VERSION",
+                version=version,
                 build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
                 metadata={}
             )
@@ -95,6 +97,8 @@ async def check_docling() -> ComponentStatus:
 
 async def check_langflow() -> ComponentStatus:
     start = perf_counter()
+    version = None
+
     try:
         langflow_client = clients.langflow_http_client
         if not langflow_client:
@@ -105,7 +109,7 @@ async def check_langflow() -> ComponentStatus:
                 required=True,
                 latency_ms=int((perf_counter() - start) * 1000),
                 message="Langflow client is not initialized",
-                version="UNKNOWN_VERSION",
+                version=version,
                 build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
                 metadata={}
             )
@@ -135,6 +139,9 @@ async def check_langflow() -> ComponentStatus:
 
 async def check_opensearch() -> ComponentStatus:
     start = perf_counter()
+    version = None
+    os_version = None
+
     try:
         opensearch = clients.opensearch
         if opensearch is None:
@@ -145,7 +152,7 @@ async def check_opensearch() -> ComponentStatus:
                 required=True,
                 latency_ms=int((perf_counter() - start) * 1000),
                 message="OpenSearch client is not initialized",
-                version="UNKNOWN_VERSION",
+                version=version,
                 build=ComponentBuild(), # NOTE: deferring this to later Version and build traceability step
                 metadata={}
             )
@@ -172,7 +179,7 @@ async def check_opensearch() -> ComponentStatus:
         logger.warning("OpenSearch status check failed", error=str(e))
 
         status, message = ComponentState.UNHEALTHY, "OpenSearch is unreachable"
-        build, metadata = ComponentBuild(), {}
+        metadata = {}
 
     return ComponentStatus(
         name="opensearch",

--- a/src/services/status_checks.py
+++ b/src/services/status_checks.py
@@ -7,7 +7,7 @@ from utils.version_utils import OPENRAG_VERSION
 
 logger = get_logger(__name__)
 
-_CHECK_TIMEOUT_S = 3.0
+_CHECK_TIMEOUT_S = 2.0
 
 
 async def check_openrag_backend() -> ComponentStatus:

--- a/src/services/status_service.py
+++ b/src/services/status_service.py
@@ -13,7 +13,7 @@ from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-CHECK_TIMEOUT_S = 3.0
+CHECK_TIMEOUT_S = 5.0
 
 CHECK_SPECS = [check_openrag_backend, check_docling, check_langflow, check_opensearch]
 

--- a/src/services/status_service.py
+++ b/src/services/status_service.py
@@ -1,6 +1,6 @@
 import asyncio
-from datetime import datetime, UTC
-from typing import Awaitable, Callable
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
 
 from api.schemas.status import ComponentState, ComponentStatus, StatusResponse
 from services.status_checks import (
@@ -17,6 +17,7 @@ CHECK_TIMEOUT_S = 3.0
 
 CHECK_SPECS = [check_openrag_backend, check_docling, check_langflow, check_opensearch]
 
+
 async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentStatus:
     """TODO: add docstrings here"""
     try:
@@ -30,8 +31,9 @@ async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentS
             display_name=name.title(),
             status=ComponentState.UNKNOWN,
             required=True,
-            message="Status check did not complete"
+            message="Status check did not complete",
         )
+
 
 def _worst_status(results: list[ComponentStatus]) -> ComponentState:
     """This calculates the final status (the worst one)"""
@@ -39,12 +41,13 @@ def _worst_status(results: list[ComponentStatus]) -> ComponentState:
         ComponentState.HEALTHY: 0,
         ComponentState.DEGRADED: 1,
         ComponentState.UNKNOWN: 2,
-        ComponentState.UNHEALTHY: 2
+        ComponentState.UNHEALTHY: 2,
     }
 
     severity_in_order = [ComponentState.HEALTHY, ComponentState.DEGRADED, ComponentState.UNHEALTHY]
 
     return severity_in_order[max((severity[r.status] for r in results), default=0)]
+
 
 async def aggregate_status() -> StatusResponse:
     """TODO: add docstrings here"""
@@ -53,5 +56,5 @@ async def aggregate_status() -> StatusResponse:
     return StatusResponse(
         overall_status=_worst_status(list(results)),
         checked_at=datetime.now(UTC).isoformat(),
-        components=list(results)
+        components=list(results),
     )

--- a/src/services/status_service.py
+++ b/src/services/status_service.py
@@ -1,0 +1,57 @@
+import asyncio
+from datetime import datetime, UTC
+from typing import Awaitable, Callable
+
+from api.schemas.status import ComponentState, ComponentStatus, StatusResponse
+from services.status_checks import (
+    check_docling,
+    check_langflow,
+    check_openrag_backend,
+    check_opensearch,
+)
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+CHECK_TIMEOUT_S = 3.0
+
+CHECK_SPECS = [check_openrag_backend, check_docling, check_langflow, check_opensearch]
+
+async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentStatus:
+    """TODO: add docstrings here"""
+    try:
+        return await asyncio.wait_for(fn(), timeout=CHECK_TIMEOUT_S)
+    except Exception as e:
+        name = fn.__name__.replace("check_", "")
+        logger.warning("Status check did not complete", component=name, error=str(e))
+
+        return ComponentStatus(
+            name=name,
+            display_name=name.title(),
+            status=ComponentState.UNKNOWN,
+            required=True,
+            message="Status check did not complete"
+        )
+
+def _worst_status(results: list[ComponentStatus]) -> ComponentState:
+    """This calculates the final status (the worst one)"""
+    severity = {
+        ComponentState.HEALTHY: 0,
+        ComponentState.DEGRADED: 1,
+        ComponentState.UNKNOWN: 2,
+        ComponentState.UNHEALTHY: 2
+    }
+
+    severity_in_order = [ComponentState.HEALTHY, ComponentState.DEGRADED, ComponentState.UNHEALTHY]
+
+    return severity_in_order[max((severity[r.status] for r in results), default=0)]
+
+async def aggregate_status() -> StatusResponse:
+    """TODO: add docstrings here"""
+    results = await asyncio.gather(*(_run_check(fn) for fn in CHECK_SPECS))
+
+    return StatusResponse(
+        overall_status=_worst_status(list(results)),
+        checked_at=datetime.now(UTC).isoformat(),
+        components=list(results)
+    )

--- a/tests/unit/services/test_status_checks.py
+++ b/tests/unit/services/test_status_checks.py
@@ -1,22 +1,26 @@
+from unittest.mock import AsyncMock, MagicMock
+
 import httpx
 import pytest
 
-from unittest.mock import AsyncMock, MagicMock
-
-from config.settings import clients
 from api.schemas.status import ComponentState
+from config.settings import clients
 from services import status_checks
 from services.status_checks import (
-    check_openrag_backend, check_opensearch, check_langflow, check_docling
+    check_docling,
+    check_langflow,
+    check_openrag_backend,
+    check_opensearch,
 )
 from utils.version_utils import OPENRAG_VERSION
 
-
 # OpenRAG backend check tests
+
 
 @pytest.fixture
 def config_ok(monkeypatch):
     monkeypatch.setattr(status_checks, "get_openrag_config", lambda: object(), raising=True)
+
 
 @pytest.mark.asyncio
 async def test_openrag_all_initialized_is_healthy(monkeypatch, config_ok):
@@ -30,6 +34,7 @@ async def test_openrag_all_initialized_is_healthy(monkeypatch, config_ok):
     assert r.status == ComponentState.HEALTHY
     assert r.version == OPENRAG_VERSION
 
+
 @pytest.mark.asyncio
 async def test_openrag_missing_client_is_degraded(monkeypatch, config_ok):
     monkeypatch.setattr(clients, "opensearch", None, raising=False)
@@ -41,16 +46,19 @@ async def test_openrag_missing_client_is_degraded(monkeypatch, config_ok):
     assert r.status == ComponentState.DEGRADED
     assert "opensearch" in (r.message or "").lower()
 
+
 @pytest.mark.asyncio
 async def test_openrag_config_not_loaded_is_unhealthy(monkeypatch):
     def _raise():
         raise RuntimeError("config not loaded")
+
     monkeypatch.setattr(status_checks, "get_openrag_config", _raise, raising=True)
 
     r = await check_openrag_backend()
 
     assert r.status == ComponentState.UNHEALTHY
     assert "configuration" in (r.message or "").lower()
+
 
 @pytest.mark.asyncio
 async def test_openrag_latency_is_measured(monkeypatch, config_ok):
@@ -64,7 +72,9 @@ async def test_openrag_latency_is_measured(monkeypatch, config_ok):
 
     assert r.latency_ms == 250
 
+
 # Docling check tests
+
 
 def _mock_http(status_code=None, raises=None, json_data=None):
     c = MagicMock()
@@ -74,18 +84,21 @@ def _mock_http(status_code=None, raises=None, json_data=None):
         resp = MagicMock(spec=httpx.Response)
         resp.status_code = status_code
         resp.json.return_value = (
-            json_data if json_data is not None
+            json_data
+            if json_data is not None
             else {"docling-serve": "1.26.0", "version": "0.11.2rc0"}
         )
         c.get = AsyncMock(return_value=resp)
     return c
 
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize(argnames="status_code,expected_status",
+@pytest.mark.parametrize(
+    argnames="status_code,expected_status",
     argvalues=[
         (200, ComponentState.HEALTHY),
         (503, ComponentState.UNHEALTHY),
-    ]
+    ],
 )
 async def test_docling_correct_status(monkeypatch, status_code, expected_status):
     monkeypatch.setattr(clients, "docling_http_client", _mock_http(status_code), raising=False)
@@ -98,24 +111,28 @@ async def test_docling_correct_status(monkeypatch, status_code, expected_status)
     if expected_status == ComponentState.HEALTHY:
         assert r.version == "1.26.0"
 
+
 @pytest.mark.asyncio
 async def test_docling_unreachable_is_unhealthy(monkeypatch):
-    monkeypatch.setattr(clients, "docling_http_client",
-                        _mock_http(raises=httpx.ConnectError("refused")), raising=False)
+    monkeypatch.setattr(
+        clients,
+        "docling_http_client",
+        _mock_http(raises=httpx.ConnectError("refused")),
+        raising=False,
+    )
     r = await check_docling()
     assert r.status == ComponentState.UNHEALTHY
     assert "unreachable" in (r.message or "").lower()
-    assert r.version is None   # guards the unbound-variable regression on the failure path
+    assert r.version is None  # guards the unbound-variable regression on the failure path
 
 
 # Langflow check tests
 
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize(argnames="status_code,expected_status",
-    argvalues=[
-        (200, ComponentState.HEALTHY),
-        (500, ComponentState.UNHEALTHY)
-    ]
+@pytest.mark.parametrize(
+    argnames="status_code,expected_status",
+    argvalues=[(200, ComponentState.HEALTHY), (500, ComponentState.UNHEALTHY)],
 )
 async def test_langflow_correct_status(monkeypatch, status_code, expected_status):
     monkeypatch.setattr(clients, "langflow_http_client", _mock_http(status_code), raising=False)
@@ -125,39 +142,47 @@ async def test_langflow_correct_status(monkeypatch, status_code, expected_status
     if expected_status == ComponentState.HEALTHY:
         assert r.version == "0.11.2rc0"
 
+
 @pytest.mark.asyncio
 async def test_langflow_unreachable_is_unhealthy(monkeypatch):
-    monkeypatch.setattr(clients, "langflow_http_client",
-                        _mock_http(raises=httpx.ConnectError("refused")), raising=False)
+    monkeypatch.setattr(
+        clients,
+        "langflow_http_client",
+        _mock_http(raises=httpx.ConnectError("refused")),
+        raising=False,
+    )
     r = await check_langflow()
     assert r.status == ComponentState.UNHEALTHY
     assert "unreachable" in (r.message or "").lower()
     assert r.version is None
 
+
 # OpenSearch Check tests
+
 
 def _mock_os(health=None, raises=None):
     os = MagicMock()
-    os.info = AsyncMock(
-        return_value={"version": {"number": "3.2.0", "distribution": "opensearch"}}
-    )
+    os.info = AsyncMock(return_value={"version": {"number": "3.2.0", "distribution": "opensearch"}})
     if raises is not None:
         os.cluster.health = AsyncMock(side_effect=raises)
     else:
         os.cluster.health = AsyncMock(return_value=health)
     return os
 
+
 @pytest.mark.asyncio
-@pytest.mark.parametrize(argnames="os_status,expected_status",
+@pytest.mark.parametrize(
+    argnames="os_status,expected_status",
     argvalues=[
         ("green", ComponentState.HEALTHY),
         ("yellow", ComponentState.DEGRADED),
-        ("red", ComponentState.UNHEALTHY)
-    ]
+        ("red", ComponentState.UNHEALTHY),
+    ],
 )
 async def test_opensearch_status_is_correct(monkeypatch, os_status, expected_status):
-    monkeypatch.setattr(clients, "opensearch",
-                        _mock_os({"status": os_status, "cluster_name": "c"}), raising=False)
+    monkeypatch.setattr(
+        clients, "opensearch", _mock_os({"status": os_status, "cluster_name": "c"}), raising=False
+    )
 
     r = await check_opensearch()
 
@@ -166,10 +191,12 @@ async def test_opensearch_status_is_correct(monkeypatch, os_status, expected_sta
     assert r.version == "3.2.0"
     assert r.metadata.get("distribution") == "opensearch"
 
+
 @pytest.mark.asyncio
 async def test_opensearch_unreachable_is_unhealthy(monkeypatch):
-    monkeypatch.setattr(clients, "opensearch",
-                        _mock_os(raises=ConnectionError("down")), raising=False)
+    monkeypatch.setattr(
+        clients, "opensearch", _mock_os(raises=ConnectionError("down")), raising=False
+    )
     r = await check_opensearch()
     assert r.status == ComponentState.UNHEALTHY
     assert "unreachable" in (r.message or "").lower()

--- a/tests/unit/services/test_status_checks.py
+++ b/tests/unit/services/test_status_checks.py
@@ -1,0 +1,176 @@
+import httpx
+import pytest
+
+from unittest.mock import AsyncMock, MagicMock
+
+from config.settings import clients
+from api.schemas.status import ComponentState
+from services import status_checks
+from services.status_checks import (
+    check_openrag_backend, check_opensearch, check_langflow, check_docling
+)
+from utils.version_utils import OPENRAG_VERSION
+
+
+# OpenRAG backend check tests
+
+@pytest.fixture
+def config_ok(monkeypatch):
+    monkeypatch.setattr(status_checks, "get_openrag_config", lambda: object(), raising=True)
+
+@pytest.mark.asyncio
+async def test_openrag_all_initialized_is_healthy(monkeypatch, config_ok):
+    monkeypatch.setattr(clients, "opensearch", MagicMock(), raising=True)
+    monkeypatch.setattr(clients, "langflow_http_client", MagicMock(), raising=True)
+    monkeypatch.setattr(clients, "docling_http_client", MagicMock(), raising=True)
+
+    r = await check_openrag_backend()
+
+    assert r.name == "openrag"
+    assert r.status == ComponentState.HEALTHY
+    assert r.version == OPENRAG_VERSION
+
+@pytest.mark.asyncio
+async def test_openrag_missing_client_is_degraded(monkeypatch, config_ok):
+    monkeypatch.setattr(clients, "opensearch", None, raising=False)
+    monkeypatch.setattr(clients, "langflow_http_client", MagicMock(), raising=False)
+    monkeypatch.setattr(clients, "docling_http_client", MagicMock(), raising=False)
+
+    r = await check_openrag_backend()
+
+    assert r.status == ComponentState.DEGRADED
+    assert "opensearch" in (r.message or "").lower()
+
+@pytest.mark.asyncio
+async def test_openrag_config_not_loaded_is_unhealthy(monkeypatch):
+    def _raise():
+        raise RuntimeError("config not loaded")
+    monkeypatch.setattr(status_checks, "get_openrag_config", _raise, raising=True)
+
+    r = await check_openrag_backend()
+
+    assert r.status == ComponentState.UNHEALTHY
+    assert "configuration" in (r.message or "").lower()
+
+@pytest.mark.asyncio
+async def test_openrag_latency_is_measured(monkeypatch, config_ok):
+    ticks = iter([1000.0, 1000.25])
+    monkeypatch.setattr(status_checks, "perf_counter", lambda: next(ticks))
+    monkeypatch.setattr(clients, "opensearch", MagicMock(), raising=False)
+    monkeypatch.setattr(clients, "langflow_http_client", MagicMock(), raising=False)
+    monkeypatch.setattr(clients, "docling_http_client", MagicMock(), raising=False)
+
+    r = await check_openrag_backend()
+
+    assert r.latency_ms == 250
+
+# Docling check tests
+
+def _mock_http(status_code=None, raises=None, json_data=None):
+    c = MagicMock()
+    if raises is not None:
+        c.get = AsyncMock(side_effect=raises)
+    else:
+        resp = MagicMock(spec=httpx.Response)
+        resp.status_code = status_code
+        resp.json.return_value = (
+            json_data if json_data is not None
+            else {"docling-serve": "1.26.0", "version": "0.11.2rc0"}
+        )
+        c.get = AsyncMock(return_value=resp)
+    return c
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(argnames="status_code,expected_status",
+    argvalues=[
+        (200, ComponentState.HEALTHY),
+        (503, ComponentState.UNHEALTHY),
+    ]
+)
+async def test_docling_correct_status(monkeypatch, status_code, expected_status):
+    monkeypatch.setattr(clients, "docling_http_client", _mock_http(status_code), raising=False)
+
+    r = await check_docling()
+
+    assert r.name == "docling"
+    assert r.status == expected_status
+    assert r.required is True
+    if expected_status == ComponentState.HEALTHY:
+        assert r.version == "1.26.0"
+
+@pytest.mark.asyncio
+async def test_docling_unreachable_is_unhealthy(monkeypatch):
+    monkeypatch.setattr(clients, "docling_http_client",
+                        _mock_http(raises=httpx.ConnectError("refused")), raising=False)
+    r = await check_docling()
+    assert r.status == ComponentState.UNHEALTHY
+    assert "unreachable" in (r.message or "").lower()
+    assert r.version is None   # guards the unbound-variable regression on the failure path
+
+
+# Langflow check tests
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(argnames="status_code,expected_status",
+    argvalues=[
+        (200, ComponentState.HEALTHY),
+        (500, ComponentState.UNHEALTHY)
+    ]
+)
+async def test_langflow_correct_status(monkeypatch, status_code, expected_status):
+    monkeypatch.setattr(clients, "langflow_http_client", _mock_http(status_code), raising=False)
+    r = await check_langflow()
+    assert r.name == "langflow"
+    assert r.status == expected_status
+    if expected_status == ComponentState.HEALTHY:
+        assert r.version == "0.11.2rc0"
+
+@pytest.mark.asyncio
+async def test_langflow_unreachable_is_unhealthy(monkeypatch):
+    monkeypatch.setattr(clients, "langflow_http_client",
+                        _mock_http(raises=httpx.ConnectError("refused")), raising=False)
+    r = await check_langflow()
+    assert r.status == ComponentState.UNHEALTHY
+    assert "unreachable" in (r.message or "").lower()
+    assert r.version is None
+
+# OpenSearch Check tests
+
+def _mock_os(health=None, raises=None):
+    os = MagicMock()
+    os.info = AsyncMock(
+        return_value={"version": {"number": "3.2.0", "distribution": "opensearch"}}
+    )
+    if raises is not None:
+        os.cluster.health = AsyncMock(side_effect=raises)
+    else:
+        os.cluster.health = AsyncMock(return_value=health)
+    return os
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(argnames="os_status,expected_status",
+    argvalues=[
+        ("green", ComponentState.HEALTHY),
+        ("yellow", ComponentState.DEGRADED),
+        ("red", ComponentState.UNHEALTHY)
+    ]
+)
+async def test_opensearch_status_is_correct(monkeypatch, os_status, expected_status):
+    monkeypatch.setattr(clients, "opensearch",
+                        _mock_os({"status": os_status, "cluster_name": "c"}), raising=False)
+
+    r = await check_opensearch()
+
+    assert r.name == "opensearch"
+    assert r.status == expected_status
+    assert r.version == "3.2.0"
+    assert r.metadata.get("distribution") == "opensearch"
+
+@pytest.mark.asyncio
+async def test_opensearch_unreachable_is_unhealthy(monkeypatch):
+    monkeypatch.setattr(clients, "opensearch",
+                        _mock_os(raises=ConnectionError("down")), raising=False)
+    r = await check_opensearch()
+    assert r.status == ComponentState.UNHEALTHY
+    assert "unreachable" in (r.message or "").lower()
+    assert r.version is None

--- a/tests/unit/services/test_status_service.py
+++ b/tests/unit/services/test_status_service.py
@@ -1,21 +1,29 @@
 import asyncio
+
 import pytest
 
 from api.schemas.status import ComponentState, ComponentStatus
 from services import status_service
 
+
 def _result(name, status, required=True):
-    return ComponentStatus(name=name, display_name=name.title(),
-                           status=status, required=required)
+    return ComponentStatus(name=name, display_name=name.title(), status=status, required=required)
+
 
 @pytest.mark.asyncio
 async def test_all_healthy_overall_healthy(monkeypatch):
-    async def ok(name): 
+    async def ok(name):
         return _result(name, ComponentState.HEALTHY)
-    monkeypatch.setattr(status_service, "CHECK_SPECS", [
-        lambda: ok("openrag"),
-        lambda: ok("opensearch"),
-    ], raising=True)
+
+    monkeypatch.setattr(
+        status_service,
+        "CHECK_SPECS",
+        [
+            lambda: ok("openrag"),
+            lambda: ok("opensearch"),
+        ],
+        raising=True,
+    )
 
     result = await status_service.aggregate_status()
     assert result.overall_status == ComponentState.HEALTHY
@@ -26,10 +34,12 @@ async def test_all_healthy_overall_healthy(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_worst_wins(monkeypatch):
-    async def healthy(): 
+    async def healthy():
         return _result("openrag", ComponentState.HEALTHY)
-    async def unhealthy(): 
+
+    async def unhealthy():
         return _result("opensearch", ComponentState.UNHEALTHY)
+
     monkeypatch.setattr(status_service, "CHECK_SPECS", [healthy, unhealthy], raising=True)
 
     result = await status_service.aggregate_status()
@@ -41,9 +51,10 @@ async def test_timeout_becomes_unknown_and_does_not_block(monkeypatch):
     async def slow():
         await asyncio.sleep(5)
         return _result("docling", ComponentState.HEALTHY)
+
     async def fast():
         return _result("openrag", ComponentState.HEALTHY)
-    
+
     monkeypatch.setattr(status_service, "CHECK_TIMEOUT_S", 0.05, raising=True)
     monkeypatch.setattr(status_service, "CHECK_SPECS", [fast, slow], raising=True)
 
@@ -58,11 +69,12 @@ async def test_timeout_becomes_unknown_and_does_not_block(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_check_exception_becomes_unknown(monkeypatch):
-    async def healthy(): 
+    async def healthy():
         return _result("openrag", ComponentState.HEALTHY)
-    async def boom(): 
+
+    async def boom():
         raise RuntimeError("x")
-    
+
     monkeypatch.setattr(status_service, "CHECK_SPECS", [healthy, boom], raising=True)
 
     result = await status_service.aggregate_status()

--- a/tests/unit/services/test_status_service.py
+++ b/tests/unit/services/test_status_service.py
@@ -1,0 +1,70 @@
+import asyncio
+import pytest
+
+from api.schemas.status import ComponentState, ComponentStatus
+from services import status_service
+
+def _result(name, status, required=True):
+    return ComponentStatus(name=name, display_name=name.title(),
+                           status=status, required=required)
+
+@pytest.mark.asyncio
+async def test_all_healthy_overall_healthy(monkeypatch):
+    async def ok(name): 
+        return _result(name, ComponentState.HEALTHY)
+    monkeypatch.setattr(status_service, "CHECK_SPECS", [
+        lambda: ok("openrag"),
+        lambda: ok("opensearch"),
+    ], raising=True)
+
+    result = await status_service.aggregate_status()
+    assert result.overall_status == ComponentState.HEALTHY
+    assert len(result.components) == 2
+    assert isinstance(result.components[0], ComponentStatus)
+    assert result.checked_at
+
+
+@pytest.mark.asyncio
+async def test_worst_wins(monkeypatch):
+    async def healthy(): 
+        return _result("openrag", ComponentState.HEALTHY)
+    async def unhealthy(): 
+        return _result("opensearch", ComponentState.UNHEALTHY)
+    monkeypatch.setattr(status_service, "CHECK_SPECS", [healthy, unhealthy], raising=True)
+
+    result = await status_service.aggregate_status()
+    assert result.overall_status == ComponentState.UNHEALTHY
+
+
+@pytest.mark.asyncio
+async def test_timeout_becomes_unknown_and_does_not_block(monkeypatch):
+    async def slow():
+        await asyncio.sleep(5)
+        return _result("docling", ComponentState.HEALTHY)
+    async def fast():
+        return _result("openrag", ComponentState.HEALTHY)
+    
+    monkeypatch.setattr(status_service, "CHECK_TIMEOUT_S", 0.05, raising=True)
+    monkeypatch.setattr(status_service, "CHECK_SPECS", [fast, slow], raising=True)
+
+    result = await status_service.aggregate_status()
+
+    assert len(result.components) == 2
+    unknown = [c for c in result.components if c.status == ComponentState.UNKNOWN]
+    assert len(unknown) == 1, [(c.name, c.status) for c in result.components]
+
+    assert result.overall_status == ComponentState.UNHEALTHY
+
+
+@pytest.mark.asyncio
+async def test_check_exception_becomes_unknown(monkeypatch):
+    async def healthy(): 
+        return _result("openrag", ComponentState.HEALTHY)
+    async def boom(): 
+        raise RuntimeError("x")
+    
+    monkeypatch.setattr(status_service, "CHECK_SPECS", [healthy, boom], raising=True)
+
+    result = await status_service.aggregate_status()
+
+    assert result.overall_status == ComponentState.UNHEALTHY


### PR DESCRIPTION
## Summary
Fixes #2177 . Adds a new status backend route `/v1/status` that queries the health of openrag services (openrag-backend, langflow, docling, opensearch) and returns their status along with various other metadata/metrics. This runs in asyncio to avoid blocking the main event loop.

## Example Api response (All services healthy)
```
{
    "overall_status": "healthy",
    "checked_at": "2026-07-31T06:49:46.811503+00:00",
    "components": [
        {
            "name": "openrag",
            "display_name": "OpenRAG Backend",
            "status": "healthy",
            "required": true,
            "latency_ms": 0,
            "message": "OpenRAG backend is ready",
            "version": "0.5.0",
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {}
        },
        {
            "name": "docling",
            "display_name": "Docling",
            "status": "healthy",
            "required": true,
            "latency_ms": 4,
            "message": "Docling Serve reachable",
            "version": "1.26.0",
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {}
        },
        {
            "name": "langflow",
            "display_name": "Langflow",
            "status": "healthy",
            "required": true,
            "latency_ms": 4,
            "message": "Langflow API reachable",
            "version": "0.11.2rc0",
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {}
        },
        {
            "name": "opensearch",
            "display_name": "OpenSearch",
            "status": "healthy",
            "required": true,
            "latency_ms": 3,
            "message": "Cluster Health is green",
            "version": "3.2.0",
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {
                "cluster_name": "docker-cluster",
                "cluster_health": "green",
                "distribution": "opensearch"
            }
        }
    ]
}
```

## Example Api Response (Docling down)

```
{
    "overall_status": "unhealthy",
    "checked_at": "2026-07-31T07:02:01.799331+00:00",
    "components": [
        {
            "name": "openrag",
            "display_name": "OpenRAG Backend",
            "status": "healthy",
            "required": true,
            "latency_ms": 0,
            "message": "OpenRAG backend is ready",
            "version": "0.5.0",
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {}
        },
        {
            "name": "docling",
            "display_name": "Docling",
            "status": "unhealthy",
            "required": true,
            "latency_ms": 2,
            "message": "Docling Serve unreachable",
            "version": null,
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {}
        },
        {
            "name": "langflow",
            "display_name": "Langflow",
            "status": "healthy",
            "required": true,
            "latency_ms": 4,
            "message": "Langflow API reachable",
            "version": "0.11.2rc0",
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {}
        },
        {
            "name": "opensearch",
            "display_name": "OpenSearch",
            "status": "healthy",
            "required": true,
            "latency_ms": 3,
            "message": "Cluster Health is green",
            "version": "3.2.0",
            "build": {
                "git_sha": null,
                "build_time": null,
                "image": null,
                "image_digest": null
            },
            "metadata": {
                "cluster_name": "docker-cluster",
                "cluster_health": "green",
                "distribution": "opensearch"
            }
        }
    ]
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a status endpoint at `/v1/status` for viewing overall service health.
  * Reports health, latency, versions, build details, diagnostics, and metadata for key components.
  * Distinguishes healthy, degraded, unhealthy, and unknown states.
  * Runs component checks concurrently with timeouts and returns structured results.

* **Tests**
  * Added comprehensive coverage for service checks, failures, timeouts, and status aggregation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->