### PR TITLE
fix: remove hardcoded index name in acl utils

### DIFF
--- a/securityconfig/roles.yml
+++ b/securityconfig/roles.yml
@@ -10,7 +10,7 @@ openrag_user_role:
     - "cluster:monitor/*"
 
   index_permissions:
-    - index_patterns: ["documents", "documents*", "knowledge_filters", "knowledge_filters*"]
+    - index_patterns: ["documents", "*documents*", "knowledge_filters", "knowledge_filters*"]
       allowed_actions:
         - read
       dls: >
@@ -22,7 +22,7 @@ openrag_user_role:
           {"terms":{"allowed_principals":{"index":"openrag_dls_principals","id":"${user.name}","path":"principals"}}},
           {"bool":{"must_not":{"exists":{"field":"owner"}}}}
         ],"minimum_should_match":1}}
-    - index_patterns: ["documents", "documents*", "knowledge_filters", "knowledge_filters*"]
+    - index_patterns: ["documents", "*documents*", "knowledge_filters", "knowledge_filters*"]
       allowed_actions:
         - indices:admin/mappings/get
         - indices:admin/exists

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -56,7 +56,7 @@ from api.settings.models import (
     SettingsUpdateResponse,
     WatsonXProviderConfig,
 )
-from config.config_manager import ALLOWED_INDEX_NAME_PREFIXES, is_permitted_index_name
+from config.config_manager import ALLOWED_INDEX_NAME_PATTERNS, is_permitted_index_name
 from config.settings import (
     DEFAULT_DOCS_URL,
     ENVIRONMENT,
@@ -632,8 +632,8 @@ async def update_settings(
                     status_code=422,
                     detail=(
                         f"Index name '{new_index_name}' is not permitted. The OpenSearch "
-                        "security role only grants search access to indices starting "
-                        f"with {' or '.join(ALLOWED_INDEX_NAME_PREFIXES)}."
+                        "security role only grants search access to indices matching "
+                        f"{' or '.join(ALLOWED_INDEX_NAME_PATTERNS)}."
                     ),
                 )
             working_config.knowledge.index_name = new_index_name

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -67,7 +67,9 @@ _SAFE_CONFIG_PATH = re.compile(r"^/?(?:[A-Za-z0-9_.\-]+/)*[A-Za-z0-9_.\-]+\.ya?m
 # AuthorizationException. Keep this allowlist in sync with securityconfig/roles.yml.
 # ---------------------------------------------------------------------------
 ALLOWED_INDEX_NAME_PATTERNS = ("*documents*", "knowledge_filters*")
-_PERMITTED_INDEX_NAME = re.compile(r"^[a-z0-9._-]*documents[a-z0-9._-]*$|^knowledge_filters[a-z0-9._-]*$")
+_PERMITTED_INDEX_NAME = re.compile(
+    r"^[a-z0-9._-]*documents[a-z0-9._-]*$|^knowledge_filters[a-z0-9._-]*$"
+)
 
 
 def is_permitted_index_name(index_name: str) -> bool:

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -61,13 +61,13 @@ _SAFE_CONFIG_PATH = re.compile(r"^/?(?:[A-Za-z0-9_.\-]+/)*[A-Za-z0-9_.\-]+\.ya?m
 # ---------------------------------------------------------------------------
 # The OpenSearch security role `openrag_user_role` (securityconfig/roles.yml)
 # only grants indices:data/read/search on the index_patterns "documents",
-# "documents*", "knowledge_filters", "knowledge_filters*". Nothing re-templates
+# "*documents*", "knowledge_filters", "knowledge_filters*". Nothing re-templates
 # that static role config from OPENSEARCH_INDEX_NAME, so an index name outside
 # those patterns causes ingestion/search to fail with a 403
 # AuthorizationException. Keep this allowlist in sync with securityconfig/roles.yml.
 # ---------------------------------------------------------------------------
-ALLOWED_INDEX_NAME_PREFIXES = ("documents", "knowledge_filters")
-_PERMITTED_INDEX_NAME = re.compile(r"^(documents|knowledge_filters)[a-z0-9._-]*$")
+ALLOWED_INDEX_NAME_PATTERNS = ("*documents*", "knowledge_filters*")
+_PERMITTED_INDEX_NAME = re.compile(r"^[a-z0-9._-]*documents[a-z0-9._-]*$|^knowledge_filters[a-z0-9._-]*$")
 
 
 def is_permitted_index_name(index_name: str) -> bool:
@@ -421,8 +421,8 @@ class ConfigManager:
             else:
                 logger.error(
                     f"OPENSEARCH_INDEX_NAME={env_index_name!r} is not permitted by the "
-                    f"OpenSearch security role (must start with one of "
-                    f"{ALLOWED_INDEX_NAME_PREFIXES}); ignoring and keeping "
+                    f"OpenSearch security role (must match one of "
+                    f"{ALLOWED_INDEX_NAME_PATTERNS}); ignoring and keeping "
                     f"{config_data['knowledge'].get('index_name', 'documents')!r}. "
                     "See securityconfig/roles.yml."
                 )

--- a/src/connectors/service.py
+++ b/src/connectors/service.py
@@ -1,9 +1,9 @@
 from typing import Any
 
+from config.settings import get_index_name
 from utils.file_utils import clean_connector_filename, get_file_extension
 from utils.logging_config import get_logger
 
-from config.settings import get_index_name
 from .base import BaseConnector, ConnectorDocument
 from .connection_manager import ConnectionManager
 

--- a/src/connectors/service.py
+++ b/src/connectors/service.py
@@ -3,6 +3,7 @@ from typing import Any
 from utils.file_utils import clean_connector_filename, get_file_extension
 from utils.logging_config import get_logger
 
+from config.settings import get_index_name
 from .base import BaseConnector, ConnectorDocument
 from .connection_manager import ConnectionManager
 
@@ -291,7 +292,7 @@ class ConnectorService:
         # used for DLS visibility/ACL-change checks.
         try:
             await write_client.update_by_query(
-                index=self.index_name,
+                index=get_index_name(),
                 body={
                     # Match both fields: both ingestion paths carry the raw
                     # connector id in connector_file_id (document_id is a

--- a/src/services/monitor_service.py
+++ b/src/services/monitor_service.py
@@ -2,7 +2,7 @@ import json
 import uuid
 from typing import Any
 
-from config.settings import OPENRAG_BACKEND_INTERNAL_URL, clients
+from config.settings import OPENRAG_BACKEND_INTERNAL_URL, clients, get_index_name
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -65,7 +65,7 @@ class MonitorService:
                     {
                         "doc_level_input": {
                             "description": f"Monitor for knowledge filter: {filter_name}",
-                            "indices": ["documents"],
+                            "indices": [get_index_name()],
                             "queries": [
                                 {
                                     "id": f"kf_query_{filter_id}",

--- a/src/utils/acl_utils.py
+++ b/src/utils/acl_utils.py
@@ -10,9 +10,9 @@ import hashlib
 import json
 from typing import Any
 
+from config.settings import get_index_name
 from src.connectors.base import DocumentACL
 from utils.logging_config import get_logger
-from config.settings import get_index_name
 
 logger = get_logger(__name__)
 

--- a/src/utils/acl_utils.py
+++ b/src/utils/acl_utils.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from src.connectors.base import DocumentACL
 from utils.logging_config import get_logger
+from config.settings import get_index_name
 
 logger = get_logger(__name__)
 
@@ -76,7 +77,7 @@ async def should_update_acl(
     """
     try:
         response = await opensearch_client.search(
-            index="documents",
+            index=get_index_name(),
             body={
                 "query": _build_id_query(document_id, id_fields),
                 "size": 1,
@@ -136,7 +137,7 @@ async def update_document_acl(
 
     try:
         response = await write_client.update_by_query(
-            index="documents",
+            index=get_index_name(),
             body={
                 "query": _build_id_query(document_id, id_fields),
                 "script": {
@@ -199,7 +200,7 @@ async def batch_update_acls(
 
     update_tasks = [
         write_client.update_by_query(
-            index="documents",
+            index=get_index_name(),
             body={
                 "query": _build_id_query(doc_id, id_fields),
                 "script": {


### PR DESCRIPTION
This fixes the error where, if a different index name was used, the connectors would upload files successfully but would return a failure at the task.

This pull request updates how the index name is referenced in both the monitor and ACL utilities to improve maintainability and consistency. Instead of hardcoding the `"documents"` index name, the code now uses the `get_index_name()` function from the settings, ensuring that any future changes to the index name only need to be made in one place.

**Index referencing improvements:**

* Replaced all hardcoded `"documents"` index references in `src/utils/acl_utils.py` with calls to `get_index_name()`, including in the `should_update_acl`, `update_document_acl`, and `batch_update_acls` functions. [[1]](diffhunk://#diff-f97892c4d0e7ac08371844deb0b4940a4974bc77927a5e34706460e3b29b8dbbL79-R80) [[2]](diffhunk://#diff-f97892c4d0e7ac08371844deb0b4940a4974bc77927a5e34706460e3b29b8dbbL139-R140) [[3]](diffhunk://#diff-f97892c4d0e7ac08371844deb0b4940a4974bc77927a5e34706460e3b29b8dbbL202-R203)
* Updated the `create_knowledge_filter_monitor` function in `src/services/monitor_service.py` to use `get_index_name()` instead of a hardcoded index name for the `indices` field.

**Imports and dependencies:**

* Added import of `get_index_name` from `config.settings` in both `src/services/monitor_service.py` and `src/utils/acl_utils.py`. [[1]](diffhunk://#diff-8d4ad1ca54f332f4445608d1132cbc59e0579567016b193dfd49a1d1f2c14967L5-R5) [[2]](diffhunk://#diff-f97892c4d0e7ac08371844deb0b4940a4974bc77927a5e34706460e3b29b8dbbR15)