### PR TITLE
feat: v2 public facing endpoint

### DIFF
--- a/src/app/routes/__init__.py
+++ b/src/app/routes/__init__.py
@@ -9,6 +9,7 @@ from fastapi import FastAPI
 from app.routes.internal import register_internal_routes
 from app.routes.mcp import mount_mcp
 from app.routes.public_v1 import register_public_v1_routes
+from app.routes.public_v2 import register_public_v2_routes
 
 
 def register_all_routes(app: FastAPI):
@@ -19,5 +20,6 @@ def register_all_routes(app: FastAPI):
     """
     register_internal_routes(app)
     register_public_v1_routes(app)
+    register_public_v2_routes(app)
     mcp_lifespan_ctx = mount_mcp(app)
     return mcp_lifespan_ctx

--- a/src/app/routes/public_v2.py
+++ b/src/app/routes/public_v2.py
@@ -1,23 +1,80 @@
 """Public /v2/* route registrations (API-key auth)."""
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Query
 
-from api.v1 import files as v1_files
+from api.v2 import files as files_v2
+from dependencies import get_file_service_v2, require_api_key_permission
+from session_manager import User
+
+
+async def _list_files(
+    page: int = Query(
+        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
+    ),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
+    sort_by: str = Query("filename", description="Sort field"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
+    connector_type: str | None = Query(None, description="Filter by connector type"),
+    mimetype: str | None = Query(None, description="Filter by MIME type"),
+    owner: str | None = Query(None, description="Filter by owner"),
+    search: str | None = Query(None, description="Search filename"),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
+    user: User = Depends(require_api_key_permission("knowledge:read:own")),
+):
+    """List all ingested files. GET /v2/files"""
+    return await files_v2.list_files(
+        page=page,
+        page_size=page_size,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        connector_type=connector_type,
+        mimetype=mimetype,
+        owner=owner,
+        search=search,
+        after_key=after_key,
+        file_service=file_service,
+        user=user,
+    )
+
+
+async def _search_files(
+    q: str = Query(..., min_length=1, description="Search query"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
+    connector_type: str | None = Query(None, description="Filter by connector type"),
+    mimetype: str | None = Query(None, description="Filter by MIME type"),
+    owner: str | None = Query(None, description="Filter by owner"),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
+    user: User = Depends(require_api_key_permission("knowledge:read:own")),
+):
+    """Search ingested files by name. GET /v2/files/search"""
+    return await files_v2.search_files(
+        q=q,
+        page=page,
+        page_size=page_size,
+        connector_type=connector_type,
+        mimetype=mimetype,
+        owner=owner,
+        after_key=after_key,
+        file_service=file_service,
+        user=user,
+    )
 
 
 def register_public_v2_routes(app: FastAPI):
 
-    # Files endpoints (composite-agg pagination)
     # /v2/files/search must be registered before /v2/files to avoid path shadowing
     app.add_api_route(
         "/v2/files/search",
-        v1_files.search_files,
+        _search_files,
         methods=["GET"],
         tags=["public"],
     )
     app.add_api_route(
         "/v2/files",
-        v1_files.list_files,
+        _list_files,
         methods=["GET"],
         tags=["public"],
     )

--- a/src/app/routes/public_v2.py
+++ b/src/app/routes/public_v2.py
@@ -1,0 +1,23 @@
+"""Public /v2/* route registrations (API-key auth)."""
+
+from fastapi import FastAPI
+
+from api.v1 import files as v1_files
+
+
+def register_public_v2_routes(app: FastAPI):
+
+    # Files endpoints (composite-agg pagination)
+    # /v2/files/search must be registered before /v2/files to avoid path shadowing
+    app.add_api_route(
+        "/v2/files/search",
+        v1_files.search_files,
+        methods=["GET"],
+        tags=["public"],
+    )
+    app.add_api_route(
+        "/v2/files",
+        v1_files.list_files,
+        methods=["GET"],
+        tags=["public"],
+    )

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -197,6 +197,14 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
         "name": "openrag_search_files",
         "description": "Search files by query parameters.",
     },
+    ("/v2/files", "GET"): {
+        "name": "openrag_list_files_v2",
+        "description": "Search files by query parameters.",
+    },
+    ("/v2/files/search", "GET"): {
+        "name": "openrag_search_files_v2",
+         "description": "Search ingested files by file name (case-insensitive).",
+    },
 }
 
 
@@ -250,13 +258,19 @@ def create_mcp_server(app: FastAPI) -> FastMCP:
             pattern=r"^/v1/documents/ingest$",
             mcp_type=MCPType.EXCLUDE,
         ),
-        # Expose all /v1/ routes (read + write) as MCP tools.
+        # expose all /v1/ routes as tools
         RouteMap(
             methods=["GET", "POST", "PUT", "DELETE", "PATCH"],
             pattern=r"^/v1/",
             mcp_type=MCPType.TOOL,
         ),
-        # Exclude everything else
+        # expose /v2/files and /v2/files/search as tools
+        RouteMap(
+            methods=["GET"],
+            pattern=r"^/v2/files",
+            mcp_type=MCPType.TOOL,
+        ),
+        # exclude everything else
         RouteMap(
             pattern=r".*",
             mcp_type=MCPType.EXCLUDE,

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -203,7 +203,7 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
     },
     ("/v2/files/search", "GET"): {
         "name": "openrag_search_files_v2",
-         "description": "Search ingested files by file name (case-insensitive).",
+        "description": "Search ingested files by file name (case-insensitive).",
     },
 }
 

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -199,11 +199,11 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
     },
     ("/v2/files", "GET"): {
         "name": "openrag_list_files_v2",
-        "description": "Search files by query parameters.",
+        "description": "lists all ingested files.",
     },
     ("/v2/files/search", "GET"): {
         "name": "openrag_search_files_v2",
-         "description": "Search ingested files by file name (case-insensitive).",
+        "description": "Search ingested files by file name (case-insensitive).",
     },
 }
 
@@ -230,14 +230,16 @@ def _customize_mcp_component(
 
 def create_mcp_server(app: FastAPI) -> FastMCP:
     """
-    Build a FastMCP server from the FastAPI app, exposing only /v1/ routes as tools.
+    Build a FastMCP server from the FastAPI app.
 
     Must be called AFTER all routes are registered on `app` so that
     FastMCP.from_fastapi() can discover them.
 
     Route mapping:
+    - POST /v1/documents/ingest → excluded (multipart not supported by FastMCP proxy)
     - /v1/* routes → MCP tools (GET, POST, PUT, DELETE, PATCH)
-    - All other routes → excluded
+    - GET /v2/files, GET /v2/files/search → MCP tools
+    - all other routes → excluded
 
     Note: GET endpoints are exposed as TOOLS, not resources/resource templates.
     The MCP convention is "GET = resource," but most LLM clients in agent mode


### PR DESCRIPTION
-2 new endpoints: v2/files and v2/files/search?q=
-implemented file ingestion endpoint based on a v2 endpoint for consistency / future roadmaps
-currently calls the same function from v1's file ingestion endpoint 

**Future Note**:
-right now, v1 and v2 share the same composite agg endpoint call (both public endpoint calls from v2's file ingestion); therefore, the code right now is just duplicated. If we were to keep it this way, we can create shared helpers to optimize code flow and reduce duplications.
-since the code duplicated, integration testing, sdk testing, mcp testing all yield same results as v1/files/ and v1/files/search

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added v2 file APIs for listing and searching files.
  * Added support for pagination, sorting, filtering, search terms, and cursor-based navigation.
  * Added API-key authentication for v2 file operations.
  * Exposed v2 file listing and search through MCP tools with dedicated names and descriptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->