### PR TITLE
fix: add env to set opensearch pool maxsize

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -31,6 +31,7 @@ logger = get_logger(__name__)
 OPENSEARCH_HOST = os.getenv("OPENSEARCH_HOST", "localhost")
 OPENSEARCH_PORT = get_env_int("OPENSEARCH_PORT", 9200)
 OPENSEARCH_URL = f"https://{OPENSEARCH_HOST}:{OPENSEARCH_PORT}"
+OPENSEARCH_POOL_MAXSIZE: int = max(get_env_int("OPENSEARCH_POOL_MAXSIZE", 8) or 8, 1)
 
 # Optional: Langflow-specific OpenSearch endpoint
 LANGFLOW_OPENSEARCH_HOST = os.getenv("LANGFLOW_OPENSEARCH_HOST")
@@ -1011,6 +1012,7 @@ class AppClients:
                 ssl_assert_fingerprint=None,
                 http_auth=os_auth,
                 http_compress=True,
+                pool_maxsize=OPENSEARCH_POOL_MAXSIZE,
             )
 
         # Initialize patched OpenAI client if API key is available
@@ -1687,6 +1689,7 @@ class AppClients:
             timeout=30,  # 30 second timeout
             max_retries=3,
             retry_on_timeout=True,
+            pool_maxsize=OPENSEARCH_POOL_MAXSIZE,
         )
 
     def create_basic_opensearch_client(self, username: str, password: str):
@@ -1703,6 +1706,7 @@ class AppClients:
             timeout=30,
             max_retries=3,
             retry_on_timeout=True,
+            pool_maxsize=OPENSEARCH_POOL_MAXSIZE,
         )
 
     def create_user_opensearch_client(self, jwt_token: str):

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -32,7 +32,7 @@ OPENSEARCH_HOST = os.getenv("OPENSEARCH_HOST", "localhost")
 OPENSEARCH_PORT = get_env_int("OPENSEARCH_PORT", 9200)
 OPENSEARCH_URL = f"https://{OPENSEARCH_HOST}:{OPENSEARCH_PORT}"
 _os_pool_maxsize = get_env_int("OPENSEARCH_POOL_MAXSIZE")
-OPENSEARCH_POOL_MAXSIZE: int = max(8 if _os_pool_maxsize is None else _os_pool_maxsize, 1)
+OPENSEARCH_POOL_MAXSIZE: int = max(10 if _os_pool_maxsize is None else _os_pool_maxsize, 1)
 
 # Optional: Langflow-specific OpenSearch endpoint
 LANGFLOW_OPENSEARCH_HOST = os.getenv("LANGFLOW_OPENSEARCH_HOST")

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -31,7 +31,8 @@ logger = get_logger(__name__)
 OPENSEARCH_HOST = os.getenv("OPENSEARCH_HOST", "localhost")
 OPENSEARCH_PORT = get_env_int("OPENSEARCH_PORT", 9200)
 OPENSEARCH_URL = f"https://{OPENSEARCH_HOST}:{OPENSEARCH_PORT}"
-OPENSEARCH_POOL_MAXSIZE: int = max(get_env_int("OPENSEARCH_POOL_MAXSIZE", 8) or 8, 1)
+_os_pool_maxsize = get_env_int("OPENSEARCH_POOL_MAXSIZE")
+OPENSEARCH_POOL_MAXSIZE: int = max(8 if _os_pool_maxsize is None else _os_pool_maxsize, 1)
 
 # Optional: Langflow-specific OpenSearch endpoint
 LANGFLOW_OPENSEARCH_HOST = os.getenv("LANGFLOW_OPENSEARCH_HOST")

--- a/tests/unit/config/test_opensearch_pool_maxsize.py
+++ b/tests/unit/config/test_opensearch_pool_maxsize.py
@@ -82,3 +82,25 @@ def test_opensearch_client_uses_configured_pool_maxsize():
         cwd=str(ROOT),
     )
     assert result.stdout.splitlines()[-1].strip() == "48"
+
+
+def test_settings_clamps_zero_pool_maxsize_to_one():
+    env = _python_env(
+        {
+            "OPENSEARCH_POOL_MAXSIZE": "0",
+            "PYTHONPATH": str(SRC),
+        }
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from config.settings import OPENSEARCH_POOL_MAXSIZE; print(OPENSEARCH_POOL_MAXSIZE)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    assert result.stdout.splitlines()[-1].strip() == "1"

--- a/tests/unit/config/test_opensearch_pool_maxsize.py
+++ b/tests/unit/config/test_opensearch_pool_maxsize.py
@@ -1,0 +1,84 @@
+"""Regression tests for OpenSearch connection pool maxsize configuration."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+
+
+def _python_env(env: dict[str, str]) -> dict[str, str]:
+    merged = os.environ.copy()
+    merged.update(env)
+    return merged
+
+
+def test_settings_reads_canonical_pool_maxsize_env_var():
+    env = _python_env(
+        {
+            "OPENSEARCH_POOL_MAXSIZE": "64",
+            "PYTHONPATH": str(SRC),
+        }
+    )
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from config.settings import OPENSEARCH_POOL_MAXSIZE; print(OPENSEARCH_POOL_MAXSIZE)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    assert result.stdout.splitlines()[-1].strip() == "64"
+
+
+def test_settings_default_pool_maxsize_fallback():
+    env = _python_env(
+        {
+            "PYTHONPATH": str(SRC),
+        }
+    )
+    env.pop("OPENSEARCH_POOL_MAXSIZE", None)
+    result = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            "from config.settings import OPENSEARCH_POOL_MAXSIZE; print(OPENSEARCH_POOL_MAXSIZE)",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    assert result.stdout.splitlines()[-1].strip() == "8"
+
+
+def test_opensearch_client_uses_configured_pool_maxsize():
+    env = _python_env(
+        {
+            "OPENSEARCH_POOL_MAXSIZE": "48",
+            "PYTHONPATH": str(SRC),
+        }
+    )
+    code = (
+        "from config.settings import clients; "
+        "client = clients.create_basic_opensearch_client('admin', 'pass'); "
+        "client.transport.set_connections([{'host': 'localhost', 'port': 9200}]); "
+        "conn = client.transport.get_connection(); "
+        "print(conn._limit)"
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    assert result.stdout.splitlines()[-1].strip() == "48"


### PR DESCRIPTION
This pull request adds support for configuring the OpenSearch connection pool size via the `OPENSEARCH_POOL_MAXSIZE` environment variable, ensuring that all OpenSearch clients use this value. It also introduces regression tests to verify that the configuration is correctly read and applied.

**OpenSearch pool size configuration:**

* Added `OPENSEARCH_POOL_MAXSIZE` to `settings.py`, allowing configuration of the OpenSearch connection pool size via an environment variable, with a default and enforced minimum value.
* Updated all OpenSearch client creation methods to use the new `pool_maxsize` setting, ensuring consistent connection pool sizing across the application. [[1]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690R1015) [[2]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690R1692) [[3]](diffhunk://#diff-6ff8f6f489c49cfc2185aa6bdee4b6ee87be730175eed7d6a67fc11194861690R1709)

**Testing:**

* Added regression tests in `tests/unit/config/test_opensearch_pool_maxsize.py` to verify that the pool size is correctly read from the environment and applied to OpenSearch clients.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Added configurable OpenSearch connection pool sizing through an environment setting.
  - Applied the pool-size configuration consistently across supported authentication methods.
  - Added safeguards to prevent invalid pool sizes and ensure a usable minimum value.
- **Tests**
  - Added regression coverage for default settings, custom configuration values, and invalid-value handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->