### PR TITLE
fix: remove setting the documents path on startup, set default langflow superuser

### DIFF
--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -351,6 +351,7 @@ def _start_services_cli(
 
     # Check for version mismatch before starting services / writing version
     if hasattr(container_manager, "check_version_mismatch"):
+
         async def _check_version():
             return await container_manager.check_version_mismatch()
 
@@ -358,12 +359,18 @@ def _start_services_cli(
         if has_mismatch and container_version:
             console.print()
             console.print("[bold yellow]⚠ Version Mismatch Detected[/bold yellow]")
-            console.print(f"  Existing containers are running version [bold]{container_version}[/bold]")
+            console.print(
+                f"  Existing containers are running version [bold]{container_version}[/bold]"
+            )
             console.print(f"  Current version is [bold]{cli_version}[/bold]\n")
-            console.print(f"  Starting services will update containers to version [bold]{cli_version}[/bold].")
+            console.print(
+                f"  Starting services will update containers to version [bold]{cli_version}[/bold]."
+            )
             console.print("  This may cause compatibility issues with your flows.\n")
             console.print("  [yellow]⚠️  Please backup your flows before continuing.[/yellow]")
-            console.print("     Customizations to OpenRAG built-in flows are backed up in ~/.openrag/flows/backup/")
+            console.print(
+                "     Customizations to OpenRAG built-in flows are backed up in ~/.openrag/flows/backup/"
+            )
             console.print("     Other user created flows are not backed up automatically.\n")
             try:
                 proceed = input("Do you want to continue? [y/N]: ").strip().lower()

--- a/src/tui/cli.py
+++ b/src/tui/cli.py
@@ -51,7 +51,6 @@ def run_cli():
         pass  # Non-critical bootstrap errors
 
     env_manager = EnvManager()
-    env_manager.ensure_openrag_version()
     container_manager = ContainerManager()
     docling_manager = DoclingManager()
 
@@ -349,11 +348,37 @@ def _start_services_cli(
     env_manager = EnvManager()
     env_manager.load_existing_env()
     env_manager.setup_secure_defaults()
+
+    # Check for version mismatch before starting services / writing version
+    if hasattr(container_manager, "check_version_mismatch"):
+        async def _check_version():
+            return await container_manager.check_version_mismatch()
+
+        has_mismatch, container_version, cli_version = asyncio.run(_check_version())
+        if has_mismatch and container_version:
+            console.print()
+            console.print("[bold yellow]⚠ Version Mismatch Detected[/bold yellow]")
+            console.print(f"  Existing containers are running version [bold]{container_version}[/bold]")
+            console.print(f"  Current version is [bold]{cli_version}[/bold]\n")
+            console.print(f"  Starting services will update containers to version [bold]{cli_version}[/bold].")
+            console.print("  This may cause compatibility issues with your flows.\n")
+            console.print("  [yellow]⚠️  Please backup your flows before continuing.[/yellow]")
+            console.print("     Customizations to OpenRAG built-in flows are backed up in ~/.openrag/flows/backup/")
+            console.print("     Other user created flows are not backed up automatically.\n")
+            try:
+                proceed = input("Do you want to continue? [y/N]: ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                console.print()
+                proceed = "n"
+            if proceed != "y":
+                console.print("[yellow]Start cancelled.[/yellow]")
+                return False
+
     env_manager.ensure_openrag_version()
 
     if not env_manager.config.langflow_superuser_password:
         console.print("[red]✗ Error: Langflow password is required. Cannot start services.[/red]")
-        return
+        return False
 
     console.print()
     console.print("Starting OpenRAG services...", style="bold")

--- a/src/tui/config_fields.py
+++ b/src/tui/config_fields.py
@@ -149,8 +149,8 @@ CONFIG_SECTIONS: list[ConfigSection] = [
                 "langflow_superuser",
                 "LANGFLOW_SUPERUSER",
                 "Admin Username",
-                placeholder="admin",
-                default="admin",
+                placeholder="langflow",
+                default="langflow",
             ),
             ConfigField(
                 "langflow_data_path",

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -488,18 +488,6 @@ def copy_sample_documents(*, force: bool = False) -> None:
         logger.debug(f"Could not copy sample documents: {e}")
         # This is not a critical error - the app can work without sample documents
 
-    # Ensure OPENRAG_DOCUMENTS_PATH in .env points to the resolved documents directory.
-    # Docker Compose uses this for the volume mount; if unset it defaults to ./openrag-documents
-    # (CWD-relative), which may not contain the PDFs copied above.
-    try:
-        from dotenv import set_key
-        resolved_path = str(documents_dir.resolve())
-        current = env_manager.config.openrag_documents_path
-        if not current or current in ("$HOME/.openrag/documents", "./openrag-documents", "./documents"):
-            set_key(str(env_manager.env_file), "OPENRAG_DOCUMENTS_PATH", resolved_path)
-            logger.debug(f"Set OPENRAG_DOCUMENTS_PATH={resolved_path} in {env_manager.env_file}")
-    except Exception as e:
-        logger.debug(f"Could not update OPENRAG_DOCUMENTS_PATH in .env: {e}")
 
 
 def copy_sample_flows(*, force: bool = False) -> None:

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -3,10 +3,14 @@
 import os
 import subprocess
 import sys
+from collections.abc import Iterable
 from pathlib import Path
-from typing import Iterable, Optional
+from typing import Optional
+
 from textual.app import App, ComposeResult
+
 from utils.logging_config import get_logger
+
 try:
     from importlib.resources import files
 except ImportError:
@@ -14,14 +18,14 @@ except ImportError:
 
 logger = get_logger(__name__)
 
-from .screens.welcome import WelcomeScreen
-from .screens.config import ConfigScreen
-from .screens.monitor import MonitorScreen
-from .screens.logs import LogsScreen
-from .screens.diagnostics import DiagnosticsScreen
-from .managers.env_manager import EnvManager
 from .managers.container_manager import ContainerManager
 from .managers.docling_manager import DoclingManager
+from .managers.env_manager import EnvManager
+from .screens.config import ConfigScreen
+from .screens.diagnostics import DiagnosticsScreen
+from .screens.logs import LogsScreen
+from .screens.monitor import MonitorScreen
+from .screens.welcome import WelcomeScreen
 from .utils.platform import PlatformDetector
 from .widgets.diagnostics_notification import notify_with_diagnostics
 
@@ -414,16 +418,20 @@ class OpenRAGTUI(App):
         # Check Podman macOS memory if applicable
         runtime_info = self.container_manager.get_runtime_info()
         if runtime_info.runtime_type.value == "podman":
-            is_sufficient, _, message = (
-                self.platform_detector.check_podman_macos_memory()
-            )
+            is_sufficient, _, message = self.platform_detector.check_podman_macos_memory()
             if not is_sufficient:
                 return False, f"Podman VM memory insufficient:\n{message}"
 
         return True, "Runtime requirements satisfied"
 
 
-def _copy_assets(resource_tree, destination: Path, allowed_suffixes: Optional[Iterable[str]] = None, *, force: bool = False) -> None:
+def _copy_assets(
+    resource_tree,
+    destination: Path,
+    allowed_suffixes: Iterable[str] | None = None,
+    *,
+    force: bool = False,
+) -> None:
     """Copy packaged assets into destination and optionally overwrite existing files.
 
     When ``force`` is True, files are refreshed if the packaged bytes differ.
@@ -437,7 +445,9 @@ def _copy_assets(resource_tree, destination: Path, allowed_suffixes: Optional[It
             _copy_assets(resource, target_path, allowed_suffixes, force=force)
             continue
 
-        if allowed_suffixes and not any(resource.name.endswith(suffix) for suffix in allowed_suffixes):
+        if allowed_suffixes and not any(
+            resource.name.endswith(suffix) for suffix in allowed_suffixes
+        ):
             continue
         resource_bytes = resource.read_bytes()
 
@@ -461,8 +471,9 @@ def copy_sample_documents(*, force: bool = False) -> None:
     Uses the first path from OPENRAG_DOCUMENTS_PATHS env var.
     Defaults to ~/.openrag/documents if not configured.
     """
-    from .managers.env_manager import EnvManager
     from pathlib import Path
+
+    from .managers.env_manager import EnvManager
 
     # Get the configured documents path from env
     env_manager = EnvManager()
@@ -471,7 +482,7 @@ def copy_sample_documents(*, force: bool = False) -> None:
     # Parse the first path from the documents paths config
     documents_path_str = env_manager.config.openrag_documents_paths
     if documents_path_str:
-        first_path = documents_path_str.split(',')[0].strip()
+        first_path = documents_path_str.split(",")[0].strip()
         # Expand $HOME and ~
         first_path = first_path.replace("$HOME", str(Path.home()))
         documents_dir = Path(first_path).expanduser()
@@ -487,7 +498,6 @@ def copy_sample_documents(*, force: bool = False) -> None:
     except Exception as e:
         logger.debug(f"Could not copy sample documents: {e}")
         # This is not a critical error - the app can work without sample documents
-
 
 
 def copy_sample_flows(*, force: bool = False) -> None:
@@ -538,7 +548,9 @@ def copy_compose_files(*, force: bool = False) -> None:
                     if destination.read_bytes() == resource_bytes:
                         continue
                 except Exception as read_error:
-                    logger.debug(f"Failed to read existing compose file {destination}: {read_error}")
+                    logger.debug(
+                        f"Failed to read existing compose file {destination}: {read_error}"
+                    )
 
             destination.write_bytes(resource_bytes)
             logger.info(f"Copied docker-compose template to {destination}")
@@ -587,6 +599,7 @@ def migrate_legacy_data_directories():
         # Still need to update .env with centralized paths
         try:
             from managers.env_manager import EnvManager
+
             env_manager = EnvManager()
             env_manager.load_existing_env()
             # Explicitly set centralized paths (overrides any old CWD-relative paths)
@@ -608,7 +621,7 @@ def migrate_legacy_data_directories():
     print("\n" + "=" * 60)
     print("  OpenRAG Data Migration Required")
     print("=" * 60)
-    print(f"\nStarting with this version, OpenRAG stores data in:")
+    print("\nStarting with this version, OpenRAG stores data in:")
     print(f"  {target_base}")
     print("\nThe following will be copied from your current directory:")
     for source, target, desc in sources_to_migrate:
@@ -666,6 +679,7 @@ def migrate_legacy_data_directories():
     # Update .env file with centralized paths
     try:
         from managers.env_manager import EnvManager
+
         env_manager = EnvManager()
         env_manager.load_existing_env()
         # Explicitly set centralized paths (overrides any old CWD-relative paths)
@@ -711,11 +725,7 @@ def _reclaim_host_ownership(directories: list[Path]) -> None:
     if not needs_reclaim:
         return
 
-    runtime = (
-        "docker" if _shutil.which("docker")
-        else "podman" if _shutil.which("podman")
-        else None
-    )
+    runtime = "docker" if _shutil.which("docker") else "podman" if _shutil.which("podman") else None
     if not runtime:
         logger.error("No container runtime found; cannot reclaim directory ownership")
         return
@@ -724,9 +734,16 @@ def _reclaim_host_ownership(directories: list[Path]) -> None:
         try:
             subprocess.run(
                 [
-                    runtime, "run", "--rm",
-                    "-v", f"{directory}:/mnt/target",
-                    "alpine", "chown", "-R", f"{host_uid}:{host_gid}", "/mnt/target",
+                    runtime,
+                    "run",
+                    "--rm",
+                    "-v",
+                    f"{directory}:/mnt/target",
+                    "alpine",
+                    "chown",
+                    "-R",
+                    f"{host_uid}:{host_gid}",
+                    "/mnt/target",
                 ],
                 check=True,
                 capture_output=True,
@@ -765,9 +782,11 @@ def generate_jwt_keys(keys_dir: Path):
             [
                 "openssl",
                 "rsa",
-                "-in", str(private_key_path),
+                "-in",
+                str(private_key_path),
                 "-pubout",
-                "-out", str(public_key_path),
+                "-out",
+                str(public_key_path),
             ],
             check=True,
             capture_output=True,
@@ -777,7 +796,9 @@ def generate_jwt_keys(keys_dir: Path):
 
         logger.info("Generated RSA keys for JWT signing")
     except FileNotFoundError:
-        logger.warning("openssl not found, skipping JWT key generation (will be generated in container)")
+        logger.warning(
+            "openssl not found, skipping JWT key generation (will be generated in container)"
+        )
     except subprocess.CalledProcessError as e:
         logger.error(f"Failed to generate RSA keys: {e}")
 
@@ -865,6 +886,7 @@ def _resolve_langflow_data_path(base_dir: Path) -> Path:
     default = base_dir / "data" / "langflow-data"
     try:
         from .managers.env_manager import EnvManager
+
         env_manager = EnvManager()
         env_manager.load_existing_env()
         raw = env_manager.config.langflow_data_path
@@ -913,7 +935,7 @@ def _run_tui_app():
         logger.error("Error running OpenRAG TUI", error=str(e))
     finally:
         # Ensure cleanup happens even on exceptions
-        if app and hasattr(app, 'docling_manager'):
+        if app and hasattr(app, "docling_manager"):
             app.docling_manager.cleanup()
         sys.exit(0)
 
@@ -935,6 +957,7 @@ def run_tui():
 
     # Check for native Windows before launching anything
     from .utils.platform import PlatformDetector
+
     platform_detector = PlatformDetector()
 
     if platform_detector.is_native_windows():
@@ -947,6 +970,7 @@ def run_tui():
 
     # Run startup prerequisites (install runtime, health checks, etc.)
     from .utils.startup_checks import run_startup_checks
+
     if not run_startup_checks():
         sys.exit(1)
 
@@ -954,6 +978,7 @@ def run_tui():
         _run_tui_app()
     else:
         from .cli import run_cli
+
         run_cli()
 
 

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -5,11 +5,17 @@ import subprocess
 import sys
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Optional
 
-from textual.app import App, ComposeResult
+from textual.app import App
 
 from utils.logging_config import get_logger
+
+from .managers.container_manager import ContainerManager
+from .managers.docling_manager import DoclingManager
+from .managers.env_manager import EnvManager
+from .screens.welcome import WelcomeScreen
+from .utils.platform import PlatformDetector
+from .widgets.diagnostics_notification import notify_with_diagnostics
 
 try:
     from importlib.resources import files
@@ -17,17 +23,6 @@ except ImportError:
     from importlib_resources import files
 
 logger = get_logger(__name__)
-
-from .managers.container_manager import ContainerManager
-from .managers.docling_manager import DoclingManager
-from .managers.env_manager import EnvManager
-from .screens.config import ConfigScreen
-from .screens.diagnostics import DiagnosticsScreen
-from .screens.logs import LogsScreen
-from .screens.monitor import MonitorScreen
-from .screens.welcome import WelcomeScreen
-from .utils.platform import PlatformDetector
-from .widgets.diagnostics_notification import notify_with_diagnostics
 
 
 class OpenRAGTUI(App):
@@ -399,7 +394,7 @@ class OpenRAGTUI(App):
             )
 
         # Load existing config if available
-        config_exists = self.env_manager.load_existing_env()
+        self.env_manager.load_existing_env()
 
         # Start with welcome screen
         self.push_screen(WelcomeScreen())

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -599,6 +599,7 @@ def migrate_legacy_data_directories():
         # Still need to update .env with centralized paths
         try:
             from .managers.env_manager import EnvManager
+
             env_manager = EnvManager()
             env_manager.load_existing_env()
             # Explicitly set centralized paths (overrides any old CWD-relative paths)
@@ -678,6 +679,7 @@ def migrate_legacy_data_directories():
     # Update .env file with centralized paths
     try:
         from .managers.env_manager import EnvManager
+
         env_manager = EnvManager()
         env_manager.load_existing_env()
         # Explicitly set centralized paths (overrides any old CWD-relative paths)

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -5,6 +5,7 @@ import subprocess
 import sys
 from collections.abc import Iterable
 from pathlib import Path
+from typing import Literal
 
 from textual.app import App
 
@@ -20,7 +21,7 @@ from .widgets.diagnostics_notification import notify_with_diagnostics
 try:
     from importlib.resources import files
 except ImportError:
-    from importlib_resources import files
+    from importlib_resources import files  # type: ignore[no-redef]
 
 logger = get_logger(__name__)
 
@@ -372,7 +373,7 @@ class OpenRAGTUI(App):
         message: str,
         *,
         title: str = "",
-        severity: str = "information",
+        severity: Literal["information", "warning", "error"] = "information",
         timeout: float | None = None,
         markup: bool = True,
     ) -> None:

--- a/src/tui/main.py
+++ b/src/tui/main.py
@@ -598,8 +598,7 @@ def migrate_legacy_data_directories():
         marker.touch()
         # Still need to update .env with centralized paths
         try:
-            from managers.env_manager import EnvManager
-
+            from .managers.env_manager import EnvManager
             env_manager = EnvManager()
             env_manager.load_existing_env()
             # Explicitly set centralized paths (overrides any old CWD-relative paths)
@@ -678,8 +677,7 @@ def migrate_legacy_data_directories():
 
     # Update .env file with centralized paths
     try:
-        from managers.env_manager import EnvManager
-
+        from .managers.env_manager import EnvManager
         env_manager = EnvManager()
         env_manager.load_existing_env()
         # Explicitly set centralized paths (overrides any old CWD-relative paths)

--- a/src/tui/managers/env_manager.py
+++ b/src/tui/managers/env_manager.py
@@ -43,7 +43,7 @@ class EnvConfig:
     langflow_port: str = "7860"
     opensearch_index_name: str = "documents"
     langflow_secret_key: str = ""
-    langflow_superuser: str = "admin"
+    langflow_superuser: str = "langflow"
     langflow_superuser_password: str = ""
     langflow_chat_flow_id: str = "1098eea1-6649-4e1d-aed1-b77249fb8dd0"
     langflow_ingest_flow_id: str = "5488df7c-b93f-4f87-a446-b67028bc0813"
@@ -481,7 +481,7 @@ class EnvManager:
                     f"LANGFLOW_SECRET_KEY={self._quote_env_value(self.config.langflow_secret_key)}\n"
                 )
                 f.write(
-                    f"LANGFLOW_SUPERUSER={self._quote_env_value(self.config.langflow_superuser or 'admin')}\n"
+                    f"LANGFLOW_SUPERUSER={self._quote_env_value(self.config.langflow_superuser or 'langflow')}\n"
                 )
                 f.write(
                     f"LANGFLOW_SUPERUSER_PASSWORD={self._quote_env_value(self.config.langflow_superuser_password)}\n"

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -151,4 +151,3 @@ def test_start_services_cli_version_mismatch_warning(tmp_path, monkeypatch):
 
     assert fully_started is True
     assert "Version Mismatch Detected" in output
-

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -118,3 +118,37 @@ def test_start_services_cli_ensures_openrag_version(tmp_path, monkeypatch):
 
     assert env_file.exists()
     assert "OPENRAG_VERSION='9.9.9'" in env_file.read_text()
+
+
+def test_start_services_cli_version_mismatch_warning(tmp_path, monkeypatch):
+    """CLI _start_services_cli surfaces version mismatch warning notice."""
+    env_file = tmp_path / ".env"
+    env_file.write_text("LANGFLOW_SUPERUSER_PASSWORD='secret'\n")
+
+    class MismatchContainerManager(StubContainerManager):
+        async def check_version_mismatch(self):
+            return True, "0.5.0", "0.7.0"
+
+    # Test user cancelling prompt ('n')
+    monkeypatch.setattr("builtins.input", lambda prompt="": "n")
+    with patch("utils.paths.get_tui_env_file", return_value=env_file):
+        fully_started, output = _run(
+            MismatchContainerManager(events=[(True, "Started", False)]),
+            StubDoclingManager(running=True),
+        )
+
+    assert fully_started is False
+    assert "Version Mismatch Detected" in output
+    assert "Start cancelled" in output
+
+    # Test user accepting prompt ('y')
+    monkeypatch.setattr("builtins.input", lambda prompt="": "y")
+    with patch("utils.paths.get_tui_env_file", return_value=env_file):
+        fully_started, output = _run(
+            MismatchContainerManager(events=[(True, "Started", False)]),
+            StubDoclingManager(running=True),
+        )
+
+    assert fully_started is True
+    assert "Version Mismatch Detected" in output
+

--- a/tests/unit/test_env_manager.py
+++ b/tests/unit/test_env_manager.py
@@ -240,7 +240,7 @@ class TestLangflowPasswordAndAutoLogin:
         content = env_file.read_text()
         assert "LANGFLOW_SUPERUSER_PASSWORD='LangflowPass123!'" in content
         assert "LANGFLOW_AUTO_LOGIN='True'" in content
-        assert "LANGFLOW_SUPERUSER='admin'" in content
+        assert "LANGFLOW_SUPERUSER='langflow'" in content
 
     def test_validate_config_requires_langflow_password(self, env_manager):
         env_manager.config.opensearch_password = "Pass123!"


### PR DESCRIPTION
This pull request updates the default superuser username for Langflow from "admin" to "langflow" throughout the codebase, ensuring consistency in configuration, environment file generation, and tests. Additionally, it removes logic that automatically updates the `OPENRAG_DOCUMENTS_PATH` in the `.env` file if unset.

**Langflow superuser username changes:**

* Changed the default value and placeholder for `langflow_superuser` from "admin" to "langflow" in the `ConfigSection` and `EnvConfig` classes, and updated the environment file writing logic to reflect this new default. [[1]](diffhunk://#diff-6e41c9c8008a4d431a159062b3a21caf92777fca9736a36db3e84f5bbe894f95L152-R153) [[2]](diffhunk://#diff-5408077f55d63f67ee40e20ce9b6b1a19f84af6dfe1efaab8a8b4a731739bbc7L46-R46) [[3]](diffhunk://#diff-5408077f55d63f67ee40e20ce9b6b1a19f84af6dfe1efaab8a8b4a731739bbc7L484-R484)
* Updated the corresponding unit test assertion to expect "langflow" as the default superuser username.

**Environment variable management:**

* Removed the code that automatically updates `OPENRAG_DOCUMENTS_PATH` in the `.env` file if it is unset or set to a default path, simplifying environment variable management.