### PR TITLE
fix: remove committed OpenSearch password from agent flow

### DIFF
--- a/flows/openrag_agent.json
+++ b/flows/openrag_agent.json
@@ -3007,7 +3007,7 @@
                 "title_case": false,
                 "track_in_telemetry": false,
                 "type": "str",
-                "value": "8$8@SqVR&ZvbGBrd"
+                "value": ""
               },
               "request_timeout": {
                 "_input_type": "StrInput",


### PR DESCRIPTION
This pull request makes a small but important configuration change to the `flows/openrag_agent.json` file. The value for a particular string parameter has been cleared, likely to remove a hardcoded sensitive value.

* Configuration update:
  * Cleared the value of a string parameter (previously set to `"8$8@SqVR&ZvbGBrd"`) in `flows/openrag_agent.json`, potentially to remove sensitive information or credentials.