### PR TITLE
fix: bump brace-expansion to 5.0.9 for CVE-2026-14257 and CVE-2026-69152

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -6756,15 +6756,15 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {

--- a/docs/package.json
+++ b/docs/package.json
@@ -55,7 +55,7 @@
     "qs": "^6.15.2",
     "minimatch": "^3.1.4",
     "picomatch": "^4.0.4",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.9",
     "follow-redirects": "^1.16.0",
     "svgo": "^3.3.3",
     "dompurify": "^3.4.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -86,7 +86,7 @@
   },
   "overrides": {
     "postcss-selector-parser": "6.1.4",
-    "brace-expansion": "5.0.7",
+    "brace-expansion": "5.0.9",
     "nanoid": "5.1.16",
     "js-cookie": "3.0.7",
     "picomatch": "4.0.4",


### PR DESCRIPTION
## Summary
- Bump the `brace-expansion` npm override from 5.0.7 to 5.0.9 in the frontend and docs apps.
- 5.0.7 is the `brace-expansion-5.0.7.tgz` finding: CVE-2026-14257 (DoS via unbounded expansion length) and CVE-2026-69152 (bypass of the 5.0.8 fix). 5.0.9 is the first 5.x patch that closes both.

## Test plan
- [ ] Confirm `docs/package-lock.json` resolves `brace-expansion-5.0.9.tgz`, not 5.0.7.
- [ ] `cd frontend && npm install` succeeds with the 5.0.9 override.
- [ ] `cd docs && npm install` succeeds and docs still build.


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the brace expansion package override to version 5.0.9 in the documentation and frontend projects.
  * Includes maintenance updates with no visible changes to the application experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->