### PR TITLE
fix: bump mcp to fix CVE-2026-52869, CVE-2026-52870, CVE-2026-59950

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ dependencies = [
     "pyyaml>=6.0",
     "tiktoken>=0.7.0",
     "fastmcp>=3.2.3",
+    "mcp>=1.28.1",
     "openai==2.24.0",
     "tenacity>=9.1.4",
     "pygments>=2.20.0",

--- a/uv.lock
+++ b/uv.lock
@@ -3,7 +3,10 @@ revision = 3
 requires-python = ">=3.13"
 resolution-markers = [
     "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform != 'win32'",
 ]
 
 [manifest]
@@ -1599,7 +1602,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.29.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1617,9 +1620,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/d3/f9acc21dfc886e4f78e2add1a47db46ce16884346afde53f8a064c02c891/mcp-1.29.0.tar.gz", hash = "sha256:52d01f334de1868cc3bb2d6604931126a67631f99a6c5d3b82ba47290315ec36", size = 643148, upload-time = "2026-07-28T13:41:41.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/01/c8/248b201f6d753d69fd5d6506011abbb35a946d9142b2ae311a948fd0be3d/mcp-1.29.0-py3-none-any.whl", hash = "sha256:f5a075bb611f23d6f4d080c6a1699fa62772eebc562ba9e66b306ddde1c755f7", size = 223436, upload-time = "2026-07-28T13:41:40.337Z" },
 ]
 
 [[package]]
@@ -1889,6 +1892,7 @@ dependencies = [
     { name = "ibm-cos-sdk" },
     { name = "idna" },
     { name = "litellm" },
+    { name = "mcp" },
     { name = "msal" },
     { name = "openai" },
     { name = "opensearch-py", extra = ["async"] },
@@ -1951,6 +1955,7 @@ requires-dist = [
     { name = "idna", specifier = ">=3.15" },
     { name = "idna", specifier = ">=3.18" },
     { name = "litellm", specifier = "==1.84.0" },
+    { name = "mcp", specifier = ">=1.28.1" },
     { name = "msal", specifier = ">=1.29.0" },
     { name = "openai", specifier = "==2.24.0" },
     { name = "opensearch-py", extras = ["async"], specifier = ">=3.0.0" },


### PR DESCRIPTION
Updated mcp dependency to fix security vulnerabilities.

- CVE-2026-52869: MCP session hijacking via unauthenticated HTTP transport
- CVE-2026-52870: IDOR in task handlers allowing cross-client access
- CVE-2026-59950: WebSocket transport missing Host/Origin validation

mcp 1.27.0 -> 1.29.0 (pyproject.toml + uv.lock)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added the MCP runtime dependency to support the latest integration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->