### PR TITLE
fix: updated pdf password protected docling parsing error message with more actionable message

### DIFF
--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -988,7 +988,7 @@ class TaskService:
                 "actionable_by": "USER_ACTIONABLE",
             }
 
-        if "incorrect password" in error.lower(): # for password protected pdf cases
+        if "incorrect password" in error.lower():  # for password protected pdf cases
             return {
                 "component": "docling",
                 "failure_phase": "parsing",

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -988,6 +988,14 @@ class TaskService:
                 "actionable_by": "USER_ACTIONABLE",
             }
 
+        if "incorrect password" in error.lower(): # for password protected pdf cases
+            return {
+                "component": "docling",
+                "failure_phase": "parsing",
+                "user_facing_message": "This PDF is password-protected. Password-protected PDFs are not supported. Remove the password and upload the PDF again.",
+                "actionable_by": "USER_ACTIONABLE",
+            }
+
         if docling_status == DoclingPhaseStatus.EXPIRED:
             return {
                 "component": "docling",

--- a/tests/unit/test_task_service_get_task_status2.py
+++ b/tests/unit/test_task_service_get_task_status2.py
@@ -148,7 +148,7 @@ class TestInferFailureMetadata:
         assert "pdfium" not in msg.lower()
         assert "docling-parse" not in msg.lower()
         assert "cbfc231c" not in msg
-        
+
     def test_langflow_empty_content_not_retryable(self, task_service):
         ft = _make_file_task(
             phase=IngestionPhase.LANGFLOW,

--- a/tests/unit/test_task_service_get_task_status2.py
+++ b/tests/unit/test_task_service_get_task_status2.py
@@ -141,7 +141,7 @@ class TestInferFailureMetadata:
         assert meta["actionable_by"] == "USER_ACTIONABLE"
 
         msg = meta["user_facing_message"]
-        
+
         assert "password-protected" in msg.lower()
         # no internals leaked
         assert "pdfium" not in msg.lower()

--- a/tests/unit/test_task_service_get_task_status2.py
+++ b/tests/unit/test_task_service_get_task_status2.py
@@ -123,6 +123,31 @@ class TestInferFailureMetadata:
         assert meta is not None
         assert meta["actionable_by"] == "USER_ACTIONABLE"
 
+    def test_password_protected_pdf_maps_to_clean_message(self, task_service):
+        ft = _make_file_task(
+            docling_status=DoclingPhaseStatus.FAILED,
+            error=(
+                "Docling conversion did not complete (failed): "
+                "Docling result unavailable after SUCCESS status: Docling processing "
+                "failed: docling-parse could not load document "
+                "cbfc231c73e85df69b34cfa56b4bb0696dc0f10d0536bcca821f92c324041bac: "
+                "Failed to load document (PDFium: Incorrect password error)."
+            ),
+        )
+
+        meta = task_service._infer_failure_metadata(ft)
+
+        assert meta is not None
+        assert meta["actionable_by"] == "USER_ACTIONABLE"
+
+        msg = meta["user_facing_message"]
+        
+        assert "password-protected" in msg.lower()
+        # no internals leaked
+        assert "pdfium" not in msg.lower()
+        assert "docling-parse" not in msg.lower()
+        assert "cbfc231c" not in msg
+
     def test_langflow_empty_content_not_retryable(self, task_service):
         ft = _make_file_task(
             phase=IngestionPhase.LANGFLOW,

--- a/tests/unit/test_task_service_get_task_status2.py
+++ b/tests/unit/test_task_service_get_task_status2.py
@@ -134,20 +134,21 @@ class TestInferFailureMetadata:
                 "Failed to load document (PDFium: Incorrect password error)."
             ),
         )
-
         meta = task_service._infer_failure_metadata(ft)
-
         assert meta is not None
         assert meta["actionable_by"] == "USER_ACTIONABLE"
-
+        assert meta["component"] == "docling"
+        assert meta["failure_phase"] == "parsing"
         msg = meta["user_facing_message"]
-
         assert "password-protected" in msg.lower()
+        assert "not supported" in msg.lower()
+        assert "remove the password" in msg.lower()
+        assert "upload the pdf again" in msg.lower()
         # no internals leaked
         assert "pdfium" not in msg.lower()
         assert "docling-parse" not in msg.lower()
         assert "cbfc231c" not in msg
-
+        
     def test_langflow_empty_content_not_retryable(self, task_service):
         ft = _make_file_task(
             phase=IngestionPhase.LANGFLOW,


### PR DESCRIPTION
## Summary
Fixes #1196 . Adds logic to detect docling's parsing error message `PDFium: Incorrect password error` for trying to upload password protected pdfs. Updates the error message to be clearer and more actionable for the end user.

## Before
<img width="641" height="578" alt="password-detect-before" src="https://github.com/user-attachments/assets/b5c2b481-6380-4a5b-bad4-b8b5bd16ffa5" />

## After
<img width="638" height="569" alt="password-protect-after" src="https://github.com/user-attachments/assets/76112284-4ab4-4e1e-a400-07d711028c1f" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Bug Fixes

- Improved error handling for password-protected PDFs.
- Added a clear, actionable message explaining that password-protected PDFs aren’t supported.
- Sanitized error details to prevent exposure of internal processing information.
- Improved parsing error metadata to help users understand and resolve unsupported PDF issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->