### PR TITLE
fix: cherry pick to align buttons padding color

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -314,12 +314,10 @@
     display: grid !important;
     grid-template-columns: repeat(2, minmax(0, 1fr)) !important;
     gap: 1px !important;
-    background-color: hsl(var(--border)) !important;
     margin-left: 0 !important;
     margin-right: 0 !important;
     margin-bottom: 0 !important;
     margin-top: 1rem !important;
-    padding-top: 0 !important;
   }
 
   /*

--- a/frontend/app/settings/_components/model-provider-dialog-footer.tsx
+++ b/frontend/app/settings/_components/model-provider-dialog-footer.tsx
@@ -50,8 +50,8 @@ const ModelProviderDialogFooter = ({
   if (showRemoveConfirm) {
     const hasAffected = !!affectedModels && affectedModels.length > 0;
     return (
-      <DialogFooter className="mt-4 flex flex-col gap-3 rounded-lg border border-red-500/10 bg-red-500/5 px-4 py-3 animate-in fade-in-0 slide-in-from-bottom-2 duration-150 sm:flex-row sm:items-start">
-        <div className="border-l-2 border-destructive pl-3 mr-auto text-sm text-red-100">
+      <DialogFooter className="mt-4 flex flex-col items-stretch gap-3 rounded-lg border border-red-500/10 bg-red-500/5 px-4 py-3 animate-in fade-in-0 slide-in-from-bottom-2 duration-150 sm:flex-row sm:items-center">
+        <div className="min-w-0 flex-1 border-l-2 border-destructive pl-3 text-sm text-red-100">
           {hasAffected ? (
             <div className="flex flex-col gap-1">
               <span>
@@ -76,7 +76,7 @@ const ModelProviderDialogFooter = ({
             "Remove configuration?"
           )}
         </div>
-        <div className="flex items-center gap-2 sm:self-center">
+        <div className="flex shrink-0 items-center justify-end gap-2">
           <Button variant="ghost" type="button" onClick={onCancelRemove}>
             Cancel
           </Button>

--- a/frontend/components/task-dialog/task-dialog.tsx
+++ b/frontend/components/task-dialog/task-dialog.tsx
@@ -128,7 +128,7 @@ function TaskDialogContent({
 
       <DialogFooter
         className={cn(
-          "w-full shrink-0 flex-row items-stretch sm:space-x-0",
+          "w-full shrink-0 flex-row items-stretch",
           isCloudBrand
             ? "gap-0 border-t bg-layer-contextual p-0"
             : cn(

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -114,7 +114,7 @@ function DialogDescription({
     <DialogPrimitive.Description
       ref={ref}
       data-slot="dialog-description"
-      className={cn("text-sm text-muted-foreground", className)}
+      className={cn("text-sm text-muted-foreground ", className)}
       {...props}
     />
   );

--- a/frontend/components/ui/dialog.tsx
+++ b/frontend/components/ui/dialog.tsx
@@ -80,7 +80,7 @@ const DialogFooter = ({
   <div
     data-slot="dialog-footer"
     className={cn(
-      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
       className,
     )}
     {...props}


### PR DESCRIPTION
cherry-pick of https://github.com/langflow-ai/openrag/pull/2257

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved dialog styling, spacing, borders, colors, focus states, and responsive footer layouts.
  * Updated task dialogs for clearer cloud-branded action layouts.
  * Refined file chunk and ingest review cards with improved text contrast, badges, and readability.
  * Improved settings confirmation footer alignment across screen sizes.

* **Bug Fixes**
  * Removed a duplicate component index from the container image.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->