### PR TITLE
feat: Add ppc64le Dockerfile for opensearch-openrag

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -40,7 +40,9 @@ RUN dnf install -y git make gcc-c++ libstdc++-static java-25-openjdk-devel && dn
 
 ENV JAVA_HOME=/usr/lib/jvm/java-25-openjdk
 
+# make source and target option 8 for async-profiler ppc64le builds on java 25
 RUN git clone --depth 1 --branch v4.2 https://github.com/async-profiler/async-profiler.git /async-profiler && \
+    sed -i 's/-source 7 -target 7/--release $(JAVA_TARGET)/g' /async-profiler/Makefile && \
     cd /async-profiler && \
     make
 

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,136 @@
+########################################
+# Stage 1: ppc64le OpenSearch with plugins
+########################################
+FROM icr.io/ppc64le-oss/opensearch-ppc64le:3.6.0 AS upstream_opensearch
+
+USER root
+
+# jvector is already bundled in the image; remove the stock knn/neural-search plugins
+RUN opensearch-plugin remove opensearch-neural-search || true && \
+    opensearch-plugin remove opensearch-knn || true
+
+#Install jvector and prometheus exporter plugin, .zip files is included in image
+RUN echo y | opensearch-plugin install file://`pwd`/opensearch-jvector-3.6.0.0.zip && \
+    echo y | opensearch-plugin install file://`pwd`/prometheus-exporter-3.6.0.0.zip
+
+# Install ppc64le-compatible neural-search plugin
+RUN mkdir -p /tmp/opensearch-neural-search && \
+    curl -L -s https://github.com/IBM/neural-search-jvector/releases/download/3.6.0.0/opensearch-neural-search-3.6.0.0.zip \
+      > /tmp/opensearch-neural-search/plugin.zip && \
+    opensearch-plugin install --batch file:///tmp/opensearch-neural-search/plugin.zip
+
+# Install additional plugins
+RUN opensearch-plugin install --batch repository-gcs && \
+    opensearch-plugin install --batch repository-azure
+
+# Apply Netty patch
+COPY patch-netty.sh /tmp/
+RUN bash /tmp/patch-netty.sh
+
+# Set permissions for OpenShift compatibility before copying
+RUN chmod -R g=u /usr/share/opensearch
+
+
+########################################
+# Stage 2: Build async-profiler from source
+########################################
+FROM registry.access.redhat.com/ubi10/ubi:latest AS async_profiler_build
+
+RUN dnf install -y git make gcc-c++ libstdc++-static java-25-openjdk-devel && dnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/java-25-openjdk
+
+RUN git clone --depth 1 --branch v4.2 https://github.com/async-profiler/async-profiler.git /async-profiler && \
+    cd /async-profiler && \
+    make
+
+########################################
+# Stage 3: UBI10 runtime image
+########################################
+FROM registry.access.redhat.com/ubi10/ubi:latest
+
+USER root
+
+RUN dnf update -y && \
+    dnf install -y --allowerasing \
+      less procps-ng findutils sudo curl tar gzip shadow-utils which && \
+    dnf clean all
+
+ARG UID=1000
+ARG GID=1000
+ARG OPENSEARCH_HOME=/usr/share/opensearch
+
+WORKDIR $OPENSEARCH_HOME
+
+RUN groupadd -g $GID opensearch && \
+    adduser -u $UID -g $GID -d $OPENSEARCH_HOME opensearch
+
+# Grant the opensearch user sudo privileges (passwordless sudo)
+RUN usermod -aG wheel opensearch && \
+    echo "opensearch ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Copy OpenSearch from upstream stage
+COPY --from=upstream_opensearch --chown=$UID:0 $OPENSEARCH_HOME $OPENSEARCH_HOME
+
+# Copy async-profiler built from source
+COPY --from=async_profiler_build /async-profiler/build/bin /opt/async-profiler/bin
+COPY --from=async_profiler_build /async-profiler/build/lib /opt/async-profiler/lib
+RUN chown -R opensearch:opensearch /opt/async-profiler
+
+# Create profiling script
+RUN echo "#!/bin/bash" > /usr/share/opensearch/profile.sh && \
+    echo "export PATH=\$PATH:/opt/async-profiler/bin" >> /usr/share/opensearch/profile.sh && \
+    echo "echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null" >> /usr/share/opensearch/profile.sh && \
+    echo "echo 0 | sudo tee /proc/sys/kernel/kptr_restrict >/dev/null" >> /usr/share/opensearch/profile.sh && \
+    echo "asprof \$@" >> /usr/share/opensearch/profile.sh && \
+    chmod 777 /usr/share/opensearch/profile.sh
+
+
+########################################
+# Security config (OIDC/DLS) and setup script
+########################################
+
+COPY securityconfig/ /usr/share/opensearch/securityconfig/
+COPY cloud_securityconfig/ /usr/share/opensearch/cloud_securityconfig/
+RUN chown -R opensearch:opensearch /usr/share/opensearch/securityconfig/ /usr/share/opensearch/cloud_securityconfig/
+
+RUN echo '#!/bin/bash' > /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Waiting for OpenSearch to start..."' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD:-${OPENSEARCH_PASSWORD}}' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'if [ -z "$PASSWORD" ]; then echo "[ERROR] OPENSEARCH_INITIAL_ADMIN_PASSWORD or OPENSEARCH_PASSWORD must be set"; exit 1; fi' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'until curl -s -k -u admin:$PASSWORD https://localhost:9200; do sleep 1; done' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Generating admin hash from configured password..."' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'HASH=$(/usr/share/opensearch/plugins/opensearch-security/tools/hash.sh -p "$PASSWORD")' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'if [ -z "$HASH" ]; then echo "[ERROR] Failed to generate admin hash"; exit 1; fi' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'sed -i "s|^  hash: \".*\"|  hash: \"$HASH\"|" /usr/share/opensearch/securityconfig/internal_users.yml' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Updated internal_users.yml with runtime-generated admin hash"' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'BACKEND_URL=${OPENRAG_BACKEND_INTERNAL_URL:-http://${OPENRAG_BACKEND_HOST:-openrag-backend}:${OPENRAG_BACKEND_PORT:-8000}}' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'sed -i "s|http://openrag-backend:8000|$BACKEND_URL|g" /usr/share/opensearch/securityconfig/config.yml /usr/share/opensearch/cloud_securityconfig/config.yml' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Applying OIDC and DLS security configuration..."' >> /usr/share/opensearch/setup-security.sh && \
+    echo '/usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -cd /usr/share/opensearch/securityconfig \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -icl -nhnv \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -cacert /usr/share/opensearch/config/root-ca.pem \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -cert /usr/share/opensearch/config/kirk.pem \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -key /usr/share/opensearch/config/kirk-key.pem' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Security configuration applied successfully"' >> /usr/share/opensearch/setup-security.sh && \
+    chmod +x /usr/share/opensearch/setup-security.sh
+
+COPY opensearch-entrypoint-wrapper.sh /usr/share/opensearch/
+RUN chmod +x /usr/share/opensearch/opensearch-entrypoint-wrapper.sh && \
+    chown opensearch:opensearch /usr/share/opensearch/opensearch-entrypoint-wrapper.sh
+
+
+########################################
+# Final runtime settings
+########################################
+USER opensearch
+WORKDIR $OPENSEARCH_HOME
+ENV JAVA_HOME=$OPENSEARCH_HOME/jdk
+ENV PATH=$PATH:$JAVA_HOME/bin:$OPENSEARCH_HOME/bin
+
+EXPOSE 9200 9300 9600 9650
+
+ENTRYPOINT ["./opensearch-entrypoint-wrapper.sh"]
+CMD []
+


### PR DESCRIPTION
Add Dockerfile.ppc64le 
Pulls from icr.io/ppc64le-oss/opensearch-ppc64le:3.6.0 as upstream OpenSearch 3.6.0 ppc64le base image.
Jvector and prometheus exporter plugin .zip files are already included in base image.
Install async-profiler from source for ppc64le

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a ppc64le-compatible OpenSearch container image.
  * Included OpenSearch plugins, security configuration, OIDC and document-level security settings.
  * Added profiling capabilities and exposed the required service and profiling ports.
  * Added runtime configuration for administrator credentials and backend connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->