### PR TITLE
fix: -CVE-2026-69153 PostCSS is now 8.5.26

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -14797,9 +14797,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -14817,7 +14817,7 @@
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/docs/package.json
+++ b/docs/package.json
@@ -51,7 +51,7 @@
     "webpackbar": "^7.0.0",
     "webpack-dev-server": { ".": "^5.2.6", "ws": "^8.20.1", "ajv": "^8.18.0" },
     "mini-css-extract-plugin": { "ajv": "^8.18.0" },
-    "postcss": "^8.5.10",
+    "postcss": "8.5.26",
     "qs": "^6.15.2",
     "minimatch": "^3.1.4",
     "picomatch": "^4.0.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -51,7 +51,7 @@
     "webpackbar": "^7.0.0",
     "webpack-dev-server": { ".": "^5.2.6", "ws": "^8.20.1", "ajv": "^8.18.0" },
     "mini-css-extract-plugin": { "ajv": "^8.18.0" },
-    "postcss": "8.5.26",
+    "postcss": "^8.5.26",
     "qs": "^6.15.2",
     "minimatch": "^3.1.4",
     "picomatch": "^4.0.4",

--- a/sdks/typescript/package-lock.json
+++ b/sdks/typescript/package-lock.json
@@ -2036,9 +2036,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -2056,7 +2056,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -54,7 +54,7 @@
   },
   "overrides": {
     "picomatch": "^4.0.4",
-    "postcss": "8.5.26",
+    "postcss": "^8.5.26",
     "rollup": "^4.59.0"
   },
   "engines": {

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -54,7 +54,7 @@
   },
   "overrides": {
     "picomatch": "^4.0.4",
-    "postcss": "^8.5.10",
+    "postcss": "8.5.26",
     "rollup": "^4.59.0"
   },
   "engines": {


### PR DESCRIPTION
Bump the postcss override from ^8.5.10 (resolved 8.5.15) to 8.5.26 in docs and the TypeScript SDK.
Closes CVE-2026-69153: PostCSS could read arbitrary .map files via an attacker-controlled sourceMappingURL when from is unset. Fixed upstream in 8.5.19; 8.5.26 matches the frontend pin already on main.
Frontend was already on 8.5.26 and is unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build tooling for the documentation site and TypeScript SDK.
  * Builds now use a newer, consistent PostCSS version, improving reliability and consistency across supported project areas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->