### PR TITLE
fix: remove mention of docs.openr.ag

### DIFF
--- a/docs/static/CNAME
+++ b/docs/static/CNAME
@@ -1,1 +1,0 @@
-docs.openr.ag


### PR DESCRIPTION
Docs now live in at www.openr.ag/docs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed the configured custom domain for the documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->