### PR TITLE
fix: properly redirect after oauth signin

### DIFF
--- a/frontend/app/auth/callback/page.tsx
+++ b/frontend/app/auth/callback/page.tsx
@@ -46,9 +46,12 @@ function AuthCallbackContent() {
   const errorParam = searchParams.get("error");
   const code = searchParams.get("code");
   const state = searchParams.get("state");
-  const finalConnectorId =
-    localStorage.getItem("connecting_connector_id") || state;
-  const storedConnectorType = localStorage.getItem("connecting_connector_type");
+  const [finalConnectorId] = useState(
+    () => localStorage.getItem("connecting_connector_id") || state,
+  );
+  const [storedConnectorType] = useState(() =>
+    localStorage.getItem("connecting_connector_type"),
+  );
 
   const validationError = errorParam
     ? `OAuth error: ${errorParam}`


### PR DESCRIPTION
User isn't properly redirect during oauth

**Root cause**: `storedConnectorType` and `finalConnectorId` were read from `localStorage` on every render (plain `localStorage.getItem()` calls) and included in the `useEffect` dependency array. When `onSuccess` called `cleanupOAuthStorage()` — which removes those `localStorage` keys — the next re-render read null for both values. This dependency change triggered the effect to re-run, and its cleanup function (`clearTimeout(redirectTimeoutRef.current)`) cleared the 2-second redirect timeout before it could fire.

**Fix:** Wrapped both values in `useState` initializers (same pattern already used for purpose), so they're read once on mount and remain stable across re-renders. The `cleanupOAuthStorage()` call still clears `localStorage`, but the component's state values don't change, so the effect doesn't re-run and the redirect timeout fires as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth callback handling by preserving connector details consistently during authentication redirects.
  * Increased reliability when restoring connector information from browser storage and URL parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->