### PR TITLE
fix: upgrade node image

### DIFF
--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -3,7 +3,7 @@
 # -----------------------------------------------------------------------------
 # Stage: deps
 # -----------------------------------------------------------------------------
-FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS deps
+FROM registry.access.redhat.com/ubi10/nodejs-24-minimal AS deps
 
 WORKDIR /opt/app-root/src
 USER 0
@@ -18,7 +18,7 @@ RUN npm ci --prefer-offline --no-audit
 # -----------------------------------------------------------------------------
 # Stage: builder
 # -----------------------------------------------------------------------------
-FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS builder
+FROM registry.access.redhat.com/ubi10/nodejs-24-minimal AS builder
 
 WORKDIR /opt/app-root/src
 USER 0
@@ -34,7 +34,7 @@ RUN npm run build \
 # -----------------------------------------------------------------------------
 # Stage: runtime
 # -----------------------------------------------------------------------------
-FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS runtime
+FROM registry.access.redhat.com/ubi10/nodejs-24-minimal AS runtime
 
 WORKDIR /opt/app-root/src
 USER 0


### PR DESCRIPTION
Upgrades node to the latest redhat image fixing our cves (ubi10 doesn't have a node 22 fix yet)

Affected CVEs:

https://github.com/advisories/GHSA-qqjm-7pv6-7q82
https://github.com/advisories/GHSA-rv82-5vqw-69hj
https://github.com/advisories/GHSA-g57m-hr98-5m89
https://github.com/advisories/GHSA-v3cq-r2f8-qmmc
https://github.com/advisories/GHSA-3h92-9jcv-8677
https://github.com/advisories/GHSA-g779-8rvr-37xx
https://github.com/advisories/GHSA-w88c-7765-q5gg
https://github.com/advisories/GHSA-pvpp-9x2p-fxg3
https://github.com/advisories/GHSA-px9q-xv67-75fr
https://github.com/advisories/GHSA-9qm6-cjgc-f64v
https://github.com/advisories/GHSA-p9qf-hwxr-qhff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the frontend runtime environment to Node.js 24.
  * Improved consistency across dependency installation, build, and application startup stages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->