### PR TITLE
fix: onboarding progress bar is centered again

### DIFF
--- a/frontend/components/chat-renderer.tsx
+++ b/frontend/components/chat-renderer.tsx
@@ -302,7 +302,12 @@ export function ChatRenderer({
       </div>
 
       {/* Main Content */}
-      <main className="overflow-hidden flex-1 flex items-center justify-center relative">
+      <main
+        className={cn(
+          "overflow-hidden flex-1 flex items-center justify-center",
+          isSelectingChats && "relative",
+        )}
+      >
         {isSelectingChats && (
           <div className="absolute inset-0 z-10 backdrop-blur-sm bg-background/60 flex items-center justify-center">
             <div className="flex flex-col items-center gap-3 text-center px-8">


### PR DESCRIPTION
## Summary
fixes a regression introduced by pr https://github.com/langflow-ai/openrag/pull/2208. The feature adds a new unconditional relative to chat-renderer which shifted the progress bar that appears during onboarding to the right and non-centered. I made this relative conditional on isSelectingChats being true so the progress bar during onboarding is centered again

## Before
<img width="1649" height="952" alt="regression-before" src="https://github.com/user-attachments/assets/23575ef3-9fd3-4514-bfe5-d99cb381ac4c" />

## After
<img width="1687" height="960" alt="regression-after" src="https://github.com/user-attachments/assets/d18356f1-fa1a-427f-83b9-2a42024b9c29" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved chat layout behavior by applying positioning styles only when chat selection mode is active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->