### PR TITLE
chore(sdk): bump openrag-sdk version to 0.7.0.dev1 for PyPI prerelease

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "openrag-sdk"
-version = "0.7.0"
+version = "0.7.0.dev1"
 description = "Official Python SDK for OpenRAG API"
 readme = "README.md"
 license = "MIT"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -121,7 +121,7 @@ wheels = [
 
 [[package]]
 name = "openrag-sdk"
-version = "0.7.0"
+version = "0.7.0.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
for sdk testing