### PR TITLE
fix: patch OS and npm CVEs in backend and frontend images

### DIFF
--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -10,7 +10,9 @@ FROM registry.access.redhat.com/ubi10/python-314-minimal AS base
 
 # Install system dependencies using microdnf (UBI minimal package manager)
 USER 0
-RUN microdnf install -y \
+
+RUN microdnf update -y \
+    && microdnf install -y \
     ca-certificates \
     curl \
     openssl \
@@ -67,7 +69,9 @@ FROM registry.access.redhat.com/ubi10/python-314-minimal AS runtime
 
 # Install runtime dependencies
 USER 0
-RUN microdnf install -y \
+
+RUN microdnf update -y \
+    && microdnf install -y \
     ca-certificates \
     openssl \
     shadow-utils \

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -20,6 +20,7 @@ RUN microdnf update -y \
     tar \
     gzip \
     && microdnf clean all \
+    && rm -rf /var/cache/yum \
     && curl -LsSf https://astral.sh/uv/install.sh | sh \
     && python -m ensurepip --upgrade \
     && python -m pip install --no-cache-dir --upgrade "pip>=26.1" "setuptools>=78.1.1"
@@ -40,7 +41,8 @@ RUN microdnf install -y \
     gcc-c++ \
     make \
     python3.14-devel \
-    && microdnf clean all
+    && microdnf clean all \
+    && rm -rf /var/cache/yum
 
 WORKDIR /app
 
@@ -78,6 +80,7 @@ RUN microdnf update -y \
     shadow-utils \
     util-linux \
     && microdnf clean all \
+    && rm -rf /var/cache/yum \
     && python -m ensurepip --upgrade \
     && python -m pip install --no-cache-dir --upgrade "pip>=26.1" "setuptools>=78.1.1"
 

--- a/Dockerfile.backend
+++ b/Dockerfile.backend
@@ -11,6 +11,7 @@ FROM registry.access.redhat.com/ubi10/python-314-minimal AS base
 # Install system dependencies using microdnf (UBI minimal package manager)
 USER 0
 
+
 RUN microdnf update -y \
     && microdnf install -y \
     ca-certificates \

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -9,7 +9,7 @@ WORKDIR /opt/app-root/src
 USER 0
 
 
-RUN microdnf update -y && microdnf clean all
+RUN microdnf update -y && microdnf clean all && rm -rf /var/cache/yum
 
 COPY frontend/package.json frontend/package-lock.json ./
 # Copy local stub packages referenced via file: in package.json (e.g. sharp stub
@@ -43,7 +43,7 @@ WORKDIR /opt/app-root/src
 USER 0
 
 
-RUN microdnf update -y && microdnf clean all
+RUN microdnf update -y && microdnf clean all && rm -rf /var/cache/yum
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1

--- a/Dockerfile.frontend
+++ b/Dockerfile.frontend
@@ -8,6 +8,9 @@ FROM registry.access.redhat.com/ubi10/nodejs-24-minimal AS deps
 WORKDIR /opt/app-root/src
 USER 0
 
+
+RUN microdnf update -y && microdnf clean all
+
 COPY frontend/package.json frontend/package-lock.json ./
 # Copy local stub packages referenced via file: in package.json (e.g. sharp stub
 # that keeps LGPL libvips binaries out of the tree). npm ci needs these present.
@@ -39,6 +42,8 @@ FROM registry.access.redhat.com/ubi10/nodejs-24-minimal AS runtime
 WORKDIR /opt/app-root/src
 USER 0
 
+
+RUN microdnf update -y && microdnf clean all
 
 ENV NODE_ENV=production \
     NEXT_TELEMETRY_DISABLED=1

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -71,7 +71,7 @@
         "husky": "^9.1.7",
         "knip": "^6.23.0",
         "lint-staged": "^17.0.8",
-        "postcss": "8.5.18",
+        "postcss": "8.5.26",
         "tailwindcss": "^3.4.19",
         "typescript": "^6.0.3"
       },
@@ -5366,9 +5366,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -5720,9 +5720,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.18",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
-      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -5739,7 +5739,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -80,13 +80,14 @@
     "husky": "^9.1.7",
     "knip": "^6.23.0",
     "lint-staged": "^17.0.8",
-    "postcss": "8.5.18",
+    "postcss": "8.5.26",
     "tailwindcss": "^3.4.19",
     "typescript": "^6.0.3"
   },
   "overrides": {
     "postcss-selector-parser": "6.1.4",
     "brace-expansion": "5.0.7",
+    "nanoid": "3.3.18",
     "js-cookie": "3.0.7",
     "picomatch": "4.0.4",
     "sharp": "file:./stubs/sharp-0.35.0.tgz",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated system packages used during backend and frontend application builds for more current container images.
  * Improved cleanup of temporary package data during image creation, helping keep resulting images leaner.
  * Refreshed frontend build tooling and pinned the identifier-generation package version for more consistent builds.

* **New Features**
  * Added support for exposing the frontend application on port 9090, alongside the existing port 3000.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->