### PR TITLE
fix: updated bucket -> container label

### DIFF
--- a/frontend/components/connectors/aws-s3/bucket-view.tsx
+++ b/frontend/components/connectors/aws-s3/bucket-view.tsx
@@ -39,6 +39,8 @@ export function S3BucketView({
       addTask={addTask}
       onBack={onBack}
       onDone={onDone}
+      resourceLabel="bucket"
+      resourceLabelPlural="buckets"
       initialSelectedBuckets={
         defaults?.connection_id === connector.connectionId
           ? defaults?.bucket_names

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -48,6 +48,10 @@ export interface SharedBucketViewProps {
   showShared?: boolean;
   /** Buckets to pre-select once `buckets` has loaded, e.g. from saved connector defaults. */
   initialSelectedBuckets?: string[];
+  /** Singular label for the resource type, e.g. "bucket" or "container". Defaults to "container". */
+  resourceLabel?: string;
+  /** Plural label for the resource type, e.g. "buckets" or "containers". Defaults to "containers". */
+  resourceLabelPlural?: string;
 }
 
 export function SharedBucketView({
@@ -58,12 +62,15 @@ export function SharedBucketView({
   onRefetch,
   invalidateQueryKey,
   syncMutation,
+  resourceLabel = "container",
+  resourceLabelPlural = "containers",
   addTask,
   onBack,
   onDone,
   showShared = false,
   initialSelectedBuckets,
 }: SharedBucketViewProps) {
+  const capitalize = (s: string) => s.charAt(0).toUpperCase() + s.slice(1);
   const queryClient = useQueryClient();
   const { isAuthenticated, isNoAuthMode } = useAuth();
   const { data: apiSettings } = useGetSettingsQuery({
@@ -323,7 +330,7 @@ export function SharedBucketView({
       <div className="max-w-3xl mx-auto space-y-4">
         <div className="flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
-            Select containers to ingest.
+            Select {resourceLabelPlural} to ingest.
           </p>
           <div className="flex items-center gap-2">
             {selectedBuckets.size > 0 && (
@@ -355,7 +362,7 @@ export function SharedBucketView({
                 size={14}
                 className={isLoading ? "animate-spin" : ""}
               />
-              Refresh Containers
+              Refresh {capitalize(resourceLabelPlural)}
             </Button>
           </div>
         </div>
@@ -371,7 +378,7 @@ export function SharedBucketView({
           </div>
         ) : !buckets?.length ? (
           <div className="rounded-lg border p-6 text-center text-muted-foreground text-sm">
-            No buckets found. Check your credentials and endpoint.
+            No {resourceLabelPlural} found. Check your credentials and endpoint.
           </div>
         ) : (
           <div className="rounded-lg border divide-y">
@@ -484,8 +491,8 @@ export function SharedBucketView({
               : isCheckingDuplicates
                 ? "Checking…"
                 : selectedBuckets.size > 0
-                  ? `Ingest ${selectedBuckets.size} Bucket${selectedBuckets.size !== 1 ? "s" : ""}`
-                  : "Select Containers to Ingest"}
+                  ? `Ingest ${selectedBuckets.size} ${selectedBuckets.size === 1 ? capitalize(resourceLabel) : capitalize(resourceLabelPlural)}`
+                  : `Select ${capitalize(resourceLabelPlural)} to Ingest`}
           </Button>
         </div>
       </div>

--- a/frontend/components/connectors/shared-bucket-view.tsx
+++ b/frontend/components/connectors/shared-bucket-view.tsx
@@ -323,7 +323,7 @@ export function SharedBucketView({
       <div className="max-w-3xl mx-auto space-y-4">
         <div className="flex items-center justify-between">
           <p className="text-sm text-muted-foreground">
-            Select buckets to ingest.
+            Select containers to ingest.
           </p>
           <div className="flex items-center gap-2">
             {selectedBuckets.size > 0 && (
@@ -355,7 +355,7 @@ export function SharedBucketView({
                 size={14}
                 className={isLoading ? "animate-spin" : ""}
               />
-              Refresh Buckets
+              Refresh Containers
             </Button>
           </div>
         </div>
@@ -485,7 +485,7 @@ export function SharedBucketView({
                 ? "Checking…"
                 : selectedBuckets.size > 0
                   ? `Ingest ${selectedBuckets.size} Bucket${selectedBuckets.size !== 1 ? "s" : ""}`
-                  : "Select Buckets to Ingest"}
+                  : "Select Containers to Ingest"}
           </Button>
         </div>
       </div>


### PR DESCRIPTION
-updated label for azure blob storage as per the issue request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Updated shared resource views to use configurable singular and plural labels across prompts, refresh messages, empty states, and ingest actions.
  * AWS S3 views now consistently display “bucket” and “buckets” terminology.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->