### PR TITLE
feat: public file listing on v2 endpoint with SDK and MCP support

### DIFF
--- a/frontend/app/api/queries/useListFiles.ts
+++ b/frontend/app/api/queries/useListFiles.ts
@@ -47,7 +47,7 @@ export const useListFiles = (
     if (params.afterKey)
       searchParams.set("after_key", JSON.stringify(params.afterKey));
 
-    const url = `/api/v2/files?${searchParams.toString()}`; //v2 endpoint
+    const url = `/api/files/v2?${searchParams.toString()}`; //internal v2 (cookie auth)
 
     const response = await fetch(url);
 

--- a/frontend/app/api/queries/useListFiles.ts
+++ b/frontend/app/api/queries/useListFiles.ts
@@ -47,7 +47,7 @@ export const useListFiles = (
     if (params.afterKey)
       searchParams.set("after_key", JSON.stringify(params.afterKey));
 
-    const url = `/api/files/v2?${searchParams.toString()}`; //internal v2 (cookie auth)
+    const url = `/api/files?${searchParams.toString()}`; //internal (cookie auth)
 
     const response = await fetch(url);
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5439,6 +5439,9 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
+    "node_modules/next/node_modules/sharp": {
+      "optional": true
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -5439,9 +5439,6 @@
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
       }
     },
-    "node_modules/next/node_modules/sharp": {
-      "optional": true
-    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -216,11 +216,11 @@ response = await client.chat.create(message="Summarise Q3", filter_id=filter_id)
 ```
 
 For a one-shot listing without managing a cursor, `client.documents.get_all_files()`
-returns up to `limit` files using simple offset pagination:
+returns all files in a single call — no parameters needed:
 
 ```python
-# Grab up to 200 files in a single call (no cursor to track)
-page = await client.documents.get_all_files(limit=200, connector_type="sharepoint")
+# Get all files in a single call (no cursor to track)
+page = await client.documents.get_all_files()
 for f in page.files:
     print(f.filename)
 ```

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -216,7 +216,11 @@ response = await client.chat.create(message="Summarise Q3", filter_id=filter_id)
 ```
 
 For a one-shot listing without managing a cursor, `client.documents.get_all_files()`
-returns all files in a single call — no parameters needed:
+returns all files in a single call — no parameters needed.
+
+> **Note:** `get_all_files()` returns at most **500 files**. If your knowledge
+> base contains more than 500 files, use `list_files()` with cursor pagination
+> (`after_key`) to page through the full set.
 
 ```python
 # Get all files in a single call (no cursor to track)

--- a/sdks/python/README.md
+++ b/sdks/python/README.md
@@ -215,6 +215,16 @@ results = await client.search.query("quarterly report", filter_id=filter_id)
 response = await client.chat.create(message="Summarise Q3", filter_id=filter_id)
 ```
 
+For a one-shot listing without managing a cursor, `client.documents.get_all_files()`
+returns up to `limit` files using simple offset pagination:
+
+```python
+# Grab up to 200 files in a single call (no cursor to track)
+page = await client.documents.get_all_files(limit=200, connector_type="sharepoint")
+for f in page.files:
+    print(f.filename)
+```
+
 ## Settings
 
 ```python

--- a/sdks/python/openrag_sdk/__init__.py
+++ b/sdks/python/openrag_sdk/__init__.py
@@ -50,6 +50,7 @@ from .models import (
     DeleteKnowledgeFilterResponse,
     DoneEvent,
     FileRecord,
+    GetAllFilesResponse,
     GetKnowledgeFilterResponse,
     IngestResponse,
     KnowledgeFilter,
@@ -87,6 +88,7 @@ __all__ = [
     "ServerError",
     # File models
     "FileRecord",
+    "GetAllFilesResponse",
     "ListFilesResponse",
     "PrincipalLabel",
     # Models

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -249,54 +249,18 @@ class DocumentsClient:
             after_key=data.get("after_key"),
         )
 
-    async def get_all_files(
-        self,
-        *,
-        limit: int = 100,
-        sort_by: str = "filename",
-        sort_order: str = "asc",
-        connector_type: str | None = None,
-        mimetype: str | None = None,
-        owner: str | None = None,
-        search: str | None = None,
-    ) -> GetAllFilesResponse:
+    async def get_all_files(self) -> GetAllFilesResponse:
         """
-        Return up to ``limit`` ingested files using simple offset pagination (v1).
+        Return all ingested files (v1).
 
-        No cursor is required or returned. Use this for a straightforward
-        "get all files" call without managing pagination state.
-
-        Args:
-            limit: Maximum number of files to return (1–500, default 100).
-            sort_by: Field to sort by. One of: filename, file_size, mimetype,
-                indexed_time, connector_type, chunk_count, owner.
-            sort_order: "asc" or "desc".
-            connector_type: Filter to files from a specific connector type.
-            mimetype: Filter to files with a specific MIME type.
-            owner: Filter to files owned by a specific user ID.
-            search: Substring/prefix match against filename.
+        No parameters — just returns everything in the knowledge base.
 
         Returns:
             GetAllFilesResponse with files list, total count, page, and page_size.
         """
-        params: dict[str, str | int] = {
-            "limit": limit,
-            "sort_by": sort_by,
-            "sort_order": sort_order,
-        }
-        if connector_type is not None:
-            params["connector_type"] = connector_type
-        if mimetype is not None:
-            params["mimetype"] = mimetype
-        if owner is not None:
-            params["owner"] = owner
-        if search is not None:
-            params["search"] = search
-
         response = await self._client._request(
             "GET",
             "/api/v1/files/getAll",
-            params=params,
         )
         data = response.json()
         return GetAllFilesResponse(

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -8,6 +8,7 @@ from .exceptions import NotFoundError
 from .models import (
     DeleteDocumentResponse,
     FileRecord,
+    GetAllFilesResponse,
     IngestResponse,
     IngestTaskStatus,
     ListFilesResponse,
@@ -183,6 +184,70 @@ class DocumentsClient:
         data = response.json()
         return DeleteDocumentResponse(**data)
 
+    async def list_files(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 25,
+        sort_by: str = "filename",
+        sort_order: str = "asc",
+        connector_type: str | None = None,
+        mimetype: str | None = None,
+        owner: str | None = None,
+        search: str | None = None,
+        after_key: str | None = None,
+    ) -> ListFilesResponse:
+        """
+        List ingested files with cursor-based composite-aggregation pagination (v2).
+
+        Args:
+            page: Page number (display only; use after_key for cursor navigation).
+            page_size: Number of files per page (1–500, default 25).
+            sort_by: Field to sort by. One of: filename, file_size, mimetype,
+                indexed_time, connector_type, chunk_count, owner.
+            sort_order: "asc" or "desc".
+            connector_type: Filter to files from a specific connector type.
+            mimetype: Filter to files with a specific MIME type.
+            owner: Filter to files owned by a specific user ID.
+            search: Substring/prefix match against filename.
+            after_key: JSON-encoded composite cursor from a previous response's
+                after_key field. Pass to fetch the next page.
+
+        Returns:
+            ListFilesResponse with files list, approximate total, and next after_key cursor.
+        """
+        params: dict[str, str | int] = {
+            "page": page,
+            "page_size": page_size,
+            "sort_by": sort_by,
+            "sort_order": sort_order,
+        }
+        if connector_type is not None:
+            params["connector_type"] = connector_type
+        if mimetype is not None:
+            params["mimetype"] = mimetype
+        if owner is not None:
+            params["owner"] = owner
+        if search is not None:
+            params["search"] = search
+        if after_key is not None:
+            params["after_key"] = after_key
+
+        response = await self._client._request(
+            "GET",
+            "/api/v2/files",
+            params=params,
+        )
+        data = response.json()
+        return ListFilesResponse(
+            files=[FileRecord(**f) for f in data.get("files", [])],
+            total=data.get("total", 0),
+            is_approximate=data.get("is_approximate", True),
+            page=data.get("page", page),
+            page_size=data.get("page_size", page_size),
+            after_key=data.get("after_key"),
+        )
+
     async def get_all_files(
         self,
         *,
@@ -193,12 +258,12 @@ class DocumentsClient:
         mimetype: str | None = None,
         owner: str | None = None,
         search: str | None = None,
-    ) -> ListFilesResponse:
+    ) -> GetAllFilesResponse:
         """
-        Return up to ``limit`` ingested files from the knowledge base.
+        Return up to ``limit`` ingested files using simple offset pagination (v1).
 
-        Uses simple offset-based pagination (always page 1); no cursor is required
-        or returned. This is the v1 public endpoint.
+        No cursor is required or returned. Use this for a straightforward
+        "get all files" call without managing pagination state.
 
         Args:
             limit: Maximum number of files to return (1–500, default 100).
@@ -211,7 +276,7 @@ class DocumentsClient:
             search: Substring/prefix match against filename.
 
         Returns:
-            ListFilesResponse with files list, total count, page, and page_size.
+            GetAllFilesResponse with files list, total count, page, and page_size.
         """
         params: dict[str, str | int] = {
             "limit": limit,
@@ -233,7 +298,7 @@ class DocumentsClient:
             params=params,
         )
         data = response.json()
-        return ListFilesResponse(
+        return GetAllFilesResponse(
             files=[FileRecord(**f) for f in data.get("files", [])],
             total=data.get("total", 0),
             page=data.get("page", 1),

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -214,7 +214,8 @@ class DocumentsClient:
                 after_key field. Pass to fetch the next page.
 
         Returns:
-            ListFilesResponse with files list, approximate total, and next after_key cursor.
+            ListFilesResponse with files list, approximate total, and next
+            after_key cursor.
         """
         params: dict[str, str | int] = {
             "page": page,

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -255,6 +255,11 @@ class DocumentsClient:
 
         No parameters — just returns everything in the knowledge base.
 
+        Note:
+            Returns at most 500 files. If your knowledge base contains more
+            than 500 files, use ``list_files()`` with cursor pagination
+            (``after_key``) to page through the full set.
+
         Returns:
             GetAllFilesResponse with files list, total count, page, and page_size.
         """

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -183,25 +183,25 @@ class DocumentsClient:
         data = response.json()
         return DeleteDocumentResponse(**data)
 
-    async def list_files(
+    async def get_all_files(
         self,
         *,
-        page: int = 1,
-        page_size: int = 25,
+        limit: int = 100,
         sort_by: str = "filename",
         sort_order: str = "asc",
         connector_type: str | None = None,
         mimetype: str | None = None,
         owner: str | None = None,
         search: str | None = None,
-        after_key: str | None = None,
     ) -> ListFilesResponse:
         """
-        List ingested files in the knowledge base.
+        Return up to ``limit`` ingested files from the knowledge base.
+
+        Uses simple offset-based pagination (always page 1); no cursor is required
+        or returned. This is the v1 public endpoint.
 
         Args:
-            page: Page number (display only; use after_key for cursor navigation).
-            page_size: Number of files per page (1–500, default 25).
+            limit: Maximum number of files to return (1–500, default 100).
             sort_by: Field to sort by. One of: filename, file_size, mimetype,
                 indexed_time, connector_type, chunk_count, owner.
             sort_order: "asc" or "desc".
@@ -209,15 +209,12 @@ class DocumentsClient:
             mimetype: Filter to files with a specific MIME type.
             owner: Filter to files owned by a specific user ID.
             search: Substring/prefix match against filename.
-            after_key: JSON-encoded composite cursor from a previous response's
-                after_key field. Pass to fetch the next page.
 
         Returns:
-            ListFilesResponse with files list, total count, and next after_key.
+            ListFilesResponse with files list, total count, page, and page_size.
         """
         params: dict[str, str | int] = {
-            "page": page,
-            "page_size": page_size,
+            "limit": limit,
             "sort_by": sort_by,
             "sort_order": sort_order,
         }
@@ -229,20 +226,16 @@ class DocumentsClient:
             params["owner"] = owner
         if search is not None:
             params["search"] = search
-        if after_key is not None:
-            params["after_key"] = after_key
 
         response = await self._client._request(
             "GET",
-            "/api/v1/files",
+            "/api/v1/files/getAll",
             params=params,
         )
         data = response.json()
         return ListFilesResponse(
             files=[FileRecord(**f) for f in data.get("files", [])],
             total=data.get("total", 0),
-            is_approximate=data.get("is_approximate", True),
-            page=data.get("page", page),
-            page_size=data.get("page_size", page_size),
-            after_key=data.get("after_key"),
+            page=data.get("page", 1),
+            page_size=data.get("page_size", limit),
         )

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -267,5 +267,5 @@ class DocumentsClient:
             files=[FileRecord(**f) for f in data.get("files", [])],
             total=data.get("total", 0),
             page=data.get("page", 1),
-            page_size=data.get("page_size", limit),
+            page_size=data.get("page_size", 500),
         )

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -260,7 +260,7 @@ class DocumentsClient:
         """
         response = await self._client._request(
             "GET",
-            "/api/v1/files/getAll",
+            "/api/v1/files/getall",
         )
         data = response.json()
         return GetAllFilesResponse(

--- a/sdks/python/openrag_sdk/documents.py
+++ b/sdks/python/openrag_sdk/documents.py
@@ -260,7 +260,7 @@ class DocumentsClient:
         """
         response = await self._client._request(
             "GET",
-            "/api/v1/files/getall",
+            "/api/v1/files/get_all",
         )
         data = response.json()
         return GetAllFilesResponse(

--- a/sdks/python/openrag_sdk/models.py
+++ b/sdks/python/openrag_sdk/models.py
@@ -319,7 +319,7 @@ class FileRecord(BaseModel):
 
 
 class GetAllFilesResponse(BaseModel):
-    """Response from GET /v1/files/getAll — offset pagination, no cursor."""
+    """Response from GET /v1/files/getall — offset pagination, no cursor."""
 
     files: list[FileRecord]
     total: int

--- a/sdks/python/openrag_sdk/models.py
+++ b/sdks/python/openrag_sdk/models.py
@@ -318,10 +318,21 @@ class FileRecord(BaseModel):
     allowed_principal_labels: list[PrincipalLabel] = Field(default_factory=list)
 
 
-class ListFilesResponse(BaseModel):
-    """Response from the GET /v1/files/getAll endpoint."""
+class GetAllFilesResponse(BaseModel):
+    """Response from GET /v1/files/getAll — offset pagination, no cursor."""
 
     files: list[FileRecord]
     total: int
     page: int
     page_size: int
+
+
+class ListFilesResponse(BaseModel):
+    """Response from GET /v2/files — cursor-based composite-aggregation pagination."""
+
+    files: list[FileRecord]
+    total: int
+    is_approximate: bool
+    page: int
+    page_size: int
+    after_key: dict | None = None

--- a/sdks/python/openrag_sdk/models.py
+++ b/sdks/python/openrag_sdk/models.py
@@ -319,11 +319,9 @@ class FileRecord(BaseModel):
 
 
 class ListFilesResponse(BaseModel):
-    """Response from the list-files endpoint."""
+    """Response from the GET /v1/files/getAll endpoint."""
 
     files: list[FileRecord]
     total: int
-    is_approximate: bool
     page: int
     page_size: int
-    after_key: dict | None = None

--- a/sdks/python/openrag_sdk/models.py
+++ b/sdks/python/openrag_sdk/models.py
@@ -319,7 +319,7 @@ class FileRecord(BaseModel):
 
 
 class GetAllFilesResponse(BaseModel):
-    """Response from GET /v1/files/getall — offset pagination, no cursor."""
+    """Response from GET /v1/files/get_all — offset pagination, no cursor."""
 
     files: list[FileRecord]
     total: int

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -241,6 +241,15 @@ const results = await client.search.query("quarterly report", { filterId });
 const response = await client.chat.create({ message: "Summarise Q3", filterId });
 ```
 
+For a one-shot listing without managing a cursor, `client.documents.getAllFiles()`
+returns up to `limit` files using simple offset pagination:
+
+```typescript
+// Grab up to 200 files in a single call (no cursor to track)
+const page = await client.documents.getAllFiles({ limit: 200, connector_type: "sharepoint" });
+for (const f of page.files) console.log(f.filename);
+```
+
 ## Settings
 
 ```typescript

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -242,11 +242,11 @@ const response = await client.chat.create({ message: "Summarise Q3", filterId })
 ```
 
 For a one-shot listing without managing a cursor, `client.documents.getAllFiles()`
-returns up to `limit` files using simple offset pagination:
+returns all files in a single call — no parameters needed:
 
 ```typescript
-// Grab up to 200 files in a single call (no cursor to track)
-const page = await client.documents.getAllFiles({ limit: 200, connector_type: "sharepoint" });
+// Get all files in a single call (no cursor to track)
+const page = await client.documents.getAllFiles();
 for (const f of page.files) console.log(f.filename);
 ```
 

--- a/sdks/typescript/README.md
+++ b/sdks/typescript/README.md
@@ -242,7 +242,11 @@ const response = await client.chat.create({ message: "Summarise Q3", filterId })
 ```
 
 For a one-shot listing without managing a cursor, `client.documents.getAllFiles()`
-returns all files in a single call — no parameters needed:
+returns all files in a single call — no parameters needed.
+
+> **Note:** `getAllFiles()` returns at most **500 files**. If your knowledge
+> base contains more than 500 files, use `listFiles()` with cursor pagination
+> (`after_key`) to page through the full set.
 
 ```typescript
 // Get all files in a single call (no cursor to track)

--- a/sdks/typescript/src/documents.ts
+++ b/sdks/typescript/src/documents.ts
@@ -189,7 +189,7 @@ export class DocumentsClient {
    * @returns GetAllFilesResponse with files list and total count.
    */
   async getAllFiles(): Promise<GetAllFilesResponse> {
-    const response = await this.client._request("GET", "/api/v1/files/getAll");
+    const response = await this.client._request("GET", "/api/v1/files/getall");
     const data = await response.json();
 
     return {

--- a/sdks/typescript/src/documents.ts
+++ b/sdks/typescript/src/documents.ts
@@ -189,7 +189,7 @@ export class DocumentsClient {
    * @returns GetAllFilesResponse with files list and total count.
    */
   async getAllFiles(): Promise<GetAllFilesResponse> {
-    const response = await this.client._request("GET", "/api/v1/files/getall");
+    const response = await this.client._request("GET", "/api/v1/files/get_all");
     const data = await response.json();
 
     return {

--- a/sdks/typescript/src/documents.ts
+++ b/sdks/typescript/src/documents.ts
@@ -7,6 +7,8 @@ import type {
   DeleteDocumentOptions,
   DeleteDocumentResponse,
   FileRecord,
+  GetAllFilesOptions,
+  GetAllFilesResponse,
   IngestResponse,
   IngestTaskStatus,
   ListFilesOptions,
@@ -148,10 +150,10 @@ export class DocumentsClient {
   }
 
   /**
-   * List ingested files in the knowledge base.
+   * List ingested files with cursor-based composite-aggregation pagination (v2).
    *
-   * @param options - Filtering, sorting, and pagination options.
-   * @returns ListFilesResponse with files list, total count, and next after_key.
+   * @param options - Filtering, sorting, and cursor pagination options.
+   * @returns ListFilesResponse with files list, approximate total, and next after_key cursor.
    */
   async listFiles(options: ListFilesOptions = {}): Promise<ListFilesResponse> {
     const params = new URLSearchParams();
@@ -166,7 +168,7 @@ export class DocumentsClient {
     if (options.after_key !== undefined) params.set("after_key", options.after_key);
 
     const qs = params.toString();
-    const path = qs ? `/api/v1/files?${qs}` : "/api/v1/files";
+    const path = qs ? `/api/v2/files?${qs}` : "/api/v2/files";
     const response = await this.client._request("GET", path);
     const data = await response.json();
 
@@ -177,6 +179,38 @@ export class DocumentsClient {
       page: data.page ?? 1,
       page_size: data.page_size ?? 25,
       after_key: data.after_key ?? null,
+    };
+  }
+
+  /**
+   * Return up to `limit` ingested files using simple offset pagination (v1).
+   *
+   * No cursor required or returned. Use this for a straightforward "get all files"
+   * call without managing pagination state.
+   *
+   * @param options - Filtering, sorting, and limit options.
+   * @returns GetAllFilesResponse with files list and total count.
+   */
+  async getAllFiles(options: GetAllFilesOptions = {}): Promise<GetAllFilesResponse> {
+    const params = new URLSearchParams();
+    if (options.limit !== undefined) params.set("limit", String(options.limit));
+    if (options.sort_by !== undefined) params.set("sort_by", options.sort_by);
+    if (options.sort_order !== undefined) params.set("sort_order", options.sort_order);
+    if (options.connector_type !== undefined) params.set("connector_type", options.connector_type);
+    if (options.mimetype !== undefined) params.set("mimetype", options.mimetype);
+    if (options.owner !== undefined) params.set("owner", options.owner);
+    if (options.search !== undefined) params.set("search", options.search);
+
+    const qs = params.toString();
+    const path = qs ? `/api/v1/files/getAll?${qs}` : "/api/v1/files/getAll";
+    const response = await this.client._request("GET", path);
+    const data = await response.json();
+
+    return {
+      files: (data.files ?? []) as FileRecord[],
+      total: data.total ?? 0,
+      page: data.page ?? 1,
+      page_size: data.page_size ?? 100,
     };
   }
 

--- a/sdks/typescript/src/documents.ts
+++ b/sdks/typescript/src/documents.ts
@@ -7,7 +7,6 @@ import type {
   DeleteDocumentOptions,
   DeleteDocumentResponse,
   FileRecord,
-  GetAllFilesOptions,
   GetAllFilesResponse,
   IngestResponse,
   IngestTaskStatus,
@@ -183,27 +182,14 @@ export class DocumentsClient {
   }
 
   /**
-   * Return up to `limit` ingested files using simple offset pagination (v1).
+   * Return all ingested files (v1).
    *
-   * No cursor required or returned. Use this for a straightforward "get all files"
-   * call without managing pagination state.
+   * No parameters — just returns everything in the knowledge base.
    *
-   * @param options - Filtering, sorting, and limit options.
    * @returns GetAllFilesResponse with files list and total count.
    */
-  async getAllFiles(options: GetAllFilesOptions = {}): Promise<GetAllFilesResponse> {
-    const params = new URLSearchParams();
-    if (options.limit !== undefined) params.set("limit", String(options.limit));
-    if (options.sort_by !== undefined) params.set("sort_by", options.sort_by);
-    if (options.sort_order !== undefined) params.set("sort_order", options.sort_order);
-    if (options.connector_type !== undefined) params.set("connector_type", options.connector_type);
-    if (options.mimetype !== undefined) params.set("mimetype", options.mimetype);
-    if (options.owner !== undefined) params.set("owner", options.owner);
-    if (options.search !== undefined) params.set("search", options.search);
-
-    const qs = params.toString();
-    const path = qs ? `/api/v1/files/getAll?${qs}` : "/api/v1/files/getAll";
-    const response = await this.client._request("GET", path);
+  async getAllFiles(): Promise<GetAllFilesResponse> {
+    const response = await this.client._request("GET", "/api/v1/files/getAll");
     const data = await response.json();
 
     return {

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -68,7 +68,6 @@ export {
   PrincipalLabel,
   FileRecord,
   GetAllFilesResponse,
-  GetAllFilesOptions,
   ListFilesResponse,
   ListFilesOptions,
   // Conversation types

--- a/sdks/typescript/src/index.ts
+++ b/sdks/typescript/src/index.ts
@@ -67,6 +67,8 @@ export {
   DeleteDocumentResponse,
   PrincipalLabel,
   FileRecord,
+  GetAllFilesResponse,
+  GetAllFilesOptions,
   ListFilesResponse,
   ListFilesOptions,
   // Conversation types

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -118,7 +118,7 @@ export interface FileRecord {
   allowed_principal_labels: PrincipalLabel[];
 }
 
-/** Response from GET /v1/files/getAll (original v1 offset pagination) */
+/** Response from GET /v1/files/getall (original v1 offset pagination) */
 export interface GetAllFilesResponse {
   files: FileRecord[];
   total: number;

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -126,17 +126,6 @@ export interface GetAllFilesResponse {
   page_size: number;
 }
 
-/** Options for GET /v1/files/getAll. */
-export interface GetAllFilesOptions {
-  limit?: number;
-  sort_by?: string;
-  sort_order?: "asc" | "desc";
-  connector_type?: string;
-  mimetype?: string;
-  owner?: string;
-  search?: string;
-}
-
 /** Response from GET /v2/files (cursor-based composite-aggregation pagination) */
 export interface ListFilesResponse {
   files: FileRecord[];

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -118,7 +118,26 @@ export interface FileRecord {
   allowed_principal_labels: PrincipalLabel[];
 }
 
-//Response from the list-files endpoint
+/** Response from GET /v1/files/getAll (original v1 offset pagination) */
+export interface GetAllFilesResponse {
+  files: FileRecord[];
+  total: number;
+  page: number;
+  page_size: number;
+}
+
+/** Options for GET /v1/files/getAll. */
+export interface GetAllFilesOptions {
+  limit?: number;
+  sort_by?: string;
+  sort_order?: "asc" | "desc";
+  connector_type?: string;
+  mimetype?: string;
+  owner?: string;
+  search?: string;
+}
+
+/** Response from GET /v2/files (cursor-based composite-aggregation pagination) */
 export interface ListFilesResponse {
   files: FileRecord[];
   total: number;
@@ -128,25 +147,16 @@ export interface ListFilesResponse {
   after_key: Record<string, unknown> | null;
 }
 
-/** Options for listing files. */
+/** Options for GET /v2/files (cursor-based pagination). */
 export interface ListFilesOptions {
-  /** Page number (display only; use after_key for cursor navigation). Default: 1. */
   page?: number;
-  /** Files per page (1–500). Default: 25. */
   page_size?: number;
-  /** Sort field: filename | file_size | mimetype | indexed_time | connector_type | chunk_count | owner. */
   sort_by?: string;
-  /** Sort direction. Default: "asc". */
   sort_order?: "asc" | "desc";
-  /** Filter by connector type. */
   connector_type?: string;
-  /** Filter by MIME type. */
   mimetype?: string;
-  /** Filter by owner user ID. */
   owner?: string;
-  /** Substring/prefix filename search. */
   search?: string;
-  /** JSON-encoded composite cursor from a previous response's after_key. */
   after_key?: string;
 }
 

--- a/sdks/typescript/src/types.ts
+++ b/sdks/typescript/src/types.ts
@@ -118,7 +118,7 @@ export interface FileRecord {
   allowed_principal_labels: PrincipalLabel[];
 }
 
-/** Response from GET /v1/files/getall (original v1 offset pagination) */
+/** Response from GET /v1/files/get_all (original v1 offset pagination) */
 export interface GetAllFilesResponse {
   files: FileRecord[];
   total: number;

--- a/src/api/files.py
+++ b/src/api/files.py
@@ -1,39 +1,60 @@
 """
-File listing and search API endpoints.
+Internal file listing and search handlers (cookie auth).
 
-Provides server-side file-level views over the chunk-based OpenSearch index.
-Uses terms aggregation with in-memory sort/slice (v1).
+Serves the unversioned internal/UI routes GET /files and GET /files/search
+using FileServiceV2 (composite-aggregation cursor pagination). Pass `after_key`
+(JSON-encoded) to advance pages.
+
 """
 
-from fastapi import Depends, Query
+import json
+
+from fastapi import Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
-from dependencies import get_current_user, get_session_manager
+from dependencies import get_current_user, get_file_service_v2
 from session_manager import User
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 
-def _get_file_service(session_manager=Depends(get_session_manager)):
-    from services.file_service import FileService
+def _parse_after_key(after_key: str | None) -> dict | None:
+    """Parse a JSON-encoded composite cursor.
 
-    return FileService(session_manager=session_manager)
+    Returns None when after_key is absent.
+    Raises HTTPException 400 when the value is present but is not valid JSON
+    or does not decode to a dict (e.g. a bare string or number is invalid).
+    """
+    if not after_key:
+        return None
+    try:
+        parsed = json.loads(after_key)
+    except (json.JSONDecodeError, ValueError) as err:
+        raise HTTPException(status_code=400, detail="after_key is not valid JSON") from err
+    if not isinstance(parsed, dict):
+        raise HTTPException(status_code=400, detail="after_key must be a JSON object")
+    return parsed
 
 
 async def list_files(
-    page: int = Query(1, ge=1, description="Page number"),
-    page_size: int = Query(25, ge=1, le=100, description="Items per page"),
+    page: int = Query(
+        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
+    ),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
     sort_by: str = Query("filename", description="Sort field"),
     sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
     connector_type: str | None = Query(None, description="Filter by connector type"),
     mimetype: str | None = Query(None, description="Filter by MIME type"),
     owner: str | None = Query(None, description="Filter by owner"),
     search: str | None = Query(None, description="Search filename"),
-    file_service=Depends(_get_file_service),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
     user: User = Depends(get_current_user),
 ):
-    """List ingested files with pagination, filtering, and sorting."""
+    """List ingested files with composite-aggregation pagination, filtering, and sorting."""
+    parsed_after_key = _parse_after_key(after_key)
+
     try:
         result = await file_service.list_files(
             user_id=user.user_id,
@@ -46,16 +67,17 @@ async def list_files(
             mimetype=mimetype,
             owner=owner,
             search=search,
+            after_key=parsed_after_key,
         )
         return JSONResponse(result)
     except Exception as e:
-        logger.error("Failed to list files", error=str(e))
+        logger.error("Failed to list files (v2)", error=str(e))
         from utils.opensearch_utils import AUTH_ERROR_MESSAGE, is_opensearch_auth_error
 
         if is_opensearch_auth_error(e):
             return JSONResponse({"error": AUTH_ERROR_MESSAGE}, status_code=401)
         return JSONResponse(
-            {"error": "Failed to list files", "detail": str(e)},
+            {"error": "Failed to list files"},
             status_code=500,
         )
 
@@ -63,14 +85,17 @@ async def list_files(
 async def search_files(
     q: str = Query(..., min_length=1, description="Search query"),
     page: int = Query(1, ge=1, description="Page number"),
-    page_size: int = Query(25, ge=1, le=100, description="Items per page"),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
     connector_type: str | None = Query(None, description="Filter by connector type"),
     mimetype: str | None = Query(None, description="Filter by MIME type"),
     owner: str | None = Query(None, description="Filter by owner"),
-    file_service=Depends(_get_file_service),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
     user: User = Depends(get_current_user),
 ):
-    """Search files by name with fuzzy/partial matching."""
+    """Search files by name with fuzzy/partial matching (composite pagination)."""
+    parsed_after_key = _parse_after_key(after_key)
+
     try:
         result = await file_service.search_files(
             user_id=user.user_id,
@@ -81,15 +106,16 @@ async def search_files(
             connector_type=connector_type,
             mimetype=mimetype,
             owner=owner,
+            after_key=parsed_after_key,
         )
         return JSONResponse(result)
     except Exception as e:
-        logger.error("Failed to search files", error=str(e))
+        logger.error("Failed to search files (v2)", error=str(e))
         from utils.opensearch_utils import AUTH_ERROR_MESSAGE, is_opensearch_auth_error
 
         if is_opensearch_auth_error(e):
             return JSONResponse({"error": AUTH_ERROR_MESSAGE}, status_code=401)
         return JSONResponse(
-            {"error": "Failed to search files", "detail": str(e)},
+            {"error": "Failed to search files"},
             status_code=500,
         )

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -1,9 +1,10 @@
 """
 Public API v1 Files endpoints.
 
-Provides file listing and search over the ingested knowledge base.
-Uses API key authentication — delegates to the api/v2/files.py handlers
-but overrides the user dependency to use API keys.
+Provides offset-paginated file listing over the ingested knowledge base
+(GET /v1/files/getAll). Uses API-key authentication and calls the shared
+FileServiceV2 directly. Cursor-paginated variants live in api/v2/files.py
+(list_files_public / search_files_public, served at /v2/files).
 """
 
 from fastapi import Depends, Query

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -7,74 +7,50 @@ but overrides the user dependency to use API keys.
 """
 
 from fastapi import Depends, Query
+from fastapi.responses import JSONResponse
 
 from api.v2 import files as files_v2
-from dependencies import get_file_service_v2, require_api_key_permission
+from dependencies import get_file_service, get_file_service_v2, require_api_key_permission
 from session_manager import User
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
 
 
-async def list_files(
-    page: int = Query(
-        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
-    ),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
+async def get_all_files(
+    limit: int = Query(100, ge=1, le=500, description="Maximum number of files to return"),
     sort_by: str = Query("filename", description="Sort field"),
     sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
     connector_type: str | None = Query(None, description="Filter by connector type"),
     mimetype: str | None = Query(None, description="Filter by MIME type"),
     owner: str | None = Query(None, description="Filter by owner"),
     search: str | None = Query(None, description="Search filename"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
+    file_service=Depends(get_file_service),
     user: User = Depends(require_api_key_permission("knowledge:read:own")),
 ):
     """
-    List all ingested files.
+    Return up to `limit` ingested files using offset-based pagination (page 1).
 
-    GET /v1/files
+    GET /v1/files/getAll
     """
-    return await files_v2.list_files(
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_order=sort_order,
-        connector_type=connector_type,
-        mimetype=mimetype,
-        owner=owner,
-        search=search,
-        after_key=after_key,
-        file_service=file_service,
-        user=user,
-    )
+    try:
+        result = await file_service.list_files(
+            user_id=user.user_id,
+            jwt_token=user.jwt_token,
+            page=1,
+            page_size=limit,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            connector_type=connector_type,
+            mimetype=mimetype,
+            owner=owner,
+            search=search,
+        )
+        return JSONResponse(result)
+    except Exception as e:
+        logger.error("Failed to get all files (v1)", error=str(e))
+        from utils.opensearch_utils import AUTH_ERROR_MESSAGE, is_opensearch_auth_error
 
-
-async def search_files(
-    q: str = Query(..., min_length=1, description="Search query"),
-    page: int = Query(1, ge=1, description="Page number"),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
-    user: User = Depends(require_api_key_permission("knowledge:read:own")),
-):
-    """
-    Search ingested files by name with fuzzy/partial matching.
-
-    GET /v1/files/search
-    """
-    return await files_v2.search_files(
-        q=q,
-        page=page,
-        page_size=page_size,
-        connector_type=connector_type,
-        mimetype=mimetype,
-        owner=owner,
-        after_key=after_key,
-        file_service=file_service,
-        user=user,
-    )
+        if is_opensearch_auth_error(e):
+            return JSONResponse({"error": AUTH_ERROR_MESSAGE}, status_code=401)
+        return JSONResponse({"error": "Failed to get files"}, status_code=500)

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -2,7 +2,7 @@
 Public API v1 Files endpoints.
 
 Provides a simple file listing over the ingested knowledge base
-(GET /v1/files/getall). Uses API-key authentication and calls FileService
+(GET /v1/files/get_all). Uses API-key authentication and calls FileService
 (v1, offset pagination) directly.
 """
 
@@ -23,7 +23,7 @@ async def get_all_files(
     """
     Return all ingested files.
 
-    GET /v1/files/getall
+    GET /v1/files/get_all
     """
     try:
         result = await file_service.list_files(

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -1,12 +1,12 @@
 """
 Public API v1 Files endpoints.
 
-Provides offset-paginated file listing over the ingested knowledge base
+Provides a simple file listing over the ingested knowledge base
 (GET /v1/files/getAll). Uses API-key authentication and calls FileService
-(v1, offset pagination) directly. .
+(v1, offset pagination) directly.
 """
 
-from fastapi import Depends, Query
+from fastapi import Depends
 from fastapi.responses import JSONResponse
 
 from dependencies import get_file_service, require_api_key_permission
@@ -17,18 +17,11 @@ logger = get_logger(__name__)
 
 
 async def get_all_files(
-    limit: int = Query(100, ge=1, le=500, description="Maximum number of files to return"),
-    sort_by: str = Query("filename", description="Sort field"),
-    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    search: str | None = Query(None, description="Search filename"),
     file_service=Depends(get_file_service),
     user: User = Depends(require_api_key_permission("knowledge:read:own")),
 ):
     """
-    Return up to `limit` ingested files using offset-based pagination (page 1).
+    Return all ingested files.
 
     GET /v1/files/getAll
     """
@@ -37,13 +30,7 @@ async def get_all_files(
             user_id=user.user_id,
             jwt_token=user.jwt_token,
             page=1,
-            page_size=limit,
-            sort_by=sort_by,
-            sort_order=sort_order,
-            connector_type=connector_type,
-            mimetype=mimetype,
-            owner=owner,
-            search=search,
+            page_size=500,
         )
         return JSONResponse(result)
     except Exception as e:

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -9,8 +9,7 @@ but overrides the user dependency to use API keys.
 from fastapi import Depends, Query
 from fastapi.responses import JSONResponse
 
-from api.v2 import files as files_v2
-from dependencies import get_file_service, get_file_service_v2, require_api_key_permission
+from dependencies import get_file_service, require_api_key_permission
 from session_manager import User
 from utils.logging_config import get_logger
 

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -2,9 +2,8 @@
 Public API v1 Files endpoints.
 
 Provides offset-paginated file listing over the ingested knowledge base
-(GET /v1/files/getAll). Uses API-key authentication and calls the shared
-FileServiceV2 directly. Cursor-paginated variants live in api/v2/files.py
-(list_files_public / search_files_public, served at /v2/files).
+(GET /v1/files/getAll). Uses API-key authentication and calls FileService
+(v1, offset pagination) directly. .
 """
 
 from fastapi import Depends, Query

--- a/src/api/v1/files.py
+++ b/src/api/v1/files.py
@@ -2,7 +2,7 @@
 Public API v1 Files endpoints.
 
 Provides a simple file listing over the ingested knowledge base
-(GET /v1/files/getAll). Uses API-key authentication and calls FileService
+(GET /v1/files/getall). Uses API-key authentication and calls FileService
 (v1, offset pagination) directly.
 """
 
@@ -23,7 +23,7 @@ async def get_all_files(
     """
     Return all ingested files.
 
-    GET /v1/files/getAll
+    GET /v1/files/getall
     """
     try:
         result = await file_service.list_files(

--- a/src/api/v2/files.py
+++ b/src/api/v2/files.py
@@ -1,38 +1,18 @@
 """
-File listing and search API endpoints — v2 (composite aggregation).
+Public API v2 Files endpoints (API-key auth).
 
-Uses composite aggregation for true O(page_size) server-side pagination.
-Cursor-based: pass `after_key` (JSON-encoded) to advance pages.
+Cursor-paginated file listing/search over the ingested knowledge base, served
+at GET /v2/files and GET /v2/files/search. These handlers delegate to the
+internal handlers in api/files.py, overriding only the auth dependency to use
+an API key instead of the session cookie.
 """
 
-import json
+from fastapi import Depends, Query
 
-from fastapi import Depends, HTTPException, Query
-from fastapi.responses import JSONResponse
-
-from dependencies import get_current_user, get_file_service_v2, require_api_key_permission
+from api.files import list_files as _internal_list_files
+from api.files import search_files as _internal_search_files
+from dependencies import get_file_service_v2, require_api_key_permission
 from session_manager import User
-from utils.logging_config import get_logger
-
-logger = get_logger(__name__)
-
-
-def _parse_after_key(after_key: str | None) -> dict | None:
-    """Parse a JSON-encoded composite cursor.
-
-    Returns None when after_key is absent.
-    Raises HTTPException 400 when the value is present but is not valid JSON
-    or does not decode to a dict (e.g. a bare string or number is invalid).
-    """
-    if not after_key:
-        return None
-    try:
-        parsed = json.loads(after_key)
-    except (json.JSONDecodeError, ValueError) as err:
-        raise HTTPException(status_code=400, detail="after_key is not valid JSON") from err
-    if not isinstance(parsed, dict):
-        raise HTTPException(status_code=400, detail="after_key must be a JSON object")
-    return parsed
 
 
 async def list_files(
@@ -48,94 +28,10 @@ async def list_files(
     search: str | None = Query(None, description="Search filename"),
     after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
     file_service=Depends(get_file_service_v2),
-    user: User = Depends(get_current_user),
-):
-    """List ingested files with composite-aggregation pagination, filtering, and sorting."""
-    parsed_after_key = _parse_after_key(after_key)
-
-    try:
-        result = await file_service.list_files(
-            user_id=user.user_id,
-            jwt_token=user.jwt_token,
-            page=page,
-            page_size=page_size,
-            sort_by=sort_by,
-            sort_order=sort_order,
-            connector_type=connector_type,
-            mimetype=mimetype,
-            owner=owner,
-            search=search,
-            after_key=parsed_after_key,
-        )
-        return JSONResponse(result)
-    except Exception as e:
-        logger.error("Failed to list files (v2)", error=str(e))
-        from utils.opensearch_utils import AUTH_ERROR_MESSAGE, is_opensearch_auth_error
-
-        if is_opensearch_auth_error(e):
-            return JSONResponse({"error": AUTH_ERROR_MESSAGE}, status_code=401)
-        return JSONResponse(
-            {"error": "Failed to list files"},
-            status_code=500,
-        )
-
-
-async def search_files(
-    q: str = Query(..., min_length=1, description="Search query"),
-    page: int = Query(1, ge=1, description="Page number"),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
-    user: User = Depends(get_current_user),
-):
-    """Search files by name with fuzzy/partial matching (v2 — composite pagination)."""
-    parsed_after_key = _parse_after_key(after_key)
-
-    try:
-        result = await file_service.search_files(
-            user_id=user.user_id,
-            jwt_token=user.jwt_token,
-            query=q,
-            page=page,
-            page_size=page_size,
-            connector_type=connector_type,
-            mimetype=mimetype,
-            owner=owner,
-            after_key=parsed_after_key,
-        )
-        return JSONResponse(result)
-    except Exception as e:
-        logger.error("Failed to search files (v2)", error=str(e))
-        from utils.opensearch_utils import AUTH_ERROR_MESSAGE, is_opensearch_auth_error
-
-        if is_opensearch_auth_error(e):
-            return JSONResponse({"error": AUTH_ERROR_MESSAGE}, status_code=401)
-        return JSONResponse(
-            {"error": "Failed to search files"},
-            status_code=500,
-        )
-
-
-async def list_files_public(
-    page: int = Query(
-        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
-    ),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
-    sort_by: str = Query("filename", description="Sort field"),
-    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    search: str | None = Query(None, description="Search filename"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
     user: User = Depends(require_api_key_permission("knowledge:read:own")),
 ):
     """List all ingested files (API-key auth). GET /v2/files"""
-    return await list_files(
+    return await _internal_list_files(
         page=page,
         page_size=page_size,
         sort_by=sort_by,
@@ -150,7 +46,7 @@ async def list_files_public(
     )
 
 
-async def search_files_public(
+async def search_files(
     q: str = Query(..., min_length=1, description="Search query"),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(25, ge=1, le=500, description="Items per page"),
@@ -162,7 +58,7 @@ async def search_files_public(
     user: User = Depends(require_api_key_permission("knowledge:read:own")),
 ):
     """Search ingested files by name (API-key auth). GET /v2/files/search"""
-    return await search_files(
+    return await _internal_search_files(
         q=q,
         page=page,
         page_size=page_size,

--- a/src/api/v2/files.py
+++ b/src/api/v2/files.py
@@ -117,6 +117,8 @@ async def search_files(
             {"error": "Failed to search files"},
             status_code=500,
         )
+
+
 async def list_files_public(
     page: int = Query(
         1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"

--- a/src/api/v2/files.py
+++ b/src/api/v2/files.py
@@ -10,7 +10,7 @@ import json
 from fastapi import Depends, HTTPException, Query
 from fastapi.responses import JSONResponse
 
-from dependencies import get_current_user, get_file_service_v2
+from dependencies import get_current_user, get_file_service_v2, require_api_key_permission
 from session_manager import User
 from utils.logging_config import get_logger
 
@@ -117,3 +117,57 @@ async def search_files(
             {"error": "Failed to search files"},
             status_code=500,
         )
+async def list_files_public(
+    page: int = Query(
+        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
+    ),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
+    sort_by: str = Query("filename", description="Sort field"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
+    connector_type: str | None = Query(None, description="Filter by connector type"),
+    mimetype: str | None = Query(None, description="Filter by MIME type"),
+    owner: str | None = Query(None, description="Filter by owner"),
+    search: str | None = Query(None, description="Search filename"),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
+    user: User = Depends(require_api_key_permission("knowledge:read:own")),
+):
+    """List all ingested files (API-key auth). GET /v2/files"""
+    return await list_files(
+        page=page,
+        page_size=page_size,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        connector_type=connector_type,
+        mimetype=mimetype,
+        owner=owner,
+        search=search,
+        after_key=after_key,
+        file_service=file_service,
+        user=user,
+    )
+
+
+async def search_files_public(
+    q: str = Query(..., min_length=1, description="Search query"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
+    connector_type: str | None = Query(None, description="Filter by connector type"),
+    mimetype: str | None = Query(None, description="Filter by MIME type"),
+    owner: str | None = Query(None, description="Filter by owner"),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
+    user: User = Depends(require_api_key_permission("knowledge:read:own")),
+):
+    """Search ingested files by name (API-key auth). GET /v2/files/search"""
+    return await search_files(
+        q=q,
+        page=page,
+        page_size=page_size,
+        connector_type=connector_type,
+        mimetype=mimetype,
+        owner=owner,
+        after_key=after_key,
+        file_service=file_service,
+        user=user,
+    )

--- a/src/app/container.py
+++ b/src/app/container.py
@@ -23,6 +23,7 @@ from services.dls_principal_service import DLSPrincipalService
 from services.docling_polling_service import DoclingPollingService
 from services.document_index_writer import DocumentIndexWriter
 from services.document_service import DocumentService
+from services.file_service import FileService
 from services.file_service_v2 import FileServiceV2
 from services.flows_service import FlowsService
 from services.group_acl_service import GroupACLService
@@ -216,6 +217,7 @@ async def initialize_services():
     conversation_persistence._session_factory = _lazy_session_factory
 
     file_service_v2 = FileServiceV2(session_manager=session_manager)
+    file_service = FileService(session_manager=session_manager)
 
     return {
         "document_service": document_service,
@@ -242,4 +244,5 @@ async def initialize_services():
         "rbac_service": rbac_service,
         "workspace_config_service": workspace_config_service,
         "file_service_v2": file_service_v2,
+        "file_service": file_service,
     }

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -33,7 +33,6 @@ from api import (
 from api import keys as api_keys
 from api.health import health_check, opensearch_health_ready
 from api.schemas.tasks import ErrorResponse, TaskRetryResponse
-from api.v2 import files as files_v2
 from connectors.registry import get_connector_classes
 
 
@@ -128,13 +127,9 @@ def register_internal_routes(app: FastAPI):
     # Search endpoint
     app.add_api_route("/search", search.search, methods=["POST"], tags=["internal"])
 
-    # File listing/search endpoints (v1 — terms-agg, in-memory sort)
+    # File listing/search endpoints 
     app.add_api_route("/files", files.list_files, methods=["GET"], tags=["internal"])
     app.add_api_route("/files/search", files.search_files, methods=["GET"], tags=["internal"])
-
-    # File listing/search endpoints (v2 — composite-agg, cursor pagination); internal v2 uses /files/v2 , public uses v2/files
-    app.add_api_route("/files/v2/search", files_v2.search_files, methods=["GET"], tags=["internal"])
-    app.add_api_route("/files/v2", files_v2.list_files, methods=["GET"], tags=["internal"])
 
     # Knowledge Filter endpoints
     app.add_api_route(

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -132,9 +132,11 @@ def register_internal_routes(app: FastAPI):
     app.add_api_route("/files", files.list_files, methods=["GET"], tags=["internal"])
     app.add_api_route("/files/search", files.search_files, methods=["GET"], tags=["internal"])
 
-    # File listing/search endpoints (v2 — composite-agg, cursor pagination)
-    app.add_api_route("/v2/files/search", files_v2.search_files, methods=["GET"], tags=["internal"])
-    app.add_api_route("/v2/files", files_v2.list_files, methods=["GET"], tags=["internal"])
+   # File listing/search endpoints (v2 — composite-agg, cursor pagination); internal v2 uses /files/v2 , public uses v2/files 
+    app.add_api_route(
+        "/files/v2/search", files_v2.search_files, methods=["GET"], tags=["internal"]
+    )
+    app.add_api_route("/files/v2", files_v2.list_files, methods=["GET"], tags=["internal"])
 
     # Knowledge Filter endpoints
     app.add_api_route(

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -132,10 +132,8 @@ def register_internal_routes(app: FastAPI):
     app.add_api_route("/files", files.list_files, methods=["GET"], tags=["internal"])
     app.add_api_route("/files/search", files.search_files, methods=["GET"], tags=["internal"])
 
-   # File listing/search endpoints (v2 — composite-agg, cursor pagination); internal v2 uses /files/v2 , public uses v2/files 
-    app.add_api_route(
-        "/files/v2/search", files_v2.search_files, methods=["GET"], tags=["internal"]
-    )
+    # File listing/search endpoints (v2 — composite-agg, cursor pagination); internal v2 uses /files/v2 , public uses v2/files
+    app.add_api_route("/files/v2/search", files_v2.search_files, methods=["GET"], tags=["internal"])
     app.add_api_route("/files/v2", files_v2.list_files, methods=["GET"], tags=["internal"])
 
     # Knowledge Filter endpoints

--- a/src/app/routes/internal.py
+++ b/src/app/routes/internal.py
@@ -127,7 +127,7 @@ def register_internal_routes(app: FastAPI):
     # Search endpoint
     app.add_api_route("/search", search.search, methods=["POST"], tags=["internal"])
 
-    # File listing/search endpoints 
+    # File listing/search endpoints
     app.add_api_route("/files", files.list_files, methods=["GET"], tags=["internal"])
     app.add_api_route("/files/search", files.search_files, methods=["GET"], tags=["internal"])
 

--- a/src/app/routes/public_v1.py
+++ b/src/app/routes/public_v1.py
@@ -133,17 +133,11 @@ def register_public_v1_routes(app: FastAPI):
         methods=["DELETE"],
         tags=["public"],
     )
-    # Files endpoints
-    # /v1/files/search must be registered before /v1/files to avoid path shadowing
+
+    # Files getAll endpoint
     app.add_api_route(
-        "/v1/files/search",
-        v1_files.search_files,
-        methods=["GET"],
-        tags=["public"],
-    )
-    app.add_api_route(
-        "/v1/files",
-        v1_files.list_files,
+        "/v1/files/getAll",
+        v1_files.get_all_files,
         methods=["GET"],
         tags=["public"],
     )

--- a/src/app/routes/public_v1.py
+++ b/src/app/routes/public_v1.py
@@ -134,9 +134,9 @@ def register_public_v1_routes(app: FastAPI):
         tags=["public"],
     )
 
-    # Files getAll endpoint
+    # Files getall endpoint
     app.add_api_route(
-        "/v1/files/getAll",
+        "/v1/files/getall",
         v1_files.get_all_files,
         methods=["GET"],
         tags=["public"],

--- a/src/app/routes/public_v1.py
+++ b/src/app/routes/public_v1.py
@@ -134,9 +134,9 @@ def register_public_v1_routes(app: FastAPI):
         tags=["public"],
     )
 
-    # Files getall endpoint
+    # Files get_all endpoint
     app.add_api_route(
-        "/v1/files/getall",
+        "/v1/files/get_all",
         v1_files.get_all_files,
         methods=["GET"],
         tags=["public"],

--- a/src/app/routes/public_v2.py
+++ b/src/app/routes/public_v2.py
@@ -1,80 +1,23 @@
 """Public /v2/* route registrations (API-key auth)."""
 
-from fastapi import Depends, FastAPI, Query
+from fastapi import FastAPI
 
-from api.v2 import files as files_v2
-from dependencies import get_file_service_v2, require_api_key_permission
-from session_manager import User
-
-
-async def _list_files(
-    page: int = Query(
-        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
-    ),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
-    sort_by: str = Query("filename", description="Sort field"),
-    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    search: str | None = Query(None, description="Search filename"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
-    user: User = Depends(require_api_key_permission("knowledge:read:own")),
-):
-    """List all ingested files. GET /v2/files"""
-    return await files_v2.list_files(
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_order=sort_order,
-        connector_type=connector_type,
-        mimetype=mimetype,
-        owner=owner,
-        search=search,
-        after_key=after_key,
-        file_service=file_service,
-        user=user,
-    )
-
-
-async def _search_files(
-    q: str = Query(..., min_length=1, description="Search query"),
-    page: int = Query(1, ge=1, description="Page number"),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
-    user: User = Depends(require_api_key_permission("knowledge:read:own")),
-):
-    """Search ingested files by name. GET /v2/files/search"""
-    return await files_v2.search_files(
-        q=q,
-        page=page,
-        page_size=page_size,
-        connector_type=connector_type,
-        mimetype=mimetype,
-        owner=owner,
-        after_key=after_key,
-        file_service=file_service,
-        user=user,
-    )
+from api.v2 import files as v2_files
 
 
 def register_public_v2_routes(app: FastAPI):
 
+    # Files endpoints (composite-agg pagination)
     # /v2/files/search must be registered before /v2/files to avoid path shadowing
     app.add_api_route(
         "/v2/files/search",
-        _search_files,
+        v2_files.search_files,
         methods=["GET"],
         tags=["public"],
     )
     app.add_api_route(
         "/v2/files",
-        _list_files,
+        v2_files.list_files,
         methods=["GET"],
         tags=["public"],
     )

--- a/src/app/routes/public_v2.py
+++ b/src/app/routes/public_v2.py
@@ -1,80 +1,23 @@
 """Public /v2/* route registrations (API-key auth)."""
 
-from fastapi import Depends, FastAPI, Query
+from fastapi import FastAPI
 
-from api.v2 import files as files_v2
-from dependencies import get_file_service_v2, require_api_key_permission
-from session_manager import User
-
-
-async def _list_files(
-    page: int = Query(
-        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
-    ),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
-    sort_by: str = Query("filename", description="Sort field"),
-    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    search: str | None = Query(None, description="Search filename"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
-    user: User = Depends(require_api_key_permission("knowledge:read:own")),
-):
-    """List all ingested files. GET /v2/files"""
-    return await files_v2.list_files(
-        page=page,
-        page_size=page_size,
-        sort_by=sort_by,
-        sort_order=sort_order,
-        connector_type=connector_type,
-        mimetype=mimetype,
-        owner=owner,
-        search=search,
-        after_key=after_key,
-        file_service=file_service,
-        user=user,
-    )
-
-
-async def _search_files(
-    q: str = Query(..., min_length=1, description="Search query"),
-    page: int = Query(1, ge=1, description="Page number"),
-    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
-    connector_type: str | None = Query(None, description="Filter by connector type"),
-    mimetype: str | None = Query(None, description="Filter by MIME type"),
-    owner: str | None = Query(None, description="Filter by owner"),
-    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
-    file_service=Depends(get_file_service_v2),
-    user: User = Depends(require_api_key_permission("knowledge:read:own")),
-):
-    """Search ingested files by name. GET /v2/files/search"""
-    return await files_v2.search_files(
-        q=q,
-        page=page,
-        page_size=page_size,
-        connector_type=connector_type,
-        mimetype=mimetype,
-        owner=owner,
-        after_key=after_key,
-        file_service=file_service,
-        user=user,
-    )
+from api.v2 import files as v2_files
 
 
 def register_public_v2_routes(app: FastAPI):
 
-    # /v2/files/search must be registered before /v2/files to avoid path shadowing
+    # Files endpoints (composite-agg cursor pagination), API-key authenticated.
+    # /v2/files/search must be registered before /v2/files to avoid path shadowing.
     app.add_api_route(
         "/v2/files/search",
-        _search_files,
+        v2_files.search_files_public,
         methods=["GET"],
         tags=["public"],
     )
     app.add_api_route(
         "/v2/files",
-        _list_files,
+        v2_files.list_files_public,
         methods=["GET"],
         tags=["public"],
     )

--- a/src/app/routes/public_v2.py
+++ b/src/app/routes/public_v2.py
@@ -7,17 +7,16 @@ from api.v2 import files as v2_files
 
 def register_public_v2_routes(app: FastAPI):
 
-    # Files endpoints (composite-agg cursor pagination), API-key authenticated.
-    # /v2/files/search must be registered before /v2/files to avoid path shadowing.
+    # Files endpoints (composite-agg cursor pagination)
     app.add_api_route(
         "/v2/files/search",
-        v2_files.search_files_public,
+        v2_files.search_files,
         methods=["GET"],
         tags=["public"],
     )
     app.add_api_route(
         "/v2/files",
-        v2_files.list_files_public,
+        v2_files.list_files,
         methods=["GET"],
         tags=["public"],
     )

--- a/src/app/routes/public_v2.py
+++ b/src/app/routes/public_v2.py
@@ -1,23 +1,80 @@
 """Public /v2/* route registrations (API-key auth)."""
 
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, Query
 
-from api.v2 import files as v2_files
+from api.v2 import files as files_v2
+from dependencies import get_file_service_v2, require_api_key_permission
+from session_manager import User
+
+
+async def _list_files(
+    page: int = Query(
+        1, ge=1, description="Page number (for display only; navigation uses after_key cursor)"
+    ),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
+    sort_by: str = Query("filename", description="Sort field"),
+    sort_order: str = Query("asc", pattern="^(asc|desc)$", description="Sort order"),
+    connector_type: str | None = Query(None, description="Filter by connector type"),
+    mimetype: str | None = Query(None, description="Filter by MIME type"),
+    owner: str | None = Query(None, description="Filter by owner"),
+    search: str | None = Query(None, description="Search filename"),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
+    user: User = Depends(require_api_key_permission("knowledge:read:own")),
+):
+    """List all ingested files. GET /v2/files"""
+    return await files_v2.list_files(
+        page=page,
+        page_size=page_size,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        connector_type=connector_type,
+        mimetype=mimetype,
+        owner=owner,
+        search=search,
+        after_key=after_key,
+        file_service=file_service,
+        user=user,
+    )
+
+
+async def _search_files(
+    q: str = Query(..., min_length=1, description="Search query"),
+    page: int = Query(1, ge=1, description="Page number"),
+    page_size: int = Query(25, ge=1, le=500, description="Items per page"),
+    connector_type: str | None = Query(None, description="Filter by connector type"),
+    mimetype: str | None = Query(None, description="Filter by MIME type"),
+    owner: str | None = Query(None, description="Filter by owner"),
+    after_key: str | None = Query(None, description="Composite pagination cursor (JSON-encoded)"),
+    file_service=Depends(get_file_service_v2),
+    user: User = Depends(require_api_key_permission("knowledge:read:own")),
+):
+    """Search ingested files by name. GET /v2/files/search"""
+    return await files_v2.search_files(
+        q=q,
+        page=page,
+        page_size=page_size,
+        connector_type=connector_type,
+        mimetype=mimetype,
+        owner=owner,
+        after_key=after_key,
+        file_service=file_service,
+        user=user,
+    )
 
 
 def register_public_v2_routes(app: FastAPI):
 
-    # Files endpoints (composite-agg pagination)
     # /v2/files/search must be registered before /v2/files to avoid path shadowing
     app.add_api_route(
         "/v2/files/search",
-        v2_files.search_files,
+        _search_files,
         methods=["GET"],
         tags=["public"],
     )
     app.add_api_route(
         "/v2/files",
-        v2_files.list_files,
+        _list_files,
         methods=["GET"],
         tags=["public"],
     )

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -66,6 +66,7 @@ __all__ = [
     "get_api_key_service",
     "get_api_key_user_async",
     "get_auth_service",
+    "get_file_service",
     "get_file_service_v2",
     "get_chat_service",
     "get_connector_service",

--- a/src/dependencies.py
+++ b/src/dependencies.py
@@ -177,6 +177,10 @@ def get_api_key_service(services: dict = Depends(get_services)):
     return services["api_key_service"]
 
 
+def get_file_service(services: dict = Depends(get_services)):
+    return services["file_service"]
+
+
 def get_file_service_v2(services: dict = Depends(get_services)):
     return services["file_service_v2"]
 

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -189,13 +189,14 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
         "description": "Delete a knowledge filter by ID.",
     },
     # files endpoints
-    ("/v1/files", "GET"): {
-        "name": "openrag_list_files",
-        "description": "List all ingested files",
-    },
-    ("/v1/files/search", "GET"): {
-        "name": "openrag_search_files",
-        "description": "Search files by query parameters.",
+    ("/v1/files/getAll", "GET"): {
+        "name": "openrag_get_all_files",
+        "description": (
+            "Return up to `limit` ingested files from the knowledge base using "
+            "simple offset pagination (no cursor required). Supports filtering by "
+            "connector_type, mimetype, and owner, plus filename search. "
+            "Default limit is 100; maximum is 500."
+        ),
     },
     ("/v2/files", "GET"): {
         "name": "openrag_list_files_v2",

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -189,7 +189,7 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
         "description": "Delete a knowledge filter by ID.",
     },
     # files endpoints (v1 — offset pagination)
-    ("/v1/files/getall", "GET"): {
+    ("/v1/files/get_all", "GET"): {
         "name": "openrag_get_all_files",
         "description": (
             "Return all ingested files from the knowledge base. "

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -192,10 +192,8 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
     ("/v1/files/getAll", "GET"): {
         "name": "openrag_get_all_files",
         "description": (
-            "Return up to `limit` ingested files from the knowledge base using "
-            "simple offset pagination (no cursor required). Supports filtering by "
-            "connector_type, mimetype, and owner, plus filename search. "
-            "Default limit is 100; maximum is 500."
+            "Return all ingested files from the knowledge base. "
+            "No parameters — use GET /v2/files for filtering, sorting, or pagination."
         ),
     },
     # files endpoints (v2 — composite-agg cursor pagination)

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -268,21 +268,13 @@ def create_mcp_server(app: FastAPI) -> FastMCP:
             pattern=r"^/v1/",
             mcp_type=MCPType.TOOL,
         ),
-<<<<<<< HEAD
-        # expose /v2/files and /v2/files/search as tools
-=======
         # Expose v2 file listing/search endpoints as MCP tools.
->>>>>>> e1e7eccf (Updated v1 and v2 endpoints respectively to required states)
         RouteMap(
             methods=["GET"],
             pattern=r"^/v2/files",
             mcp_type=MCPType.TOOL,
         ),
-<<<<<<< HEAD
-        # exclude everything else
-=======
         # Exclude everything else
->>>>>>> e1e7eccf (Updated v1 and v2 endpoints respectively to required states)
         RouteMap(
             pattern=r".*",
             mcp_type=MCPType.EXCLUDE,

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -189,7 +189,7 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
         "description": "Delete a knowledge filter by ID.",
     },
     # files endpoints (v1 — offset pagination)
-    ("/v1/files/getAll", "GET"): {
+    ("/v1/files/getall", "GET"): {
         "name": "openrag_get_all_files",
         "description": (
             "Return all ingested files from the knowledge base. "

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -188,7 +188,7 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
         "name": "openrag_delete_knowledge_filter",
         "description": "Delete a knowledge filter by ID.",
     },
-    # files endpoints (v1)
+    # files endpoints (v1 — offset pagination)
     ("/v1/files/getAll", "GET"): {
         "name": "openrag_get_all_files",
         "description": (
@@ -268,13 +268,21 @@ def create_mcp_server(app: FastAPI) -> FastMCP:
             pattern=r"^/v1/",
             mcp_type=MCPType.TOOL,
         ),
+<<<<<<< HEAD
         # expose /v2/files and /v2/files/search as tools
+=======
+        # Expose v2 file listing/search endpoints as MCP tools.
+>>>>>>> e1e7eccf (Updated v1 and v2 endpoints respectively to required states)
         RouteMap(
             methods=["GET"],
             pattern=r"^/v2/files",
             mcp_type=MCPType.TOOL,
         ),
+<<<<<<< HEAD
         # exclude everything else
+=======
+        # Exclude everything else
+>>>>>>> e1e7eccf (Updated v1 and v2 endpoints respectively to required states)
         RouteMap(
             pattern=r".*",
             mcp_type=MCPType.EXCLUDE,

--- a/src/mcp_http/server.py
+++ b/src/mcp_http/server.py
@@ -188,7 +188,7 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
         "name": "openrag_delete_knowledge_filter",
         "description": "Delete a knowledge filter by ID.",
     },
-    # files endpoints
+    # files endpoints (v1)
     ("/v1/files/getAll", "GET"): {
         "name": "openrag_get_all_files",
         "description": (
@@ -198,9 +198,10 @@ COMPONENT_CUSTOMIZATIONS: dict[tuple[str, str], dict[str, str]] = {
             "Default limit is 100; maximum is 500."
         ),
     },
+    # files endpoints (v2 — composite-agg cursor pagination)
     ("/v2/files", "GET"): {
         "name": "openrag_list_files_v2",
-        "description": "lists all ingested files.",
+        "description": "List all ingested files with cursor-based composite-aggregation pagination.",
     },
     ("/v2/files/search", "GET"): {
         "name": "openrag_search_files_v2",

--- a/src/services/file_service.py
+++ b/src/services/file_service.py
@@ -50,13 +50,7 @@ class FileService:
             )
         except Exception as e:
             logger.error("Failed to list files", error=str(e))
-            # An auth failure (OpenSearch rejected the credential) must not be
-            # masked as an empty result — surface it so the route returns 401.
-            from utils.opensearch_utils import is_opensearch_auth_error
-
-            if is_opensearch_auth_error(e):
-                raise
-            return {"files": [], "total": 0, "page": page, "page_size": page_size}
+            raise
 
         files = self._parse_aggregation_buckets(result)
         files = self._sort_files(files, sort_by, sort_order)

--- a/tests/integration/sdk/test_list_files.py
+++ b/tests/integration/sdk/test_list_files.py
@@ -18,7 +18,7 @@ pytestmark = pytest.mark.skipif(
 
 
 class TestListFiles:
-    """Verify GET /v1/files via the Python SDK."""
+    """Verify GET /v2/files (cursor pagination) via the Python SDK."""
 
     @pytest.mark.asyncio
     async def test_list_files_returns_valid_response_shape(self, client, test_file: Path):

--- a/tests/unit/api/test_v1_files.py
+++ b/tests/unit/api/test_v1_files.py
@@ -3,7 +3,7 @@ Unit tests for the public (API-key) file listing/search handlers.
 
 The public files surface is served by two handler sets, all gated by
 require_api_key_permission("knowledge:read:own"):
-- api.v1.files.get_all_files    → GET /v1/files/getAll  (offset pagination)
+- api.v1.files.get_all_files    → GET /v1/files/getall  (offset pagination)
 - api.v2.files.list_files       → GET /v2/files         (cursor pagination)
 - api.v2.files.search_files     → GET /v2/files/search  (cursor pagination)
 

--- a/tests/unit/api/test_v1_files.py
+++ b/tests/unit/api/test_v1_files.py
@@ -3,7 +3,7 @@ Unit tests for the public (API-key) file listing/search handlers.
 
 The public files surface is served by two handler sets, all gated by
 require_api_key_permission("knowledge:read:own"):
-- api.v1.files.get_all_files    → GET /v1/files/getall  (offset pagination)
+- api.v1.files.get_all_files    → GET /v1/files/get_all  (offset pagination)
 - api.v2.files.list_files       → GET /v2/files         (cursor pagination)
 - api.v2.files.search_files     → GET /v2/files/search  (cursor pagination)
 

--- a/tests/unit/api/test_v1_files.py
+++ b/tests/unit/api/test_v1_files.py
@@ -3,9 +3,9 @@ Unit tests for the public (API-key) file listing/search handlers.
 
 The public files surface is served by two handler sets, all gated by
 require_api_key_permission("knowledge:read:own"):
-- api.v1.files.get_all_files           → GET /v1/files/getAll  (offset pagination)
-- api.v2.files.list_files_public       → GET /v2/files         (cursor pagination)
-- api.v2.files.search_files_public     → GET /v2/files/search  (cursor pagination)
+- api.v1.files.get_all_files    → GET /v1/files/getAll  (offset pagination)
+- api.v2.files.list_files       → GET /v2/files         (cursor pagination)
+- api.v2.files.search_files     → GET /v2/files/search  (cursor pagination)
 
 Tests cover:
 - All public handlers authenticate with require_api_key_permission, NOT
@@ -22,17 +22,15 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import params as fastapi_params
 
-from api.v1.files import get_all_files
-from api.v2.files import (
+from api.files import (
     list_files as internal_list_files,
 )
-from api.v2.files import (
-    list_files_public,
-    search_files_public,
-)
-from api.v2.files import (
+from api.files import (
     search_files as internal_search_files,
 )
+from api.v1.files import get_all_files
+from api.v2.files import list_files as list_files_public
+from api.v2.files import search_files as search_files_public
 from session_manager import User
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/api/test_v1_files.py
+++ b/tests/unit/api/test_v1_files.py
@@ -102,9 +102,7 @@ def _query_params(fn) -> dict:
     injected service, so it should stay identical too.
     """
     return {
-        name: p.annotation
-        for name, p in inspect.signature(fn).parameters.items()
-        if name != "user"
+        name: p.annotation for name, p in inspect.signature(fn).parameters.items() if name != "user"
     }
 
 

--- a/tests/unit/api/test_v1_files.py
+++ b/tests/unit/api/test_v1_files.py
@@ -1,13 +1,19 @@
 """
-Unit tests for the GET /v1/files and GET /v1/files/search route handlers.
+Unit tests for the public (API-key) file listing/search handlers.
+
+The public files surface is served by two handler sets, all gated by
+require_api_key_permission("knowledge:read:own"):
+- api.v1.files.get_all_files           → GET /v1/files/getAll  (offset pagination)
+- api.v2.files.list_files_public       → GET /v2/files         (cursor pagination)
+- api.v2.files.search_files_public     → GET /v2/files/search  (cursor pagination)
 
 Tests cover:
-- Route delegates to the v2 handler with all params forwarded correctly
-- Auth dependency is require_api_key_permission("knowledge:read:own"),
-  NOT get_current_user
-- 401 returned on OpenSearch auth errors
-- 400 returned on malformed after_key cursor
-- 500 returned on unexpected errors
+- All public handlers authenticate with require_api_key_permission, NOT
+  get_current_user
+- The v2 public handlers forward every param to FileServiceV2 and delegate to
+  the internal handlers
+- The public wrappers do not drift from the internal handler signatures
+- 401 on OpenSearch auth errors, 400 on malformed after_key, 500 on unexpected
 """
 
 import inspect
@@ -16,7 +22,17 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from fastapi import params as fastapi_params
 
-from api.v1.files import list_files, search_files
+from api.v1.files import get_all_files
+from api.v2.files import (
+    list_files as internal_list_files,
+)
+from api.v2.files import (
+    list_files_public,
+    search_files_public,
+)
+from api.v2.files import (
+    search_files as internal_search_files,
+)
 from session_manager import User
 
 # ---------------------------------------------------------------------------
@@ -54,23 +70,52 @@ def _extract_permission(dep) -> str:
 
 
 class TestAuthDependency:
-    def test_list_files_uses_require_api_key_permission(self):
-        """list_files must be gated by require_api_key_permission, not get_current_user."""
-        dep = _get_user_dependency(list_files)
+    @pytest.mark.parametrize(
+        "handler",
+        [get_all_files, list_files_public, search_files_public],
+        ids=["get_all_files", "list_files_public", "search_files_public"],
+    )
+    def test_public_handler_uses_require_api_key_permission(self, handler):
+        """Every public handler must be gated by require_api_key_permission."""
+        dep = _get_user_dependency(handler)
         perm = _extract_permission(dep)
         assert perm == "knowledge:read:own", f"Expected 'knowledge:read:own', got '{perm}'"
 
-    def test_search_files_uses_require_api_key_permission(self):
-        """search_files must be gated by require_api_key_permission, not get_current_user."""
-        dep = _get_user_dependency(search_files)
-        perm = _extract_permission(dep)
-        assert perm == "knowledge:read:own", f"Expected 'knowledge:read:own', got '{perm}'"
+    def test_all_public_handlers_use_same_permission(self):
+        """All public handlers must require the same permission — no divergence."""
+        perms = {
+            _extract_permission(_get_user_dependency(h))
+            for h in (get_all_files, list_files_public, search_files_public)
+        }
+        assert perms == {"knowledge:read:own"}
 
-    def test_list_files_and_search_files_use_same_permission(self):
-        """Both handlers must require the same permission — no accidental divergence."""
-        list_perm = _extract_permission(_get_user_dependency(list_files))
-        search_perm = _extract_permission(_get_user_dependency(search_files))
-        assert list_perm == search_perm
+
+# ---------------------------------------------------------------------------
+# Signature drift guard
+# ---------------------------------------------------------------------------
+
+
+def _query_params(fn) -> dict:
+    """Parameter name -> annotation for every param except the auth `user`.
+
+    `file_service` is kept: internal and public handlers share the same
+    injected service, so it should stay identical too.
+    """
+    return {
+        name: p.annotation
+        for name, p in inspect.signature(fn).parameters.items()
+        if name != "user"
+    }
+
+
+class TestSignatureParity:
+    """The public wrappers re-declare the query signature; guard against drift."""
+
+    def test_list_files_public_matches_internal(self):
+        assert _query_params(list_files_public) == _query_params(internal_list_files)
+
+    def test_search_files_public_matches_internal(self):
+        assert _query_params(search_files_public) == _query_params(internal_search_files)
 
 
 def _make_user() -> User:
@@ -117,18 +162,18 @@ _SAMPLE_RESPONSE = {
 
 
 # ---------------------------------------------------------------------------
-# list_files
+# list_files_public  (GET /v2/files)
 # ---------------------------------------------------------------------------
 
 
-class TestListFiles:
+class TestListFilesPublic:
     @pytest.mark.asyncio
     async def test_returns_file_list_on_success(self):
         """Handler returns the service response as JSONResponse."""
         file_service = _make_file_service(_SAMPLE_RESPONSE)
         user = _make_user()
 
-        response = await list_files(
+        response = await list_files_public(
             page=1,
             page_size=25,
             sort_by="filename",
@@ -167,7 +212,7 @@ class TestListFiles:
         file_service = _make_file_service(_SAMPLE_RESPONSE)
         user = _make_user()
 
-        await list_files(
+        await list_files_public(
             page=2,
             page_size=50,
             sort_by="indexed_time",
@@ -202,7 +247,7 @@ class TestListFiles:
         file_service.list_files = AsyncMock(side_effect=AuthenticationException(401, "auth failed"))
         user = _make_user()
 
-        response = await list_files(
+        response = await list_files_public(
             page=1,
             page_size=25,
             sort_by="filename",
@@ -225,7 +270,7 @@ class TestListFiles:
         file_service.list_files = AsyncMock(side_effect=RuntimeError("boom"))
         user = _make_user()
 
-        response = await list_files(
+        response = await list_files_public(
             page=1,
             page_size=25,
             sort_by="filename",
@@ -250,7 +295,7 @@ class TestListFiles:
         user = _make_user()
 
         with pytest.raises(HTTPException) as exc_info:
-            await list_files(
+            await list_files_public(
                 page=1,
                 page_size=25,
                 sort_by="filename",
@@ -277,7 +322,7 @@ class TestListFiles:
         user = _make_user()
 
         with pytest.raises(HTTPException) as exc_info:
-            await list_files(
+            await list_files_public(
                 page=1,
                 page_size=25,
                 sort_by="filename",
@@ -295,18 +340,18 @@ class TestListFiles:
 
 
 # ---------------------------------------------------------------------------
-# search_files
+# search_files_public  (GET /v2/files/search)
 # ---------------------------------------------------------------------------
 
 
-class TestSearchFiles:
+class TestSearchFilesPublic:
     @pytest.mark.asyncio
     async def test_returns_search_results_on_success(self):
-        """search_files delegates to v2.search_files and returns its result."""
+        """search_files_public delegates to v2.search_files and returns its result."""
         file_service = _make_file_service(_SAMPLE_RESPONSE)
         user = _make_user()
 
-        response = await search_files(
+        response = await search_files_public(
             q="report",
             page=1,
             page_size=25,
@@ -330,7 +375,7 @@ class TestSearchFiles:
         file_service = _make_file_service(_SAMPLE_RESPONSE)
         user = _make_user()
 
-        await search_files(
+        await search_files_public(
             q="annual report",
             page=2,
             page_size=10,


### PR DESCRIPTION
feat: public ingested files endpoint
- Added public file listing endpoints (GET /v1/getAll, GET /v2/files, GET /v2/files/search) for API key, SDK, and MCP clients
- Fixed case-insensitive filename search
- Added file listing support to Python and TypeScript SDKs: models/types, list_files()/listFiles(), exports, and docs examples
- Added unit tests for v1 endpoints, plus integration tests for both SDKs
- Updated API documentation with file listing examples and pagination

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added one-shot file retrieval with offset-based pagination and response metadata.
  * Added file retrieval methods and response types to the Python and TypeScript SDKs.
  * Added API-key access for v2 file listing and search.

* **Improvements**
  * Updated v2 listing and search to use cursor-based pagination with page sizes up to 500.
  * Preserved existing filtering and sorting options.
  * Updated API routing, MCP descriptions, SDK documentation, and integration coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->