### PR TITLE
feat: expose component logs for status console (#2178)

### DIFF
--- a/src/api/schemas/status.py
+++ b/src/api/schemas/status.py
@@ -28,6 +28,22 @@ class ComponentStatus(BaseModel):
     version: str | None = None
     build: ComponentBuild = Field(default_factory=ComponentBuild)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    # Added by #2178 — None when healthy, last exception detail when not.
+    # The frontend uses this as the signal to show the Logs button.
+    last_error: str | None = None
+
+
+class LogEntry(BaseModel):
+    timestamp: str  # ISO-8601 UTC
+    level: str
+    message: str
+    detail: str | None = None
+
+
+class LogsResponse(BaseModel):
+    component: str
+    entries: list[LogEntry] = Field(default_factory=list)
+    count: int
 
 
 class StatusResponse(BaseModel):

--- a/src/api/v1/status.py
+++ b/src/api/v1/status.py
@@ -1,7 +1,8 @@
-from fastapi import Depends, HTTPException
+from fastapi import Depends, HTTPException, Query
 
-from api.schemas.status import StatusResponse
+from api.schemas.status import LogEntry, LogsResponse, StatusResponse
 from dependencies import require_api_key_permission
+from services.component_logs import KNOWN_COMPONENTS, get_entries
 from services.status_service import aggregate_status
 from session_manager import User
 from utils.logging_config import get_logger
@@ -17,5 +18,28 @@ async def get_status_endpoint(
         return await aggregate_status()
     except Exception as e:
         logger.error("Failed to get status", error=str(e))
-
         raise HTTPException(status_code=500, detail="Failed to get status") from e
+
+
+async def get_component_logs_endpoint(
+    component: str,
+    tail: int = Query(default=100, ge=1, le=500),
+    user: User = Depends(require_api_key_permission("providers:read")),
+) -> LogsResponse:
+    """Return recent log entries for one component. GET /v1/status/{component}/logs
+
+    The in-process ring buffer is the uniform source of truth for all four
+    components.  A Langflow native-logs proxy was evaluated and dropped:
+    the endpoint path, auth requirements, and response shape are unstable
+    across Langflow versions (0.9.6 vs 0.11.2rc0+).
+    """
+    if component not in KNOWN_COMPONENTS:
+        valid = ", ".join(sorted(KNOWN_COMPONENTS))
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown component '{component}'. Valid names: {valid}",
+        )
+
+    raw = get_entries(component, tail=tail)
+    entries = [LogEntry(**e) for e in raw]
+    return LogsResponse(component=component, entries=entries, count=len(entries))

--- a/src/app/routes/public_v1.py
+++ b/src/app/routes/public_v1.py
@@ -132,7 +132,15 @@ def register_public_v1_routes(app: FastAPI):
         tags=["public"],
     )
 
-    # Status endpoint
+    # Status endpoints — component logs route must be registered before the
+    # bare /v1/status route so Starlette matches the literal "/logs" suffix
+    # rather than treating it as a {component} path parameter.
+    app.add_api_route(
+        "/v1/status/{component}/logs",
+        v1_status.get_component_logs_endpoint,
+        methods=["GET"],
+        tags=["public"],
+    )
     app.add_api_route(
         "/v1/status",
         v1_status.get_status_endpoint,

--- a/src/services/component_logs.py
+++ b/src/services/component_logs.py
@@ -21,9 +21,7 @@ KNOWN_COMPONENTS: frozenset[str] = frozenset({"openrag", "langflow", "docling", 
 
 # Reuse the same pattern as logging_config._SENSITIVE_HEADER_RE so that keys
 # / tokens never surface in HTTP responses.
-_SENSITIVE_RE = re.compile(
-    r"(key|token|secret|password|apikey|credential|jwt|auth)", re.IGNORECASE
-)
+_SENSITIVE_RE = re.compile(r"(key|token|secret|password|apikey|credential|jwt|auth)", re.IGNORECASE)
 # Strip bare Bearer tokens from free-form detail strings.
 _BEARER_RE = re.compile(r"Bearer\s+\S+", re.IGNORECASE)
 
@@ -35,7 +33,7 @@ _BEARER_RE = re.compile(r"Bearer\s+\S+", re.IGNORECASE)
 
 class LogEntry(TypedDict):
     timestamp: str  # ISO-8601 UTC
-    level: str      # "debug" | "info" | "warning" | "error" | "critical"
+    level: str  # "debug" | "info" | "warning" | "error" | "critical"
     message: str
     detail: str | None
 

--- a/src/services/component_logs.py
+++ b/src/services/component_logs.py
@@ -1,0 +1,148 @@
+"""In-memory ring buffer for per-component log entries.
+
+Intentionally free of FastAPI imports so services can use it at any layer.
+Thread-safe via a per-component threading.Lock.
+"""
+
+import re
+import threading
+from collections import deque
+from datetime import UTC, datetime
+from typing import TypedDict
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+BUFFER_MAXLEN = 200
+
+# Valid component names — used by the API layer for 404 gating.
+KNOWN_COMPONENTS: frozenset[str] = frozenset({"openrag", "langflow", "docling", "opensearch"})
+
+# Reuse the same pattern as logging_config._SENSITIVE_HEADER_RE so that keys
+# / tokens never surface in HTTP responses.
+_SENSITIVE_RE = re.compile(
+    r"(key|token|secret|password|apikey|credential|jwt|auth)", re.IGNORECASE
+)
+# Strip bare Bearer tokens from free-form detail strings.
+_BEARER_RE = re.compile(r"Bearer\s+\S+", re.IGNORECASE)
+
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+
+class LogEntry(TypedDict):
+    timestamp: str  # ISO-8601 UTC
+    level: str      # "debug" | "info" | "warning" | "error" | "critical"
+    message: str
+    detail: str | None
+
+
+# ---------------------------------------------------------------------------
+# Internal state
+# ---------------------------------------------------------------------------
+
+# deque per component name
+_buffers: dict[str, deque[LogEntry]] = {}
+_locks: dict[str, threading.Lock] = {}
+# last outcome per component: True = last check was healthy, False = unhealthy/unknown
+_last_ok: dict[str, bool] = {}
+_state_lock = threading.Lock()
+
+
+def _get_or_create(component: str) -> tuple[deque[LogEntry], threading.Lock]:
+    """Return (buffer, lock) for *component*, creating them on first access."""
+    with _state_lock:
+        if component not in _buffers:
+            _buffers[component] = deque(maxlen=BUFFER_MAXLEN)
+            _locks[component] = threading.Lock()
+        return _buffers[component], _locks[component]
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def _redact(text: str | None) -> str | None:
+    """Strip Bearer tokens from *text*. Key/secret values are not present in
+    free-form detail strings (they come from exception messages), but Bearer
+    tokens can appear in httpx error repr if auth headers are dumped."""
+    if text is None:
+        return None
+    return _BEARER_RE.sub("Bearer ***", text)
+
+
+def _redact_dict(event_dict: dict) -> dict:
+    """Return a shallow copy of *event_dict* with sensitive values masked."""
+    out = {}
+    for k, v in event_dict.items():
+        if _SENSITIVE_RE.search(str(k)):
+            out[k] = "***"
+        elif isinstance(v, str):
+            out[k] = _BEARER_RE.sub("Bearer ***", v)
+        else:
+            out[k] = v
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def record(component: str, level: str, message: str, detail: str | None = None) -> None:
+    """Append one entry to *component*'s ring buffer.
+
+    Unknown component names are silently accepted so callers never need to
+    guard — the buffer just grows dynamically (still capped at BUFFER_MAXLEN).
+    """
+    buf, lock = _get_or_create(component)
+    entry: LogEntry = {
+        "timestamp": datetime.now(UTC).isoformat(),
+        "level": level,
+        "message": message,
+        "detail": _redact(detail),
+    }
+    with lock:
+        buf.append(entry)
+
+
+def record_check_result(
+    component: str,
+    ok: bool,
+    message: str,
+    detail: str | None = None,
+) -> None:
+    """Write to the buffer with flood-prevention logic.
+
+    - Failure (ok=False): always records an error entry.
+    - Recovery (False→True transition): records one info "recovered" entry.
+    - Steady healthy (True→True): records nothing, keeping error history intact.
+    """
+    with _state_lock:
+        was_ok = _last_ok.get(component, True)  # assume healthy on first call
+        _last_ok[component] = ok
+
+    if not ok:
+        record(component, "error", message, detail=detail)
+    elif not was_ok:
+        # Transition: unhealthy → healthy
+        record(component, "info", f"recovered: {message}")
+
+
+def get_entries(component: str, tail: int = 100) -> list[LogEntry]:
+    """Return up to *tail* most-recent entries for *component* (oldest→newest).
+
+    Returns an empty list for unknown / never-recorded components.
+    """
+    if component not in _buffers:
+        return []
+    buf, lock = _get_or_create(component)
+    with lock:
+        entries = list(buf)
+    if tail >= len(entries):
+        return entries
+    return entries[-tail:]

--- a/src/services/status_checks.py
+++ b/src/services/status_checks.py
@@ -1,7 +1,8 @@
 from time import perf_counter
 
 from api.schemas.status import ComponentBuild, ComponentState, ComponentStatus
-from config.settings import DOCLING_SERVE_URL, clients, get_openrag_config
+from config.settings import DOCLING_SERVE_URL, LANGFLOW_URL, clients, get_openrag_config
+from services.component_logs import record_check_result
 from utils.logging_config import get_logger
 from utils.version_utils import OPENRAG_VERSION
 
@@ -16,17 +17,22 @@ async def check_openrag_backend() -> ComponentStatus:
         get_openrag_config()
     except Exception as e:
         logger.warning("OpenRAG config not loaded", error=str(e))
-
+        message = "OpenRAG configuration is not loaded"
+        record_check_result(
+            "openrag", False, message,
+            detail=f"{type(e).__name__}: {e}",
+        )
         return ComponentStatus(
             name="openrag",
             display_name="OpenRAG Backend",
             status=ComponentState.UNHEALTHY,
             required=True,
             latency_ms=int((perf_counter() - start) * 1000),
-            message="OpenRAG configuration is not loaded",
+            message=message,
             version=None,
             build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
             metadata={},
+            last_error=f"{type(e).__name__}: {e}",
         )
 
     missing = []
@@ -40,8 +46,12 @@ async def check_openrag_backend() -> ComponentStatus:
     if missing:
         status = ComponentState.DEGRADED
         message = "Backend serving but not fully initialized: " + ", ".join(missing)
+        record_check_result("openrag", False, message)
+        last_error: str | None = message
     else:
         status, message = ComponentState.HEALTHY, "OpenRAG backend is ready"
+        record_check_result("openrag", True, message)
+        last_error = None
 
     return ComponentStatus(
         name="openrag",
@@ -53,37 +63,56 @@ async def check_openrag_backend() -> ComponentStatus:
         version=OPENRAG_VERSION,
         build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
         metadata={},
+        last_error=last_error,
     )
 
 
 async def check_docling() -> ComponentStatus:
     start = perf_counter()
     version = None
+    target_url = f"{DOCLING_SERVE_URL}/version"
 
     try:
         docling_client = clients.docling_http_client
         if not docling_client:
+            message = "Docling client is not initialized"
+            record_check_result("docling", False, message)
             return ComponentStatus(
                 name="docling",
                 display_name="Docling",
                 status=ComponentState.UNKNOWN,
                 required=True,
                 latency_ms=int((perf_counter() - start) * 1000),
-                message="Docling client is not initialized",
+                message=message,
                 version=version,
                 build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
                 metadata={},
+                last_error=message,
             )
 
-        resp = await docling_client.get(f"{DOCLING_SERVE_URL}/version", timeout=_CHECK_TIMEOUT_S)
+        resp = await docling_client.get(target_url, timeout=_CHECK_TIMEOUT_S)
         if resp.status_code == 200:
             status, message = ComponentState.HEALTHY, "Docling Serve reachable"
             version = resp.json().get("docling-serve")
+            record_check_result("docling", True, message)
+            last_error = None
         else:
-            status, message = ComponentState.UNHEALTHY, f"Docling returned HTTP {resp.status_code}"
+            message = f"Docling returned HTTP {resp.status_code}"
+            status = ComponentState.UNHEALTHY
+            record_check_result(
+                "docling", False, message,
+                detail=f"HTTP {resp.status_code} — target: {target_url}",
+            )
+            last_error = message
     except Exception as e:
         logger.warning("Docling status check failed", error=str(e))
-        status, message = ComponentState.UNHEALTHY, "Docling Serve unreachable"
+        message = "Docling Serve unreachable"
+        status = ComponentState.UNHEALTHY
+        record_check_result(
+            "docling", False, message,
+            detail=f"{type(e).__name__}: {e} — target: {target_url}",
+        )
+        last_error = f"{type(e).__name__}: {e} — target: {target_url}"
 
     return ComponentStatus(
         name="docling",
@@ -95,38 +124,56 @@ async def check_docling() -> ComponentStatus:
         version=version,
         build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
         metadata={},
+        last_error=last_error,
     )
 
 
 async def check_langflow() -> ComponentStatus:
     start = perf_counter()
     version = None
+    target_url = f"{LANGFLOW_URL}/api/v1/version"
 
     try:
         langflow_client = clients.langflow_http_client
         if not langflow_client:
+            message = "Langflow client is not initialized"
+            record_check_result("langflow", False, message)
             return ComponentStatus(
                 name="langflow",
                 display_name="Langflow",
                 status=ComponentState.UNKNOWN,
                 required=True,
                 latency_ms=int((perf_counter() - start) * 1000),
-                message="Langflow client is not initialized",
+                message=message,
                 version=version,
                 build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
                 metadata={},
+                last_error=message,
             )
 
         resp = await langflow_client.get("/api/v1/version", timeout=_CHECK_TIMEOUT_S)
         if resp.status_code == 200:
             status, message = ComponentState.HEALTHY, "Langflow API reachable"
             version = resp.json().get("version")
+            record_check_result("langflow", True, message)
+            last_error = None
         else:
-            status, message = ComponentState.UNHEALTHY, f"Langflow returned HTTP {resp.status_code}"
+            message = f"Langflow returned HTTP {resp.status_code}"
+            status = ComponentState.UNHEALTHY
+            record_check_result(
+                "langflow", False, message,
+                detail=f"HTTP {resp.status_code} — target: {target_url}",
+            )
+            last_error = message
     except Exception as e:
         logger.warning("Langflow status check failed", error=str(e))
-
-        status, message = ComponentState.UNHEALTHY, "Langflow is unreachable"
+        message = "Langflow is unreachable"
+        status = ComponentState.UNHEALTHY
+        record_check_result(
+            "langflow", False, message,
+            detail=f"{type(e).__name__}: {e} — target: {target_url}",
+        )
+        last_error = f"{type(e).__name__}: {e} — target: {target_url}"
 
     return ComponentStatus(
         name="langflow",
@@ -138,6 +185,7 @@ async def check_langflow() -> ComponentStatus:
         version=version,
         build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
         metadata={},
+        last_error=last_error,
     )
 
 
@@ -149,16 +197,19 @@ async def check_opensearch() -> ComponentStatus:
     try:
         opensearch = clients.opensearch
         if opensearch is None:
+            message = "OpenSearch client is not initialized"
+            record_check_result("opensearch", False, message)
             return ComponentStatus(
                 name="opensearch",
                 display_name="OpenSearch",
                 status=ComponentState.UNKNOWN,
                 required=True,
                 latency_ms=int((perf_counter() - start) * 1000),
-                message="OpenSearch client is not initialized",
+                message=message,
                 version=version,
                 build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
                 metadata={},
+                last_error=message,
             )
 
         health = await opensearch.cluster.health()
@@ -178,12 +229,23 @@ async def check_opensearch() -> ComponentStatus:
             "cluster_health": cluster_status,
             "distribution": distribution,
         }
+        ok = status in (ComponentState.HEALTHY, ComponentState.DEGRADED)
+        record_check_result(
+            "opensearch", ok, message,
+            detail=None if ok else f"cluster_health={cluster_status}",
+        )
+        last_error = None if ok else f"cluster_health={cluster_status}"
 
     except Exception as e:
         logger.warning("OpenSearch status check failed", error=str(e))
-
-        status, message = ComponentState.UNHEALTHY, "OpenSearch is unreachable"
+        message = "OpenSearch is unreachable"
+        status = ComponentState.UNHEALTHY
         metadata = {}
+        record_check_result(
+            "opensearch", False, message,
+            detail=f"{type(e).__name__}: {e}",
+        )
+        last_error = f"{type(e).__name__}: {e}"
 
     return ComponentStatus(
         name="opensearch",
@@ -195,4 +257,5 @@ async def check_opensearch() -> ComponentStatus:
         version=os_version,
         build=ComponentBuild(),  # NOTE: deferring this to later Version and build traceability step
         metadata=metadata,
+        last_error=last_error,
     )

--- a/src/services/status_checks.py
+++ b/src/services/status_checks.py
@@ -19,7 +19,9 @@ async def check_openrag_backend() -> ComponentStatus:
         logger.warning("OpenRAG config not loaded", error=str(e))
         message = "OpenRAG configuration is not loaded"
         record_check_result(
-            "openrag", False, message,
+            "openrag",
+            False,
+            message,
             detail=f"{type(e).__name__}: {e}",
         )
         return ComponentStatus(
@@ -100,7 +102,9 @@ async def check_docling() -> ComponentStatus:
             message = f"Docling returned HTTP {resp.status_code}"
             status = ComponentState.UNHEALTHY
             record_check_result(
-                "docling", False, message,
+                "docling",
+                False,
+                message,
                 detail=f"HTTP {resp.status_code} — target: {target_url}",
             )
             last_error = message
@@ -109,7 +113,9 @@ async def check_docling() -> ComponentStatus:
         message = "Docling Serve unreachable"
         status = ComponentState.UNHEALTHY
         record_check_result(
-            "docling", False, message,
+            "docling",
+            False,
+            message,
             detail=f"{type(e).__name__}: {e} — target: {target_url}",
         )
         last_error = f"{type(e).__name__}: {e} — target: {target_url}"
@@ -161,7 +167,9 @@ async def check_langflow() -> ComponentStatus:
             message = f"Langflow returned HTTP {resp.status_code}"
             status = ComponentState.UNHEALTHY
             record_check_result(
-                "langflow", False, message,
+                "langflow",
+                False,
+                message,
                 detail=f"HTTP {resp.status_code} — target: {target_url}",
             )
             last_error = message
@@ -170,7 +178,9 @@ async def check_langflow() -> ComponentStatus:
         message = "Langflow is unreachable"
         status = ComponentState.UNHEALTHY
         record_check_result(
-            "langflow", False, message,
+            "langflow",
+            False,
+            message,
             detail=f"{type(e).__name__}: {e} — target: {target_url}",
         )
         last_error = f"{type(e).__name__}: {e} — target: {target_url}"
@@ -231,7 +241,9 @@ async def check_opensearch() -> ComponentStatus:
         }
         ok = status in (ComponentState.HEALTHY, ComponentState.DEGRADED)
         record_check_result(
-            "opensearch", ok, message,
+            "opensearch",
+            ok,
+            message,
             detail=None if ok else f"cluster_health={cluster_status}",
         )
         last_error = None if ok else f"cluster_health={cluster_status}"
@@ -242,7 +254,9 @@ async def check_opensearch() -> ComponentStatus:
         status = ComponentState.UNHEALTHY
         metadata = {}
         record_check_result(
-            "opensearch", False, message,
+            "opensearch",
+            False,
+            message,
             detail=f"{type(e).__name__}: {e}",
         )
         last_error = f"{type(e).__name__}: {e}"

--- a/src/services/status_service.py
+++ b/src/services/status_service.py
@@ -3,6 +3,7 @@ from collections.abc import Awaitable, Callable
 from datetime import UTC, datetime
 
 from api.schemas.status import ComponentState, ComponentStatus, StatusResponse
+from services.component_logs import record
 from services.status_checks import (
     check_docling,
     check_langflow,
@@ -19,19 +20,37 @@ CHECK_SPECS = [check_openrag_backend, check_docling, check_langflow, check_opens
 
 
 async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentStatus:
-    """TODO: add docstrings here"""
+    """Run one check function, wrapping timeouts and unexpected exceptions.
+
+    Both failure modes are recorded to the component log buffer so that the
+    /v1/status/{component}/logs endpoint can surface the detail later.
+    """
+    name = fn.__name__.replace("check_", "")
     try:
         return await asyncio.wait_for(fn(), timeout=CHECK_TIMEOUT_S)
-    except Exception as e:
-        name = fn.__name__.replace("check_", "")
-        logger.warning("Status check did not complete", component=name, error=str(e))
-
+    except asyncio.TimeoutError as e:
+        msg = f"Status check timed out after {CHECK_TIMEOUT_S}s"
+        logger.warning("Status check timed out", component=name, timeout_s=CHECK_TIMEOUT_S)
+        record(name, "error", msg, detail=f"asyncio.TimeoutError — timeout={CHECK_TIMEOUT_S}s")
         return ComponentStatus(
             name=name,
             display_name=name.title(),
             status=ComponentState.UNKNOWN,
             required=True,
             message="Status check did not complete",
+            last_error=msg,
+        )
+    except Exception as e:
+        msg = "Status check did not complete"
+        logger.warning("Status check did not complete", component=name, error=str(e))
+        record(name, "error", msg, detail=f"{type(e).__name__}: {e}")
+        return ComponentStatus(
+            name=name,
+            display_name=name.title(),
+            status=ComponentState.UNKNOWN,
+            required=True,
+            message=msg,
+            last_error=f"{type(e).__name__}: {e}",
         )
 
 

--- a/src/services/status_service.py
+++ b/src/services/status_service.py
@@ -28,7 +28,7 @@ async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentS
     name = fn.__name__.replace("check_", "")
     try:
         return await asyncio.wait_for(fn(), timeout=CHECK_TIMEOUT_S)
-    except asyncio.TimeoutError as e:
+    except TimeoutError:
         msg = f"Status check timed out after {CHECK_TIMEOUT_S}s"
         logger.warning("Status check timed out", component=name, timeout_s=CHECK_TIMEOUT_S)
         record(name, "error", msg, detail=f"asyncio.TimeoutError — timeout={CHECK_TIMEOUT_S}s")

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -116,8 +116,17 @@ def mirror_to_component_buffer(_, __, event_dict: dict[str, Any]) -> dict[str, A
         message = str(safe.pop("event", ""))
         # Build a compact detail string from remaining context keys (skip
         # structlog internals and the fields already in message/level).
-        skip = {"level", "service", "env", "version", "timestamp",
-                "func_name", "filename", "lineno", "pathname"}
+        skip = {
+            "level",
+            "service",
+            "env",
+            "version",
+            "timestamp",
+            "func_name",
+            "filename",
+            "lineno",
+            "pathname",
+        }
         detail_parts = [f"{k}={v}" for k, v in safe.items() if k not in skip and v is not None]
         detail = "; ".join(detail_parts) if detail_parts else None
 

--- a/src/utils/logging_config.py
+++ b/src/utils/logging_config.py
@@ -32,6 +32,10 @@ _SENSITIVE_HEADER_RE = re.compile(
 # reference the same chain that configure_logging() assembled.
 _shared_processors: list = []
 
+# Minimum stdlib level integer that gets mirrored into the component buffer.
+# WARNING=30, ERROR=40, CRITICAL=50.
+_MIRROR_MIN_LEVEL = logging.WARNING
+
 
 # ---------------------------------------------------------------------------
 # Standalone processors (module-level so they can be reused in stdlib bridge)
@@ -92,6 +96,37 @@ def add_global_fields_factory(service: str, env: str, version: str):
     return processor
 
 
+def mirror_to_component_buffer(_, __, event_dict: dict[str, Any]) -> dict[str, Any]:
+    """Structlog processor: mirror WARNING+ backend events into the 'openrag' buffer.
+
+    Runs after add_log_level so event_dict["level"] is always present.
+    Uses lazy import to avoid circular imports at module load time.
+    Reuses _SENSITIVE_HEADER_RE for key redaction; also strips Bearer tokens.
+    This processor is a pass-through — it never drops or modifies the event.
+    """
+    try:
+        level_str = event_dict.get("level", "info")
+        level_int = getattr(logging, level_str.upper(), logging.INFO)
+        if level_int < _MIRROR_MIN_LEVEL:
+            return event_dict
+
+        from services.component_logs import _redact_dict, record  # noqa: PLC0415
+
+        safe = _redact_dict(dict(event_dict))
+        message = str(safe.pop("event", ""))
+        # Build a compact detail string from remaining context keys (skip
+        # structlog internals and the fields already in message/level).
+        skip = {"level", "service", "env", "version", "timestamp",
+                "func_name", "filename", "lineno", "pathname"}
+        detail_parts = [f"{k}={v}" for k, v in safe.items() if k not in skip and v is not None]
+        detail = "; ".join(detail_parts) if detail_parts else None
+
+        record("openrag", level_str.lower(), message, detail=detail)
+    except Exception:  # pragma: no cover — never let logging crash the app
+        pass
+    return event_dict
+
+
 # ---------------------------------------------------------------------------
 # Security helper
 # ---------------------------------------------------------------------------
@@ -130,6 +165,9 @@ def configure_logging(
         clean_log_location,
         add_global_fields_factory(service_name, app_env, app_version),
         structlog.processors.add_log_level,
+        # Mirror WARNING+ to the per-component ring buffer (must come after
+        # add_log_level so event_dict["level"] is populated).
+        mirror_to_component_buffer,
         structlog.processors.StackInfoRenderer(),
         drop_color_message_key,
     ]

--- a/tests/unit/api/test_status_logs_endpoint.py
+++ b/tests/unit/api/test_status_logs_endpoint.py
@@ -21,7 +21,6 @@ from api.schemas.status import LogsResponse  # noqa: E402
 from api.v1.status import get_component_logs_endpoint  # noqa: E402
 from session_manager import User  # noqa: E402
 
-
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_status_logs_endpoint.py
+++ b/tests/unit/api/test_status_logs_endpoint.py
@@ -1,0 +1,168 @@
+"""Unit tests for GET /v1/status/{component}/logs endpoint handler.
+
+Tests call the endpoint function directly (not via a full TestClient stack)
+to stay consistent with the other unit/api tests in this directory.
+"""
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import services.component_logs as cl  # noqa: E402
+from api.schemas.status import LogsResponse  # noqa: E402
+from api.v1.status import get_component_logs_endpoint  # noqa: E402
+from session_manager import User  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _user():
+    return MagicMock(spec=User)
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffer():
+    cl._buffers.clear()
+    cl._locks.clear()
+    cl._last_ok.clear()
+    yield
+    cl._buffers.clear()
+    cl._locks.clear()
+    cl._last_ok.clear()
+
+
+# ---------------------------------------------------------------------------
+# 404 — unknown component
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unknown_component_raises_404():
+    with pytest.raises(HTTPException) as exc_info:
+        await get_component_logs_endpoint(component="foobar", tail=50, user=_user())
+
+    assert exc_info.value.status_code == 404
+    assert "foobar" in exc_info.value.detail
+    assert "Valid names" in exc_info.value.detail
+
+
+@pytest.mark.asyncio
+async def test_404_detail_lists_all_known_names():
+    with pytest.raises(HTTPException) as exc_info:
+        await get_component_logs_endpoint(component="unknown", tail=50, user=_user())
+
+    detail = exc_info.value.detail
+    for name in ("docling", "langflow", "openrag", "opensearch"):
+        assert name in detail
+
+
+# ---------------------------------------------------------------------------
+# 200 — known components from buffer
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_known_component_returns_200_shape():
+    cl.record("opensearch", "error", "cluster red", detail="status=red")
+
+    result = await get_component_logs_endpoint(component="opensearch", tail=50, user=_user())
+
+    assert isinstance(result, LogsResponse)
+    assert result.component == "opensearch"
+    assert result.count == 1
+    assert len(result.entries) == 1
+    e = result.entries[0]
+    assert e.level == "error"
+    assert e.message == "cluster red"
+    assert e.detail == "status=red"
+
+
+@pytest.mark.asyncio
+async def test_empty_buffer_returns_zero_count():
+    result = await get_component_logs_endpoint(component="docling", tail=50, user=_user())
+
+    assert result.component == "docling"
+    assert result.count == 0
+    assert result.entries == []
+
+
+@pytest.mark.asyncio
+async def test_tail_parameter_limits_entries():
+    for i in range(20):
+        cl.record("openrag", "warning", f"msg-{i}")
+
+    result = await get_component_logs_endpoint(component="openrag", tail=5, user=_user())
+
+    assert result.count == 5
+    assert len(result.entries) == 5
+    # Should be most recent 5
+    assert result.entries[-1].message == "msg-19"
+    assert result.entries[0].message == "msg-15"
+
+
+@pytest.mark.asyncio
+async def test_entries_are_oldest_to_newest():
+    for i in range(3):
+        cl.record("docling", "error", f"err-{i}")
+
+    result = await get_component_logs_endpoint(component="docling", tail=10, user=_user())
+
+    messages = [e.message for e in result.entries]
+    assert messages == ["err-0", "err-1", "err-2"]
+
+
+@pytest.mark.asyncio
+async def test_count_matches_entries_length():
+    cl.record("opensearch", "error", "a")
+    cl.record("opensearch", "error", "b")
+    cl.record("opensearch", "error", "c")
+
+    result = await get_component_logs_endpoint(component="opensearch", tail=100, user=_user())
+
+    assert result.count == len(result.entries) == 3
+
+
+# ---------------------------------------------------------------------------
+# Response schema validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_entry_detail_can_be_none():
+    cl.record("openrag", "warning", "no detail")
+
+    result = await get_component_logs_endpoint(component="openrag", tail=10, user=_user())
+
+    assert result.entries[0].detail is None
+
+
+@pytest.mark.asyncio
+async def test_langflow_uses_buffer_like_all_other_components():
+    """Langflow now goes through the same buffer path as every other component."""
+    cl.record("langflow", "error", "langflow-down", detail="ConnectError")
+
+    result = await get_component_logs_endpoint(component="langflow", tail=50, user=_user())
+
+    assert result.component == "langflow"
+    assert result.count == 1
+    assert result.entries[0].message == "langflow-down"
+
+
+@pytest.mark.asyncio
+async def test_all_known_components_return_200():
+    """All four known components must not raise, even with empty buffers."""
+    for name in ("openrag", "langflow", "docling", "opensearch"):
+        result = await get_component_logs_endpoint(component=name, tail=10, user=_user())
+        assert result.component == name
+        assert isinstance(result.entries, list)

--- a/tests/unit/services/test_component_logs.py
+++ b/tests/unit/services/test_component_logs.py
@@ -1,0 +1,183 @@
+"""Unit tests for services.component_logs.
+
+Covers: ring buffer behaviour, record_check_result() transition logic,
+get_entries() tail slicing, redaction of sensitive values and Bearer tokens.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+import services.component_logs as cl  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _reset_buffer():
+    """Clear all buffer state before every test so tests are independent."""
+    cl._buffers.clear()
+    cl._locks.clear()
+    cl._last_ok.clear()
+    yield
+    cl._buffers.clear()
+    cl._locks.clear()
+    cl._last_ok.clear()
+
+
+# ---------------------------------------------------------------------------
+# record() and get_entries() basics
+# ---------------------------------------------------------------------------
+
+
+def test_record_stores_entry():
+    cl.record("langflow", "error", "down", detail="ConnectError")
+    entries = cl.get_entries("langflow", tail=10)
+    assert len(entries) == 1
+    e = entries[0]
+    assert e["level"] == "error"
+    assert e["message"] == "down"
+    assert e["detail"] == "ConnectError"
+    assert "timestamp" in e
+
+
+def test_get_entries_unknown_component_returns_empty():
+    result = cl.get_entries("nope", tail=50)
+    assert result == []
+
+
+def test_get_entries_tail_slices_most_recent():
+    for i in range(10):
+        cl.record("opensearch", "error", f"msg-{i}")
+    entries = cl.get_entries("opensearch", tail=3)
+    assert len(entries) == 3
+    # Last three messages
+    assert entries[-1]["message"] == "msg-9"
+    assert entries[0]["message"] == "msg-7"
+
+
+def test_get_entries_tail_larger_than_buffer_returns_all():
+    cl.record("docling", "error", "one")
+    cl.record("docling", "error", "two")
+    assert len(cl.get_entries("docling", tail=500)) == 2
+
+
+def test_buffer_respects_maxlen():
+    """Oldest entries are evicted once maxlen is hit."""
+    for i in range(cl.BUFFER_MAXLEN + 5):
+        cl.record("langflow", "error", f"msg-{i}")
+    entries = cl.get_entries("langflow", tail=cl.BUFFER_MAXLEN + 5)
+    assert len(entries) == cl.BUFFER_MAXLEN
+    # First entry should be msg-5 (the first five were evicted)
+    assert entries[0]["message"] == "msg-5"
+
+
+def test_entries_oldest_to_newest_order():
+    for i in range(5):
+        cl.record("openrag", "warning", f"w{i}")
+    msgs = [e["message"] for e in cl.get_entries("openrag", tail=10)]
+    assert msgs == ["w0", "w1", "w2", "w3", "w4"]
+
+
+def test_separate_components_have_independent_buffers():
+    cl.record("langflow", "error", "langflow-err")
+    cl.record("docling", "error", "docling-err")
+    assert cl.get_entries("langflow", 10)[0]["message"] == "langflow-err"
+    assert cl.get_entries("docling", 10)[0]["message"] == "docling-err"
+    assert len(cl.get_entries("opensearch", 10)) == 0
+
+
+# ---------------------------------------------------------------------------
+# record_check_result() transition logic
+# ---------------------------------------------------------------------------
+
+
+def test_failure_always_records():
+    cl.record_check_result("langflow", False, "down", detail="err")
+    entries = cl.get_entries("langflow", 10)
+    assert len(entries) == 1
+    assert entries[0]["level"] == "error"
+
+
+def test_repeated_failures_all_recorded():
+    for _ in range(3):
+        cl.record_check_result("langflow", False, "still down")
+    assert len(cl.get_entries("langflow", 10)) == 3
+
+
+def test_healthy_after_healthy_records_nothing():
+    """Steady-state healthy should not write anything."""
+    cl.record_check_result("langflow", True, "ok")
+    cl.record_check_result("langflow", True, "ok")
+    assert cl.get_entries("langflow", 10) == []
+
+
+def test_recovery_transition_writes_one_info_entry():
+    """False→True transition: exactly one info 'recovered' entry."""
+    cl.record_check_result("opensearch", False, "cluster red")
+    cl.record_check_result("opensearch", True, "cluster green")
+    entries = cl.get_entries("opensearch", 10)
+    assert len(entries) == 2  # 1 error + 1 info
+    assert entries[0]["level"] == "error"
+    assert entries[1]["level"] == "info"
+    assert "recovered" in entries[1]["message"]
+
+
+def test_no_recovery_entry_when_first_call_is_healthy():
+    """The very first call with ok=True (no prior failure) records nothing."""
+    cl.record_check_result("docling", True, "reachable")
+    assert cl.get_entries("docling", 10) == []
+
+
+def test_healthy_after_recovery_records_nothing_more():
+    """After a recovery entry, subsequent healthy calls are still silent."""
+    cl.record_check_result("langflow", False, "down")
+    cl.record_check_result("langflow", True, "up")   # recovery → 1 info
+    cl.record_check_result("langflow", True, "up")   # steady healthy → nothing
+    cl.record_check_result("langflow", True, "up")
+    assert len(cl.get_entries("langflow", 10)) == 2  # still just error + recovery
+
+
+def test_second_failure_after_recovery_is_recorded():
+    """Failure → recovery → failure again: second failure should be recorded."""
+    cl.record_check_result("opensearch", False, "down1")     # error
+    cl.record_check_result("opensearch", True, "up")         # info recovery
+    cl.record_check_result("opensearch", False, "down2")     # error again
+    entries = cl.get_entries("opensearch", 10)
+    assert len(entries) == 3
+    levels = [e["level"] for e in entries]
+    assert levels == ["error", "info", "error"]
+
+
+# ---------------------------------------------------------------------------
+# Redaction
+# ---------------------------------------------------------------------------
+
+
+def test_bearer_token_in_detail_is_redacted():
+    cl.record("openrag", "error", "auth failed", detail="Authorization: Bearer abc123token")
+    detail = cl.get_entries("openrag", 1)[0]["detail"]
+    assert "abc123token" not in detail
+    assert "Bearer ***" in detail
+
+
+def test_redact_dict_masks_sensitive_keys():
+    safe = cl._redact_dict({"api_key": "sk-secret", "message": "hello", "token": "xyz"})
+    assert safe["api_key"] == "***"
+    assert safe["token"] == "***"
+    assert safe["message"] == "hello"
+
+
+def test_redact_dict_strips_bearer_from_string_values():
+    safe = cl._redact_dict({"info": "header: Bearer supersecret rest"})
+    assert "supersecret" not in safe["info"]
+    assert "Bearer ***" in safe["info"]
+
+
+def test_detail_none_stored_as_none():
+    cl.record("docling", "error", "fail", detail=None)
+    assert cl.get_entries("docling", 1)[0]["detail"] is None

--- a/tests/unit/services/test_component_logs.py
+++ b/tests/unit/services/test_component_logs.py
@@ -136,17 +136,17 @@ def test_no_recovery_entry_when_first_call_is_healthy():
 def test_healthy_after_recovery_records_nothing_more():
     """After a recovery entry, subsequent healthy calls are still silent."""
     cl.record_check_result("langflow", False, "down")
-    cl.record_check_result("langflow", True, "up")   # recovery → 1 info
-    cl.record_check_result("langflow", True, "up")   # steady healthy → nothing
+    cl.record_check_result("langflow", True, "up")  # recovery → 1 info
+    cl.record_check_result("langflow", True, "up")  # steady healthy → nothing
     cl.record_check_result("langflow", True, "up")
     assert len(cl.get_entries("langflow", 10)) == 2  # still just error + recovery
 
 
 def test_second_failure_after_recovery_is_recorded():
     """Failure → recovery → failure again: second failure should be recorded."""
-    cl.record_check_result("opensearch", False, "down1")     # error
-    cl.record_check_result("opensearch", True, "up")         # info recovery
-    cl.record_check_result("opensearch", False, "down2")     # error again
+    cl.record_check_result("opensearch", False, "down1")  # error
+    cl.record_check_result("opensearch", True, "up")  # info recovery
+    cl.record_check_result("opensearch", False, "down2")  # error again
     entries = cl.get_entries("opensearch", 10)
     assert len(entries) == 3
     levels = [e["level"] for e in entries]

--- a/tests/unit/services/test_status_checks.py
+++ b/tests/unit/services/test_status_checks.py
@@ -201,3 +201,185 @@ async def test_opensearch_unreachable_is_unhealthy(monkeypatch):
     assert r.status == ComponentState.UNHEALTHY
     assert "unreachable" in (r.message or "").lower()
     assert r.version is None
+
+# ---------------------------------------------------------------------------
+# Buffer recording assertions (added by #2178)
+# ---------------------------------------------------------------------------
+# Each block verifies that record_check_result() is called correctly by the
+# check functions: errors land in the buffer, healthy checks do not.
+
+import services.component_logs as _cl
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_buffer():
+    _cl._buffers.clear()
+    _cl._locks.clear()
+    _cl._last_ok.clear()
+    yield
+    _cl._buffers.clear()
+    _cl._locks.clear()
+    _cl._last_ok.clear()
+
+
+@pytest.mark.asyncio
+async def test_openrag_unhealthy_records_to_buffer(monkeypatch):
+    def _raise():
+        raise RuntimeError("config missing")
+
+    monkeypatch.setattr(status_checks, "get_openrag_config", _raise, raising=True)
+
+    r = await check_openrag_backend()
+
+    assert r.status == ComponentState.UNHEALTHY
+    entries = _cl.get_entries("openrag", 10)
+    assert len(entries) >= 1
+    assert entries[-1]["level"] == "error"
+    assert entries[-1]["detail"] is not None
+    assert "RuntimeError" in entries[-1]["detail"]
+
+
+@pytest.mark.asyncio
+async def test_openrag_degraded_records_to_buffer(monkeypatch):
+    monkeypatch.setattr(status_checks, "get_openrag_config", lambda: object(), raising=True)
+    monkeypatch.setattr(clients, "opensearch", None, raising=False)
+    monkeypatch.setattr(clients, "langflow_http_client", MagicMock(), raising=False)
+    monkeypatch.setattr(clients, "docling_http_client", MagicMock(), raising=False)
+
+    r = await check_openrag_backend()
+
+    assert r.status == ComponentState.DEGRADED
+    entries = _cl.get_entries("openrag", 10)
+    assert len(entries) >= 1
+    assert entries[-1]["level"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_openrag_healthy_does_not_flood_buffer(monkeypatch):
+    """Steady-state healthy should not write to the buffer on repeated calls."""
+    monkeypatch.setattr(status_checks, "get_openrag_config", lambda: object(), raising=True)
+    monkeypatch.setattr(clients, "opensearch", MagicMock(), raising=False)
+    monkeypatch.setattr(clients, "langflow_http_client", MagicMock(), raising=False)
+    monkeypatch.setattr(clients, "docling_http_client", MagicMock(), raising=False)
+
+    await check_openrag_backend()
+    await check_openrag_backend()
+    await check_openrag_backend()
+
+    # No error entries; buffer is empty (first-healthy → nothing written)
+    assert _cl.get_entries("openrag", 10) == []
+
+
+@pytest.mark.asyncio
+async def test_docling_unreachable_records_detail_with_target_url(monkeypatch):
+    monkeypatch.setattr(
+        clients,
+        "docling_http_client",
+        _mock_http(raises=httpx.ConnectError("refused")),
+        raising=False,
+    )
+
+    r = await check_docling()
+
+    assert r.status == ComponentState.UNHEALTHY
+    entries = _cl.get_entries("docling", 10)
+    assert len(entries) >= 1
+    e = entries[-1]
+    assert e["level"] == "error"
+    assert "ConnectError" in (e["detail"] or "")
+    assert "target:" in (e["detail"] or "")
+
+
+@pytest.mark.asyncio
+async def test_docling_healthy_does_not_flood_buffer(monkeypatch):
+    monkeypatch.setattr(clients, "docling_http_client", _mock_http(200), raising=False)
+
+    await check_docling()
+    await check_docling()
+
+    assert _cl.get_entries("docling", 10) == []
+
+
+@pytest.mark.asyncio
+async def test_langflow_unreachable_records_detail_with_target_url(monkeypatch):
+    monkeypatch.setattr(
+        clients,
+        "langflow_http_client",
+        _mock_http(raises=httpx.ConnectError("refused")),
+        raising=False,
+    )
+
+    r = await check_langflow()
+
+    assert r.status == ComponentState.UNHEALTHY
+    entries = _cl.get_entries("langflow", 10)
+    assert len(entries) >= 1
+    e = entries[-1]
+    assert e["level"] == "error"
+    assert "ConnectError" in (e["detail"] or "")
+    assert "target:" in (e["detail"] or "")
+    # last_error on the returned status should match detail prefix
+    assert r.last_error is not None
+    assert "ConnectError" in r.last_error
+
+
+@pytest.mark.asyncio
+async def test_opensearch_unreachable_records_to_buffer(monkeypatch):
+    monkeypatch.setattr(
+        clients, "opensearch", _mock_os(raises=ConnectionError("down")), raising=False
+    )
+
+    r = await check_opensearch()
+
+    assert r.status == ComponentState.UNHEALTHY
+    entries = _cl.get_entries("opensearch", 10)
+    assert len(entries) >= 1
+    assert entries[-1]["level"] == "error"
+    assert "ConnectionError" in (entries[-1]["detail"] or "")
+    assert r.last_error is not None
+
+
+@pytest.mark.asyncio
+async def test_opensearch_recovery_writes_info_entry(monkeypatch):
+    """After a failure, a subsequent healthy check writes one 'recovered' info entry."""
+    # First call: unhealthy
+    monkeypatch.setattr(
+        clients, "opensearch", _mock_os(raises=ConnectionError("down")), raising=False
+    )
+    await check_opensearch()
+
+    # Second call: healthy
+    monkeypatch.setattr(
+        clients, "opensearch", _mock_os({"status": "green", "cluster_name": "c"}), raising=False
+    )
+    await check_opensearch()
+
+    entries = _cl.get_entries("opensearch", 10)
+    levels = [e["level"] for e in entries]
+    assert "error" in levels
+    assert "info" in levels
+    info_entries = [e for e in entries if e["level"] == "info"]
+    assert any("recovered" in e["message"] for e in info_entries)
+
+
+@pytest.mark.asyncio
+async def test_last_error_is_none_when_healthy(monkeypatch):
+    """last_error on ComponentStatus must be None for a healthy check."""
+    monkeypatch.setattr(clients, "docling_http_client", _mock_http(200), raising=False)
+    r = await check_docling()
+    assert r.status == ComponentState.HEALTHY
+    assert r.last_error is None
+
+
+@pytest.mark.asyncio
+async def test_last_error_populated_on_failure(monkeypatch):
+    monkeypatch.setattr(
+        clients,
+        "langflow_http_client",
+        _mock_http(raises=httpx.ConnectError("refused")),
+        raising=False,
+    )
+    r = await check_langflow()
+    assert r.last_error is not None
+    assert len(r.last_error) > 0
+

--- a/tests/unit/services/test_status_checks.py
+++ b/tests/unit/services/test_status_checks.py
@@ -202,6 +202,7 @@ async def test_opensearch_unreachable_is_unhealthy(monkeypatch):
     assert "unreachable" in (r.message or "").lower()
     assert r.version is None
 
+
 # ---------------------------------------------------------------------------
 # Buffer recording assertions (added by #2178)
 # ---------------------------------------------------------------------------
@@ -382,4 +383,3 @@ async def test_last_error_populated_on_failure(monkeypatch):
     r = await check_langflow()
     assert r.last_error is not None
     assert len(r.last_error) > 0
-

--- a/tests/unit/services/test_status_checks.py
+++ b/tests/unit/services/test_status_checks.py
@@ -3,6 +3,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
+import services.component_logs as _cl
 from api.schemas.status import ComponentState
 from config.settings import clients
 from services import status_checks
@@ -208,8 +209,6 @@ async def test_opensearch_unreachable_is_unhealthy(monkeypatch):
 # ---------------------------------------------------------------------------
 # Each block verifies that record_check_result() is called correctly by the
 # check functions: errors land in the buffer, healthy checks do not.
-
-import services.component_logs as _cl
 
 
 @pytest.fixture(autouse=True)

--- a/tests/unit/services/test_status_service.py
+++ b/tests/unit/services/test_status_service.py
@@ -81,6 +81,7 @@ async def test_check_exception_becomes_unknown(monkeypatch):
 
     assert result.overall_status == ComponentState.UNHEALTHY
 
+
 # ---------------------------------------------------------------------------
 # Buffer recording assertions for _run_check (added by #2178)
 # ---------------------------------------------------------------------------
@@ -102,6 +103,7 @@ def _reset_log_buffer():
 @pytest.mark.asyncio
 async def test_timeout_records_error_to_buffer(monkeypatch):
     """A timed-out check must write an error entry to the component buffer."""
+
     async def slow():
         await asyncio.sleep(5)
         return _result("docling", ComponentState.HEALTHY)
@@ -117,13 +119,16 @@ async def test_timeout_records_error_to_buffer(monkeypatch):
     entries = _cl.get_entries("slow", tail=10)
     assert len(entries) >= 1
     assert entries[-1]["level"] == "error"
-    assert "timeout" in entries[-1]["message"].lower() or "timed out" in entries[-1]["message"].lower()
+    assert (
+        "timeout" in entries[-1]["message"].lower() or "timed out" in entries[-1]["message"].lower()
+    )
     assert result.components[0].last_error is not None
 
 
 @pytest.mark.asyncio
 async def test_check_exception_records_error_to_buffer(monkeypatch):
     """An unexpected exception must write an error entry to the component buffer."""
+
     async def boom():
         raise ValueError("unexpected")
 
@@ -138,4 +143,3 @@ async def test_check_exception_records_error_to_buffer(monkeypatch):
     assert "ValueError" in (entries[-1]["detail"] or "")
     assert result.components[0].last_error is not None
     assert "ValueError" in result.components[0].last_error
-

--- a/tests/unit/services/test_status_service.py
+++ b/tests/unit/services/test_status_service.py
@@ -80,3 +80,62 @@ async def test_check_exception_becomes_unknown(monkeypatch):
     result = await status_service.aggregate_status()
 
     assert result.overall_status == ComponentState.UNHEALTHY
+
+# ---------------------------------------------------------------------------
+# Buffer recording assertions for _run_check (added by #2178)
+# ---------------------------------------------------------------------------
+
+import services.component_logs as _cl
+
+
+@pytest.fixture(autouse=True)
+def _reset_log_buffer():
+    _cl._buffers.clear()
+    _cl._locks.clear()
+    _cl._last_ok.clear()
+    yield
+    _cl._buffers.clear()
+    _cl._locks.clear()
+    _cl._last_ok.clear()
+
+
+@pytest.mark.asyncio
+async def test_timeout_records_error_to_buffer(monkeypatch):
+    """A timed-out check must write an error entry to the component buffer."""
+    async def slow():
+        await asyncio.sleep(5)
+        return _result("docling", ComponentState.HEALTHY)
+
+    monkeypatch.setattr(status_service, "CHECK_TIMEOUT_S", 0.05, raising=True)
+    monkeypatch.setattr(status_service, "CHECK_SPECS", [slow], raising=True)
+
+    result = await status_service.aggregate_status()
+
+    assert result.components[0].status == ComponentState.UNKNOWN
+    # _run_check names the component from the function name: "slow" → but we
+    # patch the name via fn.__name__. Use the actual function name here.
+    entries = _cl.get_entries("slow", tail=10)
+    assert len(entries) >= 1
+    assert entries[-1]["level"] == "error"
+    assert "timeout" in entries[-1]["message"].lower() or "timed out" in entries[-1]["message"].lower()
+    assert result.components[0].last_error is not None
+
+
+@pytest.mark.asyncio
+async def test_check_exception_records_error_to_buffer(monkeypatch):
+    """An unexpected exception must write an error entry to the component buffer."""
+    async def boom():
+        raise ValueError("unexpected")
+
+    monkeypatch.setattr(status_service, "CHECK_SPECS", [boom], raising=True)
+
+    result = await status_service.aggregate_status()
+
+    assert result.components[0].status == ComponentState.UNKNOWN
+    entries = _cl.get_entries("boom", tail=10)
+    assert len(entries) >= 1
+    assert entries[-1]["level"] == "error"
+    assert "ValueError" in (entries[-1]["detail"] or "")
+    assert result.components[0].last_error is not None
+    assert "ValueError" in result.components[0].last_error
+

--- a/tests/unit/services/test_status_service.py
+++ b/tests/unit/services/test_status_service.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+import services.component_logs as _cl
 from api.schemas.status import ComponentState, ComponentStatus
 from services import status_service
 
@@ -85,8 +86,6 @@ async def test_check_exception_becomes_unknown(monkeypatch):
 # ---------------------------------------------------------------------------
 # Buffer recording assertions for _run_check (added by #2178)
 # ---------------------------------------------------------------------------
-
-import services.component_logs as _cl
 
 
 @pytest.fixture(autouse=True)


### PR DESCRIPTION
Closes #2178. Adds a per-component in-memory ring buffer (`component_logs.py`), a `last_error` field on `ComponentStatus` (flows through both `/v1/status` and the internal `/status` automatically via the shared `StatusResponse` model), and `GET /v1/status/{component}/logs` with 404 gating.

Recovery entries are written only on failure→success transitions, so status polling can't flood the buffer. A Langflow native-log proxy was evaluated and dropped: its endpoint path, auth requirement, and response shape all vary across Langflow versions (verified live on 0.9.6).

Rebased onto #2193; no file overlap. Live smoke-tested on a running Podman stack: stop langflow → `unhealthy` + `last_error` + buffer entries → single `recovered` entry on restart; 404 contract and API-key auth verified.

Tests: +40 passing (1235 vs base 1195). The 23 failures and 3 collection errors are identical on the base branch (import drift vs main) and unrelated. Known minor: check-failure warnings also mirror into the `openrag` buffer via the WARNING mirror — filter candidate for a follow-up.