### PR TITLE
fix: update vlm prompt

### DIFF
--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -274,9 +274,12 @@ class KnowledgeConfig:
     vlm_provider: str = "openai"  # "openai" | "watsonx" | "anthropic" | "local" | "ollama"
     vlm_model: str = ""  # e.g. "gpt-4o" or a watsonx model_id
     vlm_prompt: str = (
-        "Extract ALL the text from the page, ensuring no words are omitted, "
-        "and present it as accurately as possible. "
-        "Then describe the content of the page in English."
+        "Describe the visual content of this image in plain English. "
+        "Include layout, structure, colors, shapes, diagrams, charts, and any visible elements. "
+        "If the image contains text, reproduce it exactly as it appears. "
+        "If there is no text, do not mention text. "
+        "Do not ask follow-up questions. Do not add commentary or suggestions. "
+        "Respond only with the description."
     )
     # Per-page VLM response format only; the docling-serve output stays
     # to_formats="json" so downstream json_content consumers are unaffected.


### PR DESCRIPTION
Updates the VLM prompt to avoid responses like this

<img width="2048" height="410" alt="image" src="https://github.com/user-attachments/assets/56758c64-ff95-4e45-8550-5f19fa4bee32" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced visual image descriptions with clearer coverage of layouts, colors, shapes, diagrams, charts, and visible elements.
  * Preserves text exactly as displayed and avoids unnecessary commentary when no text is present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->