### PR TITLE
chore: Add SDK tests for filename search filtering

### DIFF
--- a/sdks/typescript/tests/integration.test.ts
+++ b/sdks/typescript/tests/integration.test.ts
@@ -641,22 +641,33 @@ describe.skipIf(SKIP_TESTS)("OpenRAG TypeScript SDK Integration", () => {
       expect(results.results.length).toBeLessThanOrEqual(5);
     });
 
-    it("should filter by a raw filters dict (data_sources)", async () => {
+    it("should filter search by filename via data_sources", async () => {
+      // Ingest two distinguishable docs, then wildcard-search scoped to one
+      // filename so the assertion does not depend on semantic ranking.
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "sdk-search-filter-"));
-      const filterDocName = `search_filter_doc_${Date.now()}.md`;
-      const filterDocPath = path.join(tmpDir, filterDocName);
-      fs.writeFileSync(filterDocPath, "# Search Filter Doc\n\nMagenta wombats hopping.\n");
-      await client.documents.ingest({ filePath: filterDocPath });
+      const token = Date.now();
+      const alphaName = `alpha_${token}.md`;
+      const betaName = `beta_${token}.md`;
+      const alphaPath = path.join(tmpDir, alphaName);
+      const betaPath = path.join(tmpDir, betaName);
+      fs.writeFileSync(alphaPath, "# Alpha\n\nUnique content about purple elephants.\n");
+      fs.writeFileSync(betaPath, "# Beta\n\nUnique content about yellow tigers.\n");
+      await client.documents.ingest({ filePath: alphaPath });
+      await client.documents.ingest({ filePath: betaPath });
 
       try {
-        const results = await client.search.query("wombats", {
-          filters: { data_sources: [filterDocName] },
+        const results = await client.search.query("*", {
+          filters: { data_sources: [alphaName] },
         });
+        const filenames = results.results.map((r) => r.filename);
+        expect(filenames).toContain(alphaName);
+        expect(filenames).not.toContain(betaName);
         for (const r of results.results) {
-          expect(r.filename).toBe(filterDocName);
+          expect(r.filename).toBe(alphaName);
         }
       } finally {
-        await client.documents.delete(filterDocName);
+        await client.documents.delete(alphaName);
+        await client.documents.delete(betaName);
       }
     }, 120_000);
 

--- a/tests/integration/sdk/README.md
+++ b/tests/integration/sdk/README.md
@@ -78,6 +78,7 @@ make test-sdk
 | 42 | Unicode and emoji in query | Returns list, no error |
 | 43 | Result fields (`limit=5`) | At most 5 results; `text` is a non-empty string; `page`/`mimetype` are `None` or correctly typed |
 | 44 | Whitespace-only query (`"   "`) | Raises `ValidationError` |
+| 44a | Search with `SearchFilters(data_sources=[filename])` | Wildcard query returns only chunks from that file; a second ingested file is excluded |
 
 ---
 
@@ -141,4 +142,4 @@ make test-sdk
 
 ---
 
-**Total: 69 tests across 9 domains.**
+**Total: 70 tests across 9 domains.**

--- a/tests/integration/sdk/test_search.py
+++ b/tests/integration/sdk/test_search.py
@@ -138,9 +138,7 @@ class TestSearchFilenameFilter:
             assert alpha.name in filenames, (
                 f"Expected alpha in filename-filtered search, got {filenames}"
             )
-            assert beta.name not in filenames, (
-                f"Filename filter leaked: beta in {filenames}"
-            )
+            assert beta.name not in filenames, f"Filename filter leaked: beta in {filenames}"
             assert all(r.filename == alpha.name for r in results.results)
         finally:
             await client.documents.delete(alpha.name)

--- a/tests/integration/sdk/test_search.py
+++ b/tests/integration/sdk/test_search.py
@@ -1,9 +1,11 @@
 """Tests for the search endpoint."""
 
 import os
+import uuid
 from pathlib import Path
 
 import pytest
+from openrag_sdk import SearchFilters
 from openrag_sdk.exceptions import ValidationError
 
 pytestmark = pytest.mark.skipif(
@@ -105,3 +107,41 @@ class TestSearchExtended:
         """A whitespace-only query must raise ValidationError, not be treated as valid."""
         with pytest.raises(ValidationError):
             await client.search.query("   ")
+
+
+class TestSearchFilenameFilter:
+    """Verify inline `filters.data_sources` scopes search to exact filenames."""
+
+    @pytest.mark.asyncio
+    async def test_search_filters_by_filename(self, client, tmp_path):
+        """Search with SearchFilters(data_sources=[filename]) returns only that file.
+
+        Ingests two distinguishable documents, then uses a wildcard query so the
+        assertion does not depend on semantic ranking.
+        """
+        token = uuid.uuid4().hex[:8]
+        alpha = tmp_path / f"alpha_{token}.md"
+        beta = tmp_path / f"beta_{token}.md"
+        alpha.write_text("# Alpha\n\nUnique content about purple elephants.\n")
+        beta.write_text("# Beta\n\nUnique content about yellow tigers.\n")
+
+        try:
+            await client.documents.ingest(file_path=str(alpha))
+            await client.documents.ingest(file_path=str(beta))
+
+            results = await client.search.query(
+                "*",
+                filters=SearchFilters(data_sources=[alpha.name]),
+            )
+            assert results.results is not None
+            filenames = [r.filename for r in results.results]
+            assert alpha.name in filenames, (
+                f"Expected alpha in filename-filtered search, got {filenames}"
+            )
+            assert beta.name not in filenames, (
+                f"Filename filter leaked: beta in {filenames}"
+            )
+            assert all(r.filename == alpha.name for r in results.results)
+        finally:
+            await client.documents.delete(alpha.name)
+            await client.documents.delete(beta.name)


### PR DESCRIPTION
Adds a new integration case in both TypeScript and Python SDK suites to verify `filters.data_sources` correctly scopes wildcard search results to a specific ingested filename while excluding others. The tests now ingest two distinct files, assert only the targeted filename is returned, and clean up both documents. The integration test README was updated with the new case and total test count.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added integration coverage for wildcard searches restricted to a specific document source.
  - Verified that filename-based filtering returns only results from the selected document.
  - Expanded coverage across the TypeScript and Python SDK integrations, including cleanup validation for test documents.

- **Documentation**
  - Updated the SDK integration test count to reflect the newly added coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->