### PR TITLE
feat: ingestion tab 

### DIFF
--- a/frontend/app/settings/[tab]/page.tsx
+++ b/frontend/app/settings/[tab]/page.tsx
@@ -11,8 +11,7 @@ import { AgentSettingsSection } from "../_components/agent-settings-section";
 import { ApiKeysSection } from "../_components/api-keys-section";
 import { ConnectorAccessSection } from "../_components/connector-access-section";
 import { ConnectorsTab } from "../_components/connectors-tab";
-import { IngestPreviewSettingsSection } from "../_components/ingest-preview-settings-section";
-import { IngestSettingsSection } from "../_components/ingest-settings-section";
+import { IngestionTab } from "../_components/ingestion-tab";
 import { LangflowUpdatesBanner } from "../_components/langflow-updates-banner";
 import ModelProviders from "../_components/model-providers";
 
@@ -20,12 +19,16 @@ const VALID_TABS = [
   "connectors",
   "providers",
   "langflow",
+  "ingestion",
   "api-keys",
   "connector-access",
-  "ingest-preview",
 ] as const;
 
 type Tab = (typeof VALID_TABS)[number];
+
+function isValidTab(tab: string): tab is Tab {
+  return (VALID_TABS as readonly string[]).includes(tab);
+}
 
 async function getTabAuthContext() {
   const [authRes, meRes] = await Promise.allSettled([
@@ -67,7 +70,7 @@ export default async function SettingsTabPage({
 }) {
   const { tab } = await params;
 
-  if (!VALID_TABS.includes(tab as Tab)) {
+  if (!isValidTab(tab)) {
     redirect("/settings/connectors");
   }
 
@@ -105,7 +108,7 @@ export default async function SettingsTabPage({
     redirect("/settings/connectors");
   }
   if (
-    tab === "langflow" &&
+    (tab === "langflow" || tab === "ingestion") &&
     !canShowRbacGatedSettingsTab("config:write", tabAccess)
   ) {
     redirect("/settings/connectors");
@@ -148,12 +151,11 @@ export default async function SettingsTabPage({
         <div className="space-y-6">
           <LangflowUpdatesBanner />
           <AgentSettingsSection />
-          <IngestSettingsSection />
         </div>
       )}
+      {tab === "ingestion" && <IngestionTab />}
       {tab === "api-keys" && <ApiKeysSection />}
       {tab === "connector-access" && <ConnectorAccessSection />}
-      {tab === "ingest-preview" && <IngestPreviewSettingsSection />}
     </HydrationBoundary>
   );
 }

--- a/frontend/app/settings/[tab]/page.tsx
+++ b/frontend/app/settings/[tab]/page.tsx
@@ -18,8 +18,8 @@ import ModelProviders from "../_components/model-providers";
 const VALID_TABS = [
   "connectors",
   "providers",
-  "langflow",
   "ingestion",
+  "agent",
   "api-keys",
   "connector-access",
 ] as const;
@@ -108,7 +108,7 @@ export default async function SettingsTabPage({
     redirect("/settings/connectors");
   }
   if (
-    (tab === "langflow" || tab === "ingestion") &&
+    (tab === "agent" || tab === "ingestion") &&
     !canShowRbacGatedSettingsTab("config:write", tabAccess)
   ) {
     redirect("/settings/connectors");
@@ -147,13 +147,13 @@ export default async function SettingsTabPage({
     <HydrationBoundary state={dehydrate(queryClient)}>
       {tab === "connectors" && <ConnectorsTab />}
       {tab === "providers" && <ModelProviders />}
-      {tab === "langflow" && (
+      {tab === "ingestion" && <IngestionTab />}
+      {tab === "agent" && (
         <div className="space-y-6">
           <LangflowUpdatesBanner />
           <AgentSettingsSection />
         </div>
       )}
-      {tab === "ingestion" && <IngestionTab />}
       {tab === "api-keys" && <ApiKeysSection />}
       {tab === "connector-access" && <ConnectorAccessSection />}
     </HydrationBoundary>

--- a/frontend/app/settings/_components/anthropic-settings-dialog.tsx
+++ b/frontend/app/settings/_components/anthropic-settings-dialog.tsx
@@ -92,7 +92,7 @@ const AnthropicSettingsDialog = ({
         action: {
           label: "Settings",
           onClick: () => {
-            router.push("/settings/langflow?focusLlmModel=true");
+            router.push("/settings/agent?focusLlmModel=true");
           },
         },
       });

--- a/frontend/app/settings/_components/ingest-preview-settings-section.tsx
+++ b/frontend/app/settings/_components/ingest-preview-settings-section.tsx
@@ -1,34 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { IngestPreviewAutoOpenControl } from "@/components/ingest-preview-auto-open-control";
 import { IngestReviewDialog } from "@/components/ingest-review";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
-import { Switch } from "@/components/ui/switch";
 import {
   INGEST_PREVIEW_AUTO_OPEN_OPTIONS,
   type IngestPreviewSettings,
   useIngestPreviewSettings,
 } from "@/hooks/use-ingest-preview-settings";
 import { createSampleDemoFile } from "@/lib/ingest-preview-demo";
-import { cn } from "@/lib/utils";
 
-const INGEST_PREVIEW_SETTING_KEYS = [
-  "autoOpen",
-  "showChunkBoundaries",
-  "showIndexingPipeline",
-  "showChunkContents",
-  "completionNotification",
-] as const satisfies ReadonlyArray<keyof IngestPreviewSettings>;
-
-function settingsEqual(
-  a: IngestPreviewSettings,
-  b: IngestPreviewSettings,
-): boolean {
-  return INGEST_PREVIEW_SETTING_KEYS.every((key) => a[key] === b[key]);
-}
+const EMPTY_PREVIEW_FILES: File[] = [];
 
 export function IngestPreviewSettingsSection() {
   const { settings, updateSettings } = useIngestPreviewSettings();
@@ -45,18 +30,18 @@ export function IngestPreviewSettingsSection() {
     setDraft(settings);
   }
 
-  const isDirty = !settingsEqual(draft, settings);
+  const isDirty = draft.autoOpen !== settings.autoOpen;
   const autoOpenDescription =
     INGEST_PREVIEW_AUTO_OPEN_OPTIONS.find(
       (option) => option.value === draft.autoOpen,
     )?.description ?? INGEST_PREVIEW_AUTO_OPEN_OPTIONS[0].description;
-
-  const patchDraft = (patch: Partial<IngestPreviewSettings>) => {
-    setDraft((prev) => ({ ...prev, ...patch }));
-  };
+  const previewFiles = useMemo(
+    () => (previewFile ? [previewFile] : EMPTY_PREVIEW_FILES),
+    [previewFile],
+  );
 
   const saveChanges = () => {
-    updateSettings(draft);
+    updateSettings({ autoOpen: draft.autoOpen });
     toast.success("Ingest preview settings saved");
   };
 
@@ -67,7 +52,7 @@ export function IngestPreviewSettingsSection() {
 
   return (
     <div className="space-y-0" data-testid="ingest-preview-settings">
-      <div className="flex items-center justify-between gap-4 py-4 border-b border-border">
+      <div className="flex items-center justify-between gap-4 py-4">
         <div className="flex-1 min-w-0">
           <Label className="text-base font-medium">
             Auto-open ingest preview
@@ -78,48 +63,10 @@ export function IngestPreviewSettingsSection() {
         </div>
         <IngestPreviewAutoOpenControl
           value={draft.autoOpen}
-          onChange={(autoOpen) => patchDraft({ autoOpen })}
+          onChange={(autoOpen) => setDraft((prev) => ({ ...prev, autoOpen }))}
           aria-label="Auto-open ingest preview"
         />
       </div>
-
-      <SettingToggle
-        id="show-chunk-boundaries"
-        label="Show chunk boundaries"
-        description="Show the indexed chunk list for each document."
-        checked={draft.showChunkBoundaries}
-        onCheckedChange={(checked) =>
-          patchDraft({ showChunkBoundaries: checked })
-        }
-      />
-      <SettingToggle
-        id="show-indexing-pipeline"
-        label="Show indexing pipeline"
-        description="Reading layout, creating chunks, embeddings, stored."
-        checked={draft.showIndexingPipeline}
-        onCheckedChange={(checked) =>
-          patchDraft({ showIndexingPipeline: checked })
-        }
-      />
-      <SettingToggle
-        id="show-chunk-contents"
-        label="Show chunk contents"
-        description="Stream each chunk's extracted text as it is created."
-        checked={draft.showChunkContents}
-        onCheckedChange={(checked) =>
-          patchDraft({ showChunkContents: checked })
-        }
-      />
-      <SettingToggle
-        id="completion-notification"
-        label="Completion notification"
-        description="Show a 'Task completed' toast when ingestion finishes."
-        checked={draft.completionNotification}
-        onCheckedChange={(checked) =>
-          patchDraft({ completionNotification: checked })
-        }
-        last
-      />
 
       <div className="flex flex-wrap items-center justify-end gap-2 pt-6">
         <Button
@@ -129,7 +76,7 @@ export function IngestPreviewSettingsSection() {
           onClick={runSampleIngest}
           data-testid="ingest-preview-run-sample"
         >
-          <div>Run a sample ingest</div>
+          Run a sample ingest
         </Button>
         <Button
           type="button"
@@ -148,41 +95,8 @@ export function IngestPreviewSettingsSection() {
         onOpenChange={setShowPreviewDialog}
         demo
         settingsOverride={draft}
-        previewFiles={previewFile ? [previewFile] : []}
+        previewFiles={previewFiles}
       />
-    </div>
-  );
-}
-
-function SettingToggle({
-  id,
-  label,
-  description,
-  checked,
-  onCheckedChange,
-  last = false,
-}: {
-  id: string;
-  label: string;
-  description: string;
-  checked: boolean;
-  onCheckedChange: (checked: boolean) => void;
-  last?: boolean;
-}) {
-  return (
-    <div
-      className={cn(
-        "flex items-center justify-between gap-4 py-4",
-        !last && "border-b border-border",
-      )}
-    >
-      <div className="flex-1 min-w-0">
-        <Label htmlFor={id} className="text-base font-medium">
-          {label}
-        </Label>
-        <p className="text-sm text-muted-foreground mt-1">{description}</p>
-      </div>
-      <Switch id={id} checked={checked} onCheckedChange={onCheckedChange} />
     </div>
   );
 }

--- a/frontend/app/settings/_components/ingestion-tab.tsx
+++ b/frontend/app/settings/_components/ingestion-tab.tsx
@@ -1,0 +1,25 @@
+"use client";
+
+import { useAuth } from "@/contexts/auth-context";
+import { useIsCloudBrand } from "@/contexts/brand-context";
+import { isIngestPreviewEnabled } from "@/lib/ingest-preview";
+import { IngestPreviewSettingsSection } from "./ingest-preview-settings-section";
+import { IngestSettingsSection } from "./ingest-settings-section";
+
+export function IngestionTab() {
+  const { runMode } = useAuth();
+  const isCloudBrand = useIsCloudBrand();
+  const showPreview = isIngestPreviewEnabled(runMode, { isCloudBrand });
+
+  return (
+    <div className="space-y-6">
+      <IngestSettingsSection />
+      {showPreview ? (
+        <div className="space-y-4">
+          <h2 className="text-lg font-medium">Ingest preview</h2>
+          <IngestPreviewSettingsSection />
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/app/settings/_components/ollama-settings-dialog.tsx
+++ b/frontend/app/settings/_components/ollama-settings-dialog.tsx
@@ -102,7 +102,7 @@ const OllamaSettingsDialog = ({
         action: {
           label: "Settings",
           onClick: () => {
-            router.push("/settings/langflow?focusLlmModel=true");
+            router.push("/settings/agent?focusLlmModel=true");
           },
         },
       });

--- a/frontend/app/settings/_components/openai-settings-dialog.tsx
+++ b/frontend/app/settings/_components/openai-settings-dialog.tsx
@@ -99,7 +99,7 @@ const OpenAISettingsDialog = ({
         action: {
           label: "Settings",
           onClick: () => {
-            router.push("/settings/langflow?focusLlmModel=true");
+            router.push("/settings/agent?focusLlmModel=true");
           },
         },
       });

--- a/frontend/app/settings/_components/settings-nav.tsx
+++ b/frontend/app/settings/_components/settings-nav.tsx
@@ -15,11 +15,11 @@ import { cn } from "@/lib/utils";
 const TABS = [
   { value: "connectors", label: "Connectors" },
   { value: "providers", label: "Providers", perm: "providers:write" },
-  // Agent settings write workspace config (admin-only).
-  { value: "langflow", label: "Langflow", perm: "config:write" },
   // Knowledge ingest settings write workspace config (admin-only).
   // Preview controls on this tab stay gated by isIngestPreviewEnabled.
   { value: "ingestion", label: "Ingestion", perm: "config:write" },
+  // Agent settings write workspace config (admin-only).
+  { value: "agent", label: "Agent", perm: "config:write" },
   { value: "api-keys", label: "API Keys", apiKeysTab: true },
   {
     value: "connector-access",

--- a/frontend/app/settings/_components/settings-nav.tsx
+++ b/frontend/app/settings/_components/settings-nav.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { usePathname, useRouter } from "next/navigation";
-import { useEffect } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 import { Tabs, TabsList, TabsTrigger } from "@/components/ui/settings-tabs";
 import { useAuth } from "@/contexts/auth-context";
 import { useIsCloudBrand } from "@/contexts/brand-context";
@@ -10,34 +10,27 @@ import {
   canAccessConnectorAccessTab,
   canShowRbacGatedSettingsTab,
 } from "@/lib/brand";
-import { isIngestPreviewEnabled } from "@/lib/ingest-preview";
 import { cn } from "@/lib/utils";
 
 const TABS = [
   { value: "connectors", label: "Connectors" },
   { value: "providers", label: "Providers", perm: "providers:write" },
-  // Agent + ingest settings write workspace config (admin-only).
+  // Agent settings write workspace config (admin-only).
   { value: "langflow", label: "Langflow", perm: "config:write" },
+  // Knowledge ingest settings write workspace config (admin-only).
+  // Preview controls on this tab stay gated by isIngestPreviewEnabled.
+  { value: "ingestion", label: "Ingestion", perm: "config:write" },
   { value: "api-keys", label: "API Keys", apiKeysTab: true },
   {
     value: "connector-access",
     label: "Connector Settings",
     perm: "connectors:manage:access",
   },
-  { value: "ingest-preview", label: "Ingest preview", ingestPreviewTab: true },
 ] as const;
 
 export function SettingsNav() {
   const pathname = usePathname();
-  const router = useRouter();
-  const {
-    isAuthenticated,
-    isNoAuthMode,
-    isIbmAuthMode,
-    isLoading,
-    permissionsResolved,
-    runMode,
-  } = useAuth();
+  const { isAuthenticated, isNoAuthMode, isIbmAuthMode } = useAuth();
   const isCloudBrand = useIsCloudBrand();
   const tabAccess = useSettingsTabAccess();
 
@@ -50,20 +43,8 @@ export function SettingsNav() {
     if ("perm" in tab) return canShowRbacGatedSettingsTab(tab.perm, tabAccess);
     if ("apiKeysTab" in tab)
       return (isAuthenticated || isNoAuthMode) && !isIbmAuthMode;
-    if ("ingestPreviewTab" in tab)
-      return isIngestPreviewEnabled(runMode, { isCloudBrand });
     return true;
   });
-
-  const _visibleTabKey = visibleTabs.map((tab) => tab.value).join("|");
-  const tabIsVisible = visibleTabs.some((tab) => tab.value === currentTab);
-  const fallbackTab = visibleTabs[0]?.value ?? "connectors";
-
-  useEffect(() => {
-    if (isLoading || !permissionsResolved) return;
-    if (tabIsVisible) return;
-    router.replace(`/settings/${fallbackTab}`);
-  }, [isLoading, permissionsResolved, tabIsVisible, fallbackTab, router]);
 
   return (
     <Tabs value={currentTab}>
@@ -75,10 +56,10 @@ export function SettingsNav() {
           <TabsTrigger
             key={tab.value}
             value={tab.value}
-            onClick={() => router.push(`/settings/${tab.value}`)}
+            asChild
             className={cn(!isCloudBrand && "p-3 rounded-full")}
           >
-            {tab.label}
+            <Link href={`/settings/${tab.value}`}>{tab.label}</Link>
           </TabsTrigger>
         ))}
       </TabsList>

--- a/frontend/app/settings/_components/watsonx-settings-dialog.tsx
+++ b/frontend/app/settings/_components/watsonx-settings-dialog.tsx
@@ -105,7 +105,7 @@ const WatsonxSettingsDialog = ({
         action: {
           label: "Settings",
           onClick: () => {
-            router.push("/settings/langflow?focusLlmModel=true");
+            router.push("/settings/agent?focusLlmModel=true");
           },
         },
       });

--- a/frontend/components/ingest-preview-auto-open-control.tsx
+++ b/frontend/components/ingest-preview-auto-open-control.tsx
@@ -25,13 +25,13 @@ export function IngestPreviewAutoOpenControl({
     <Tabs
       value={value}
       onValueChange={(next) => onChange(next as IngestPreviewAutoOpen)}
-      className={className}
+      className={cn("min-w-0 w-full sm:w-auto", className)}
     >
       <TabsList
         variant="default"
         aria-label={ariaLabel}
         className={cn(
-          "grid !h-9 w-[220px] shrink-0 grid-cols-2 items-stretch gap-0 !p-0",
+          "grid !h-9 w-full min-w-0 max-w-[220px] sm:w-[220px] sm:shrink-0 grid-cols-2 items-stretch gap-0 !p-0",
           "border border-border !bg-transparent",
           isCloudBrand
             ? "rounded-none overflow-hidden"

--- a/frontend/components/ingest-preview-auto-open-control.tsx
+++ b/frontend/components/ingest-preview-auto-open-control.tsx
@@ -31,8 +31,11 @@ export function IngestPreviewAutoOpenControl({
         variant="default"
         aria-label={ariaLabel}
         className={cn(
-          "h-auto shrink-0 border border-border p-0.5",
-          isCloudBrand ? "!rounded-none overflow-hidden" : "rounded-md",
+          "grid !h-9 w-[220px] shrink-0 grid-cols-2 items-stretch gap-0 !p-0",
+          "border border-border !bg-transparent",
+          isCloudBrand
+            ? "rounded-none overflow-hidden"
+            : "rounded-md overflow-hidden",
         )}
       >
         {INGEST_PREVIEW_AUTO_OPEN_OPTIONS.map((option) => (
@@ -40,9 +43,15 @@ export function IngestPreviewAutoOpenControl({
             key={option.value}
             value={option.value}
             className={cn(
-              "px-3 py-1.5 text-xs sm:text-sm",
-              isCloudBrand &&
-                "!rounded-none dark:hover:!bg-[#F4F4F4] dark:hover:!text-neutral-900 dark:data-[state=active]:!bg-[#F4F4F4] dark:data-[state=active]:!text-neutral-900",
+              "!flex !h-full !min-h-0 items-center justify-center",
+              "!rounded-none !border-0 !px-3 !py-0 !leading-none text-sm font-medium",
+              "!shadow-none text-muted-foreground hover:text-foreground",
+              "hover:!bg-transparent data-[state=active]:!shadow-none",
+              "data-[state=active]:!bg-muted data-[state=active]:!text-foreground",
+              "dark:hover:!bg-transparent dark:hover:!text-foreground",
+              "dark:data-[state=active]:!bg-white/10 dark:data-[state=active]:!text-foreground",
+              "dark:focus-visible:!bg-white/10 dark:focus-visible:!text-foreground",
+              option.value === "every" && "!border-r !border-border",
             )}
           >
             {option.label}

--- a/frontend/tests/core/chunk-overlap-analysis.spec.ts
+++ b/frontend/tests/core/chunk-overlap-analysis.spec.ts
@@ -45,7 +45,7 @@ test.describe("Chunk Overlap Impact Analysis @33219205 , @34581144 , @34581148",
       test.setTimeout(300000); // 5 minutes timeout
 
       // Configure chunk settings (fixed size, variable overlap)
-      await settings.clickTab("Langflow");
+      await settings.clickTab("Ingestion");
       await settings.updateChunkSettings(
         TEST_CONFIG.chunkSettings.defaultSize,
         scenario.overlap.toString(),
@@ -135,7 +135,7 @@ test.describe("Chunk Overlap Edge Case - Very Low Overlap with CSV Data", () => 
 
     // Test with both overlap values
     for (const overlap of ["1", "50"]) {
-      await settings.clickTab("Langflow");
+      await settings.clickTab("Ingestion");
       await settings.updateChunkSettings(
         TEST_CONFIG.chunkSettings.defaultSize,
         overlap,

--- a/frontend/tests/core/chunk-size-analysis.spec.ts
+++ b/frontend/tests/core/chunk-size-analysis.spec.ts
@@ -43,7 +43,7 @@ test.describe("Chunk Size Impact Analysis @33219206 , @34581149 , @3481151", () 
       test.setTimeout(300000); // 5 minutes timeout
 
       // Configure chunk settings
-      await settings.clickTab("Langflow");
+      await settings.clickTab("Ingestion");
       await settings.updateChunkSettings(
         scenario.size.toString(),
         TEST_CONFIG.chunkSettings.defaultOverlap,
@@ -125,7 +125,7 @@ test.describe("Large Chunk Size - Wrong Section Retrieval Test", () => {
   }) => {
     test.setTimeout(300000);
 
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Ingestion");
     await settings.updateChunkSettings(
       "1000",
       TEST_CONFIG.chunkSettings.defaultOverlap,

--- a/frontend/tests/core/chunk_search.spec.ts
+++ b/frontend/tests/core/chunk_search.spec.ts
@@ -45,7 +45,7 @@ test("Chunk Search & Ranking - OpenAI @33219236", async ({
 
   // Step 2: Set embedding model for OpenAI
   logger.info(`  ⚙️  Setting embedding model for OpenAI...`);
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Embedding model set to: ${OPENAI_CONFIG.embedding}`);
 

--- a/frontend/tests/core/chunk_search.spec.ts
+++ b/frontend/tests/core/chunk_search.spec.ts
@@ -45,7 +45,7 @@ test("Chunk Search & Ranking - OpenAI @33219236", async ({
 
   // Step 2: Set embedding model for OpenAI
   logger.info(`  ⚙️  Setting embedding model for OpenAI...`);
-  await settings.clickTab("Agent");
+  await settings.clickTab("Ingestion");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Embedding model set to: ${OPENAI_CONFIG.embedding}`);
 

--- a/frontend/tests/core/financial_document.spec.ts
+++ b/frontend/tests/core/financial_document.spec.ts
@@ -43,7 +43,7 @@ test.describe("Financial Document - OpenAI @33219232", () => {
     await knowledge.deleteDocument(testDocument);
 
     await settings.open();
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Ingestion");
     await settings.setTableStructure(true);
 
     await knowledge.open();

--- a/frontend/tests/core/financial_document.spec.ts
+++ b/frontend/tests/core/financial_document.spec.ts
@@ -30,7 +30,7 @@ test.describe("Financial Document - OpenAI @33219232", () => {
 
     // Configure models
     await settings.open();
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Agent");
     await settings.selectModel("Language model", OPENAI_CONFIG.language);
     await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
     logger.info(`  ✓ Language model set to: ${OPENAI_CONFIG.language}`);

--- a/frontend/tests/core/financial_document.spec.ts
+++ b/frontend/tests/core/financial_document.spec.ts
@@ -32,6 +32,7 @@ test.describe("Financial Document - OpenAI @33219232", () => {
     await settings.open();
     await settings.clickTab("Agent");
     await settings.selectModel("Language model", OPENAI_CONFIG.language);
+    await settings.clickTab("Ingestion");
     await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
     logger.info(`  ✓ Language model set to: ${OPENAI_CONFIG.language}`);
     logger.info(`  ✓ Embedding model set to: ${OPENAI_CONFIG.embedding}`);

--- a/frontend/tests/core/model_switching.spec.ts
+++ b/frontend/tests/core/model_switching.spec.ts
@@ -12,7 +12,7 @@ test("Model switching transitions (Language + Embedding) - OpenAI @33219223, @33
   await navigateToHome(page);
 
   logger.info("\n🧪 Testing Model Switching with OpenAI");
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
 
   // OpenAI model sequences for testing transitions
   const languageSequence = ["gpt-4o", "gpt-4o-mini", "gpt-4o"]; // Circular: A→B→A

--- a/frontend/tests/core/model_switching.spec.ts
+++ b/frontend/tests/core/model_switching.spec.ts
@@ -47,8 +47,9 @@ test("Model switching transitions (Language + Embedding) - OpenAI @33219223, @33
     }
   }
 
-  // Test Embedding model transitions
+  // Test Embedding model transitions (embedding selector is on Ingestion)
   logger.info(`\n🔄 Testing Embedding model transitions...`);
+  await settings.clickTab("Ingestion");
   const embeddingFailures: string[] = [];
 
   for (let i = 0; i < embeddingSequence.length - 1; i++) {

--- a/frontend/tests/core/picture_desc.spec.ts
+++ b/frontend/tests/core/picture_desc.spec.ts
@@ -29,7 +29,7 @@ test("Picture Description Configuration @33219221", async ({
 
   // Set OpenAI models before starting
   logger.info("\n⚙️  Configuring OpenAI models...");
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Language model: ${OPENAI_CONFIG.language}`);

--- a/frontend/tests/core/picture_desc.spec.ts
+++ b/frontend/tests/core/picture_desc.spec.ts
@@ -51,7 +51,7 @@ test("Picture Description Configuration @33219221", async ({
 
   // Enable picture descriptions
   logger.info("\n📸 Enabling picture descriptions...");
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Ingestion");
   await settings.setPictureDescriptions(true);
 
   // Ingest first PDF with picture descriptions enabled
@@ -75,7 +75,7 @@ test("Picture Description Configuration @33219221", async ({
 
   // Disable picture descriptions
   logger.info("\n📸 Disabling picture descriptions...");
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Ingestion");
   await settings.setPictureDescriptions(false);
 
   // Ingest second PDF with picture descriptions disabled

--- a/frontend/tests/core/picture_desc.spec.ts
+++ b/frontend/tests/core/picture_desc.spec.ts
@@ -31,6 +31,7 @@ test("Picture Description Configuration @33219221", async ({
   logger.info("\n⚙️  Configuring OpenAI models...");
   await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
+  await settings.clickTab("Ingestion");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Language model: ${OPENAI_CONFIG.language}`);
   logger.info(`  ✓ Embedding model: ${OPENAI_CONFIG.embedding}`);

--- a/frontend/tests/core/restore_flow.spec.ts
+++ b/frontend/tests/core/restore_flow.spec.ts
@@ -15,7 +15,7 @@ test.describe("Restore Flow", () => {
     // Make sure we start with a clean default state
     await navigateToHome(page);
     await settings.open();
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Ingestion");
 
     const pictureDescToggle = page.getByRole("switch", {
       name: /picture descriptions/i,
@@ -77,7 +77,7 @@ test.describe("Restore Flow", () => {
     // Navigate to the application
     await navigateToHome(page);
     await settings.open();
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Ingestion");
 
     // Get references to settings elements
     const pictureDescToggle = page.getByRole("switch", {
@@ -217,7 +217,7 @@ test.describe("Restore Flow", () => {
     // Navigate to the application
     await navigateToHome(page);
     await settings.open();
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Ingestion");
 
     // Get references to settings elements
     const pictureDescToggle = page.getByRole("switch", {

--- a/frontend/tests/core/search.spec.ts
+++ b/frontend/tests/core/search.spec.ts
@@ -31,7 +31,7 @@ test("Opensearch Indexing - OpenAI @33219220", async ({
 
   // Step 2: Set embedding model for OpenAI
   logger.info(`  ⚙️  Setting embedding model for OpenAI...`);
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Embedding model set to: ${OPENAI_CONFIG.embedding}`);
 

--- a/frontend/tests/core/search.spec.ts
+++ b/frontend/tests/core/search.spec.ts
@@ -31,7 +31,7 @@ test("Opensearch Indexing - OpenAI @33219220", async ({
 
   // Step 2: Set embedding model for OpenAI
   logger.info(`  ⚙️  Setting embedding model for OpenAI...`);
-  await settings.clickTab("Agent");
+  await settings.clickTab("Ingestion");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Embedding model set to: ${OPENAI_CONFIG.embedding}`);
 

--- a/frontend/tests/core/url_ingestion.spec.ts
+++ b/frontend/tests/core/url_ingestion.spec.ts
@@ -32,7 +32,7 @@ test("@smoke URL connector ingestion reliability - OpenAI @33219228", async ({
 
   // Step 2: Set models for OpenAI
   logger.info(`  ⚙️  Setting models for OpenAI...`);
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Language model set to: ${OPENAI_CONFIG.language}`);
@@ -84,7 +84,7 @@ test("URL connector ingestion - Invalid URL handling @34581217", async ({
   logger.info(`\n🧪 Testing Invalid URL Ingestion`);
 
   // Set models
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
 
@@ -138,7 +138,7 @@ test("URL connector ingestion - Authentication-blocked URL handling @34581218", 
   logger.info(`\n🧪 Testing Authentication-Blocked URL Ingestion`);
 
   // Set models
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
 
@@ -203,7 +203,7 @@ test("URL ingestion persists after conversation deletion @34581222", async ({
 
   // Step 2: Set models for OpenAI
   logger.info(`  ⚙️  Setting models for OpenAI...`);
-  await settings.clickTab("Langflow");
+  await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Language model set to: ${OPENAI_CONFIG.language}`);

--- a/frontend/tests/core/url_ingestion.spec.ts
+++ b/frontend/tests/core/url_ingestion.spec.ts
@@ -34,6 +34,7 @@ test("@smoke URL connector ingestion reliability - OpenAI @33219228", async ({
   logger.info(`  ⚙️  Setting models for OpenAI...`);
   await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
+  await settings.clickTab("Ingestion");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Language model set to: ${OPENAI_CONFIG.language}`);
   logger.info(`  ✓ Embedding model set to: ${OPENAI_CONFIG.embedding}`);
@@ -86,6 +87,7 @@ test("URL connector ingestion - Invalid URL handling @34581217", async ({
   // Set models
   await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
+  await settings.clickTab("Ingestion");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
 
   // Attempt to ingest invalid URL
@@ -140,6 +142,7 @@ test("URL connector ingestion - Authentication-blocked URL handling @34581218", 
   // Set models
   await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
+  await settings.clickTab("Ingestion");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
 
   // Attempt to ingest authentication-blocked URL
@@ -205,6 +208,7 @@ test("URL ingestion persists after conversation deletion @34581222", async ({
   logger.info(`  ⚙️  Setting models for OpenAI...`);
   await settings.clickTab("Agent");
   await settings.selectModel("Language model", OPENAI_CONFIG.language);
+  await settings.clickTab("Ingestion");
   await settings.selectModel("Embedding model", OPENAI_CONFIG.embedding);
   logger.info(`  ✓ Language model set to: ${OPENAI_CONFIG.language}`);
   logger.info(`  ✓ Embedding model set to: ${OPENAI_CONFIG.embedding}`);

--- a/frontend/tests/core/z_update_model_providers.spec.ts
+++ b/frontend/tests/core/z_update_model_providers.spec.ts
@@ -34,7 +34,7 @@ test.describe("Update model providers to watsonx.ai and openai @33219219, @33219
     await settings.clickTab("Providers");
     await settings.configureWatsonxai();
     await settings.removeModelProviderSetup("OpenAI");
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Agent");
     await settings.selectModel("Language model", "ibm/granite-4-h-small");
     await settings.selectModel(
       "Embedding model",
@@ -65,7 +65,7 @@ test.describe("Update model providers to watsonx.ai and openai @33219219, @33219
     await settings.clickTab("Providers");
     await settings.configureOpenAPI();
     await settings.removeModelProviderSetup("IBM watsonx.ai");
-    await settings.clickTab("Langflow");
+    await settings.clickTab("Agent");
     await settings.selectModel("Language model", "gpt-4o-mini");
     await settings.selectModel("Embedding model", "text-embedding-3-small");
     await knowledge.deleteDocument(testDocumentName);

--- a/frontend/tests/core/z_update_model_providers.spec.ts
+++ b/frontend/tests/core/z_update_model_providers.spec.ts
@@ -36,6 +36,7 @@ test.describe("Update model providers to watsonx.ai and openai @33219219, @33219
     await settings.removeModelProviderSetup("OpenAI");
     await settings.clickTab("Agent");
     await settings.selectModel("Language model", "ibm/granite-4-h-small");
+    await settings.clickTab("Ingestion");
     await settings.selectModel(
       "Embedding model",
       "ibm/slate-125m-english-rtrvr-v2",
@@ -67,6 +68,7 @@ test.describe("Update model providers to watsonx.ai and openai @33219219, @33219
     await settings.removeModelProviderSetup("IBM watsonx.ai");
     await settings.clickTab("Agent");
     await settings.selectModel("Language model", "gpt-4o-mini");
+    await settings.clickTab("Ingestion");
     await settings.selectModel("Embedding model", "text-embedding-3-small");
     await knowledge.deleteDocument(testDocumentName);
     await knowledge.ingestFile(testDocumentPath);

--- a/frontend/tests/pages/Settings.ts
+++ b/frontend/tests/pages/Settings.ts
@@ -114,14 +114,24 @@ export class Settings {
 
   /**
    * Get locator for model dropdown by section name
-   * @param section - The section name (e.g., "Chat Model", "Embedding Model")
+   * @param section - The section name (e.g., "Language model", "Embedding model")
    * @returns Locator for the dropdown
    */
   private getModelDropdown(section: string) {
+    // Target the field label so we don't match helper copy such as
+    // "The embedding model saves as soon as you pick one".
     return this.page
-      .getByText(new RegExp(escapeRegExp(section), "i"))
+      .locator("label")
+      .filter({ hasText: new RegExp(`^${escapeRegExp(section)}`, "i") })
       .locator("..")
       .getByRole("combobox");
+  }
+
+  /**
+   * Language model lives on Agent; embedding model lives on Ingestion.
+   */
+  private tabForModelSection(section: string): SettingsTab {
+    return /embedding/i.test(section) ? "Ingestion" : "Agent";
   }
 
   /**
@@ -251,8 +261,12 @@ export class Settings {
     }
   }
 
+  /**
+   * Select a language or embedding model. Opens Agent for language models
+   * and Ingestion for embedding models.
+   */
   async selectModel(section: string, model: string) {
-    await this.open();
+    await this.clickTab(this.tabForModelSection(section));
     const dropdown = this.getModelDropdown(section);
     await dropdown.scrollIntoViewIfNeeded();
     const currentText = (await dropdown.textContent())?.toLowerCase() || "";

--- a/frontend/tests/pages/Settings.ts
+++ b/frontend/tests/pages/Settings.ts
@@ -9,8 +9,8 @@ function escapeRegExp(str: string): string {
 export type SettingsTab =
   | "Connectors"
   | "Providers"
-  | "Langflow"
   | "Ingestion"
+  | "Agent"
   | "Connectors Permission";
 
 export class Settings {
@@ -167,7 +167,7 @@ export class Settings {
 
   /**
    * Click a Settings page tab
-   * @param tabName - The tab to click: 'Connectors' | 'Providers' | 'Langflow' | 'Ingestion' | 'Connectors Permission'
+   * @param tabName - The tab to click: 'Connectors' | 'Providers' | 'Ingestion' | 'Agent' | 'Connectors Permission'
    */
   async clickTab(tabName: SettingsTab) {
     logger.info(`Clicking Settings tab: ${tabName}`);

--- a/frontend/tests/pages/Settings.ts
+++ b/frontend/tests/pages/Settings.ts
@@ -10,6 +10,7 @@ export type SettingsTab =
   | "Connectors"
   | "Providers"
   | "Langflow"
+  | "Ingestion"
   | "Connectors Permission";
 
 export class Settings {
@@ -166,7 +167,7 @@ export class Settings {
 
   /**
    * Click a Settings page tab
-   * @param tabName - The tab to click: 'Connectors' | 'Providers' | 'Langflow' | 'Connectors Permission'
+   * @param tabName - The tab to click: 'Connectors' | 'Providers' | 'Langflow' | 'Ingestion' | 'Connectors Permission'
    */
   async clickTab(tabName: SettingsTab) {
     logger.info(`Clicking Settings tab: ${tabName}`);
@@ -203,7 +204,7 @@ export class Settings {
   }
 
   async setPictureDescriptions(enabled: boolean) {
-    await this.open();
+    await this.clickTab("Ingestion");
     const toggle = this.pictureDescriptionsToggle();
     await toggle.scrollIntoViewIfNeeded();
     const state = await toggle.getAttribute("data-state");
@@ -215,7 +216,7 @@ export class Settings {
   }
 
   async setTableStructure(enabled: boolean) {
-    await this.open();
+    await this.clickTab("Ingestion");
     const toggle = this.tableStructureToggle();
     await toggle.scrollIntoViewIfNeeded();
     const state = await toggle.getAttribute("data-state");
@@ -227,7 +228,7 @@ export class Settings {
   }
 
   async setOCR(enabled: boolean) {
-    await this.open();
+    await this.clickTab("Ingestion");
     const toggle = this.ocrToggle();
     await toggle.scrollIntoViewIfNeeded();
     const state = await toggle.getAttribute("data-state");
@@ -239,7 +240,7 @@ export class Settings {
   }
 
   async setDisableLangflowIngestion(enabled: boolean) {
-    await this.clickTab("Langflow");
+    await this.clickTab("Ingestion");
     const toggle = this.disableLangflowIngestionToggle();
     await toggle.scrollIntoViewIfNeeded();
     const state = await toggle.getAttribute("data-state");
@@ -285,7 +286,7 @@ export class Settings {
    * @param chunkOverlap - Chunk overlap value (e.g., "50")
    */
   async updateChunkSettings(chunkSize: string, chunkOverlap: string) {
-    await this.open();
+    await this.clickTab("Ingestion");
 
     // Find and update chunk size input
     const chunkSizeInp = this.chunkSizeInput();


### PR DESCRIPTION
Summary
Add a Settings Ingestion tab (config:write) for knowledge ingest settings (chunk size, OCR, tables, restore flow).
Keep the Langflow tab for agent / Langflow settings only.
Ingest preview stays on the Ingestion tab, still OSS + OPENRAG_INGEST_PREVIEW_ENABLED. SaaS sees ingest settings, not preview.
Preview settings are auto-open, Run a sample ingest, and Save changes only.
<img width="910" height="864" alt="Screenshot 2026-08-20 at 12 49 45 PM" src="https://github.com/user-attachments/assets/c3c6575f-f3d4-49c0-b295-dcf141780acc" />
<img width="1439" height="838" alt="Screenshot 2026-08-20 at 12 50 13 PM" src="https://github.com/user-attachments/assets/00217774-465f-4c40-8239-a92656ea013d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated **Agent** and **Ingestion** tabs to Settings.
  * Consolidated ingestion options, including conditionally available ingest preview settings.
  * Updated model configuration links to open the Agent tab directly.
* **Improvements**
  * Simplified ingest preview preferences to focus on automatic opening.
  * Refined preview controls with responsive layout and clearer interaction states.
  * Improved direct navigation and access control for settings tabs.
* **Tests**
  * Updated settings, ingestion, chunk analysis, document, and restore-flow coverage for the new navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->