### PR TITLE
feat: console status component actions 2183

### DIFF
--- a/frontend/app/api/queries/useComponentActions.ts
+++ b/frontend/app/api/queries/useComponentActions.ts
@@ -1,0 +1,94 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import type {
+  ComponentState,
+  ComponentStatus,
+  ConsoleStatusResponse,
+} from "./useConsoleStatusQuery";
+
+// ─── shared types ──────────────────────────────────────────────────────────
+
+export interface ComponentActionResponse {
+  component: string;
+  ok: boolean;
+  message: string;
+  status: ComponentStatus;
+}
+
+export interface DiagnosisResponse {
+  component: string;
+  state: ComponentState;
+  summary: string;
+  likely_cause?: string | null;
+  remediation: string[];
+  last_error?: string | null;
+  target?: string | null;
+}
+
+const SEVERITY: Record<ComponentState, number> = {
+  healthy: 0,
+  degraded: 1,
+  unknown: 2,
+  unhealthy: 3,
+};
+
+const worstOf = (states: ComponentState[]): ComponentState =>
+  states.reduce<ComponentState>(
+    (worst, s) => (SEVERITY[s] > SEVERITY[worst] ? s : worst),
+    "healthy",
+  );
+
+// ─── sync mutation ───────────────────────────────────────────────────────────
+
+/** Re-checks one component and patches the ["console-status"] cache with the
+ *  returned fresh status. */
+export function useComponentSyncMutation() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (component: string): Promise<ComponentActionResponse> => {
+      const res = await fetch(
+        `/api/status/${encodeURIComponent(component)}/sync`,
+        { method: "POST" },
+      );
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          typeof body?.detail === "string" ? body.detail : `HTTP ${res.status}`,
+        );
+      }
+      return body as ComponentActionResponse;
+    },
+    onSuccess: (result) => {
+      queryClient.setQueryData<ConsoleStatusResponse>(
+        ["console-status"],
+        (prev) => {
+          if (!prev) return prev;
+          const components = prev.components.map((c) =>
+            c.name === result.component ? result.status : c,
+          );
+          return {
+            ...prev,
+            components,
+            overall_status: worstOf(components.map((c) => c.status)),
+          };
+        },
+      );
+    },
+  });
+}
+
+// ─── diagnose query (lazy — fires when the modal opens) ──────────────────────
+
+export const useComponentDiagnoseQuery = (component: string | null) =>
+  useQuery({
+    queryKey: ["component-diagnose", component],
+    queryFn: async () => {
+      const res = await fetch(
+        `/api/status/${encodeURIComponent(component as string)}/diagnose`,
+      );
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      return res.json() as Promise<DiagnosisResponse>;
+    },
+    enabled: !!component,
+    staleTime: 5000,
+    refetchOnWindowFocus: false,
+  });

--- a/frontend/app/api/queries/useComponentActions.ts
+++ b/frontend/app/api/queries/useComponentActions.ts
@@ -72,6 +72,12 @@ export function useComponentSyncMutation() {
           };
         },
       );
+      queryClient.invalidateQueries({
+        queryKey: ["component-diagnose", result.component],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["component-logs", result.component],
+      });
     },
   });
 }

--- a/frontend/app/api/queries/useComponentLogsQuery.ts
+++ b/frontend/app/api/queries/useComponentLogsQuery.ts
@@ -1,0 +1,60 @@
+import {
+  type UseQueryOptions,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+
+export interface LogEntry {
+  timestamp: string; // ISO-8601 UTC
+  level: string; // "debug" | "info" | "warning" | "error" | "critical"
+  message: string;
+  detail?: string | null;
+}
+
+export interface ComponentLogsResponse {
+  component: string;
+  entries: LogEntry[];
+  count: number;
+}
+
+async function fetchComponentLogs(
+  component: string,
+  tail = 100,
+): Promise<ComponentLogsResponse> {
+  const response = await fetch(
+    `/api/status/${encodeURIComponent(component)}/logs?tail=${tail}`,
+  );
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    const detail =
+      typeof body?.detail === "string"
+        ? body.detail
+        : `HTTP ${response.status}`;
+    throw new Error(detail);
+  }
+  return response.json() as Promise<ComponentLogsResponse>;
+}
+
+export const useComponentLogsQuery = (
+  component: string | null,
+  tail = 100,
+  options?: Omit<
+    UseQueryOptions<ComponentLogsResponse>,
+    "queryKey" | "queryFn"
+  >,
+) => {
+  const queryClient = useQueryClient();
+
+  return useQuery(
+    {
+      queryKey: ["component-logs", component, tail],
+      queryFn: () => fetchComponentLogs(component as string, tail),
+      enabled: !!component,
+      retry: 1,
+      staleTime: 5000,
+      refetchOnWindowFocus: false,
+      ...options,
+    },
+    queryClient,
+  );
+};

--- a/frontend/app/api/queries/useConsoleStatusQuery.ts
+++ b/frontend/app/api/queries/useConsoleStatusQuery.ts
@@ -25,6 +25,8 @@ export interface ComponentStatus {
   metadata?: Record<string, unknown>;
   /** Non-null when the last health-check failed; used to gate the Logs button. */
   last_error?: string | null;
+  /** ISO-8601 UTC of when this component was last checked (drives "Last Sync"). */
+  checked_at?: string | null;
 }
 
 export interface ConsoleStatusResponse {

--- a/frontend/app/api/queries/useConsoleStatusQuery.ts
+++ b/frontend/app/api/queries/useConsoleStatusQuery.ts
@@ -23,6 +23,8 @@ export interface ComponentStatus {
   version?: string | null;
   build?: ComponentBuild;
   metadata?: Record<string, unknown>;
+  /** Non-null when the last health-check failed; used to gate the Logs button. */
+  last_error?: string | null;
 }
 
 export interface ConsoleStatusResponse {

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -7,17 +7,20 @@ import {
   ChevronUp,
   HelpCircle,
   RefreshCw,
+  ScrollText,
   Settings,
   XCircle,
 } from "lucide-react";
 import { useCallback, useState } from "react";
 import {
+  type LogEntry,
+  useComponentLogsQuery,
+} from "@/app/api/queries/useComponentLogsQuery";
+import {
   type ComponentState,
   type ComponentStatus,
   useConsoleStatusQuery,
 } from "@/app/api/queries/useConsoleStatusQuery";
-import type { ProviderHealthResponse } from "@/app/api/queries/useProviderHealthQuery";
-import { useProviderHealth } from "@/components/provider-health-banner";
 import { cn } from "@/lib/utils";
 
 // ─── status helpers ──────────────────────────────────────────────────────────
@@ -100,6 +103,136 @@ function MetaRow({ label, value }: { label: string; value: string }) {
   );
 }
 
+// ─── log level helpers ────────────────────────────────────────────────────────
+
+function logLevelColor(level: string) {
+  switch (level.toLowerCase()) {
+    case "error":
+    case "critical":
+      return "text-red-400";
+    case "warning":
+      return "text-amber-400";
+    case "info":
+      return "text-sky-400";
+    default:
+      return "text-zinc-400";
+  }
+}
+
+// ─── component logs modal ─────────────────────────────────────────────────────
+
+interface ComponentLogsModalProps {
+  component: string;
+  displayName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function ComponentLogsModal({
+  component,
+  displayName,
+  open,
+  onOpenChange,
+}: ComponentLogsModalProps) {
+  const { data, isLoading, isError, error, refetch, isFetching } =
+    useComponentLogsQuery(open ? component : null, 100);
+
+  const entries: LogEntry[] = data?.entries ?? [];
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent
+        className={cn(
+          "bg-zinc-900 border-zinc-700 text-zinc-100",
+          "w-[560px] max-w-[95vw] max-h-[70vh] flex flex-col gap-0 p-0",
+        )}
+      >
+        {/* Modal header */}
+        <DialogHeader className="shrink-0 flex flex-row items-center justify-between px-4 py-3 border-b border-zinc-700/60">
+          <div className="flex items-center gap-2">
+            <ScrollText size={14} className="text-zinc-400" />
+            <DialogTitle className="text-sm font-semibold text-zinc-100">
+              {displayName} — Logs
+            </DialogTitle>
+            {isFetching && (
+              <RefreshCw size={11} className="text-zinc-500 animate-spin" />
+            )}
+          </div>
+          <button
+            type="button"
+            onClick={() => void refetch()}
+            disabled={isFetching}
+            className="text-xs text-zinc-500 hover:text-zinc-300 transition-colors disabled:opacity-40"
+          >
+            Refresh
+          </button>
+        </DialogHeader>
+
+        {/* Log list */}
+        <div className="flex-1 overflow-y-auto px-4 py-3 space-y-1.5 min-h-0">
+          {isLoading ? (
+            <div className="space-y-1.5">
+              {[...Array(5)].map((_, i) => (
+                <div
+                  // biome-ignore lint/suspicious/noArrayIndexKey: skeleton placeholders
+                  key={i}
+                  className="h-8 rounded bg-zinc-800/60 animate-pulse"
+                />
+              ))}
+            </div>
+          ) : isError ? (
+            <p className="text-sm text-red-400">
+              {error instanceof Error ? error.message : "Failed to load logs."}
+            </p>
+          ) : entries.length === 0 ? (
+            <p className="text-xs text-zinc-500 italic text-center py-6">
+              No log entries recorded yet.
+            </p>
+          ) : (
+            entries.map((entry, idx) => (
+              <div
+                // biome-ignore lint/suspicious/noArrayIndexKey: log entries have no stable id
+                key={idx}
+                className="rounded bg-zinc-800/50 border border-zinc-700/40 px-2.5 py-1.5"
+              >
+                <div className="flex items-center gap-2 flex-wrap">
+                  <span
+                    className={cn(
+                      "text-[10px] font-semibold uppercase tabular-nums shrink-0",
+                      logLevelColor(entry.level),
+                    )}
+                  >
+                    {entry.level}
+                  </span>
+                  <span className="text-[10px] text-zinc-500 tabular-nums shrink-0">
+                    {new Date(entry.timestamp).toLocaleTimeString()}
+                  </span>
+                  <span className="text-xs text-zinc-200 break-all">
+                    {entry.message}
+                  </span>
+                </div>
+                {entry.detail && (
+                  <p className="text-[11px] text-zinc-400 mt-0.5 ml-0 break-all font-mono">
+                    {entry.detail}
+                  </p>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="shrink-0 px-4 py-2 border-t border-zinc-700/60">
+          <span className="text-[11px] text-zinc-500">
+            {entries.length} entr{entries.length === 1 ? "y" : "ies"} (most
+            recent 100)
+          </span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ─── component placard ───────────────────────────────────────────────────────
 
 interface ComponentCardProps {
@@ -108,6 +241,7 @@ interface ComponentCardProps {
 
 function ComponentCard({ component }: ComponentCardProps) {
   const [expanded, setExpanded] = useState(false);
+  const [logsOpen, setLogsOpen] = useState(false);
 
   const {
     display_name,
@@ -117,7 +251,10 @@ function ComponentCard({ component }: ComponentCardProps) {
     message,
     build,
     metadata,
+    last_error,
   } = component;
+
+  const showLogsButton = last_error != null;
 
   const hasBuildDetails =
     build &&
@@ -204,7 +341,35 @@ function ComponentCard({ component }: ComponentCardProps) {
               No additional details available.
             </p>
           )}
+
+          {/* Logs button — only shown when last_error is set */}
+          {showLogsButton && (
+            <div className="pt-1.5">
+              <button
+                type="button"
+                onClick={() => setLogsOpen(true)}
+                className={cn(
+                  "flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium",
+                  "bg-zinc-700/60 border border-zinc-600/60 text-zinc-200",
+                  "hover:bg-zinc-600/60 hover:border-zinc-500/60 transition-colors",
+                )}
+              >
+                <ScrollText size={12} className="shrink-0" />
+                Logs
+              </button>
+            </div>
+          )}
         </div>
+      )}
+
+      {/* Logs modal */}
+      {showLogsButton && (
+        <ComponentLogsModal
+          component={component.name}
+          displayName={display_name}
+          open={logsOpen}
+          onOpenChange={setLogsOpen}
+        />
       )}
     </div>
   );

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -21,6 +21,16 @@ import {
   type ComponentStatus,
   useConsoleStatusQuery,
 } from "@/app/api/queries/useConsoleStatusQuery";
+import {
+  type ProviderHealthResponse,
+  useProviderHealthQuery,
+} from "@/app/api/queries/useProviderHealthQuery";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 
 // ─── status helpers ──────────────────────────────────────────────────────────
@@ -460,7 +470,7 @@ export function ConsoleStatusPanel({ onClose }: ConsoleStatusPanelProps) {
 
   // Reuses the shared /provider/health query (same cache as the banner), so an
   // API-key failure surfaces here without an extra network round-trip.
-  const { health: providerHealth } = useProviderHealth();
+  const { data: providerHealth } = useProviderHealthQuery();
 
   // Defensive: always read from data.components array
   const backendComponents = Array.isArray(data?.components)

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -260,7 +260,7 @@ function ComponentLogsModal({
             entries.map((entry, idx) => (
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: log entries have no stable id
-                key={idx}
+                key={`${entry.timestamp}-${idx}`}
                 className="rounded bg-zinc-800/50 border border-zinc-700/40 px-2.5 py-1.5"
               >
                 <div className="flex items-center gap-2 flex-wrap">

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -158,7 +158,7 @@ function ComponentLogsModal({
         )}
       >
         {/* Modal header */}
-        <DialogHeader className="shrink-0 flex flex-row items-center justify-between px-4 py-3 border-b border-zinc-700/60">
+        <DialogHeader className="shrink-0 flex flex-row items-center justify-between pl-4 pr-10 py-3 border-b border-zinc-700/60">
           <div className="flex items-center gap-2">
             <ScrollText size={14} className="text-zinc-400" />
             <DialogTitle className="text-sm font-semibold text-zinc-100">
@@ -252,6 +252,7 @@ interface ComponentCardProps {
 function ComponentCard({ component }: ComponentCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
+  const showLogsButton = component.name !== "providers";
 
   const {
     display_name,
@@ -261,10 +262,7 @@ function ComponentCard({ component }: ComponentCardProps) {
     message,
     build,
     metadata,
-    last_error,
   } = component;
-
-  const showLogsButton = last_error != null;
 
   const hasBuildDetails =
     build &&
@@ -352,7 +350,7 @@ function ComponentCard({ component }: ComponentCardProps) {
             </p>
           )}
 
-          {/* Logs button — only shown when last_error is set */}
+          {/* Logs button — not shown for the synthetic Model Providers card */}
           {showLogsButton && (
             <div className="pt-1.5">
               <button

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -9,10 +9,16 @@ import {
   HelpCircle,
   RefreshCw,
   ScrollText,
-  Settings,
+  TrendingUp,
+  Wrench,
   XCircle,
 } from "lucide-react";
-import { useCallback, useState } from "react";
+import { type ReactNode, useCallback, useState } from "react";
+import {
+  type DiagnosisResponse,
+  useComponentDiagnoseQuery,
+  useComponentSyncMutation,
+} from "@/app/api/queries/useComponentActions";
 import {
   type LogEntry,
   useComponentLogsQuery,
@@ -112,6 +118,57 @@ function MetaRow({ label, value }: { label: string; value: string }) {
       </span>
     </div>
   );
+}
+
+// ─── action button ────────────────────────────────────────────────────────────
+
+/** Compact card action. Icon-only when `label` is omitted (uses `ariaLabel`). */
+function ActionButton({
+  icon,
+  label,
+  ariaLabel,
+  disabled,
+  onClick,
+}: {
+  icon: ReactNode;
+  label?: string;
+  ariaLabel?: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={disabled}
+      aria-label={ariaLabel ?? label}
+      title={ariaLabel ?? label}
+      className={cn(
+        "flex items-center gap-1.5 rounded text-xs font-medium",
+        label ? "px-2.5 py-1" : "p-1.5",
+        "bg-zinc-700/60 border border-zinc-600/60 text-zinc-200",
+        "hover:bg-zinc-600/60 hover:border-zinc-500/60 transition-colors",
+        "disabled:opacity-50 disabled:cursor-not-allowed",
+      )}
+    >
+      <span className="shrink-0">{icon}</span>
+      {label}
+    </button>
+  );
+}
+
+/** "just now" / "5 minutes ago" from an ISO-8601 timestamp. */
+function formatRelative(iso?: string | null): string {
+  if (!iso) return "—";
+  const secs = Math.round((Date.now() - new Date(iso).getTime()) / 1000);
+  if (!Number.isFinite(secs) || secs < 0) return "just now";
+  if (secs < 45) return "just now";
+  const mins = Math.round(secs / 60);
+  if (mins < 60) return `${mins} minute${mins === 1 ? "" : "s"} ago`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 24) return `${hrs} hour${hrs === 1 ? "" : "s"} ago`;
+  const days = Math.round(hrs / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
 }
 
 // ─── log level helpers ────────────────────────────────────────────────────────
@@ -244,6 +301,82 @@ function ComponentLogsModal({
   );
 }
 
+// ─── diagnostics modal ────────────────────────────────────────────────────────
+
+interface ComponentDiagnoseModalProps {
+  component: string;
+  displayName: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function ComponentDiagnoseModal({
+  component,
+  displayName,
+  open,
+  onOpenChange,
+}: ComponentDiagnoseModalProps) {
+  const { data, isLoading, isError, error } = useComponentDiagnoseQuery(
+    open ? component : null,
+  );
+  const d: DiagnosisResponse | undefined = data;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="bg-zinc-900 border-zinc-700 text-zinc-100 w-[520px] max-w-[95vw]">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2 text-sm font-semibold">
+            <Wrench size={14} className="text-zinc-400" />
+            {displayName} — Debug
+          </DialogTitle>
+        </DialogHeader>
+
+        {isLoading ? (
+          <div className="h-24 rounded bg-zinc-800/60 animate-pulse" />
+        ) : isError ? (
+          <p className="text-sm text-red-400">
+            {error instanceof Error ? error.message : "Failed to diagnose."}
+          </p>
+        ) : d ? (
+          <div className="space-y-3 text-sm">
+            <p className="text-zinc-100">{d.summary}</p>
+            {d.likely_cause && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wide text-zinc-500">
+                  Likely cause
+                </p>
+                <p className="text-zinc-300 mt-0.5">{d.likely_cause}</p>
+              </div>
+            )}
+            {d.remediation.length > 0 && (
+              <div>
+                <p className="text-[11px] uppercase tracking-wide text-zinc-500">
+                  How to fix
+                </p>
+                <ul className="mt-1 space-y-1 list-disc list-inside text-zinc-300">
+                  {d.remediation.map((step) => (
+                    <li key={step}>{step}</li>
+                  ))}
+                </ul>
+              </div>
+            )}
+            {d.target && (
+              <p className="text-[11px] text-zinc-500">
+                Endpoint: <span className="font-mono">{d.target}</span>
+              </p>
+            )}
+            {d.last_error && (
+              <pre className="text-[11px] text-zinc-400 bg-zinc-800/60 rounded p-2 whitespace-pre-wrap break-all font-mono">
+                {d.last_error}
+              </pre>
+            )}
+          </div>
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
 // ─── component placard ───────────────────────────────────────────────────────
 
 interface ComponentCardProps {
@@ -253,7 +386,14 @@ interface ComponentCardProps {
 function ComponentCard({ component }: ComponentCardProps) {
   const [expanded, setExpanded] = useState(false);
   const [logsOpen, setLogsOpen] = useState(false);
-  const showLogsButton = component.name !== "providers";
+  const [debugOpen, setDebugOpen] = useState(false);
+
+  // The synthetic "providers" card is not a real component — no actions.
+  const isRealComponent = component.name !== "providers";
+
+  const syncMutation = useComponentSyncMutation();
+  const syncing =
+    syncMutation.isPending && syncMutation.variables === component.name;
 
   const {
     display_name,
@@ -263,6 +403,7 @@ function ComponentCard({ component }: ComponentCardProps) {
     message,
     build,
     metadata,
+    checked_at,
   } = component;
 
   const hasBuildDetails =
@@ -323,62 +464,91 @@ function ComponentCard({ component }: ComponentCardProps) {
       {/* Expanded details */}
       {expanded && (
         <div className="border-t border-zinc-700/50 px-3.5 py-2.5 space-y-1">
-          {hasBuildDetails ? (
+          {isRealComponent && (
             <>
-              {build?.git_sha && (
-                <MetaRow label="Git SHA" value={build.git_sha.slice(0, 12)} />
-              )}
-              {build?.build_time && (
-                <MetaRow label="Build Time" value={build.build_time} />
-              )}
-              {build?.image && <MetaRow label="Image" value={build.image} />}
-              {build?.image_digest && (
-                <MetaRow
-                  label="Digest"
-                  value={`${build.image_digest.slice(0, 20)}…`}
-                />
-              )}
+              <MetaRow label="Last Sync" value={formatRelative(checked_at)} />
+              <div className="flex items-center justify-between gap-2 py-1">
+                <span className="text-xs text-zinc-500 shrink-0">
+                  Response Time
+                </span>
+                <span className="flex items-center gap-1 text-xs text-zinc-300 tabular-nums">
+                  <TrendingUp size={12} className="text-emerald-400" />
+                  {latency_ms != null ? `${latency_ms}ms` : "—"}
+                </span>
+              </div>
             </>
-          ) : null}
+          )}
+          {build?.git_sha && (
+            <MetaRow label="Git SHA" value={build.git_sha.slice(0, 12)} />
+          )}
+          {build?.build_time && (
+            <MetaRow label="Build Time" value={build.build_time} />
+          )}
+          {build?.image && <MetaRow label="Image" value={build.image} />}
+          {build?.image_digest && (
+            <MetaRow
+              label="Digest"
+              value={`${build.image_digest.slice(0, 20)}…`}
+            />
+          )}
           {hasMetadata
             ? Object.entries(metadata).map(([k, v]) => (
                 <MetaRow key={k} label={k} value={String(v)} />
               ))
             : null}
-          {!hasBuildDetails && !hasMetadata && (
+          {!isRealComponent && !hasBuildDetails && !hasMetadata && (
             <p className="text-xs text-zinc-500 italic">
               No additional details available.
             </p>
           )}
 
-          {/* Logs button — not shown for the synthetic Model Providers card */}
-          {showLogsButton && (
-            <div className="pt-1.5">
-              <button
-                type="button"
-                onClick={() => setLogsOpen(true)}
-                className={cn(
-                  "flex items-center gap-1.5 px-2.5 py-1 rounded text-xs font-medium",
-                  "bg-zinc-700/60 border border-zinc-600/60 text-zinc-200",
-                  "hover:bg-zinc-600/60 hover:border-zinc-500/60 transition-colors",
-                )}
-              >
-                <ScrollText size={12} className="shrink-0" />
-                Logs
-              </button>
+          {/* Action row — not shown for the synthetic Model Providers card */}
+          {isRealComponent && (
+            <div className="flex items-center justify-between gap-2 pt-2">
+              <ActionButton
+                icon={<Wrench size={14} />}
+                ariaLabel="Debug this component"
+                onClick={() => setDebugOpen(true)}
+              />
+              <div className="flex items-center gap-1.5">
+                <ActionButton
+                  icon={<ScrollText size={13} />}
+                  label="Logs"
+                  onClick={() => setLogsOpen(true)}
+                />
+                <ActionButton
+                  icon={
+                    <RefreshCw
+                      size={13}
+                      className={cn(syncing && "animate-spin")}
+                    />
+                  }
+                  label="Sync"
+                  disabled={syncing}
+                  onClick={() => syncMutation.mutate(component.name)}
+                />
+              </div>
             </div>
           )}
         </div>
       )}
 
-      {/* Logs modal */}
-      {showLogsButton && (
-        <ComponentLogsModal
-          component={component.name}
-          displayName={display_name}
-          open={logsOpen}
-          onOpenChange={setLogsOpen}
-        />
+      {/* Modals */}
+      {isRealComponent && (
+        <>
+          <ComponentLogsModal
+            component={component.name}
+            displayName={display_name}
+            open={logsOpen}
+            onOpenChange={setLogsOpen}
+          />
+          <ComponentDiagnoseModal
+            component={component.name}
+            displayName={display_name}
+            open={debugOpen}
+            onOpenChange={setDebugOpen}
+          />
+        </>
       )}
     </div>
   );

--- a/frontend/components/console-status-panel.tsx
+++ b/frontend/components/console-status-panel.tsx
@@ -260,7 +260,7 @@ function ComponentLogsModal({
             entries.map((entry, idx) => (
               <div
                 // biome-ignore lint/suspicious/noArrayIndexKey: log entries have no stable id
-                key={`${entry.timestamp}-${idx}`}
+                key={`${entry.timestamp}-${entry.message}`}
                 className="rounded bg-zinc-800/50 border border-zinc-700/40 px-2.5 py-1.5"
               >
                 <div className="flex items-center gap-2 flex-wrap">

--- a/src/api/health.py
+++ b/src/api/health.py
@@ -6,11 +6,18 @@ import httpx
 from fastapi import Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
-from api.schemas.status import LogEntry, LogsResponse, StatusResponse
+from api.schemas.status import (
+    ComponentActionResponse,
+    DiagnosisResponse,
+    LogEntry,
+    LogsResponse,
+    StatusResponse,
+)
 from config.settings import clients
 from dependencies import require_permission
 from services.component_logs import KNOWN_COMPONENTS, get_entries
-from services.status_service import aggregate_status
+from services.status_diagnostics import diagnose_component
+from services.status_service import aggregate_status, check_one
 from session_manager import User
 from utils.logging_config import get_logger
 
@@ -44,6 +51,35 @@ async def get_console_component_logs(
     raw = get_entries(component, tail=tail)
     entries = [LogEntry(**e) for e in raw]
     return LogsResponse(component=component, entries=entries, count=len(entries))
+
+
+def _require_known_component(component: str) -> None:
+    if component not in KNOWN_COMPONENTS:
+        valid = ", ".join(sorted(KNOWN_COMPONENTS))
+        raise HTTPException(404, f"Unknown component '{component}'. Valid names: {valid}")
+
+
+async def sync_console_component(
+    component: str,
+    user: User = Depends(require_permission("providers:read")),
+) -> ComponentActionResponse:
+    """Re-run one component's health check. POST /status/{component}/sync"""
+    _require_known_component(component)
+    status = await check_one(component)
+    return ComponentActionResponse(
+        component=component, ok=True, message="Status refreshed.", status=status
+    )
+
+
+async def diagnose_console_component(
+    component: str,
+    user: User = Depends(require_permission("providers:read")),
+) -> DiagnosisResponse:
+    """Explain what's wrong with a component and how to fix it.
+    GET /status/{component}/diagnose"""
+    _require_known_component(component)
+    status = await check_one(component)
+    return diagnose_component(status, get_entries(component, tail=50))
 
 
 async def health_check(request: Request):

--- a/src/api/health.py
+++ b/src/api/health.py
@@ -3,12 +3,13 @@
 import asyncio
 
 import httpx
-from fastapi import Depends, HTTPException, Request
+from fastapi import Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 
-from api.schemas.status import StatusResponse
+from api.schemas.status import LogEntry, LogsResponse, StatusResponse
 from config.settings import clients
 from dependencies import require_permission
+from services.component_logs import KNOWN_COMPONENTS, get_entries
 from services.status_service import aggregate_status
 from session_manager import User
 from utils.logging_config import get_logger
@@ -25,6 +26,24 @@ async def get_console_status(
     except Exception as e:
         logger.error("Failed to get console status", error=str(e))
         raise HTTPException(status_code=500, detail="Failed to get status") from e
+
+
+async def get_console_component_logs(
+    component: str,
+    tail: int = Query(default=100, ge=1, le=500),
+    user: User = Depends(require_permission("providers:read")),
+) -> LogsResponse:
+    """Return recent log entries for one component. GET /status/{component}/logs"""
+    if component not in KNOWN_COMPONENTS:
+        valid = ", ".join(sorted(KNOWN_COMPONENTS))
+        raise HTTPException(
+            status_code=404,
+            detail=f"Unknown component '{component}'. Valid names: {valid}",
+        )
+
+    raw = get_entries(component, tail=tail)
+    entries = [LogEntry(**e) for e in raw]
+    return LogsResponse(component=component, entries=entries, count=len(entries))
 
 
 async def health_check(request: Request):

--- a/src/api/schemas/status.py
+++ b/src/api/schemas/status.py
@@ -31,6 +31,8 @@ class ComponentStatus(BaseModel):
     # Added by #2178 — None when healthy, last exception detail when not.
     # The frontend uses this as the signal to show the Logs button.
     last_error: str | None = None
+    # Added by #2183 — when this component was last checked (ISO-8601 UTC).
+    checked_at: str | None = None
 
 
 class LogEntry(BaseModel):
@@ -50,3 +52,24 @@ class StatusResponse(BaseModel):
     overall_status: ComponentState
     checked_at: str  # ISO 8601 UTC
     components: list[ComponentStatus] = Field(default_factory=list)
+
+
+class ComponentActionResponse(BaseModel):
+    """Result of a per-component action (sync/restart), carrying fresh status."""
+
+    component: str
+    ok: bool
+    message: str
+    status: ComponentStatus
+
+
+class DiagnosisResponse(BaseModel):
+    """Guidance for the "Debug" button: what's wrong and how to fix it."""
+
+    component: str
+    state: ComponentState
+    summary: str
+    likely_cause: str | None = None
+    remediation: list[str] = Field(default_factory=list)
+    last_error: str | None = None
+    target: str | None = None

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -31,7 +31,7 @@ from api import (
     upload,
 )
 from api import keys as api_keys
-from api.health import get_console_status, health_check, opensearch_health_ready
+from api.health import get_console_component_logs, get_console_status, health_check, opensearch_health_ready
 from api.schemas.tasks import ErrorResponse, TaskRetryResponse
 from api.v2 import files as files_v2
 from connectors.registry import get_connector_classes
@@ -392,7 +392,14 @@ def register_internal_routes(app: FastAPI):
     app.add_api_route("/health", health_check, methods=["GET"], tags=["internal"])
     app.add_api_route("/search/health", opensearch_health_ready, methods=["GET"], tags=["internal"])
 
-    # Console status endpoint (browser session auth — mirrors /v1/status for the UI)
+    # Console status endpoints (browser session auth — mirrors /v1/status* for the UI)
+    # The specific /logs sub-route must be registered before the bare /status route.
+    app.add_api_route(
+        "/status/{component}/logs",
+        get_console_component_logs,
+        methods=["GET"],
+        tags=["internal"],
+    )
     app.add_api_route("/status", get_console_status, methods=["GET"], tags=["internal"])
 
     # Models endpoints

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -427,7 +427,7 @@ def register_internal_routes(app: FastAPI):
             tags=["internal"],
         )
         app.add_api_route("/status", get_console_status, methods=["GET"], tags=["internal"])
-        
+
     # Models endpoints
     app.add_api_route(
         "/models/openai", models.get_openai_models, methods=["POST"], tags=["internal"]

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -400,33 +400,34 @@ def register_internal_routes(app: FastAPI):
     app.add_api_route("/health", health_check, methods=["GET"], tags=["internal"])
     app.add_api_route("/search/health", opensearch_health_ready, methods=["GET"], tags=["internal"])
 
-    # Console status endpoints (browser session auth — mirrors /v1/status* for the UI)
-    # The specific /logs sub-route must be registered before the bare /status route.
-    app.add_api_route(
-        "/status/{component}/logs",
-        get_console_component_logs,
-        methods=["GET"],
-        tags=["internal"],
-    )
-    # Per-component actions (#2183): sync re-checks, diagnose explains failures.
-    app.add_api_route(
-        "/status/{component}/sync",
-        sync_console_component,
-        methods=["POST"],
-        tags=["internal"],
-    )
-    app.add_api_route(
-        "/status/{component}/diagnose",
-        diagnose_console_component,
-        methods=["GET"],
-        tags=["internal"],
-    )
-    app.add_api_route("/status", get_console_status, methods=["GET"], tags=["internal"])
     # Console status endpoint (browser session auth — mirrors /v1/status for the UI).
     # OSS-only: not registered in saas or on_prem deployments.
     if is_run_mode_oss():
         app.add_api_route("/status", get_console_status, methods=["GET"], tags=["internal"])
 
+        # Console status endpoints (browser session auth — mirrors /v1/status* for the UI)
+        # The specific /logs sub-route must be registered before the bare /status route.
+        app.add_api_route(
+            "/status/{component}/logs",
+            get_console_component_logs,
+            methods=["GET"],
+            tags=["internal"],
+        )
+        # Per-component actions (#2183): sync re-checks, diagnose explains failures.
+        app.add_api_route(
+            "/status/{component}/sync",
+            sync_console_component,
+            methods=["POST"],
+            tags=["internal"],
+        )
+        app.add_api_route(
+            "/status/{component}/diagnose",
+            diagnose_console_component,
+            methods=["GET"],
+            tags=["internal"],
+        )
+        app.add_api_route("/status", get_console_status, methods=["GET"], tags=["internal"])
+        
     # Models endpoints
     app.add_api_route(
         "/models/openai", models.get_openai_models, methods=["POST"], tags=["internal"]

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -32,10 +32,12 @@ from api import (
 )
 from api import keys as api_keys
 from api.health import (
+    diagnose_console_component,
     get_console_component_logs,
     get_console_status,
     health_check,
     opensearch_health_ready,
+    sync_console_component,
 )
 from api.schemas.tasks import ErrorResponse, TaskRetryResponse
 from api.v2 import files as files_v2
@@ -403,6 +405,19 @@ def register_internal_routes(app: FastAPI):
     app.add_api_route(
         "/status/{component}/logs",
         get_console_component_logs,
+        methods=["GET"],
+        tags=["internal"],
+    )
+    # Per-component actions (#2183): sync re-checks, diagnose explains failures.
+    app.add_api_route(
+        "/status/{component}/sync",
+        sync_console_component,
+        methods=["POST"],
+        tags=["internal"],
+    )
+    app.add_api_route(
+        "/status/{component}/diagnose",
+        diagnose_console_component,
         methods=["GET"],
         tags=["internal"],
     )

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -31,7 +31,12 @@ from api import (
     upload,
 )
 from api import keys as api_keys
-from api.health import get_console_component_logs, get_console_status, health_check, opensearch_health_ready
+from api.health import (
+    get_console_component_logs,
+    get_console_status,
+    health_check,
+    opensearch_health_ready,
+)
 from api.schemas.tasks import ErrorResponse, TaskRetryResponse
 from api.v2 import files as files_v2
 from connectors.registry import get_connector_classes

--- a/src/services/status_diagnostics.py
+++ b/src/services/status_diagnostics.py
@@ -34,7 +34,11 @@ def diagnose_component(
     display = _DISPLAY.get(component, status.display_name or component)
     target = _target(component)
     last_err = next(
-        (e.get("detail") for e in reversed(entries or []) if e.get("level") in ("error", "critical")),
+        (
+            e.get("detail")
+            for e in reversed(entries or [])
+            if e.get("level") in ("error", "critical")
+        ),
         None,
     )
     detail = status.last_error or last_err

--- a/src/services/status_diagnostics.py
+++ b/src/services/status_diagnostics.py
@@ -68,11 +68,20 @@ def diagnose_component(
         )
 
     if detail and any(h in detail.lower() for h in _CONNECTION_HINTS):
+        if target:
+            return resp( 
+                f"{display} is unreachable — the backend couldn't connect to it.", 
+                f"The service isn't accepting connections at {target}. It may be stopped or still starting.",
+                [
+                    f"Confirm the service is running at {target}.",
+                    'Click "Sync" once it\'s back to re-check.',
+                    'Check "Logs" for the underlying error.',
+                ]
+            )
         return resp(
             f"{display} is unreachable — the backend couldn't connect to it.",
-            f"The service isn't accepting connections at {target}. It may be stopped or still starting.",
+            "The service may be stopped or still starting.",
             [
-                f"Confirm the service is running at {target}.",
                 'Click "Sync" once it\'s back to re-check.',
                 'Check "Logs" for the underlying error.',
             ],

--- a/src/services/status_diagnostics.py
+++ b/src/services/status_diagnostics.py
@@ -1,0 +1,91 @@
+"""Rule-based diagnosis for the Console Status "Debug" button (#2183).
+
+Turns a component's status + recent log detail into plain-English guidance:
+what's likely wrong and concrete steps to fix it.
+"""
+
+from api.schemas.status import ComponentState, ComponentStatus, DiagnosisResponse
+from services.component_logs import LogEntry
+
+_DISPLAY = {
+    "openrag": "OpenRAG Backend",
+    "langflow": "Langflow",
+    "docling": "Docling",
+    "opensearch": "OpenSearch",
+}
+
+_CONNECTION_HINTS = ("connect", "refused", "timed out", "timeout", "unreachable")
+
+
+def _target(component: str) -> str | None:
+    from config.settings import DOCLING_SERVE_URL, LANGFLOW_URL, OPENSEARCH_URL
+
+    return {
+        "langflow": f"{LANGFLOW_URL}/api/v1/version",
+        "docling": f"{DOCLING_SERVE_URL}/version",
+        "opensearch": OPENSEARCH_URL,
+    }.get(component)
+
+
+def diagnose_component(
+    status: ComponentStatus, entries: list[LogEntry] | None = None
+) -> DiagnosisResponse:
+    component = status.name
+    display = _DISPLAY.get(component, status.display_name or component)
+    target = _target(component)
+    last_err = next(
+        (e.get("detail") for e in reversed(entries or []) if e.get("level") in ("error", "critical")),
+        None,
+    )
+    detail = status.last_error or last_err
+
+    def resp(summary, cause=None, steps=None):
+        return DiagnosisResponse(
+            component=component,
+            state=status.status,
+            summary=summary,
+            likely_cause=cause,
+            remediation=steps or [],
+            last_error=detail,
+            target=target,
+        )
+
+    if status.status == ComponentState.HEALTHY:
+        return resp(f"{display} is healthy — no action needed.")
+
+    if component == "opensearch" and status.status == ComponentState.DEGRADED:
+        return resp(
+            f"{display} cluster health is yellow (degraded).",
+            "Replica shards are unassigned — normal for a single-node dev cluster.",
+            [
+                "On a single-node setup this is expected and safe to ignore.",
+                "For production, add data nodes so replicas can be assigned.",
+            ],
+        )
+
+    if detail and any(h in detail.lower() for h in _CONNECTION_HINTS):
+        return resp(
+            f"{display} is unreachable — the backend couldn't connect to it.",
+            f"The service isn't accepting connections at {target}. It may be stopped or still starting.",
+            [
+                f"Confirm the service is running at {target}.",
+                'Click "Sync" once it\'s back to re-check.',
+                'Check "Logs" for the underlying error.',
+            ],
+        )
+
+    if status.status == ComponentState.UNKNOWN:
+        return resp(
+            f"{display}'s status could not be determined.",
+            "The health check didn't complete — the client may not be initialized, or it timed out.",
+            [
+                'Click "Sync" to re-run the check.',
+                "Wait a moment if the backend is still starting.",
+            ],
+        )
+
+    return resp(
+        f"{display} reported: {status.message or status.status}.",
+        detail or "The service responded but not in a healthy state.",
+        ['Click "Sync" to confirm the current status.', 'Review "Logs" for details.'],
+    )

--- a/src/services/status_diagnostics.py
+++ b/src/services/status_diagnostics.py
@@ -69,14 +69,14 @@ def diagnose_component(
 
     if detail and any(h in detail.lower() for h in _CONNECTION_HINTS):
         if target:
-            return resp( 
-                f"{display} is unreachable — the backend couldn't connect to it.", 
+            return resp(
+                f"{display} is unreachable — the backend couldn't connect to it.",
                 f"The service isn't accepting connections at {target}. It may be stopped or still starting.",
                 [
                     f"Confirm the service is running at {target}.",
                     'Click "Sync" once it\'s back to re-check.',
                     'Check "Logs" for the underlying error.',
-                ]
+                ],
             )
         return resp(
             f"{display} is unreachable — the backend couldn't connect to it.",

--- a/src/services/status_service.py
+++ b/src/services/status_service.py
@@ -68,22 +68,22 @@ async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentS
     return result
 
 
+SEVERITY_ORDER = [
+    ComponentState.HEALTHY,
+    ComponentState.DEGRADED,
+    ComponentState.UNKNOWN,
+    ComponentState.UNHEALTHY,
+]
+
+
 def _worst_status(results: list[ComponentStatus]) -> ComponentState:
     """This calculates the final status (the worst one)"""
-    severity = {
-        ComponentState.HEALTHY: 0,
-        ComponentState.DEGRADED: 1,
-        ComponentState.UNKNOWN: 2,
-        ComponentState.UNHEALTHY: 2,
-    }
-
-    severity_in_order = [ComponentState.HEALTHY, ComponentState.DEGRADED, ComponentState.UNHEALTHY]
-
-    return severity_in_order[max((severity[r.status] for r in results), default=0)]
+    severity = {state: i for i, state in enumerate(SEVERITY_ORDER)}
+    return SEVERITY_ORDER[max((severity[r.status] for r in results), default=0)]
 
 
 async def aggregate_status() -> StatusResponse:
-    """TODO: add docstrings here"""
+    """Runs all component health checks concurrently and return the aggregate status"""
     results = await asyncio.gather(*(_run_check(fn) for fn in CHECK_SPECS))
 
     return StatusResponse(

--- a/src/services/status_service.py
+++ b/src/services/status_service.py
@@ -19,20 +19,30 @@ CHECK_TIMEOUT_S = 5.0
 CHECK_SPECS = [check_openrag_backend, check_docling, check_langflow, check_opensearch]
 
 
+def _check_name(fn: Callable) -> str:
+    return fn.__name__.replace("check_", "").replace("openrag_backend", "openrag")
+
+
+# component name → its check function, for refreshing a single component (#2183).
+CHECK_BY_NAME: dict[str, Callable[[], Awaitable[ComponentStatus]]] = {
+    _check_name(fn): fn for fn in CHECK_SPECS
+}
+
+
 async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentStatus:
     """Run one check function, wrapping timeouts and unexpected exceptions.
 
     Both failure modes are recorded to the component log buffer so that the
     /v1/status/{component}/logs endpoint can surface the detail later.
     """
-    name = fn.__name__.replace("check_", "")
+    name = _check_name(fn)
     try:
-        return await asyncio.wait_for(fn(), timeout=CHECK_TIMEOUT_S)
+        result = await asyncio.wait_for(fn(), timeout=CHECK_TIMEOUT_S)
     except TimeoutError:
         msg = f"Status check timed out after {CHECK_TIMEOUT_S}s"
         logger.warning("Status check timed out", component=name, timeout_s=CHECK_TIMEOUT_S)
         record(name, "error", msg, detail=f"asyncio.TimeoutError — timeout={CHECK_TIMEOUT_S}s")
-        return ComponentStatus(
+        result = ComponentStatus(
             name=name,
             display_name=name.title(),
             status=ComponentState.UNKNOWN,
@@ -44,7 +54,7 @@ async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentS
         msg = "Status check did not complete"
         logger.warning("Status check did not complete", component=name, error=str(e))
         record(name, "error", msg, detail=f"{type(e).__name__}: {e}")
-        return ComponentStatus(
+        result = ComponentStatus(
             name=name,
             display_name=name.title(),
             status=ComponentState.UNKNOWN,
@@ -52,6 +62,10 @@ async def _run_check(fn: Callable[[], Awaitable[ComponentStatus]]) -> ComponentS
             message=msg,
             last_error=f"{type(e).__name__}: {e}",
         )
+
+    # Stamp the check time here so every code path (aggregate or single) is consistent.
+    result.checked_at = datetime.now(UTC).isoformat()
+    return result
 
 
 def _worst_status(results: list[ComponentStatus]) -> ComponentState:
@@ -77,3 +91,9 @@ async def aggregate_status() -> StatusResponse:
         checked_at=datetime.now(UTC).isoformat(),
         components=list(results),
     )
+
+
+async def check_one(name: str) -> ComponentStatus | None:
+    """Re-run one component's health check (#2183 "Sync"). None if unknown."""
+    fn = CHECK_BY_NAME.get(name)
+    return await _run_check(fn) if fn is not None else None

--- a/tests/unit/services/test_status_service.py
+++ b/tests/unit/services/test_status_service.py
@@ -65,7 +65,7 @@ async def test_timeout_becomes_unknown_and_does_not_block(monkeypatch):
     unknown = [c for c in result.components if c.status == ComponentState.UNKNOWN]
     assert len(unknown) == 1, [(c.name, c.status) for c in result.components]
 
-    assert result.overall_status == ComponentState.UNHEALTHY
+    assert result.overall_status == ComponentState.UNKNOWN
 
 
 @pytest.mark.asyncio
@@ -80,7 +80,7 @@ async def test_check_exception_becomes_unknown(monkeypatch):
 
     result = await status_service.aggregate_status()
 
-    assert result.overall_status == ComponentState.UNHEALTHY
+    assert result.overall_status == ComponentState.UNKNOWN
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Per-component Sync & Debug for the Console Status panel

Addresses #2183. Adds per-component actions to the Console Status panel so a user can refresh and troubleshoot a single component instead of relying on the whole-panel snapshot.

## What's new
Each real component card (in its expanded view) now shows:
- **Last Sync** — relative time since that component was last checked (e.g. "5 minutes ago").
- **Response Time** — the component's latency.
- **Sync** — re-runs the health check for *just that component* and updates its card in place (no full-panel refetch).
- **Debug** — opens a modal explaining what's wrong and how to fix it: a summary, the likely cause, concrete remediation steps, the target endpoint, and the last error.

The synthetic "Model Providers" card is unaffected (no actions).

## Backend
- **New endpoints** (session-auth, OSS-only — same gating as the existing `/status` routes):
  - `POST /status/{component}/sync` → re-runs one component's health check and returns its fresh status.
  - `GET /status/{component}/diagnose` → returns rule-based guidance for the component's current state.
- `services/status_service.py`: added a `CHECK_BY_NAME` registry and `check_one(name)` to run a single check; every check result is now stamped with `checked_at`.
- `services/status_diagnostics.py` (new): `diagnose_component()` maps a component's state + recent error logs to a summary, likely cause, and remediation steps (handles healthy, OpenSearch "yellow", connection-refused, unknown, and generic cases).
- `api/schemas/status.py`: `checked_at` on `ComponentStatus`; new `ComponentActionResponse` and `DiagnosisResponse` models.
- `api/health.py`, `app/routes/internal.py`: handlers + route registration.

## Frontend
- `app/api/queries/useComponentActions.ts` (new): `useComponentSyncMutation` (patches the `console-status` cache with the returned status and recomputes the overall status) and a lazy `useComponentDiagnoseQuery` that fires when the Debug modal opens.
- `components/console-status-panel.tsx`: redesigned the expanded card (Last Sync + Response Time rows, an action row with Debug / Logs / Sync, spinner on Sync) and added a `ComponentDiagnoseModal`.
- `app/api/queries/useConsoleStatusQuery.ts`: added the `checked_at` field.

## How to verify
1. Open **Console Status** (OSS mode) and expand a component.
2. **Sync** → shows a spinner; "Last Sync" and latency update for that card only.
3. **Debug** → modal with summary, likely cause, and remediation. To see a real diagnosis, stop a service (e.g. `podman compose stop langflow`) and click **Sync**, then **Debug**.
4. **Logs** still works unchanged.

Checks run locally: `ruff` (backend), Biome + `tsc --noEmit` (frontend) all pass; the new endpoints were smoke-tested against a running stack (return the expected auth-gated responses and fresh per-component status).

## Notes
- Console status routes remain **OSS-only**; `providers:read` is required.
- A per-component **restart** button was considered but intentionally left out of this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-component Debug, Logs, Sync, and Diagnose controls.
  * Added component log viewing with severity and relative-time formatting.
  * Added diagnostic results with likely causes, remediation guidance, and target details.
  * Added timestamps and error details to component health statuses.
  * Added provider health information to the status panel.

* **Bug Fixes**
  * Improved health-check error reporting and component validation.
  * Added support for rerunning individual component health checks.
  * Improved handling and display of unknown component health states.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->