### PR TITLE
feat: surface console status in the notification bell #2182

### DIFF
--- a/frontend/app/api/queries/useConsoleStatusQuery.ts
+++ b/frontend/app/api/queries/useConsoleStatusQuery.ts
@@ -62,7 +62,9 @@ export const useConsoleStatusQuery = (
       queryFn: fetchConsoleStatus,
       retry: 1,
       refetchInterval: 30000,
-      refetchOnWindowFocus: false,
+      // Re-check when the user returns to the tab so a status change that
+      // happened while away surfaces promptly (drives the header notification).
+      refetchOnWindowFocus: true,
       staleTime: 15000,
       ...options,
     },

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -9,6 +9,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { AuthProvider } from "@/contexts/auth-context";
 import { BrandProvider } from "@/contexts/brand-context";
 import { ChatProvider } from "@/contexts/chat-context";
+import { ConsoleStatusProvider } from "@/contexts/console-status-context";
 import { KnowledgeFilterProvider } from "@/contexts/knowledge-filter-context";
 import { TaskProvider } from "@/contexts/task-context";
 import Providers from "./providers";
@@ -61,9 +62,11 @@ export default function RootLayout({
                 <BrandProvider>
                   <TaskProvider>
                     <KnowledgeFilterProvider>
-                      <ChatProvider>
-                        <LayoutWrapper>{children}</LayoutWrapper>
-                      </ChatProvider>
+                      <ConsoleStatusProvider>
+                        <ChatProvider>
+                          <LayoutWrapper>{children}</LayoutWrapper>
+                        </ChatProvider>
+                      </ConsoleStatusProvider>
                     </KnowledgeFilterProvider>
                   </TaskProvider>
                 </BrandProvider>

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -450,15 +450,21 @@ export function ConsoleStatusButton({
       <Settings size={14} className="shrink-0 text-zinc-400" />
       <span>Console Status</span>
       {overallStatus && (
-        <span
-          className={cn(
-            "w-2 h-2 rounded-full shrink-0",
-            overallStatus === "healthy" && "bg-emerald-400",
-            overallStatus === "degraded" && "bg-amber-400",
-            overallStatus === "unhealthy" && "bg-red-400",
-            overallStatus === "unknown" && "bg-zinc-400",
+        <span className="relative flex h-2 w-2 shrink-0">
+          {overallStatus === "unhealthy" && (
+            // Pulsing ring draws the eye to an outage; hidden under reduced motion.
+            <span className="absolute inline-flex h-full w-full rounded-full bg-red-400 opacity-75 animate-ping motion-reduce:hidden" />
           )}
-        />
+          <span
+            className={cn(
+              "relative inline-flex h-2 w-2 rounded-full",
+              overallStatus === "healthy" && "bg-emerald-400",
+              overallStatus === "degraded" && "bg-amber-400",
+              overallStatus === "unhealthy" && "bg-red-400",
+              overallStatus === "unknown" && "bg-zinc-400",
+            )}
+          />
+        </span>
       )}
     </button>
   );

--- a/frontend/components/header.tsx
+++ b/frontend/components/header.tsx
@@ -6,12 +6,14 @@ import { DevRoleToggle } from "@/components/dev-role-toggle";
 import Logo from "@/components/icons/openrag-logo";
 import { UserNav } from "@/components/user-nav";
 import { useIsCloudBrand } from "@/contexts/brand-context";
+import { useConsoleStatus } from "@/contexts/console-status-context";
 import { useTask } from "@/contexts/task-context";
 import { cn } from "@/lib/utils";
 
 export function Header() {
   const isCloudBrand = useIsCloudBrand();
   const { tasks, toggleMenu } = useTask();
+  const { hasProblem } = useConsoleStatus();
 
   // Calculate active tasks for the bell icon
   const activeTasks = tasks.filter(
@@ -20,6 +22,9 @@ export function Header() {
       task.status === "running" ||
       task.status === "processing",
   );
+
+  // The bell dot lights for in-flight tasks OR a degraded/down component.
+  const showNotificationDot = activeTasks.length > 0 || hasProblem;
 
   return (
     <header className={cn(`flex w-full h-full items-center justify-between`)}>
@@ -58,7 +63,7 @@ export function Header() {
             </>
           )}
 
-          {/* Task Notification Bell */}
+          {/* Task + System Notification Bell */}
           <button
             type="button"
             onClick={toggleMenu}
@@ -71,7 +76,7 @@ export function Header() {
                 isCloudBrand ? "text-foreground" : "text-muted-foreground"
               }
             />
-            {activeTasks.length > 0 && <div className="header-notifications" />}
+            {showNotificationDot && <div className="header-notifications" />}
           </button>
 
           {/* Separator */}

--- a/frontend/components/layout-wrapper.tsx
+++ b/frontend/components/layout-wrapper.tsx
@@ -2,9 +2,8 @@
 
 import { AnimatePresence, motion } from "framer-motion";
 import { usePathname, useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { createPortal } from "react-dom";
-import { useConsoleStatusQuery } from "@/app/api/queries/useConsoleStatusQuery";
 import { useGetSettingsQuery } from "@/app/api/queries/useGetSettingsQuery";
 import {
   DoclingHealthBanner,
@@ -20,6 +19,7 @@ import { TaskNotificationMenu } from "@/components/task-notification-menu";
 import { useAuth } from "@/contexts/auth-context";
 import { useIsCloudBrand } from "@/contexts/brand-context";
 import { useChat } from "@/contexts/chat-context";
+import { useConsoleStatus } from "@/contexts/console-status-context";
 import { useKnowledgeFilter } from "@/contexts/knowledge-filter-context";
 import { useTask } from "@/contexts/task-context";
 import { usePortal } from "@/hooks/use-portal";
@@ -72,10 +72,12 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   const { isPanelOpen, panelMode, closePanelOnly } = useKnowledgeFilter();
   const failedTasks = tasks.filter(isFailureLikeTask);
 
-  const [isStatusOpen, setIsStatusOpen] = useState(false);
-  const { data: statusData } = useConsoleStatusQuery({
-    enabled: true,
-  });
+  const {
+    isOpen: isStatusOpen,
+    toggle: toggleStatus,
+    close: closeStatus,
+    overallStatus: consoleOverallStatus,
+  } = useConsoleStatus();
 
   const isOnKnowledgePage = pathname.startsWith("/knowledge");
 
@@ -83,9 +85,9 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     if (isMenuOpen) {
       closePanelOnly();
-      setIsStatusOpen(false);
+      closeStatus();
     }
-  }, [isMenuOpen, closePanelOnly]);
+  }, [isMenuOpen, closePanelOnly, closeStatus]);
 
   const { isLoading, isAuthenticated, isNoAuthMode, isIbmAuthMode } = useAuth();
   const { isOnboardingComplete } = useChat();
@@ -145,7 +147,7 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
   // (shown as a card inside the panel) in addition to backend infra health.
   const overallStatus = isProviderUnhealthy
     ? "unhealthy"
-    : statusData?.overall_status;
+    : consoleOverallStatus;
 
   return (
     <div
@@ -238,8 +240,8 @@ export function LayoutWrapper({ children }: { children: React.ReactNode }) {
       {isOnboardingComplete && (
         <ConsoleStatusPortal
           isOpen={isStatusOpen}
-          onToggle={() => setIsStatusOpen((v) => !v)}
-          onClose={() => setIsStatusOpen(false)}
+          onToggle={toggleStatus}
+          onClose={closeStatus}
           overallStatus={overallStatus}
         />
       )}

--- a/frontend/components/task-notification-menu.tsx
+++ b/frontend/components/task-notification-menu.tsx
@@ -27,6 +27,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useIsCloudBrand } from "@/contexts/brand-context";
+import { useConsoleStatus } from "@/contexts/console-status-context";
 import { Task, useTask } from "@/contexts/task-context";
 import {
   hasIssueFileEntries,
@@ -149,6 +150,7 @@ export function TaskNotificationMenu() {
     closeMenu,
     openTaskDialog,
   } = useTask();
+  const { problems, hasProblem, open: openConsoleStatus } = useConsoleStatus();
   const [isPastOpen, setIsPastOpen] = useState(true);
   const lastHandledSelectionTriggerRef = useRef(0);
 
@@ -342,6 +344,47 @@ export function TaskNotificationMenu() {
 
         {/* Content */}
         <div className="flex-1 overflow-y-auto">
+          {/* System Status events — a container / service is degraded or down.
+              Clicking an event opens the Console Status panel. */}
+          {hasProblem && (
+            <div className="flex flex-col gap-2 p-4">
+              <h4 className="text-sm font-medium text-muted-foreground">
+                System Status
+              </h4>
+              {problems.map((component) => {
+                const isDown = component.status === "unhealthy";
+                return (
+                  <button
+                    key={component.name}
+                    type="button"
+                    data-testid="system-status-event"
+                    onClick={() => {
+                      openConsoleStatus();
+                      closeMenu();
+                    }}
+                    className="w-full rounded-lg border border-muted p-3 text-left transition-colors hover:bg-muted/60"
+                  >
+                    <div className="flex items-center gap-2">
+                      {isDown ? (
+                        <XCircle className="size-4 shrink-0 text-destructive" />
+                      ) : (
+                        <AlertCircle className="size-4 shrink-0 text-brand-amber" />
+                      )}
+                      <span className="text-sm font-medium">
+                        {component.display_name}{" "}
+                        {isDown ? "is down" : `is ${component.status}`}
+                      </span>
+                    </div>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      {component.message ||
+                        "Open Console Status for more details."}
+                    </p>
+                  </button>
+                );
+              })}
+            </div>
+          )}
+
           {/* Active Tasks */}
           {activeTasks.length > 0 && (
             <div className="flex flex-col gap-2 p-4">
@@ -524,18 +567,20 @@ export function TaskNotificationMenu() {
           </div>
 
           {/* Empty State */}
-          {activeTasks.length === 0 && terminalTasks.length === 0 && (
-            <div className="p-8 text-center">
-              <Bell className="h-12 w-12 text-muted-foreground/50 mx-auto mb-4" />
-              <h4 className="text-sm font-medium text-muted-foreground mb-2">
-                No tasks yet
-              </h4>
-              <p className="text-xs text-muted-foreground">
-                Task notifications will appear here when you upload files or
-                sync connectors.
-              </p>
-            </div>
-          )}
+          {activeTasks.length === 0 &&
+            terminalTasks.length === 0 &&
+            !hasProblem && (
+              <div className="p-8 text-center">
+                <Bell className="h-12 w-12 text-muted-foreground/50 mx-auto mb-4" />
+                <h4 className="text-sm font-medium text-muted-foreground mb-2">
+                  No tasks yet
+                </h4>
+                <p className="text-xs text-muted-foreground">
+                  Task notifications will appear here when you upload files or
+                  sync connectors.
+                </p>
+              </div>
+            )}
         </div>
       </div>
     </div>

--- a/frontend/contexts/console-status-context.tsx
+++ b/frontend/contexts/console-status-context.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import type React from "react";
+import {
+  createContext,
+  use,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { toast } from "sonner";
+import {
+  type ComponentState,
+  type ComponentStatus,
+  type ConsoleStatusResponse,
+  useConsoleStatusQuery,
+} from "@/app/api/queries/useConsoleStatusQuery";
+
+/** Collapses the four component states into the two things the UI reacts to:
+ *  a warning (amber) or an outage (red). `ok` means nothing to show. */
+export type StatusSeverity = "ok" | "warn" | "down";
+
+interface ConsoleStatusContextType {
+  overallStatus: ComponentState | undefined;
+  /** Components that are not healthy, sorted by name (stable order). Each of
+   *  these becomes a "system event" in the notification bell menu. */
+  problems: ComponentStatus[];
+  severity: StatusSeverity;
+  /** True when at least one component is degraded / unknown / down. Drives the
+   *  notification-bell dot. */
+  hasProblem: boolean;
+  /** Query couldn't complete (e.g. auth) — treated as neutral, never a problem. */
+  isError: boolean;
+  isOpen: boolean;
+  open: () => void;
+  close: () => void;
+  toggle: () => void;
+}
+
+const ConsoleStatusContext = createContext<
+  ConsoleStatusContextType | undefined
+>(undefined);
+
+// ─── helpers ───────────────────────────────────────────────────────────────
+
+function severityOf(status: ComponentState | undefined): StatusSeverity {
+  switch (status) {
+    case "unhealthy":
+      return "down";
+    case "degraded":
+    case "unknown":
+      return "warn";
+    default:
+      // "healthy" or no data yet
+      return "ok";
+  }
+}
+
+const SEVERITY_RANK: Record<StatusSeverity, number> = {
+  ok: 0,
+  warn: 1,
+  down: 2,
+};
+
+function problemSummary(problems: ComponentStatus[]): string {
+  if (problems.length === 0) return "A component needs attention.";
+  if (problems.length === 1) {
+    const p = problems[0];
+    return `${p.display_name} is ${p.status}.`;
+  }
+  const names = problems.map((p) => p.display_name).join(", ");
+  return `${problems.length} components need attention: ${names}.`;
+}
+
+// ─── provider ────────────────────────────────────────────────────────────────
+
+export function ConsoleStatusProvider({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Shares the ["console-status"] cache key with the panel/button — React Query
+  // dedupes, so mounting this provider does not add a second poll.
+  const { data, isError } = useConsoleStatusQuery();
+
+  const [isOpen, setIsOpen] = useState(false);
+
+  const overallStatus = (data as ConsoleStatusResponse | undefined)
+    ?.overall_status;
+
+  const problems = useMemo(() => {
+    const components = Array.isArray(data?.components) ? data.components : [];
+    return components
+      .filter((c) => c.status !== "healthy")
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }, [data]);
+
+  const severity = severityOf(overallStatus);
+  const hasProblem = severity !== "ok";
+
+  const open = useCallback(() => setIsOpen(true), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const toggle = useCallback(() => setIsOpen((v) => !v), []);
+
+  // Active push: one toast per healthy→bad / bad→worse transition. `prevRef`
+  // starts undefined and is seeded on the first successful fetch so we never
+  // toast on initial load or on a page refresh.
+  const prevStatusRef = useRef<ComponentState | undefined>(undefined);
+  useEffect(() => {
+    if (!overallStatus) return;
+
+    const prev = prevStatusRef.current;
+    prevStatusRef.current = overallStatus;
+
+    if (prev === undefined || prev === overallStatus) return;
+
+    const prevSev = severityOf(prev);
+    const nextSev = severityOf(overallStatus);
+
+    if (SEVERITY_RANK[nextSev] > SEVERITY_RANK[prevSev]) {
+      const message =
+        nextSev === "down" ? "OpenRAG component down" : "OpenRAG degraded";
+      const fire = nextSev === "down" ? toast.error : toast.warning;
+      fire(message, {
+        description: problemSummary(problems),
+        action: { label: "View", onClick: () => open() },
+      });
+    } else if (nextSev === "ok") {
+      toast.success("All systems healthy");
+    }
+  }, [overallStatus, problems, open]);
+
+  const value: ConsoleStatusContextType = {
+    overallStatus,
+    problems,
+    severity,
+    hasProblem,
+    isError,
+    isOpen,
+    open,
+    close,
+    toggle,
+  };
+
+  return (
+    <ConsoleStatusContext.Provider value={value}>
+      {children}
+    </ConsoleStatusContext.Provider>
+  );
+}
+
+export function useConsoleStatus() {
+  const context = use(ConsoleStatusContext);
+  if (context === undefined) {
+    throw new Error(
+      "useConsoleStatus must be used within a ConsoleStatusProvider",
+    );
+  }
+  return context;
+}


### PR DESCRIPTION
# feat: surface console status in the notification bell #2182 

## Summary

The core of this change is a new `ConsoleStatusProvider` that owns the status
query and derives the notification state once, so the header, notification menu,
and status panel all read from a single source of truth (no duplicate polling).

## Changes

### New shared context: `frontend/contexts/console-status-context.tsx`
- Wraps the existing `useConsoleStatusQuery` in a provider so status is fetched
  once and shared. React Query dedupes on the `["console-status"]` key, so the
  panel/button that also use the query don't add a second poll.
- Derives everything the UI reacts to:
  - `overallStatus` — the raw overall state.
  - `problems` — components that aren't `healthy`, sorted by name for stable order.
  - `severity` (`ok` / `warn` / `down`) and `hasProblem` — collapses the four
    component states into what the notification UI actually cares about.
  - `isError` — a failed query (e.g. auth) is treated as **neutral**, never a problem.
- Owns the open/close state for the status panel (`open` / `close` / `toggle`).
- **Active push:** fires a single toast on each `healthy→bad` / `bad→worse`
  transition (`toast.error` for down, `toast.warning` for degraded), with a
  "View" action that opens the panel, and a `success` toast when everything
  recovers. A `prevStatusRef` seeded on first fetch prevents a spurious toast on
  initial load or page refresh.

### Wiring — `frontend/app/layout.tsx`
- Mounts `ConsoleStatusProvider` (above `ChatProvider`) so the header and
  notification menu can consume it.

### Header bell — `frontend/components/header.tsx`
- The bell's notification dot now lights for **in-flight tasks OR a degraded/down
  component** (`activeTasks.length > 0 || hasProblem`), instead of tasks alone.

### Notification menu — `frontend/components/task-notification-menu.tsx`
- Adds a **System Status** section at the top of the menu listing each
  unhealthy component (icon + "is down" / "is degraded" + message). Clicking an
  event opens the Console Status panel and closes the menu.
- The "No tasks yet" empty state no longer shows when there's a system problem.

### Status panel — `frontend/components/layout-wrapper.tsx`
- Refactored to consume the shared context (`isOpen` / `toggle` / `close` /
  `overallStatus`) instead of holding its own local `useState` + a second
  `useConsoleStatusQuery` call.

### Status button — `frontend/components/console-status-panel.tsx`
- The status indicator dot now shows a pulsing ring (`animate-ping`) when a
  component is **unhealthy**, to draw the eye to an outage. The ring respects
  `motion-reduce` (hidden under reduced-motion preferences).

### Query — `frontend/app/api/queries/useConsoleStatusQuery.ts`
- `refetchOnWindowFocus: true` — re-checks when the user returns to the tab so a
  status change that happened while away surfaces promptly.

## Demonstration

https://github.com/user-attachments/assets/11d20ddc-fa1f-41ee-9915-1571ef7e21c1

## Testing notes
- System-status events in the menu carry `data-testid="system-status-event"`.
- Verify: no toast on initial load / refresh; toast fires only on a genuine
  transition to worse; recovery toast fires when returning to healthy; a failed
  status query (auth/500) is treated as neutral and does **not** trip the dot.

## Notes
- No backend changes — this consumes the existing `/api/status` endpoint.
- No new polling introduced; the provider shares the existing query cache key.