### PR TITLE
feat: add publish icr gh action

### DIFF
--- a/.github/workflows/publish-icr.yml
+++ b/.github/workflows/publish-icr.yml
@@ -1,0 +1,53 @@
+name: Publish to ICR.io
+
+on:
+  push:
+    branches:
+      - '**'
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: openrag-backend
+            file: ./Dockerfile.backend
+          - name: openrag-frontend
+            file: ./Dockerfile.frontend
+          - name: openrag-opensearch
+            file: ./Dockerfile
+          - name: openrag-langflow
+            file: ./Dockerfile.langflow
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Get Commit SHA
+        id: vars
+        run: echo "sha=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to ICR.io
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ secrets.ICR_REGISTRY || 'icr.io' }}
+          username: ${{ secrets.ICR_USERNAME || 'iamapikey' }}
+          password: ${{ secrets.ICR_APIKEY || secrets.ICR_PASSWORD }}
+
+      - name: Build and push ${{ matrix.name }}
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: true
+          no-cache: true
+          tags: ${{ secrets.ICR_REGISTRY || 'icr.io' }}/${{ secrets.ICR_NAMESPACE || 'wxd_dev' }}/${{ matrix.name }}:${{ steps.vars.outputs.sha }}

--- a/.github/workflows/publish-icr.yml
+++ b/.github/workflows/publish-icr.yml
@@ -1,9 +1,6 @@
 name: Publish to ICR.io
 
 on:
-  push:
-    branches:
-      - '**'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate building and publishing Docker images for multiple components to ICR.io. The workflow is triggered on every branch push and can also be run manually. It supports building images for the backend, frontend, opensearch, and langflow components.

**CI/CD Automation:**

* Added a new workflow file `.github/workflows/publish-icr.yml` that builds and pushes Docker images for four components (`openrag-backend`, `openrag-frontend`, `openrag-opensearch`, `openrag-langflow`) to ICR.io using GitHub Actions. The workflow is triggered on any branch push and via manual dispatch, and handles authentication, multi-architecture builds, and tagging images with the commit SHA.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered workflow for building and publishing container images to the image registry.
  * Supports building and publishing multiple container image variants in one workflow.
  * Published images are tagged with the corresponding commit identifier for easier version tracking and deployment.
  * Removed automatic publishing when changes are pushed to a branch.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->