### PR TITLE
feat: add console status UI

### DIFF
--- a/frontend/app/api/queries/useConsoleStatusQuery.ts
+++ b/frontend/app/api/queries/useConsoleStatusQuery.ts
@@ -1,0 +1,71 @@
+import {
+  type UseQueryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+export type ComponentState = "healthy" | "degraded" | "unhealthy" | "unknown";
+
+export interface ComponentBuild {
+  git_sha?: string | null;
+  build_time?: string | null;
+  image?: string | null;
+  image_digest?: string | null;
+}
+
+export interface ComponentStatus {
+  name: string;
+  display_name: string;
+  status: ComponentState;
+  required: boolean;
+  latency_ms?: number | null;
+  message?: string | null;
+  version?: string | null;
+  build?: ComponentBuild;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ConsoleStatusResponse {
+  overall_status: ComponentState;
+  checked_at: string;
+  components: ComponentStatus[];
+}
+
+async function fetchConsoleStatus(): Promise<ConsoleStatusResponse> {
+  const response = await fetch("/api/status");
+  if (!response.ok) {
+    // Surface the real error (401 auth, 500 server, etc.) so the query
+    // enters an error state instead of resolving to an empty components array.
+    const body = await response.json().catch(() => ({}));
+    const detail =
+      typeof body?.detail === "string"
+        ? body.detail
+        : typeof body?.error === "string"
+          ? body.error
+          : `HTTP ${response.status}`;
+    throw new Error(detail);
+  }
+  return response.json() as Promise<ConsoleStatusResponse>;
+}
+
+export const useConsoleStatusQuery = (
+  options?: Omit<
+    UseQueryOptions<ConsoleStatusResponse>,
+    "queryKey" | "queryFn"
+  >,
+) => {
+  const queryClient = useQueryClient();
+
+  return useQuery(
+    {
+      queryKey: ["console-status"],
+      queryFn: fetchConsoleStatus,
+      retry: 1,
+      refetchInterval: 30000,
+      refetchOnWindowFocus: false,
+      staleTime: 15000,
+      ...options,
+    },
+    queryClient,
+  );
+};

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -1,0 +1,388 @@
+"use client";
+
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronDown,
+  ChevronUp,
+  HelpCircle,
+  RefreshCw,
+  Settings,
+  XCircle,
+} from "lucide-react";
+import { useCallback, useState } from "react";
+import {
+  type ComponentState,
+  type ComponentStatus,
+  useConsoleStatusQuery,
+} from "@/app/api/queries/useConsoleStatusQuery";
+import { cn } from "@/lib/utils";
+
+// ─── status helpers ──────────────────────────────────────────────────────────
+
+function statusColor(status: ComponentState) {
+  switch (status) {
+    case "healthy":
+      return "text-emerald-400";
+    case "degraded":
+      return "text-amber-400";
+    case "unhealthy":
+      return "text-red-400";
+    default:
+      return "text-zinc-400";
+  }
+}
+
+function statusBadgeCls(status: ComponentState) {
+  switch (status) {
+    case "healthy":
+      return "bg-emerald-500/15 text-emerald-400 border-emerald-500/30";
+    case "degraded":
+      return "bg-amber-500/15 text-amber-400 border-amber-500/30";
+    case "unhealthy":
+      return "bg-red-500/15 text-red-400 border-red-500/30";
+    default:
+      return "bg-zinc-500/15 text-zinc-400 border-zinc-500/30";
+  }
+}
+
+function StatusIcon({
+  status,
+  size = 16,
+}: {
+  status: ComponentState;
+  size?: number;
+}) {
+  switch (status) {
+    case "healthy":
+      return <CheckCircle2 size={size} className="text-emerald-400 shrink-0" />;
+    case "degraded":
+      return <AlertTriangle size={size} className="text-amber-400 shrink-0" />;
+    case "unhealthy":
+      return <XCircle size={size} className="text-red-400 shrink-0" />;
+    default:
+      return <HelpCircle size={size} className="text-zinc-400 shrink-0" />;
+  }
+}
+
+// ─── summary placard ─────────────────────────────────────────────────────────
+
+interface SummaryCardProps {
+  label: string;
+  count: number;
+  state: ComponentState;
+}
+
+function SummaryCard({ label, count, state }: SummaryCardProps) {
+  const colorClass = statusColor(state);
+  return (
+    <div className="flex-1 rounded-lg bg-zinc-800/60 border border-zinc-700/50 px-3 py-2.5">
+      <p className="text-[11px] font-medium text-zinc-400 uppercase tracking-wide">
+        {label}
+      </p>
+      <p className={cn("text-2xl font-semibold mt-0.5", colorClass)}>{count}</p>
+    </div>
+  );
+}
+
+// ─── metadata row ────────────────────────────────────────────────────────────
+
+function MetaRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-2 py-1">
+      <span className="text-xs text-zinc-500 shrink-0">{label}</span>
+      <span className="text-xs text-zinc-300 text-right truncate max-w-[60%]">
+        {value}
+      </span>
+    </div>
+  );
+}
+
+// ─── component placard ───────────────────────────────────────────────────────
+
+interface ComponentCardProps {
+  component: ComponentStatus;
+}
+
+function ComponentCard({ component }: ComponentCardProps) {
+  const [expanded, setExpanded] = useState(false);
+
+  const {
+    display_name,
+    status,
+    version,
+    latency_ms,
+    message,
+    build,
+    metadata,
+  } = component;
+
+  const hasBuildDetails =
+    build &&
+    (build.git_sha || build.build_time || build.image || build.image_digest);
+  const hasMetadata = metadata && Object.keys(metadata).length > 0;
+
+  return (
+    <div
+      className={cn(
+        "rounded-xl border bg-zinc-800/60 transition-colors",
+        expanded ? "border-zinc-600/70" : "border-zinc-700/50",
+      )}
+    >
+      {/* Header row — always clickable; chevron always visible */}
+      <button
+        type="button"
+        className="w-full flex items-center gap-3 px-3.5 py-3 text-left"
+        onClick={() => setExpanded((v) => !v)}
+        aria-expanded={expanded}
+      >
+        <StatusIcon status={status} size={16} />
+
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span className="text-sm font-medium text-zinc-100">
+              {display_name}
+            </span>
+            <span
+              className={cn(
+                "inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold border capitalize",
+                statusBadgeCls(status),
+              )}
+            >
+              {status}
+            </span>
+            {version && (
+              <span className="text-[11px] text-zinc-500">• v{version}</span>
+            )}
+          </div>
+          {message && (
+            <p className="text-xs text-zinc-400 mt-0.5 truncate">{message}</p>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {latency_ms != null && (
+            <span className="text-[11px] text-zinc-500 tabular-nums">
+              {latency_ms}ms
+            </span>
+          )}
+          <span className="text-zinc-500">
+            {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+          </span>
+        </div>
+      </button>
+
+      {/* Expanded details */}
+      {expanded && (
+        <div className="border-t border-zinc-700/50 px-3.5 py-2.5 space-y-1">
+          {hasBuildDetails ? (
+            <>
+              {build?.git_sha && (
+                <MetaRow label="Git SHA" value={build.git_sha.slice(0, 12)} />
+              )}
+              {build?.build_time && (
+                <MetaRow label="Build Time" value={build.build_time} />
+              )}
+              {build?.image && <MetaRow label="Image" value={build.image} />}
+              {build?.image_digest && (
+                <MetaRow
+                  label="Digest"
+                  value={`${build.image_digest.slice(0, 20)}…`}
+                />
+              )}
+            </>
+          ) : null}
+          {hasMetadata
+            ? Object.entries(metadata).map(([k, v]) => (
+                <MetaRow key={k} label={k} value={String(v)} />
+              ))
+            : null}
+          {!hasBuildDetails && !hasMetadata && (
+            <p className="text-xs text-zinc-500 italic">
+              No additional details available.
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── main panel ──────────────────────────────────────────────────────────────
+
+interface ConsoleStatusPanelProps {
+  onClose: () => void;
+}
+
+export function ConsoleStatusPanel({ onClose }: ConsoleStatusPanelProps) {
+  const {
+    data,
+    isLoading,
+    isFetching,
+    isError,
+    error,
+    refetch,
+    dataUpdatedAt,
+  } = useConsoleStatusQuery();
+
+  const handleRefresh = useCallback(() => {
+    void refetch();
+  }, [refetch]);
+
+  // Defensive: always read from data.components array
+  const components = Array.isArray(data?.components) ? data.components : [];
+
+  const counts = {
+    healthy: components.filter((c) => c.status === "healthy").length,
+    degraded: components.filter((c) => c.status === "degraded").length,
+    unhealthy: components.filter((c) => c.status === "unhealthy").length,
+    unknown: components.filter((c) => c.status === "unknown").length,
+  };
+
+  const lastUpdated = dataUpdatedAt
+    ? new Date(dataUpdatedAt).toLocaleTimeString()
+    : null;
+
+  return (
+    /*
+     * Floating card — portalled into document.body so this fixed position
+     * is always relative to the true viewport (no transformed ancestors).
+     * bottom-[5.5rem] clears the button (40px tall) + 24px gap.
+     */
+    <div
+      className={cn(
+        "fixed left-6 bottom-[5.5rem] z-[9999]",
+        "w-[440px] max-h-[calc(100vh-8rem)] flex flex-col",
+        "bg-zinc-900 border border-zinc-700/70 rounded-2xl shadow-2xl overflow-hidden",
+      )}
+    >
+      {/* Panel header */}
+      <div className="flex items-center justify-between px-4 py-3 border-b border-zinc-700/60 shrink-0">
+        <div className="flex items-center gap-2">
+          <Settings size={15} className="text-zinc-400" />
+          <h2 className="text-sm font-semibold text-zinc-100">
+            Console Status
+          </h2>
+          {isFetching && (
+            <RefreshCw size={12} className="text-zinc-500 animate-spin" />
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-zinc-500 hover:text-zinc-300 transition-colors p-1 rounded hover:bg-zinc-700/50"
+          aria-label="Close console status"
+        >
+          <XCircle size={16} />
+        </button>
+      </div>
+
+      {/* Scrollable body */}
+      <div className="flex-1 overflow-y-auto scrollbar-hide px-4 py-3 space-y-3">
+        {/* Summary placards row */}
+        <div className="grid grid-cols-4 gap-2">
+          <SummaryCard label="Healthy" count={counts.healthy} state="healthy" />
+          <SummaryCard
+            label="Degraded"
+            count={counts.degraded}
+            state="degraded"
+          />
+          <SummaryCard
+            label="Unhealthy"
+            count={counts.unhealthy}
+            state="unhealthy"
+          />
+          <SummaryCard label="Unknown" count={counts.unknown} state="unknown" />
+        </div>
+
+        {/* Error state */}
+        {isError && (
+          <div className="rounded-xl border border-red-500/30 bg-red-500/10 px-3.5 py-3 text-sm text-red-400">
+            {error instanceof Error ? error.message : "Failed to load status."}
+          </div>
+        )}
+
+        {/* Component placards */}
+        {isLoading ? (
+          <div className="space-y-2">
+            {[...Array(4)].map((_, i) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders have no identity
+                key={i}
+                className="h-14 rounded-xl bg-zinc-800/50 border border-zinc-700/50 animate-pulse"
+              />
+            ))}
+          </div>
+        ) : components.length === 0 ? (
+          <p className="text-xs text-zinc-500 text-center py-6">
+            No components returned by /v1/status
+          </p>
+        ) : (
+          <div className="space-y-2">
+            {components.map((comp) => (
+              <ComponentCard key={comp.name} component={comp} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Footer */}
+      <div className="shrink-0 flex items-center justify-between px-4 py-2.5 border-t border-zinc-700/60">
+        <span className="text-xs text-zinc-500">
+          {lastUpdated ? `Last updated: ${lastUpdated}` : "Loading…"}
+        </span>
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={isFetching}
+          className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-200 transition-colors disabled:opacity-50"
+        >
+          <RefreshCw size={11} className={cn(isFetching && "animate-spin")} />
+          Refresh All
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ─── floating trigger button ──────────────────────────────────────────────────
+
+interface ConsoleStatusButtonProps {
+  onClick: () => void;
+  isOpen: boolean;
+  overallStatus?: ComponentState;
+}
+
+export function ConsoleStatusButton({
+  onClick,
+  isOpen,
+  overallStatus,
+}: ConsoleStatusButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={isOpen}
+      className={cn(
+        "fixed bottom-6 left-6 z-[9999] flex items-center gap-2 px-3 py-2 rounded-lg",
+        "bg-zinc-800 border border-zinc-700 text-zinc-200 text-sm font-medium",
+        "hover:bg-zinc-700 hover:border-zinc-600 transition-colors shadow-lg",
+        isOpen && "bg-zinc-700 border-zinc-500",
+      )}
+    >
+      <Settings size={14} className="shrink-0 text-zinc-400" />
+      <span>Console Status</span>
+      {overallStatus && (
+        <span
+          className={cn(
+            "w-2 h-2 rounded-full shrink-0",
+            overallStatus === "healthy" && "bg-emerald-400",
+            overallStatus === "degraded" && "bg-amber-400",
+            overallStatus === "unhealthy" && "bg-red-400",
+            overallStatus === "unknown" && "bg-zinc-400",
+          )}
+        />
+      )}
+    </button>
+  );
+}

--- a/frontend/components/layout-wrapper.tsx
+++ b/frontend/components/layout-wrapper.tsx
@@ -2,7 +2,9 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useConsoleStatusQuery } from "@/app/api/queries/useConsoleStatusQuery";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import {
   DoclingHealthBanner,
@@ -20,13 +22,47 @@ import { useIsCloudBrand } from "@/contexts/brand-context";
 import { useChat } from "@/contexts/chat-context";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { useTask } from "@/contexts/task-context";
+import { usePortal } from "@/hooks/use-portal";
 import { ANIMATION_DURATION, HEADER_HEIGHT } from "@/lib/constants";
 import { isFailureLikeTask } from "@/lib/task-utils";
 import { cn } from "@/lib/utils";
 import { AnimatedConditional } from "./animated-conditional";
 import { ChatRenderer } from "./chat-renderer";
+import {
+  ConsoleStatusButton,
+  ConsoleStatusPanel,
+} from "./console-status-panel";
 import { Header } from "./header";
 import FailedTasksInfo from "./tasks_details";
+
+/** Renders the Console Status button + panel directly into document.body via a
+ *  portal so that CSS transforms on ancestor elements (framer-motion sidebar
+ *  slide animation) cannot break `position: fixed` viewport anchoring. */
+function ConsoleStatusPortal({
+  isOpen,
+  onToggle,
+  onClose,
+  overallStatus,
+}: {
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  overallStatus?: import("@/app/api/queries/useConsoleStatusQuery").ComponentState;
+}) {
+  const host = usePortal("console-status-portal");
+  if (!host) return null;
+  return createPortal(
+    <>
+      <ConsoleStatusButton
+        onClick={onToggle}
+        isOpen={isOpen}
+        overallStatus={overallStatus}
+      />
+      {isOpen && <ConsoleStatusPanel onClose={onClose} />}
+    </>,
+    host,
+  );
+}
 
 export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
@@ -36,12 +72,18 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   const { isPanelOpen, panelMode, closePanelOnly } = useKnowledgeFilter();
   const failedTasks = tasks.filter(isFailureLikeTask);
 
+  const [isStatusOpen, setIsStatusOpen] = useState(false);
+  const { data: statusData } = useConsoleStatusQuery({
+    enabled: true,
+  });
+
   const isOnKnowledgePage = pathname.startsWith("/knowledge");
 
-  // Only one panel can be open at a time
+  // Close status panel when task menu opens, and vice-versa
   useEffect(() => {
     if (isMenuOpen) {
       closePanelOnly();
+      setIsStatusOpen(false);
     }
   }, [isMenuOpen, closePanelOnly]);
 
@@ -184,6 +226,17 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
           </div>
         </div>
       </div>
+
+      {/* Console Status — portalled into document.body so fixed positioning
+          is always relative to the viewport, not to any transformed ancestor */}
+      {isOnboardingComplete && (
+        <ConsoleStatusPortal
+          isOpen={isStatusOpen}
+          onToggle={() => setIsStatusOpen((v) => !v)}
+          onClose={() => setIsStatusOpen(false)}
+          overallStatus={statusData?.overall_status}
+        />
+      )}
     </div>
   );
 }

--- a/frontend/hooks/use-portal.ts
+++ b/frontend/hooks/use-portal.ts
@@ -1,0 +1,31 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * Returns a stable <div> element appended directly to document.body.
+ * Mounting is deferred to the client so SSR never touches the DOM.
+ * The element is removed on unmount.
+ */
+export function usePortal(id: string): HTMLElement | null {
+  const [host, setHost] = useState<HTMLElement | null>(null);
+
+  useEffect(() => {
+    let el = document.getElementById(id);
+    let created = false;
+    if (!el) {
+      el = document.createElement("div");
+      el.id = id;
+      document.body.appendChild(el);
+      created = true;
+    }
+    setHost(el);
+    return () => {
+      if (created && el?.parentNode) {
+        el.parentNode.removeChild(el);
+      }
+    };
+  }, [id]);
+
+  return host;
+}

--- a/src/api/health.py
+++ b/src/api/health.py
@@ -3,13 +3,29 @@
 import asyncio
 
 import httpx
-from fastapi import Request
+from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
+from api.schemas.status import StatusResponse
 from config.settings import clients
+from dependencies import require_permission
+from services.status_service import aggregate_status
+from session_manager import User
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+
+async def get_console_status(
+    user: User = Depends(require_permission("providers:read")),
+) -> StatusResponse:
+    """Aggregate component readiness for the browser UI. GET /status"""
+    try:
+        return await aggregate_status()
+    except Exception as e:
+        logger.error("Failed to get console status", error=str(e))
+        raise HTTPException(status_code=500, detail="Failed to get status") from e
+
 
 
 async def health_check(request: Request):

--- a/src/api/health.py
+++ b/src/api/health.py
@@ -27,7 +27,6 @@ async def get_console_status(
         raise HTTPException(status_code=500, detail="Failed to get status") from e
 
 
-
 async def health_check(request: Request):
     """Simple liveness probe: Indicates that the OpenRAG Backend service is online and running."""
     return JSONResponse({"status": "ok"}, status_code=200)

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -31,7 +31,7 @@ from api import (
     upload,
 )
 from api import keys as api_keys
-from api.health import health_check, opensearch_health_ready
+from api.health import get_console_status, health_check, opensearch_health_ready
 from api.schemas.tasks import ErrorResponse, TaskRetryResponse
 from connectors.registry import get_connector_classes
 
@@ -374,6 +374,9 @@ def register_internal_routes(app: FastAPI):
     # Health check endpoints
     app.add_api_route("/health", health_check, methods=["GET"], tags=["internal"])
     app.add_api_route("/search/health", opensearch_health_ready, methods=["GET"], tags=["internal"])
+
+    # Console status endpoint (browser session auth — mirrors /v1/status for the UI)
+    app.add_api_route("/status", get_console_status, methods=["GET"], tags=["internal"])
 
     # Models endpoints
     app.add_api_route(


### PR DESCRIPTION
Fixes #2179 

## Summary

Adds the frontend Console Status UI on top of the status API work.

This introduces a floating Console Status button and compact status panel that renders the `/v1/status` response, including overall health, status counts, and expandable component details.

This also includes the small backend routing/auth updates required for the frontend to call the status endpoint correctly through the app.

## Changes

- Adds a typed React Query hook for the status API response
- Adds a floating Console Status button with an overall health indicator dot
- Adds a compact Console Status panel
- Shows Healthy, Degraded, Unhealthy, and Unknown summary counts
- Renders one expandable component card per returned status component
- Displays component status, version, latency, and message
- Supports expanded build and metadata details when provided by the backend
- Adds loading, error, refresh, and last-updated states
- Moves the button and panel to the bottom-left to avoid overlapping chat input/page controls
- Wires the Console Status UI into the main layout
- Adds the backend route/auth support needed for the frontend status request

## Testing

- Verified the Console Status button appears after onboarding
- Verified the panel opens/closes correctly
- Verified the panel renders status counts and component cards from `/v1/status`
- Verified Refresh All manually refreshes status data
- Verified the overall status dot reflects `overall_status`
- Verified the button and panel no longer overlap the chat input area
- Verified the frontend can call the status endpoint successfully with the backend route/auth updates
- Ran Biome formatting/linting on the new/modified frontend files
- Ran TypeScript validation
