### PR TITLE
fix: stop Langflow crashing on component_index.json in the flows dir

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -33,6 +33,11 @@ COPY custom_components/ /app/custom_components/
 COPY --chmod=755 scripts/langflow-entrypoint.py /usr/local/bin/langflow-entrypoint
 COPY flows/component_index.json /app/component_index.json
 USER root
+# component_index.json is not a flow: Langflow scans /app/flows/ and crashes
+# trying to load it as one. Drop the copy under flows/ and keep only the one at
+# LANGFLOW_COMPONENTS_INDEX_PATH below. Must run after USER root — as uid=1000
+# the rm fails on the /app/flows/ directory.
+RUN rm -f /app/flows/component_index.json
 ENV LANGFLOW_SSRF_ALLOWED_HOSTS=localhost,127.0.0.1,host.docker.internal
 ENV LANGFLOW_LOG_TRACE_LOCALS=false
 ENV LANGFLOW_BLOCK_CODE_INTERPRETER_COMPONENTS=true


### PR DESCRIPTION
## Problem

Langflow crashes on startup in this branch. `flows/component_index.json` is a component index, not a flow, but `Dockerfile.langflow` does:

```dockerfile
COPY flows/ /app/flows/
```

which drops it into the directory Langflow scans for flows. Langflow then tries to load it as a flow and dies.

The file is still needed — just at a different path, `/app/component_index.json`, which is what `LANGFLOW_COMPONENTS_INDEX_PATH` already points at and is already copied separately on line 34.

## Fix

Delete the stray copy under `/app/flows/` after `COPY flows/`:

```dockerfile
COPY flows/component_index.json /app/component_index.json
USER root
RUN rm -f /app/flows/component_index.json
```

Placement matters: the `RUN` has to come **after** `USER root`. The base image runs as uid=1000, which cannot unlink from the `/app/flows/` directory, so an earlier `rm` fails the build.

## Provenance

This ports two fixes already on `main` that `azure-ai-rebase-main` predates:

| Commit | Message |
|---|---|
| `b8cb84d2` | fix: remove non flow json from flows |
| `1e4455de` | fix: fixed dockerfile with wrong placement for removal of component index |

They were landed as direct pushes to `main` (no PR), which is why they were easy to miss on the rebase branch. Same pair is on `release-saas-ga-0.6.5` as `499bf93c` / `8d23ccdd`.

## Scope note

This fixes image-based deployments (Kubernetes/operator, SaaS). It does **not** change `docker-compose.yml`, where the `langflow` service bind-mounts `./flows:/app/flows`, shadowing the image layer and re-introducing the file at runtime. That behavior is identical on `main`, so it's left alone here rather than diverging.

## Testing

```
docker build -f Dockerfile.langflow -t openrag-langflow:idx-fix .
docker run --rm openrag-langflow:idx-fix ls /app/flows /app/component_index.json
```

Expect no `component_index.json` under `/app/flows/`, and the file present at `/app/component_index.json`. Then start the Langflow service and confirm it reaches ready without the flow-load crash.