### PR TITLE
fix: CORS misconfiguration: replace wildcard Access-Control-Allow-Origin with explicit origin allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,7 @@ OPENRAG_BACKEND_PORT=8000
 # --- CORS -------------------------------------------------------------------
 # Comma-separated list of origins allowed to make cross-origin requests
 # (e.g. "https://app.example.com,https://admin.example.com").
-# Leave empty or unset to forbid all cross-origin requests.
+# Unset → defaults to http://localhost:3000.  Set to "" to disable CORS entirely.
 CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # --- Backend ingestion-callback proxy router --------------------------------

--- a/.env.example
+++ b/.env.example
@@ -65,7 +65,7 @@ OPENRAG_BACKEND_PORT=8000
 # Comma-separated list of origins allowed to make cross-origin requests
 # (e.g. "https://app.example.com,https://admin.example.com").
 # Leave empty or unset to forbid all cross-origin requests.
-# CORS_ALLOWED_ORIGINS=
+CORS_ALLOWED_ORIGINS=http://localhost:3000
 
 # --- Backend ingestion-callback proxy router --------------------------------
 # When enabled, a tiny standalone uvicorn app is started in the same process as

--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,12 @@ OPENRAG_BACKEND_PORT=8000
 # if you need to override the auto-derived value (e.g., custom hostname).
 # OPENRAG_BACKEND_INTERNAL_URL=http://openrag-backend:8000
 
+# --- CORS -------------------------------------------------------------------
+# Comma-separated list of origins allowed to make cross-origin requests
+# (e.g. "https://app.example.com,https://admin.example.com").
+# Leave empty or unset to forbid all cross-origin requests.
+# CORS_ALLOWED_ORIGINS=
+
 # --- Backend ingestion-callback proxy router --------------------------------
 # When enabled, a tiny standalone uvicorn app is started in the same process as
 # the backend (its own port) that proxies ONLY the Langflow ingest callback

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,6 +124,7 @@ services:
       - PLATFORM_AUTH_DEV_MODE=${PLATFORM_AUTH_DEV_MODE:-false}
       - DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-http://host.docker.internal:5001}
       - DOCLING_SERVE_VERIFY_SSL=${DOCLING_SERVE_VERIFY_SSL:-true}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
     volumes:
       - ${OPENRAG_DOCUMENTS_PATH:-./openrag-documents}:/app/openrag-documents:U,z
       - ${OPENRAG_KEYS_PATH:-./keys}:/app/keys:U,z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -124,7 +124,7 @@ services:
       - PLATFORM_AUTH_DEV_MODE=${PLATFORM_AUTH_DEV_MODE:-false}
       - DOCLING_SERVE_URL=${DOCLING_SERVE_URL:-http://host.docker.internal:5001}
       - DOCLING_SERVE_VERIFY_SSL=${DOCLING_SERVE_VERIFY_SSL:-true}
-      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS:-http://localhost:3000}
+      - CORS_ALLOWED_ORIGINS=${CORS_ALLOWED_ORIGINS-http://localhost:3000}
     volumes:
       - ${OPENRAG_DOCUMENTS_PATH:-./openrag-documents}:/app/openrag-documents:U,z
       - ${OPENRAG_KEYS_PATH:-./keys}:/app/keys:U,z

--- a/kubernetes/helm/openrag/templates/backend/backend-dotenv.yaml
+++ b/kubernetes/helm/openrag/templates/backend/backend-dotenv.yaml
@@ -214,6 +214,10 @@ stringData:
     {{- end }}
 
     # Langflow auth (OpenRag uses this to determine how to authenticate with Langflow)
+    {{- if .Values.backend.cors.allowedOrigins }}
+    CORS_ALLOWED_ORIGINS={{ .Values.backend.cors.allowedOrigins | quote }}
+    {{- end }}
+
     LANGFLOW_AUTO_LOGIN={{ ternary "true" "false" .Values.langflow.auth.autoLogin }}
 
     # OpenRag / OAuth return URL (Included in OAuth State)

--- a/kubernetes/helm/openrag/templates/backend/backend-dotenv.yaml
+++ b/kubernetes/helm/openrag/templates/backend/backend-dotenv.yaml
@@ -214,9 +214,7 @@ stringData:
     {{- end }}
 
     # Langflow auth (OpenRag uses this to determine how to authenticate with Langflow)
-    {{- if .Values.backend.cors.allowedOrigins }}
     CORS_ALLOWED_ORIGINS={{ .Values.backend.cors.allowedOrigins | quote }}
-    {{- end }}
 
     LANGFLOW_AUTO_LOGIN={{ ternary "true" "false" .Values.langflow.auth.autoLogin }}
 

--- a/kubernetes/helm/openrag/values.yaml
+++ b/kubernetes/helm/openrag/values.yaml
@@ -243,6 +243,9 @@ backend:
     repository: langflowai/openrag-backend
     tag: ""                               # Uses global.imageTag if empty
 
+  cors:
+    allowedOrigins: ""                    # Comma-separated origins; empty = CORS disabled
+
   oauthBrokerUrl: ""                      # Public return URL for OAuth redirects
 
   # Single pod for vertical scaling

--- a/src/api/chat.py
+++ b/src/api/chat.py
@@ -96,8 +96,6 @@ async def chat_endpoint(
             headers={
                 "Cache-Control": "no-cache",
                 "Connection": "keep-alive",
-                "Access-Control-Allow-Origin": "*",
-                "Access-Control-Allow-Headers": "Cache-Control",
             },
         )
     else:
@@ -159,8 +157,6 @@ async def langflow_endpoint(
                 headers={
                     "Cache-Control": "no-cache",
                     "Connection": "keep-alive",
-                    "Access-Control-Allow-Origin": "*",
-                    "Access-Control-Allow-Headers": "Cache-Control",
                 },
             )
         else:

--- a/src/app/factory.py
+++ b/src/app/factory.py
@@ -5,13 +5,14 @@ into a ready-to-serve FastAPI app.
 """
 
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 from prometheus_fastapi_instrumentator import Instrumentator
 
 from app.container import initialize_services
 from app.lifespan import run_shutdown, run_startup
 from app.middleware import RequestLoggingMiddleware
 from app.routes import register_all_routes
-from config.settings import FASTAPI_DEBUG
+from config.settings import CORS_ALLOWED_ORIGINS, FASTAPI_DEBUG
 from utils.logging_config import get_logger
 from utils.version_utils import OPENRAG_VERSION
 
@@ -25,6 +26,15 @@ async def create_app():
     app = FastAPI(title="OpenRAG API", version=OPENRAG_VERSION, debug=FASTAPI_DEBUG)
     app.state.services = services
     app.state.background_tasks = set()
+
+    if CORS_ALLOWED_ORIGINS:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=CORS_ALLOWED_ORIGINS,
+            allow_credentials=False,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
 
     # Wire up ASGI request logging middleware (pure ASGI, not BaseHTTPMiddleware)
     app.add_middleware(RequestLoggingMiddleware)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -110,7 +110,7 @@ DEFAULT_CHUNK_OVERLAP = 200
 OPENRAG_BACKEND_PORT = get_env_int("OPENRAG_BACKEND_PORT", 8000)
 
 # CORS – comma-separated list of allowed origins (e.g. "https://app.example.com,https://admin.example.com").
-# Leave empty or unset to forbid all cross-origin requests.
+# Unset → defaults to http://localhost:3000.  Set to "" to disable CORS entirely.
 _raw_cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
 CORS_ALLOWED_ORIGINS: list[str] = [o.strip() for o in _raw_cors_origins.split(",") if o.strip()]
 OPENRAG_BACKEND_INTERNAL_URL = os.getenv(

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -108,6 +108,13 @@ LANGFLOW_URL_INGEST_FLOW_ID = (
 DEFAULT_CHUNK_SIZE = 1000
 DEFAULT_CHUNK_OVERLAP = 200
 OPENRAG_BACKEND_PORT = get_env_int("OPENRAG_BACKEND_PORT", 8000)
+
+# CORS – comma-separated list of allowed origins (e.g. "https://app.example.com,https://admin.example.com").
+# Leave empty or unset to forbid all cross-origin requests.
+_raw_cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "")
+CORS_ALLOWED_ORIGINS: list[str] = [
+    o.strip() for o in _raw_cors_origins.split(",") if o.strip()
+]
 OPENRAG_BACKEND_INTERNAL_URL = os.getenv(
     "OPENRAG_BACKEND_INTERNAL_URL",
     f"http://openrag-backend:{OPENRAG_BACKEND_PORT}",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -111,7 +111,7 @@ OPENRAG_BACKEND_PORT = get_env_int("OPENRAG_BACKEND_PORT", 8000)
 
 # CORS – comma-separated list of allowed origins (e.g. "https://app.example.com,https://admin.example.com").
 # Leave empty or unset to forbid all cross-origin requests.
-_raw_cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "")
+_raw_cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
 CORS_ALLOWED_ORIGINS: list[str] = [
     o.strip() for o in _raw_cors_origins.split(",") if o.strip()
 ]

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -112,7 +112,9 @@ OPENRAG_BACKEND_PORT = get_env_int("OPENRAG_BACKEND_PORT", 8000)
 # CORS – comma-separated list of allowed origins (e.g. "https://app.example.com,https://admin.example.com").
 # Unset → defaults to http://localhost:3000.  Set to "" to disable CORS entirely.
 _raw_cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
-CORS_ALLOWED_ORIGINS: list[str] = [o.strip() for o in _raw_cors_origins.split(",") if o.strip()]
+CORS_ALLOWED_ORIGINS: list[str] = [
+    o.strip() for o in _raw_cors_origins.split(",") if o.strip() and o.strip() != "*"
+]
 OPENRAG_BACKEND_INTERNAL_URL = os.getenv(
     "OPENRAG_BACKEND_INTERNAL_URL",
     f"http://openrag-backend:{OPENRAG_BACKEND_PORT}",

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -112,9 +112,7 @@ OPENRAG_BACKEND_PORT = get_env_int("OPENRAG_BACKEND_PORT", 8000)
 # CORS – comma-separated list of allowed origins (e.g. "https://app.example.com,https://admin.example.com").
 # Leave empty or unset to forbid all cross-origin requests.
 _raw_cors_origins = os.getenv("CORS_ALLOWED_ORIGINS", "http://localhost:3000")
-CORS_ALLOWED_ORIGINS: list[str] = [
-    o.strip() for o in _raw_cors_origins.split(",") if o.strip()
-]
+CORS_ALLOWED_ORIGINS: list[str] = [o.strip() for o in _raw_cors_origins.split(",") if o.strip()]
 OPENRAG_BACKEND_INTERNAL_URL = os.getenv(
     "OPENRAG_BACKEND_INTERNAL_URL",
     f"http://openrag-backend:{OPENRAG_BACKEND_PORT}",

--- a/tests/unit/config/test_cors_allowed_origins.py
+++ b/tests/unit/config/test_cors_allowed_origins.py
@@ -112,13 +112,11 @@ async def test_factory_skips_cors_middleware_when_origins_empty():
         assert _get_cors_middleware(app) is None
 
 
-@pytest.mark.asyncio
-async def test_factory_never_uses_wildcard_origin():
-    with patch("app.factory.CORS_ALLOWED_ORIGINS", ["https://app.example.com"]), \
-         patch("app.factory.initialize_services", new_callable=AsyncMock):
-        from app.factory import create_app
+def test_wildcard_origin_rejected():
+    origins = _run_settings({"CORS_ALLOWED_ORIGINS": "*"})
+    assert origins == []
 
-        app = await create_app()
-        mw = _get_cors_middleware(app)
-        assert mw is not None
-        assert "*" not in mw.kwargs["allow_origins"]
+
+def test_wildcard_stripped_from_mixed_origins():
+    origins = _run_settings({"CORS_ALLOWED_ORIGINS": "https://a.com,*,https://b.com"})
+    assert origins == ["https://a.com", "https://b.com"]

--- a/tests/unit/config/test_cors_allowed_origins.py
+++ b/tests/unit/config/test_cors_allowed_origins.py
@@ -1,0 +1,124 @@
+"""Tests for CORS_ALLOWED_ORIGINS parsing and middleware wiring."""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.middleware.cors import CORSMiddleware
+
+ROOT = Path(__file__).resolve().parent.parent.parent.parent
+SRC = ROOT / "src"
+
+PRINT_ORIGINS = (
+    "from config.settings import CORS_ALLOWED_ORIGINS; "
+    "import json; print(json.dumps(CORS_ALLOWED_ORIGINS))"
+)
+
+
+def _python_env(env: dict[str, str]) -> dict[str, str]:
+    merged = os.environ.copy()
+    merged.update(env)
+    return merged
+
+
+def _run_settings(extra_env: dict[str, str]) -> list[str]:
+    env = _python_env({"PYTHONPATH": str(SRC), **extra_env})
+    env.pop("CORS_ALLOWED_ORIGINS", None)
+    env.update(extra_env)
+    result = subprocess.run(
+        [sys.executable, "-c", PRINT_ORIGINS],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    import json
+
+    return json.loads(result.stdout.splitlines()[-1])
+
+
+def test_parses_comma_separated_origins():
+    origins = _run_settings({"CORS_ALLOWED_ORIGINS": "https://a.com,https://b.com"})
+    assert origins == ["https://a.com", "https://b.com"]
+
+
+def test_trims_whitespace():
+    origins = _run_settings({"CORS_ALLOWED_ORIGINS": " https://a.com , https://b.com "})
+    assert origins == ["https://a.com", "https://b.com"]
+
+
+def test_filters_empty_entries():
+    origins = _run_settings({"CORS_ALLOWED_ORIGINS": "https://a.com,,https://b.com,"})
+    assert origins == ["https://a.com", "https://b.com"]
+
+
+def test_empty_string_yields_empty_list():
+    origins = _run_settings({"CORS_ALLOWED_ORIGINS": ""})
+    assert origins == []
+
+
+def test_unset_defaults_to_localhost():
+    env = _python_env({"PYTHONPATH": str(SRC)})
+    env.pop("CORS_ALLOWED_ORIGINS", None)
+    result = subprocess.run(
+        [sys.executable, "-c", PRINT_ORIGINS],
+        capture_output=True,
+        text=True,
+        check=True,
+        env=env,
+        cwd=str(ROOT),
+    )
+    import json
+
+    origins = json.loads(result.stdout.splitlines()[-1])
+    assert origins == ["http://localhost:3000"]
+
+
+# ---------------------------------------------------------------------------
+# Factory middleware wiring
+# ---------------------------------------------------------------------------
+
+
+def _get_cors_middleware(app):
+    for mw in app.user_middleware:
+        if mw.cls is CORSMiddleware:
+            return mw
+    return None
+
+
+@pytest.mark.asyncio
+async def test_factory_adds_cors_middleware_when_origins_set():
+    with patch("app.factory.CORS_ALLOWED_ORIGINS", ["https://app.example.com"]), \
+         patch("app.factory.initialize_services", new_callable=AsyncMock):
+        from app.factory import create_app
+
+        app = await create_app()
+        mw = _get_cors_middleware(app)
+        assert mw is not None
+        assert mw.kwargs["allow_origins"] == ["https://app.example.com"]
+
+
+@pytest.mark.asyncio
+async def test_factory_skips_cors_middleware_when_origins_empty():
+    with patch("app.factory.CORS_ALLOWED_ORIGINS", []), \
+         patch("app.factory.initialize_services", new_callable=AsyncMock):
+        from app.factory import create_app
+
+        app = await create_app()
+        assert _get_cors_middleware(app) is None
+
+
+@pytest.mark.asyncio
+async def test_factory_never_uses_wildcard_origin():
+    with patch("app.factory.CORS_ALLOWED_ORIGINS", ["https://app.example.com"]), \
+         patch("app.factory.initialize_services", new_callable=AsyncMock):
+        from app.factory import create_app
+
+        app = await create_app()
+        mw = _get_cors_middleware(app)
+        assert mw is not None
+        assert "*" not in mw.kwargs["allow_origins"]

--- a/tests/unit/config/test_cors_allowed_origins.py
+++ b/tests/unit/config/test_cors_allowed_origins.py
@@ -92,8 +92,10 @@ def _get_cors_middleware(app):
 
 @pytest.mark.asyncio
 async def test_factory_adds_cors_middleware_when_origins_set():
-    with patch("app.factory.CORS_ALLOWED_ORIGINS", ["https://app.example.com"]), \
-         patch("app.factory.initialize_services", new_callable=AsyncMock):
+    with (
+        patch("app.factory.CORS_ALLOWED_ORIGINS", ["https://app.example.com"]),
+        patch("app.factory.initialize_services", new_callable=AsyncMock),
+    ):
         from app.factory import create_app
 
         app = await create_app()
@@ -104,8 +106,10 @@ async def test_factory_adds_cors_middleware_when_origins_set():
 
 @pytest.mark.asyncio
 async def test_factory_skips_cors_middleware_when_origins_empty():
-    with patch("app.factory.CORS_ALLOWED_ORIGINS", []), \
-         patch("app.factory.initialize_services", new_callable=AsyncMock):
+    with (
+        patch("app.factory.CORS_ALLOWED_ORIGINS", []),
+        patch("app.factory.initialize_services", new_callable=AsyncMock),
+    ):
         from app.factory import create_app
 
         app = await create_app()
@@ -114,8 +118,10 @@ async def test_factory_skips_cors_middleware_when_origins_empty():
 
 @pytest.mark.asyncio
 async def test_factory_never_uses_wildcard_origin():
-    with patch("app.factory.CORS_ALLOWED_ORIGINS", ["https://app.example.com"]), \
-         patch("app.factory.initialize_services", new_callable=AsyncMock):
+    with (
+        patch("app.factory.CORS_ALLOWED_ORIGINS", ["https://app.example.com"]),
+        patch("app.factory.initialize_services", new_callable=AsyncMock),
+    ):
         from app.factory import create_app
 
         app = await create_app()


### PR DESCRIPTION
Issue https://github.ibm.com/lakehouse/tracker/issues/79665

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable cross-origin access for frontend applications.
  * Supports multiple comma-separated allowed origins.
  * Defaults to local frontend access during development.
  * Configuration is available across local and Kubernetes deployments.

* **Security**
  * Cross-origin access can be disabled when no origins are configured.
  * Requests from unapproved origins are not granted cross-origin access.
  * Consistent permissions apply across supported API responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->