### PR TITLE
fix: added paths to dockerfiles and entrypoints to solve CWE-426

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,7 +132,11 @@ RUN chmod +x /usr/share/opensearch/opensearch-entrypoint-wrapper.sh && \
 USER opensearch
 WORKDIR $OPENSEARCH_HOME
 ENV JAVA_HOME=$OPENSEARCH_HOME/jdk
-ENV PATH=$PATH:$JAVA_HOME/bin:$OPENSEARCH_HOME/bin
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv dirs are appended last so they cannot shadow system binaries.
+# Matches the ordering used by the upstream image but with system dirs promoted
+# to the front.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin:$JAVA_HOME/bin:$OPENSEARCH_HOME/bin
 
 # Expose ports
 EXPOSE 9200 9300 9600 9650

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -21,7 +21,7 @@ RUN microdnf install -y \
     && python -m ensurepip --upgrade \
     && python -m pip install --no-cache-dir --upgrade "pip>=26.1" "setuptools>=78.1.1"
 
-ENV PATH="/root/.local/bin:$PATH" \
+ENV PATH="$PATH:/root/.local/bin" \
     PIP_DISABLE_PIP_VERSION_CHECK=1 \
     PIP_NO_CACHE_DIR=1
 
@@ -91,7 +91,7 @@ COPY --chown=appuser:appuser cloud_securityconfig/ ./cloud_securityconfig/
 COPY --chown=appuser:appuser scripts/backend-entrypoint.sh /entrypoint.sh
 
 ENV VIRTUAL_ENV=/app/.venv
-ENV PATH="/app/.venv/bin:$PATH"
+ENV PATH="$PATH:/root/.local/bin"
 
 # Pre-create every directory the app writes to at runtime so they are owned
 # by appuser in the image layer. When Docker/Podman mounts a host volume over

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -91,7 +91,9 @@ COPY --chown=appuser:appuser cloud_securityconfig/ ./cloud_securityconfig/
 COPY --chown=appuser:appuser scripts/backend-entrypoint.sh /entrypoint.sh
 
 ENV VIRTUAL_ENV=/app/.venv
-ENV PATH="$PATH:/root/.local/bin"
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv dirs are appended last so they cannot shadow system binaries.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin:/app/.venv/bin
 
 # Pre-create every directory the app writes to at runtime so they are owned
 # by appuser in the image layer. When Docker/Podman mounts a host volume over
@@ -113,4 +115,4 @@ EXPOSE 8000
 EXPOSE 8100
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["python", "src/main.py"]
+CMD ["/app/.venv/bin/python", "src/main.py"]

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -101,7 +101,7 @@ COPY --chown=appuser:appuser scripts/backend-entrypoint.sh /entrypoint.sh
 ENV VIRTUAL_ENV=/app/.venv
 # CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
 # first. App venv dirs are appended last so they cannot shadow system binaries.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin:/app/.venv/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/.venv/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
 
 # Pre-create every directory the app writes to at runtime so they are owned
 # by appuser in the image layer. When Docker/Podman mounts a host volume over

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -43,6 +43,12 @@ USER 0
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1
 
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv dirs are appended last so they cannot shadow system binaries.
+# Matches the ordering used by the upstream image but with system dirs promoted
+# to the front.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
+
 COPY --from=builder --chown=1001:0 /opt/app-root/src/package*.json ./
 COPY --from=builder --chown=1001:0 /opt/app-root/src/stubs ./stubs
 COPY --from=builder --chown=1001:0 /opt/app-root/src/.next ./.next

--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -40,6 +40,12 @@ ENV LANGFLOW_COMPONENTS_PATH=/app/custom_components
 ENV LANGFLOW_COMPONENTS_INDEX_PATH=/app/component_index.json
 ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv dirs are appended last so they cannot shadow system binaries.
+# Matches the ordering used by the upstream image but with system dirs promoted
+# to the front.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
+
 EXPOSE 7860
 
 ENTRYPOINT ["langflow-entrypoint"]

--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -42,7 +42,7 @@ ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
 # CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
 # first. App venv and ubi python dirs are appended last so they cannot shadow system binaries.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin:/app/.venv/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/.venv/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
 
 EXPOSE 7860
 

--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -40,8 +40,9 @@ ENV LANGFLOW_COMPONENTS_PATH=/app/custom_components
 ENV LANGFLOW_COMPONENTS_INDEX_PATH=/app/component_index.json
 ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
-# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved first.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv and ubi python dirs are appended last so they cannot shadow system binaries.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin:/app/.venv/bin
 
 EXPOSE 7860
 

--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -40,11 +40,8 @@ ENV LANGFLOW_COMPONENTS_PATH=/app/custom_components
 ENV LANGFLOW_COMPONENTS_INDEX_PATH=/app/component_index.json
 ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
-# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
-# first. App venv dirs are appended last so they cannot shadow system binaries.
-# Matches the ordering used by the upstream image but with system dirs promoted
-# to the front.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved first.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 EXPOSE 7860
 

--- a/Dockerfile.langflow.dev
+++ b/Dockerfile.langflow.dev
@@ -64,11 +64,8 @@ ENV LANGFLOW_COMPONENTS_PATH=/app/custom_components
 ENV LANGFLOW_COMPONENTS_INDEX_PATH=/app/component_index.json
 ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
-# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
-# first. App venv dirs are appended last so they cannot shadow system binaries.
-# Matches the ordering used by the upstream image but with system dirs promoted
-# to the front.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved first.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Start the backend server
 CMD ["uv", "run", "langflow", "run", "--host", "0.0.0.0", "--port", "7860"]

--- a/Dockerfile.langflow.dev
+++ b/Dockerfile.langflow.dev
@@ -66,7 +66,7 @@ ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
 # CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
 # first. App venv and ubi python dirs are appended last so they cannot shadow system binaries.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin:/app/.venv/bin
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/app/.venv/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
 
 # Start the backend server
 CMD ["uv", "run", "langflow", "run", "--host", "0.0.0.0", "--port", "7860"]

--- a/Dockerfile.langflow.dev
+++ b/Dockerfile.langflow.dev
@@ -64,8 +64,9 @@ ENV LANGFLOW_COMPONENTS_PATH=/app/custom_components
 ENV LANGFLOW_COMPONENTS_INDEX_PATH=/app/component_index.json
 ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
-# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved first.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv and ubi python dirs are appended last so they cannot shadow system binaries.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin:/app/.venv/bin
 
 # Start the backend server
 CMD ["uv", "run", "langflow", "run", "--host", "0.0.0.0", "--port", "7860"]

--- a/Dockerfile.langflow.dev
+++ b/Dockerfile.langflow.dev
@@ -64,5 +64,11 @@ ENV LANGFLOW_COMPONENTS_PATH=/app/custom_components
 ENV LANGFLOW_COMPONENTS_INDEX_PATH=/app/component_index.json
 ENV LANGFLOW_ALLOW_CUSTOM_COMPONENTS=false
 
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv dirs are appended last so they cannot shadow system binaries.
+# Matches the ordering used by the upstream image but with system dirs promoted
+# to the front.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
+
 # Start the backend server
 CMD ["uv", "run", "langflow", "run", "--host", "0.0.0.0", "--port", "7860"]

--- a/kubernetes/operator/Dockerfile
+++ b/kubernetes/operator/Dockerfile
@@ -20,11 +20,8 @@ RUN microdnf install -y ca-certificates && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 
-# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
-# first. App venv dirs are appended last so they cannot shadow system binaries.
-# Matches the ordering used by the upstream image but with system dirs promoted
-# to the front.
-ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved first.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 WORKDIR /
 COPY --from=builder /workspace/manager .

--- a/kubernetes/operator/Dockerfile
+++ b/kubernetes/operator/Dockerfile
@@ -20,6 +20,12 @@ RUN microdnf install -y ca-certificates && \
     microdnf clean all && \
     rm -rf /var/cache/yum
 
+# CWE-426 fix: explicitly set PATH so system-owned directories are always resolved
+# first. App venv dirs are appended last so they cannot shadow system binaries.
+# Matches the ordering used by the upstream image but with system dirs promoted
+# to the front.
+ENV PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/app-root/bin:/opt/app-root/src/bin:/opt/app-root/src/.local/bin
+
 WORKDIR /
 COPY --from=builder /workspace/manager .
 

--- a/scripts/backend-entrypoint.sh
+++ b/scripts/backend-entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$(id -u)" = "0" ]; then
         2>/dev/null || true
     exec runuser -u appuser -- env \
         VIRTUAL_ENV=/app/.venv \
-        PATH="/app/.venv/bin:$PATH" \
+        PATH="$PATH" \
         "$@"
 else
     exec "$@"


### PR DESCRIPTION
This pull request focuses on improving the security of the Docker images by explicitly setting the `PATH` environment variable in all Dockerfiles and related scripts. The main goal is to ensure that system-owned directories are prioritized in the `PATH`, preventing application or user-installed binaries from shadowing system binaries, which addresses CWE-426 ("Untrusted Search Path"). Additionally, some redundant or potentially unsafe `PATH` settings are cleaned up.

The most important changes are:

**Security hardening: Explicit `PATH` ordering**

* All Dockerfiles (`Dockerfile`, `Dockerfile.frontend`, `Dockerfile.langflow`, `Dockerfile.langflow.dev`, `kubernetes/operator/Dockerfile`) now set `PATH` so that system directories (e.g., `/usr/local/sbin`, `/usr/bin`, etc.) come first, followed by application-specific directories. This prevents app or user binaries from taking precedence over system binaries, mitigating CWE-426 risks. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L135-R139) [[2]](diffhunk://#diff-4444de7e0285ace98379daf14b0a12432671267023fecaa9ce0bc69fb670f8fbR46-R51) [[3]](diffhunk://#diff-6cf5d1cc7b94802c5f5a7659b53b398991b8c5875dd4f526a6cfd3b46763f2c5R43-R48) [[4]](diffhunk://#diff-639678df999952c74f59efad9c7591f93b0d89f362810f5c621fbca75d731e78R67-R72) [[5]](diffhunk://#diff-655c6bfff6fc1bee916cd91509cc08e01c4841a89a3864f6703081bac4950de7R23-R28)

**Cleanup and consistency in backend Docker image and entrypoint**

* In `Dockerfile.backend`, the `PATH` is now consistently set to append `/root/.local/bin` rather than prepend it, ensuring system binaries are resolved first.
* The `PATH` setting in `Dockerfile.backend` for the app virtual environment has been changed to only append `/root/.local/bin`, removing the previous inclusion of the venv bin directory at the front.
* The backend entrypoint script now uses the `PATH` as-is instead of prepending the venv bin directory, further ensuring system binary precedence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Security**
  - Improved container command resolution by prioritizing trusted system directories over application-specific paths.
  - Reduced the risk of application files shadowing system binaries across runtime and development environments.

- **Bug Fixes**
  - Preserved configured execution paths when switching to the application user.
  - Improved reliability when launching backend services in their intended environment.
  - Standardized path handling across application, frontend, backend, and development containers.

- **New Features**
  - Frontend services are now also accessible on port 9090.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->