### PR TITLE
fix: ensure openrag version on cli

### DIFF
--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -51,6 +51,7 @@ def run_cli():
         pass  # Non-critical bootstrap errors
 
     env_manager = EnvManager()
+    env_manager.ensure_openrag_version()
     container_manager = ContainerManager()
     docling_manager = DoclingManager()
 
@@ -323,6 +324,7 @@ def _collect_config(
 def _validate_and_save(env_manager: EnvManager) -> bool:
     """Validate config and save .env file."""
     env_manager.setup_secure_defaults()
+    env_manager.ensure_openrag_version()
 
     if not env_manager.validate_config():
         console.print()
@@ -347,6 +349,7 @@ def _start_services_cli(
     env_manager = EnvManager()
     env_manager.load_existing_env()
     env_manager.setup_secure_defaults()
+    env_manager.ensure_openrag_version()
 
     if not env_manager.config.langflow_superuser_password:
         console.print("[red]✗ Error: Langflow password is required. Cannot start services.[/red]")

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -102,6 +102,7 @@ def test_container_port_conflict_from_own_containers_is_not_a_failure():
 def test_start_services_cli_ensures_openrag_version(tmp_path, monkeypatch):
     """CLI _start_services_cli must call ensure_openrag_version to set OPENRAG_VERSION in .env."""
     from unittest.mock import patch
+
     from tui.managers.env_manager import EnvManager
 
     env_file = tmp_path / ".env"
@@ -120,4 +121,3 @@ def test_start_services_cli_ensures_openrag_version(tmp_path, monkeypatch):
 
     assert env_file.exists()
     assert "OPENRAG_VERSION='9.9.9'" in env_file.read_text()
-

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -97,3 +97,27 @@ def test_container_port_conflict_from_own_containers_is_not_a_failure():
 
     assert fully_started is True
     assert "Startup incomplete" not in output
+
+
+def test_start_services_cli_ensures_openrag_version(tmp_path, monkeypatch):
+    """CLI _start_services_cli must call ensure_openrag_version to set OPENRAG_VERSION in .env."""
+    from unittest.mock import patch
+    from tui.managers.env_manager import EnvManager
+
+    env_file = tmp_path / ".env"
+    env_file.write_text("LANGFLOW_SUPERUSER_PASSWORD='secret'\n")
+
+    monkeypatch.delenv("OPENRAG_VERSION", raising=False)
+
+    with (
+        patch("utils.paths.get_tui_env_file", return_value=env_file),
+        patch("tui.utils.version_check.get_current_version", return_value="9.9.9"),
+    ):
+        _run(
+            StubContainerManager(events=[(True, "Started", False)]),
+            StubDoclingManager(running=True),
+        )
+
+    assert env_file.exists()
+    assert "OPENRAG_VERSION='9.9.9'" in env_file.read_text()
+

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -1,4 +1,5 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from rich.console import Console
 
@@ -101,10 +102,6 @@ def test_container_port_conflict_from_own_containers_is_not_a_failure():
 
 def test_start_services_cli_ensures_openrag_version(tmp_path, monkeypatch):
     """CLI _start_services_cli must call ensure_openrag_version to set OPENRAG_VERSION in .env."""
-    from unittest.mock import patch
-
-    from tui.managers.env_manager import EnvManager
-
     env_file = tmp_path / ".env"
     env_file.write_text("LANGFLOW_SUPERUSER_PASSWORD='secret'\n")
 


### PR DESCRIPTION
This pull request ensures that the `OPENRAG_VERSION` environment variable is consistently set in the `.env` file during CLI operations, improving environment reliability and version tracking. The key changes include invoking `ensure_openrag_version()` at critical points in the CLI flow and adding a unit test to verify this behavior.

Environment variable management improvements:

* Added calls to `env_manager.ensure_openrag_version()` in the main CLI entrypoint (`run_cli`), configuration validation (`_validate_and_save`), and service startup (`_start_services_cli`) to guarantee that `OPENRAG_VERSION` is always set in the environment. [[1]](diffhunk://#diff-0bec924887db4e2ee3d90750f5eb749ae1267edf0980a93c7dc4fbb59d88c30bR54) [[2]](diffhunk://#diff-0bec924887db4e2ee3d90750f5eb749ae1267edf0980a93c7dc4fbb59d88c30bR327) [[3]](diffhunk://#diff-0bec924887db4e2ee3d90750f5eb749ae1267edf0980a93c7dc4fbb59d88c30bR352)

Testing enhancements:

* Added a new unit test `test_start_services_cli_ensures_openrag_version` in `tests/unit/test_cli.py` to verify that `_start_services_cli` correctly sets the `OPENRAG_VERSION` in the `.env` file.