### PR TITLE
feat: add ppc64le Dockerfile for opensearch-openrag

### DIFF
--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -7,7 +7,9 @@ USER root
 
 # jvector is already bundled in the image; remove the stock knn/neural-search plugins
 RUN opensearch-plugin remove opensearch-neural-search || true && \
-    opensearch-plugin remove opensearch-knn || true
+    opensearch-plugin remove opensearch-knn || true && \
+    # remove due to Jetty CVE
+    opensearch-plugin remove opensearch-skills || true
 
 #Install jvector and prometheus exporter plugin, .zip files is included in image
 RUN echo y | opensearch-plugin install file://`pwd`/opensearch-jvector-3.6.0.0.zip && \
@@ -24,12 +26,13 @@ RUN opensearch-plugin install --batch repository-gcs && \
     opensearch-plugin install --batch repository-azure
 
 # Apply Netty patch
-COPY patch-netty.sh /tmp/
-RUN bash /tmp/patch-netty.sh
+COPY patch-netty.sh patch-jackson.sh /tmp/
+RUN bash /tmp/patch-netty.sh && \
+    bash /tmp/patch-jackson.sh
+
 
 # Set permissions for OpenShift compatibility before copying
 RUN chmod -R g=u /usr/share/opensearch
-
 
 ########################################
 # Stage 2: Build async-profiler from source

--- a/Dockerfile.ppc64le
+++ b/Dockerfile.ppc64le
@@ -1,0 +1,138 @@
+########################################
+# Stage 1: ppc64le OpenSearch with plugins
+########################################
+FROM icr.io/ppc64le-oss/opensearch-ppc64le:3.6.0 AS upstream_opensearch
+
+USER root
+
+# jvector is already bundled in the image; remove the stock knn/neural-search plugins
+RUN opensearch-plugin remove opensearch-neural-search || true && \
+    opensearch-plugin remove opensearch-knn || true
+
+#Install jvector and prometheus exporter plugin, .zip files is included in image
+RUN echo y | opensearch-plugin install file://`pwd`/opensearch-jvector-3.6.0.0.zip && \
+    echo y | opensearch-plugin install file://`pwd`/prometheus-exporter-3.6.0.0.zip
+
+# Install ppc64le-compatible neural-search plugin
+RUN mkdir -p /tmp/opensearch-neural-search && \
+    curl -L -s https://github.com/IBM/neural-search-jvector/releases/download/3.6.0.0/opensearch-neural-search-3.6.0.0.zip \
+      > /tmp/opensearch-neural-search/plugin.zip && \
+    opensearch-plugin install --batch file:///tmp/opensearch-neural-search/plugin.zip
+
+# Install additional plugins
+RUN opensearch-plugin install --batch repository-gcs && \
+    opensearch-plugin install --batch repository-azure
+
+# Apply Netty patch
+COPY patch-netty.sh /tmp/
+RUN bash /tmp/patch-netty.sh
+
+# Set permissions for OpenShift compatibility before copying
+RUN chmod -R g=u /usr/share/opensearch
+
+
+########################################
+# Stage 2: Build async-profiler from source
+########################################
+FROM registry.access.redhat.com/ubi10/ubi:latest AS async_profiler_build
+
+RUN dnf install -y git make gcc-c++ libstdc++-static java-25-openjdk-devel && dnf clean all
+
+ENV JAVA_HOME=/usr/lib/jvm/java-25-openjdk
+
+# make source and target option 8 for async-profiler ppc64le builds on java 25
+RUN git clone --depth 1 --branch v4.2 https://github.com/async-profiler/async-profiler.git /async-profiler && \
+    sed -i 's/-source 7 -target 7/--release $(JAVA_TARGET)/g' /async-profiler/Makefile && \
+    cd /async-profiler && \
+    make
+
+########################################
+# Stage 3: UBI10 runtime image
+########################################
+FROM registry.access.redhat.com/ubi10/ubi:latest
+
+USER root
+
+RUN dnf update -y && \
+    dnf install -y --allowerasing \
+      less procps-ng findutils sudo curl tar gzip shadow-utils which && \
+    dnf clean all
+
+ARG UID=1000
+ARG GID=1000
+ARG OPENSEARCH_HOME=/usr/share/opensearch
+
+WORKDIR $OPENSEARCH_HOME
+
+RUN groupadd -g $GID opensearch && \
+    adduser -u $UID -g $GID -d $OPENSEARCH_HOME opensearch
+
+# Grant the opensearch user sudo privileges (passwordless sudo)
+RUN usermod -aG wheel opensearch && \
+    echo "opensearch ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
+
+# Copy OpenSearch from upstream stage
+COPY --from=upstream_opensearch --chown=$UID:0 $OPENSEARCH_HOME $OPENSEARCH_HOME
+
+# Copy async-profiler built from source
+COPY --from=async_profiler_build /async-profiler/build/bin /opt/async-profiler/bin
+COPY --from=async_profiler_build /async-profiler/build/lib /opt/async-profiler/lib
+RUN chown -R opensearch:opensearch /opt/async-profiler
+
+# Create profiling script
+RUN echo "#!/bin/bash" > /usr/share/opensearch/profile.sh && \
+    echo "export PATH=\$PATH:/opt/async-profiler/bin" >> /usr/share/opensearch/profile.sh && \
+    echo "echo 1 | sudo tee /proc/sys/kernel/perf_event_paranoid >/dev/null" >> /usr/share/opensearch/profile.sh && \
+    echo "echo 0 | sudo tee /proc/sys/kernel/kptr_restrict >/dev/null" >> /usr/share/opensearch/profile.sh && \
+    echo "asprof \$@" >> /usr/share/opensearch/profile.sh && \
+    chmod 777 /usr/share/opensearch/profile.sh
+
+
+########################################
+# Security config (OIDC/DLS) and setup script
+########################################
+
+COPY securityconfig/ /usr/share/opensearch/securityconfig/
+COPY cloud_securityconfig/ /usr/share/opensearch/cloud_securityconfig/
+RUN chown -R opensearch:opensearch /usr/share/opensearch/securityconfig/ /usr/share/opensearch/cloud_securityconfig/
+
+RUN echo '#!/bin/bash' > /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Waiting for OpenSearch to start..."' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD:-${OPENSEARCH_PASSWORD}}' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'if [ -z "$PASSWORD" ]; then echo "[ERROR] OPENSEARCH_INITIAL_ADMIN_PASSWORD or OPENSEARCH_PASSWORD must be set"; exit 1; fi' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'until curl -s -k -u admin:$PASSWORD https://localhost:9200; do sleep 1; done' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Generating admin hash from configured password..."' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'HASH=$(/usr/share/opensearch/plugins/opensearch-security/tools/hash.sh -p "$PASSWORD")' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'if [ -z "$HASH" ]; then echo "[ERROR] Failed to generate admin hash"; exit 1; fi' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'sed -i "s|^  hash: \".*\"|  hash: \"$HASH\"|" /usr/share/opensearch/securityconfig/internal_users.yml' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Updated internal_users.yml with runtime-generated admin hash"' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'BACKEND_URL=${OPENRAG_BACKEND_INTERNAL_URL:-http://${OPENRAG_BACKEND_HOST:-openrag-backend}:${OPENRAG_BACKEND_PORT:-8000}}' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'sed -i "s|http://openrag-backend:8000|$BACKEND_URL|g" /usr/share/opensearch/securityconfig/config.yml /usr/share/opensearch/cloud_securityconfig/config.yml' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Applying OIDC and DLS security configuration..."' >> /usr/share/opensearch/setup-security.sh && \
+    echo '/usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -cd /usr/share/opensearch/securityconfig \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -icl -nhnv \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -cacert /usr/share/opensearch/config/root-ca.pem \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -cert /usr/share/opensearch/config/kirk.pem \' >> /usr/share/opensearch/setup-security.sh && \
+    echo '  -key /usr/share/opensearch/config/kirk-key.pem' >> /usr/share/opensearch/setup-security.sh && \
+    echo 'echo "Security configuration applied successfully"' >> /usr/share/opensearch/setup-security.sh && \
+    chmod +x /usr/share/opensearch/setup-security.sh
+
+COPY opensearch-entrypoint-wrapper.sh /usr/share/opensearch/
+RUN chmod +x /usr/share/opensearch/opensearch-entrypoint-wrapper.sh && \
+    chown opensearch:opensearch /usr/share/opensearch/opensearch-entrypoint-wrapper.sh
+
+
+########################################
+# Final runtime settings
+########################################
+USER opensearch
+WORKDIR $OPENSEARCH_HOME
+ENV JAVA_HOME=$OPENSEARCH_HOME/jdk
+ENV PATH=$PATH:$JAVA_HOME/bin:$OPENSEARCH_HOME/bin
+
+EXPOSE 9200 9300 9600 9650
+
+ENTRYPOINT ["./opensearch-entrypoint-wrapper.sh"]
+CMD []
+

--- a/patch-jackson.sh
+++ b/patch-jackson.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+set -euo pipefail
+
+JACKSON_OLD_VERSION="2.21.2"
+JACKSON_NEW_VERSION="2.21.5"
+MAVEN_BASE_URL="https://repo1.maven.org/maven2/com/fasterxml/jackson"
+DOWNLOAD_DIR="/tmp/patches/jackson"
+
+# Mapping of artifact name -> maven sub-path under ${MAVEN_BASE_URL}
+declare -A ARTIFACT_GROUP=(
+    ["jackson-core"]="core"
+    ["jackson-databind"]="core"
+    ["jackson-dataformat-yaml"]="dataformat"
+    ["jackson-dataformat-smile"]="dataformat"
+    ["jackson-dataformat-cbor"]="dataformat"
+    ["jackson-dataformat-xml"]="dataformat"
+    ["jackson-datatype-jsr310"]="datatype"
+    ["jackson-module-paranamer"]="module"
+    ["jackson-module-jaxb-annotations"]="module"
+)
+
+# Strict list of standalone jars to replace (2.21.2 -> 2.21.5)
+JACKSON_FILES=(
+    "/usr/share/opensearch/plugins/opensearch-search-relevance/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-notifications-core/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-neural-search/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-sql/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-reports-scheduler/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-performance-analyzer/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-performance-analyzer/jackson-module-paranamer-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-notifications/jackson-datatype-jsr310-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/repository-s3/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-flow-framework/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-flow-framework/jackson-datatype-jsr310-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-ubi/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-security/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-ml/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-observability/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/repository-azure/jackson-dataformat-xml-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/repository-azure/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/repository-azure/jackson-datatype-jsr310-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/repository-azure/jackson-module-jaxb-annotations-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/plugins/opensearch-anomaly-detection/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/lib/jackson-dataformat-yaml-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/lib/jackson-dataformat-smile-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/lib/jackson-core-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/lib/jackson-dataformat-cbor-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/modules/ingest-geoip/jackson-databind-${JACKSON_OLD_VERSION}.jar"
+    "/usr/share/opensearch/modules/ingest-geoip/jackson-datatype-jsr310-${JACKSON_OLD_VERSION}.jar"
+)
+
+# Special cases: jars with a non-standard old version
+# Format: "old_path:artifact_name"
+JACKSON_SPECIAL_FILES=(
+    "/usr/share/opensearch/plugins/opensearch-ml/jackson-datatype-jsr310-2.18.3.jar:jackson-datatype-jsr310"
+)
+
+# Fat/shaded JARs that contain jackson classes internally.
+# These are repacked: jackson classes are replaced in-place inside the fat jar.
+# Format: "fat_jar_path:artifact_name_to_replace"
+JACKSON_SHADED_JARS=(
+    "/usr/share/opensearch/plugins/opensearch-security/opensaml-3.6.0.0-all.jar:jackson-core"
+)
+
+# ---------------------------------------------------------------------------
+# Download phase
+# ---------------------------------------------------------------------------
+
+# Derive unique artifact names from JACKSON_FILES + JACKSON_SPECIAL_FILES
+declare -A ARTIFACTS_TO_DOWNLOAD
+for old_jar in "${JACKSON_FILES[@]}"; do
+    filename=$(basename "${old_jar}")
+    artifact="${filename%-${JACKSON_OLD_VERSION}.jar}"
+    ARTIFACTS_TO_DOWNLOAD["${artifact}"]=1
+done
+for entry in "${JACKSON_SPECIAL_FILES[@]}"; do
+    artifact="${entry#*:}"
+    ARTIFACTS_TO_DOWNLOAD["${artifact}"]=1
+done
+# Also need jackson-core for repacking shaded jars
+ARTIFACTS_TO_DOWNLOAD["jackson-core"]=1
+
+mkdir -p "${DOWNLOAD_DIR}"
+
+echo "Downloading Jackson ${JACKSON_NEW_VERSION} artifacts..."
+for artifact in "${!ARTIFACTS_TO_DOWNLOAD[@]}"; do
+    jar_file="${artifact}-${JACKSON_NEW_VERSION}.jar"
+    dest="${DOWNLOAD_DIR}/${jar_file}"
+
+    if [ ! -f "${dest}" ]; then
+        group="${ARTIFACT_GROUP[${artifact}]:-}"
+        if [ -z "${group}" ]; then
+            echo "ERROR: Unknown maven group for artifact '${artifact}'. Add it to ARTIFACT_GROUP." >&2
+            exit 1
+        fi
+        url="${MAVEN_BASE_URL}/${group}/${artifact}/${JACKSON_NEW_VERSION}/${jar_file}"
+        echo "  Downloading ${artifact} from ${url}..."
+        curl -fsSL "${url}" -o "${dest}"
+    else
+        echo "  Already cached: ${jar_file}"
+    fi
+done
+
+# Replace standalone jars
+replace_jackson_jar() {
+    local old_jar="$1"
+    if [ ! -f "${old_jar}" ]; then
+        echo "  Skipping (not found): ${old_jar}"
+        return
+    fi
+    local dir; dir=$(dirname "${old_jar}")
+    local filename; filename=$(basename "${old_jar}")
+    local artifact="${filename%-${JACKSON_OLD_VERSION}.jar}"
+    local new_jar="${DOWNLOAD_DIR}/${artifact}-${JACKSON_NEW_VERSION}.jar"
+    local new_path="${dir}/${artifact}-${JACKSON_NEW_VERSION}.jar"
+    rm -f "${old_jar}"
+    ln "${new_jar}" "${new_path}"
+    echo "  Replaced: ${old_jar} -> ${new_path}"
+}
+
+replace_jackson_jar_special() {
+    local old_jar="$1"
+    local artifact="$2"
+    if [ ! -f "${old_jar}" ]; then
+        echo "  Skipping (not found): ${old_jar}"
+        return
+    fi
+    local dir; dir=$(dirname "${old_jar}")
+    local new_jar="${DOWNLOAD_DIR}/${artifact}-${JACKSON_NEW_VERSION}.jar"
+    local new_path="${dir}/${artifact}-${JACKSON_NEW_VERSION}.jar"
+    rm -f "${old_jar}"
+    ln "${new_jar}" "${new_path}"
+    echo "  Replaced: ${old_jar} -> ${new_path}"
+}
+
+echo "Replacing standalone Jackson ${JACKSON_OLD_VERSION} jars with ${JACKSON_NEW_VERSION}..."
+for old_jar in "${JACKSON_FILES[@]}"; do
+    replace_jackson_jar "${old_jar}"
+done
+
+echo "Replacing special-versioned Jackson jars with ${JACKSON_NEW_VERSION}..."
+for entry in "${JACKSON_SPECIAL_FILES[@]}"; do
+    old_jar="${entry%%:*}"
+    artifact="${entry#*:}"
+    replace_jackson_jar_special "${old_jar}" "${artifact}"
+done
+
+# Repack shaded/fat JARs — replace jackson classes inside the fat jar
+repack_shaded_jar() {
+    local fat_jar="$1"
+    local artifact="$2"
+
+    if [ ! -f "${fat_jar}" ]; then
+        echo "  Skipping (not found): ${fat_jar}"
+        return
+    fi
+
+    echo "  Repacking shaded jar: ${fat_jar}"
+
+    # Use the JDK jar tool bundled with OpenSearch — no unzip/zip needed
+    local JAR_CMD
+    if [ -x "/usr/share/opensearch/jdk/bin/jar" ]; then
+        JAR_CMD="/usr/share/opensearch/jdk/bin/jar"
+    elif command -v jar &>/dev/null; then
+        JAR_CMD="jar"
+    else
+        echo "ERROR: no 'jar' command found. Cannot repack shaded jar." >&2
+        exit 1
+    fi
+
+    local work_dir="${DOWNLOAD_DIR}/repack/$(basename "${fat_jar}" .jar)"
+    mkdir -p "${work_dir}"
+
+    # Extract the fat jar
+    (cd "${work_dir}" && "${JAR_CMD}" xf "${fat_jar}")
+
+    # Extract the patched artifact's classes into a temp dir and overlay
+    local patched_jar="${DOWNLOAD_DIR}/${artifact}-${JACKSON_NEW_VERSION}.jar"
+    local overlay_dir="${DOWNLOAD_DIR}/overlay/$(basename "${fat_jar}" .jar)"
+    mkdir -p "${overlay_dir}"
+    (cd "${overlay_dir}" && "${JAR_CMD}" xf "${patched_jar}")
+
+    # Find where jackson classes live in the fat jar (may be shaded/relocated)
+    local jackson_dirs
+    jackson_dirs=$(find "${work_dir}" -type d -name "jackson" 2>/dev/null | head -5)
+    if [ -z "${jackson_dirs}" ]; then
+        echo "    WARNING: no jackson class directory found in $(basename "${fat_jar}") — skipping class overlay (classes may be relocated under a different package)"
+    else
+        echo "    Found jackson dirs: ${jackson_dirs}"
+        # Overlay standard com/fasterxml/jackson classes from the patched jar
+        if [ -d "${overlay_dir}/com/fasterxml/jackson" ]; then
+            while IFS= read -r target_dir; do
+                cp -rf "${overlay_dir}/com/fasterxml/jackson/" "${target_dir}/"
+                echo "    Overlaid ${artifact} classes -> ${target_dir}"
+            done <<< "${jackson_dirs}"
+        else
+            echo "    WARNING: overlay jar has no com/fasterxml/jackson dir — skipping overlay"
+        fi
+    fi
+
+    # Remove embedded maven metadata for the artifact so Trivy does not report
+    # the old version from pom.properties / pom.xml inside the fat jar.
+    local meta_dir="${work_dir}/META-INF/maven/com.fasterxml.jackson.core/${artifact}"
+    if [ -d "${meta_dir}" ]; then
+        rm -rf "${meta_dir}"
+        echo "    Removed embedded maven metadata: META-INF/maven/com.fasterxml.jackson.core/${artifact}"
+    else
+        echo "    No embedded maven metadata found for ${artifact} (nothing to remove)"
+    fi
+
+    # Repack the fat jar in-place
+    rm -f "${fat_jar}"
+    (cd "${work_dir}" && "${JAR_CMD}" cf "${fat_jar}" .)
+    echo "    Repacked: ${fat_jar}"
+
+    # Cleanup work dirs
+    rm -rf "${work_dir}" "${overlay_dir}"
+}
+
+echo "Repacking shaded JARs containing Jackson ${JACKSON_OLD_VERSION}..."
+for entry in "${JACKSON_SHADED_JARS[@]}"; do
+    fat_jar="${entry%%:*}"
+    artifact="${entry#*:}"
+    repack_shaded_jar "${fat_jar}" "${artifact}"
+done
+
+# ---------------------------------------------------------------------------
+# Cleanup
+# ---------------------------------------------------------------------------
+rm -rf "${DOWNLOAD_DIR}"
+
+echo "Successfully patched all Jackson jars to ${JACKSON_NEW_VERSION}."
+


### PR DESCRIPTION
Add Dockerfile.ppc64le
Pulls from icr.io/ppc64le-oss/opensearch-ppc64le:3.6.0 as upstream OpenSearch 3.6.0 ppc64le base image.
Jvector and prometheus exporter plugin .zip files are already included in base image.
Install async-profiler from source for ppc64le

Add patch-jackson.sh to update jackson jar files to address CVEs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features

- Added a multi-stage OpenSearch container image for ppc64le platforms.
- Included vector search, Prometheus monitoring, neural search, and cloud repository capabilities.
- Added profiling support with dedicated profiling endpoints.
- Added automated security initialization, including credential validation, OIDC, and document-level security configuration.
- Exposed OpenSearch and profiling services through the container.

## Bug Fixes

- Improved runtime compatibility and stability by updating bundled security, networking, and data-processing components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->