### PR TITLE
feat: get apiKey logs in status page #2181

### DIFF
--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -16,6 +16,8 @@ import {
   type ComponentStatus,
   useConsoleStatusQuery,
 } from "@/app/api/queries/useConsoleStatusQuery";
+import type { ProviderHealthResponse } from "@/app/api/queries/useProviderHealthQuery";
+import { useProviderHealth } from "@/components/provider-health-banner";
 import { cn } from "@/lib/utils";
 
 // ─── status helpers ──────────────────────────────────────────────────────────
@@ -208,6 +210,68 @@ function ComponentCard({ component }: ComponentCardProps) {
   );
 }
 
+// ─── provider / api-key health ───────────────────────────────────────────────
+
+/** Map the /provider/health status onto the console-status component states. */
+function providerHealthState(
+  status: ProviderHealthResponse["status"],
+): ComponentState {
+  switch (status) {
+    case "healthy":
+      return "healthy";
+    case "unhealthy":
+    case "error":
+      return "unhealthy";
+    default:
+      // "backend-unavailable" (or anything unexpected) — can't determine.
+      return "unknown";
+  }
+}
+
+/** Prefer the specific llm/embedding key errors; fall back to the summary. */
+function providerHealthMessage(health: ProviderHealthResponse): string {
+  if (health.status === "healthy") {
+    return health.message || "Providers configured and validated";
+  }
+  const { llm_error: llmError, embedding_error: embeddingError } = health;
+  if (llmError && embeddingError) {
+    return llmError === embeddingError
+      ? llmError
+      : `${llmError}; ${embeddingError}`;
+  }
+  return (
+    llmError || embeddingError || health.message || "Provider validation failed"
+  );
+}
+
+/** Adapt a provider-health response into a synthetic status component so the
+ *  panel renders API-key health with the same card UI as backend components. */
+function providerHealthToComponent(
+  health: ProviderHealthResponse,
+): ComponentStatus {
+  const metadata: Record<string, unknown> = {};
+  const llmProvider = health.llm_provider ?? health.provider;
+  if (llmProvider) metadata["LLM provider"] = llmProvider;
+  if (health.embedding_provider) {
+    metadata["Embedding provider"] = health.embedding_provider;
+  }
+  if (health.details?.llm_model) {
+    metadata["LLM model"] = health.details.llm_model;
+  }
+  if (health.details?.embedding_model) {
+    metadata["Embedding model"] = health.details.embedding_model;
+  }
+
+  return {
+    name: "providers",
+    display_name: "Model Providers",
+    status: providerHealthState(health.status),
+    required: true,
+    message: providerHealthMessage(health),
+    metadata,
+  };
+}
+
 // ─── main panel ──────────────────────────────────────────────────────────────
 
 interface ConsoleStatusPanelProps {
@@ -229,8 +293,21 @@ export function ConsoleStatusPanel({ onClose }: ConsoleStatusPanelProps) {
     void refetch();
   }, [refetch]);
 
+  // Reuses the shared /provider/health query (same cache as the banner), so an
+  // API-key failure surfaces here without an extra network round-trip.
+  const { health: providerHealth } = useProviderHealth();
+
   // Defensive: always read from data.components array
-  const components = Array.isArray(data?.components) ? data.components : [];
+  const backendComponents = Array.isArray(data?.components)
+    ? data.components
+    : [];
+
+  // Append provider / API-key health as a card so the panel is the single
+  // place to spot a key failure. Skipped while the query has no result yet
+  // (e.g. non-admins under RBAC, or during active ingestion).
+  const components = providerHealth
+    ? [...backendComponents, providerHealthToComponent(providerHealth)]
+    : backendComponents;
 
   const counts = {
     healthy: components.filter((c) => c.status === "healthy").length,

--- a/frontend/components/layout-wrapper.tsx
+++ b/frontend/components/layout-wrapper.tsx
@@ -141,6 +141,12 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   const isRightPanelOpen =
     isMenuOpen || (isPanelOpen && isOnKnowledgePage && !isMenuOpen);
 
+  // The floating status button's dot reflects provider / API-key failures
+  // (shown as a card inside the panel) in addition to backend infra health.
+  const overallStatus = isProviderUnhealthy
+    ? "unhealthy"
+    : statusData?.overall_status;
+
   return (
     <div
       className={cn(
@@ -234,7 +240,7 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
           isOpen={isStatusOpen}
           onToggle={() => setIsStatusOpen((v) => !v)}
           onClose={() => setIsStatusOpen(false)}
-          overallStatus={statusData?.overall_status}
+          overallStatus={overallStatus}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
Adds a **Model Providers** card to the Console Status panel so an LLM/embedding
API-key failure (invalid, revoked, disabled, missing, etc.) is visible in the
same place as the rest of the system health, instead of only in the separate
top-of-page banner. The floating status button's dot now also reflects provider
health.

Closes #2181 

## Issue
Previously the Console Status panel only showed infra components (OpenRAG
backend, Docling, Langflow, OpenSearch). API-key/provider health was validated
by the backend (`GET /provider/health`) but surfaced only in the red "Fix Setup"
banner. Users had no single place in Console Status to check whether their
provider keys were working. This adds that, reusing the existing backend check.

## Changes

- **`frontend/components/console-status-panel.tsx`**
  - Reuses the existing `useProviderHealth()` hook (same React Query cache as the
    banner → **no extra network round-trip**, no second polling loop).
  - New pure helpers map a `ProviderHealthResponse` into a synthetic
    `ComponentStatus` (`providerHealthState`, `providerHealthMessage`,
    `providerHealthToComponent`) so it renders with the existing `ComponentCard`
    UI, counts toward the summary tiles, and exposes provider/model info on expand.
  - The card is appended only when the shared query has a result — it's skipped
    when provider-health polling is intentionally disabled (non-admins under
    enforced RBAC, or during active ingestion), avoiding a false state.
- **`frontend/components/layout-wrapper.tsx`**
  - The floating Console Status button's status dot now escalates to red when a
    provider/API-key check is unhealthy, reusing the `isProviderUnhealthy` signal
    already computed there.

The existing top-of-page provider-health banner is **left untouched**

## Behavior (state → color)
| `/provider/health` result | When | Panel card state | Color / icon |
|---|---|---|---|
| `healthy` | key valid | `healthy` | 🟢 emerald, `CheckCircle2` |
| `unhealthy` (503) | invalid / revoked / disabled / missing key | `unhealthy` | 🔴 red, `XCircle` |
| `error` (other non-2xx) | provider check failed | `unhealthy` | 🔴 red, `XCircle` |
| `backend-unavailable` / no result | backend down, or query disabled | `unknown` | ⚪ zinc, `HelpCircle` |

The card's message prefers the specific `llm_error`/`embedding_error` from the
backend (e.g. "Incorrect API key provided", "The configured API key is invalid or
has been revoked…").

## Testing
- `npx biome check`, clean on both files.
- `npx tsc --noEmit`, 0 errors.
- Manual: set a deliberately invalid provider key in Settings → the panel shows a
  red **Model Providers** card with the error message, and the floating button dot
  turns red. Restoring a valid key flips it back to green.

<img width="430" height="693" alt="Screenshot 2026-08-03 at 1 37 46 PM" src="https://github.com/user-attachments/assets/015114b4-8011-4d17-a47c-d1c0f3c6c1f3" />

## Notes / follow-ups
- Invalid, revoked, and deleted keys currently collapse to a single red
  `unhealthy` state (differing only in message text); the backend returns one
  credential-failure status rather than a discrete category, and some providers
  (e.g. OpenAI) don't distinguish "deleted" from "invalid". Splitting these into
  distinct visual states would require a new backend classification field and is
  left as a follow-up.