### PR TITLE
fix: paginate wildcard listing to prevent documents missing from Knowledge view

### DIFF
--- a/frontend/app/api/queries/useGetSearchQuery.ts
+++ b/frontend/app/api/queries/useGetSearchQuery.ts
@@ -10,6 +10,7 @@ import { buildSearchPayloadFilters } from "@/lib/filter-normalization";
 export interface SearchPayload {
   query: string;
   limit: number;
+  offset?: number;
   scoreThreshold: number;
   filters?: {
     data_sources?: string[];
@@ -88,6 +89,95 @@ const EMPTY_SEARCH_RESULT: SearchResult = { files: [], warnings: [] };
 
 export { EMPTY_SEARCH_RESULT };
 
+// Chunk page size used when paginating the wildcard listing.
+// Smaller than WILDCARD_QUERY_LIMIT to avoid oversized individual requests
+// while still covering corpora with many thousands of chunks per pass.
+const WILDCARD_PAGE_SIZE = 1000;
+
+/** Fire one POST /api/search and return the raw JSON. */
+async function fetchSearchPage(payload: SearchPayload): Promise<{
+  results: ChunkResult[];
+  aggregations: Record<string, unknown>;
+  warnings?: SearchWarning[];
+}> {
+  const response = await fetch("/api/search", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorData = await response
+      .json()
+      .catch(() => ({ error: "Unknown error" }));
+    throw new Error(
+      errorData.error || `Search failed with status ${response.status}`,
+    );
+  }
+
+  return response.json();
+}
+
+/** Merge a batch of chunks into the running file map. */
+function mergeChunksIntoFileMap(
+  chunks: ChunkResult[],
+  fileMap: Map<
+    string,
+    {
+      filename: string;
+      mimetype: string;
+      chunks: ChunkResult[];
+      totalScore: number;
+      source_url?: string;
+      owner?: string;
+      owner_name?: string;
+      owner_email?: string;
+      file_size?: number;
+      connector_type?: string;
+      embedding_model?: string;
+      embedding_dimensions?: number;
+      allowed_users?: string[];
+      allowed_groups?: string[];
+    }
+  >,
+  getFileIdentity: (chunk: ChunkResult) => string,
+): void {
+  for (const chunk of chunks) {
+    const fileIdentity = getFileIdentity(chunk);
+    const existing = fileMap.get(fileIdentity);
+    if (existing) {
+      existing.chunks.push(chunk);
+      existing.totalScore += chunk.score;
+      if (!existing.embedding_model && chunk.embedding_model) {
+        existing.embedding_model = chunk.embedding_model;
+      }
+      if (
+        existing.embedding_dimensions == null &&
+        typeof chunk.embedding_dimensions === "number"
+      ) {
+        existing.embedding_dimensions = chunk.embedding_dimensions;
+      }
+    } else {
+      fileMap.set(fileIdentity, {
+        filename: fileIdentity,
+        mimetype: chunk.mimetype,
+        chunks: [chunk],
+        totalScore: chunk.score,
+        source_url: chunk.source_url,
+        owner: chunk.owner,
+        owner_name: chunk.owner_name,
+        owner_email: chunk.owner_email,
+        file_size: chunk.file_size,
+        connector_type: chunk.connector_type,
+        embedding_model: chunk.embedding_model,
+        embedding_dimensions: chunk.embedding_dimensions,
+        allowed_users: chunk.allowed_users || [],
+        allowed_groups: chunk.allowed_groups || [],
+      });
+    }
+  }
+}
+
 const getFileIdentity = (chunk: ChunkResult): string => {
   const normalizedFilename = chunk.filename?.trim();
   if (normalizedFilename) {
@@ -118,13 +208,96 @@ export const useGetSearchQuery = (
 
   async function getFiles(): Promise<SearchResult> {
     try {
-      // For wildcard queries, use a high limit to get all files
-      // Otherwise use the limit from queryData or default to 100
       const isWildcardQuery =
         effectiveQuery.trim() === "*" || effectiveQuery.trim() === "";
-      const searchLimit = isWildcardQuery
-        ? SEARCH_CONSTANTS.WILDCARD_QUERY_LIMIT
-        : queryData?.limit || 100;
+
+      if (isWildcardQuery) {
+        // ── Wildcard path: paginate through ALL chunks to build a complete file list ──
+        // A single request capped at WILDCARD_QUERY_LIMIT chunks misses files whose
+        // chunks happen to fall past the limit boundary. Instead, fetch pages of
+        // WILDCARD_PAGE_SIZE chunks, advancing the offset until the last page arrives
+        // (fewer results than the page size), then deduplicate into a file list.
+        const basePayload: SearchPayload = {
+          query: effectiveQuery,
+          limit: WILDCARD_PAGE_SIZE,
+          scoreThreshold: 0, // match_all — no score threshold
+        };
+        if (queryData?.filters) {
+          basePayload.filters =
+            buildSearchPayloadFilters(queryData.filters) ?? undefined;
+        }
+
+        const fileMap = new Map<
+          string,
+          {
+            filename: string;
+            mimetype: string;
+            chunks: ChunkResult[];
+            totalScore: number;
+            source_url?: string;
+            owner?: string;
+            owner_name?: string;
+            owner_email?: string;
+            file_size?: number;
+            connector_type?: string;
+            embedding_model?: string;
+            embedding_dimensions?: number;
+            allowed_users?: string[];
+            allowed_groups?: string[];
+          }
+        >();
+
+        let offset = 0;
+        let warnings: SearchWarning[] = [];
+
+        while (true) {
+          const page = await fetchSearchPage({ ...basePayload, offset });
+
+          if (offset === 0) {
+            warnings = Array.isArray(page.warnings) ? page.warnings : [];
+          }
+
+          const chunks: ChunkResult[] = page.results ?? [];
+          mergeChunksIntoFileMap(chunks, fileMap, getFileIdentity);
+
+          // Stop when this page has fewer chunks than the page size (last page)
+          if (chunks.length < WILDCARD_PAGE_SIZE) {
+            break;
+          }
+
+          offset += WILDCARD_PAGE_SIZE;
+
+          // Safety cap: never exceed WILDCARD_QUERY_LIMIT total chunks fetched.
+          // This prevents runaway loops against unexpectedly huge corpora while
+          // still being far above the previous single-request limit.
+          if (offset >= SEARCH_CONSTANTS.WILDCARD_QUERY_LIMIT) {
+            break;
+          }
+        }
+
+        const files: File[] = Array.from(fileMap.values()).map((file) => ({
+          filename: file.filename,
+          mimetype: file.mimetype,
+          chunkCount: file.chunks.length,
+          avgScore: file.totalScore / file.chunks.length,
+          source_url: file.source_url || "",
+          owner: file.owner || "",
+          owner_name: file.owner_name || "",
+          owner_email: file.owner_email || "",
+          size: file.file_size || 0,
+          connector_type: file.connector_type || "local",
+          embedding_model: file.embedding_model,
+          embedding_dimensions: file.embedding_dimensions,
+          chunks: file.chunks,
+          allowed_users: file.allowed_users || [],
+          allowed_groups: file.allowed_groups || [],
+        }));
+
+        return { files, warnings };
+      }
+
+      // ── Non-wildcard path: single semantic/keyword search, unchanged ──
+      const searchLimit = queryData?.limit || 100;
 
       const baseScoreThreshold =
         queryData?.scoreThreshold ?? SEARCH_CONSTANTS.DEFAULT_SCORE_THRESHOLD;
@@ -147,25 +320,8 @@ export const useGetSearchQuery = (
           buildSearchPayloadFilters(queryData.filters) ?? undefined;
       }
 
-      const response = await fetch(`/api/search`, {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify(searchPayload),
-      });
+      const data = await fetchSearchPage(searchPayload);
 
-      if (!response.ok) {
-        const errorData = await response
-          .json()
-          .catch(() => ({ error: "Unknown error" }));
-        throw new Error(
-          errorData.error || `Search failed with status ${response.status}`,
-        );
-      }
-
-      const data = await response.json();
-      // Group chunks by filename to create file results similar to page.tsx
       const fileMap = new Map<
         string,
         {
@@ -186,40 +342,7 @@ export const useGetSearchQuery = (
         }
       >();
 
-      (data.results || []).forEach((chunk: ChunkResult) => {
-        const fileIdentity = getFileIdentity(chunk);
-        const existing = fileMap.get(fileIdentity);
-        if (existing) {
-          existing.chunks.push(chunk);
-          existing.totalScore += chunk.score;
-          if (!existing.embedding_model && chunk.embedding_model) {
-            existing.embedding_model = chunk.embedding_model;
-          }
-          if (
-            existing.embedding_dimensions == null &&
-            typeof chunk.embedding_dimensions === "number"
-          ) {
-            existing.embedding_dimensions = chunk.embedding_dimensions;
-          }
-        } else {
-          fileMap.set(fileIdentity, {
-            filename: fileIdentity,
-            mimetype: chunk.mimetype,
-            chunks: [chunk],
-            totalScore: chunk.score,
-            source_url: chunk.source_url,
-            owner: chunk.owner,
-            owner_name: chunk.owner_name,
-            owner_email: chunk.owner_email,
-            file_size: chunk.file_size,
-            connector_type: chunk.connector_type,
-            embedding_model: chunk.embedding_model,
-            embedding_dimensions: chunk.embedding_dimensions,
-            allowed_users: chunk.allowed_users || [],
-            allowed_groups: chunk.allowed_groups || [],
-          });
-        }
-      });
+      mergeChunksIntoFileMap(data.results ?? [], fileMap, getFileIdentity);
 
       const files: File[] = Array.from(fileMap.values()).map((file) => ({
         filename: file.filename,

--- a/src/api/search.py
+++ b/src/api/search.py
@@ -1,25 +1,25 @@
 from typing import Any, Dict
 
 from fastapi import Depends
-from pydantic import BaseModel, Field
 from fastapi.responses import JSONResponse
-from utils.logging_config import get_logger
-from utils.opensearch_utils import OpenSearchDiskSpaceError, DISK_SPACE_ERROR_MESSAGE
+from pydantic import BaseModel, Field
 
 from dependencies import (
+    get_current_user,
     get_search_service,
     get_session_manager,
-    get_current_user,
     require_permission,
 )
 from session_manager import User
+from utils.logging_config import get_logger
+from utils.opensearch_utils import DISK_SPACE_ERROR_MESSAGE, OpenSearchDiskSpaceError
 
 logger = get_logger(__name__)
 
 
 class SearchBody(BaseModel):
     query: str
-    filters: Dict[str, Any] = Field(default_factory=dict)
+    filters: dict[str, Any] = Field(default_factory=dict)
     limit: int = 10
     offset: int = Field(default=0, ge=0, description="Number of chunks to skip (for pagination)")
     scoreThreshold: float = Field(default=0, alias="scoreThreshold")
@@ -62,10 +62,7 @@ async def search(
         return JSONResponse({"error": DISK_SPACE_ERROR_MESSAGE}, status_code=507)
     except Exception as e:
         error_msg = str(e)
-        if (
-            "AuthenticationException" in error_msg
-            or "access denied" in error_msg.lower()
-        ):
+        if "AuthenticationException" in error_msg or "access denied" in error_msg.lower():
             return JSONResponse({"error": error_msg}, status_code=403)
         else:
             return JSONResponse({"error": error_msg}, status_code=500)

--- a/src/api/search.py
+++ b/src/api/search.py
@@ -21,6 +21,7 @@ class SearchBody(BaseModel):
     query: str
     filters: Dict[str, Any] = Field(default_factory=dict)
     limit: int = 10
+    offset: int = Field(default=0, ge=0, description="Number of chunks to skip (for pagination)")
     scoreThreshold: float = Field(default=0, alias="scoreThreshold")
 
     model_config = {"populate_by_name": True}
@@ -43,6 +44,7 @@ async def search(
             query=body.query,
             filters=body.filters,
             limit=body.limit,
+            offset=body.offset,
             score_threshold=body.scoreThreshold,
         )
 
@@ -52,6 +54,7 @@ async def search(
             jwt_token=jwt_token,
             filters=body.filters,
             limit=body.limit,
+            offset=body.offset,
             score_threshold=body.scoreThreshold,
         )
         return JSONResponse(result, status_code=200)

--- a/src/auth_context.py
+++ b/src/auth_context.py
@@ -19,6 +19,9 @@ _current_search_filters: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
 _current_search_limit: ContextVar[Optional[int]] = ContextVar(
     "current_search_limit", default=10
 )
+_current_search_offset: ContextVar[int] = ContextVar(
+    "current_search_offset", default=0
+)
 _current_score_threshold: ContextVar[Optional[float]] = ContextVar(
     "current_score_threshold", default=0
 )
@@ -63,6 +66,16 @@ def set_search_limit(limit: int):
 def get_search_limit() -> int:
     """Get current search limit from context"""
     return _current_search_limit.get()
+
+
+def set_search_offset(offset: int):
+    """Set chunk offset for paginated wildcard listing"""
+    _current_search_offset.set(offset)
+
+
+def get_search_offset() -> int:
+    """Get current chunk offset from context"""
+    return _current_search_offset.get()
 
 
 def set_score_threshold(threshold: float):

--- a/src/auth_context.py
+++ b/src/auth_context.py
@@ -4,25 +4,17 @@ Uses contextvars to safely pass user auth info through async calls.
 """
 
 from contextvars import ContextVar
-from typing import Optional, Dict, Any
+from typing import Any, Dict, Optional
 
 # Context variables for current request authentication
-_current_user_id: ContextVar[Optional[str]] = ContextVar(
-    "current_user_id", default=None
-)
-_current_jwt_token: ContextVar[Optional[str]] = ContextVar(
-    "current_jwt_token", default=None
-)
-_current_search_filters: ContextVar[Optional[Dict[str, Any]]] = ContextVar(
+_current_user_id: ContextVar[str | None] = ContextVar("current_user_id", default=None)
+_current_jwt_token: ContextVar[str | None] = ContextVar("current_jwt_token", default=None)
+_current_search_filters: ContextVar[dict[str, Any] | None] = ContextVar(
     "current_search_filters", default=None
 )
-_current_search_limit: ContextVar[Optional[int]] = ContextVar(
-    "current_search_limit", default=10
-)
-_current_search_offset: ContextVar[int] = ContextVar(
-    "current_search_offset", default=0
-)
-_current_score_threshold: ContextVar[Optional[float]] = ContextVar(
+_current_search_limit: ContextVar[int | None] = ContextVar("current_search_limit", default=10)
+_current_search_offset: ContextVar[int] = ContextVar("current_search_offset", default=0)
+_current_score_threshold: ContextVar[float | None] = ContextVar(
     "current_score_threshold", default=0
 )
 
@@ -33,27 +25,27 @@ def set_auth_context(user_id: str, jwt_token: str):
     _current_jwt_token.set(jwt_token)
 
 
-def get_current_user_id() -> Optional[str]:
+def get_current_user_id() -> str | None:
     """Get current user ID from context"""
     return _current_user_id.get()
 
 
-def get_current_jwt_token() -> Optional[str]:
+def get_current_jwt_token() -> str | None:
     """Get current JWT token from context"""
     return _current_jwt_token.get()
 
 
-def get_auth_context() -> tuple[Optional[str], Optional[str]]:
+def get_auth_context() -> tuple[str | None, str | None]:
     """Get current authentication context (user_id, jwt_token)"""
     return _current_user_id.get(), _current_jwt_token.get()
 
 
-def set_search_filters(filters: Dict[str, Any]):
+def set_search_filters(filters: dict[str, Any]):
     """Set search filters for the current async context"""
     _current_search_filters.set(filters)
 
 
-def get_search_filters() -> Optional[Dict[str, Any]]:
+def get_search_filters() -> dict[str, Any] | None:
     """Get current search filters from context"""
     return _current_search_filters.get()
 

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -190,15 +190,17 @@ class SearchService:
 
         # Get authentication context from the current async context
         user_id, jwt_token = get_auth_context()
-        # Get search filters, limit, and score threshold from context
+        # Get search filters, limit, offset, and score threshold from context
         from auth_context import (
             get_score_threshold,
             get_search_filters,
             get_search_limit,
+            get_score_threshold,
         )
 
         filters = get_search_filters() or {}
         limit = get_search_limit()
+        offset = get_search_offset()
         score_threshold = get_score_threshold()
         # Detect wildcard request ("*") to return global facets/stats without semantic search
         is_wildcard_match_all = isinstance(query, str) and query.strip() == "*"
@@ -497,10 +499,10 @@ class SearchService:
         search_body: dict[str, Any] = {
             "query": query_block,
             "aggs": {
-                "data_sources": {"terms": {"field": "filename", "size": 20}},
-                "document_types": {"terms": {"field": "mimetype", "size": 10}},
-                "owners": {"terms": {"field": "owner", "size": 10}},
-                "connector_types": {"terms": {"field": "connector_type", "size": 10}},
+                "data_sources": {"terms": {"field": "filename", "size": 10000}},
+                "document_types": {"terms": {"field": "mimetype", "size": 100}},
+                "owners": {"terms": {"field": "owner", "size": 1000}},
+                "connector_types": {"terms": {"field": "connector_type", "size": 100}},
                 "embedding_models": {"terms": {"field": "embedding_model", "size": 10}},
             },
             "_source": [
@@ -523,6 +525,7 @@ class SearchService:
                 "allowed_groups",
                 "allowed_principal_labels",
             ],
+            "from": offset,
             "size": limit,
         }
 
@@ -701,6 +704,7 @@ class SearchService:
         jwt_token: str = None,
         filters: dict[str, Any] = None,
         limit: int = 10,
+        offset: int = 0,
         score_threshold: float = 0,
         embedding_model: str = None,
     ) -> dict[str, Any]:
@@ -718,15 +722,16 @@ class SearchService:
 
             set_auth_context(user_id, jwt_token)
 
-        # Set filters and limit in context if provided
+        # Set filters, limit, offset, and score threshold in context if provided
         if filters:
             from auth_context import set_search_filters
 
             set_search_filters(filters)
 
-        from auth_context import set_score_threshold, set_search_limit
+        from auth_context import set_search_limit, set_score_threshold
 
         set_search_limit(limit)
+        set_search_offset(offset)
         set_score_threshold(score_threshold)
 
         return await self.search_tool(query, embedding_model=embedding_model)

--- a/src/services/search_service.py
+++ b/src/services/search_service.py
@@ -195,7 +195,6 @@ class SearchService:
             get_score_threshold,
             get_search_filters,
             get_search_limit,
-            get_score_threshold,
         )
 
         filters = get_search_filters() or {}
@@ -728,7 +727,7 @@ class SearchService:
 
             set_search_filters(filters)
 
-        from auth_context import set_search_limit, set_score_threshold
+        from auth_context import set_score_threshold, set_search_limit
 
         set_search_limit(limit)
         set_search_offset(offset)


### PR DESCRIPTION
Addresses Issue #1980. Both the default listing and the filter-panel sources dropdown call POST /api/search with query: "*". The backend responds with a match_all OpenSearch query and returns results sorted by internal document order (all scores are 1.0 for a match_all). Because the limit was one hard number — 10,000 chunks — large documents that happened to be indexed later, or whose chunks landed past position 10,000 in the shard, simply never appeared in the response. Their filenames were never in the payload, so the frontend never put them in the listing. Searching "Yes_" worked because semantic ranking scores those exact files at the top and surfaces all of them within the first 100 results.

The four changes address this in two complementary ways:

src/auth_context.py + src/api/search.py + src/services/search_service.py — add an offset parameter that flows from the HTTP body all the way into OpenSearch's "from" field. This is the standard OpenSearch pagination mechanism (equivalent to SQL OFFSET). Since offset defaults to 0, every existing caller is completely unaffected.

useGetSearchQuery.ts — the wildcard path now loops: it fetches 1,000 chunks at offset=0, then 1,000 at offset=1000, and so on, merging all chunks into a single fileMap keyed by filename until a page returns fewer than 1,000 chunks (the final page), at which point the loop stops. Every filename in the index is guaranteed to pass through the merge logic. Non-wildcard searches (any real text query) are entirely unchanged.

The aggregation size fixes in search_service.py (data_sources 20→10,000, owners 10→1,000, etc.) resolve the parallel issue where the filter-panel's Document Types, Owners, and Connector Types dropdowns were also silently truncated to their first 10 entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Wildcard searches now retrieve and combine results across multiple pages, improving completeness for large result sets.
  - Search requests support pagination, allowing results to be retrieved from a specified starting position.
  - Search filtering supports larger result groups across data sources, document types, owners, and connector types.

- **Bug Fixes**
  - Search warnings are now preserved when results are combined.
  - Improved consistency in error handling across paginated and standard searches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->