### PR TITLE
fix: make connector webhook auto-sync process and remove warning when deleting a file from source

### DIFF
--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -119,6 +119,29 @@ async def _webhook_sync_jwt(connector_service, session_manager, connection, user
     return session_manager.get_effective_jwt_token(connection.user_id, jwt_token)
 
 
+def _webhook_cursor_snapshot(connector) -> tuple[Any, Any]:
+    cfg = getattr(connector, "cfg", None)
+    page_token = getattr(cfg, "changes_page_token", None) if cfg is not None else None
+    return page_token, getattr(connector, "_delta_link", None)
+
+
+def _restore_webhook_cursor(connector, snapshot: tuple[Any, Any]) -> None:
+    page_token, delta_link = snapshot
+    cfg = getattr(connector, "cfg", None)
+    if cfg is not None and hasattr(cfg, "changes_page_token"):
+        cfg.changes_page_token = page_token
+    if hasattr(connector, "_delta_link"):
+        connector._delta_link = delta_link
+
+
+async def _persist_webhook_cursor_after_processing(connector_service, connection, connector) -> None:
+    """Persist cursors via ConnectorService after scope lookup / sync succeed."""
+    persist_fn = getattr(type(connector_service), "persist_webhook_cursor", None)
+    if not callable(persist_fn):
+        return
+    await connector_service.persist_webhook_cursor(connection, connector)
+
+
 def _connector_sync_should_replace(connector_type: str) -> bool:
     """Return True when sync should replace existing indexed files for this
     connector type, so content changes propagate on re-sync.
@@ -1835,6 +1858,7 @@ async def connector_webhook(
             return JSONResponse({"status": "ignored_unknown_channel", "channel_id": channel_id})
 
         # Process webhook for the specific connection
+        cursor_snapshot: tuple[Any, Any] | None = None
         try:
             # Get the connector instance
             connector = await connector_service._get_connector(connection.connection_id)
@@ -1845,21 +1869,12 @@ async def connector_webhook(
                 )
                 return JSONResponse({"status": "error", "reason": "connector_not_found"})
 
-            # Let the connector handle the webhook and return affected file IDs
+            # Let the connector handle the webhook and return affected file IDs.
+            # Cursor persistence waits until scope lookup (and sync, when
+            # needed) succeed, so a failed queue leaves the cursor unadvanced
+            # and the next notification can reprocess the same changes.
+            cursor_snapshot = _webhook_cursor_snapshot(connector)
             affected_files = await connector.handle_webhook(payload)
-            persist_cursor = getattr(
-                type(connector_service.connection_manager), "persist_webhook_cursor", None
-            )
-            if callable(persist_cursor):
-                try:
-                    await connector_service.connection_manager.persist_webhook_cursor(
-                        connection, connector
-                    )
-                except Exception:
-                    logger.exception(
-                        "Failed to persist webhook change cursor",
-                        connection_id=connection.connection_id,
-                    )
 
             user = session_manager.get_user(connection.user_id)
             jwt_token = await _webhook_sync_jwt(
@@ -1936,6 +1951,10 @@ async def connector_webhook(
                     "reason": "no_specific_files",
                 }
 
+            await _persist_webhook_cursor_after_processing(
+                connector_service, connection, connector
+            )
+
             return JSONResponse(
                 {
                     "status": "processed",
@@ -1946,6 +1965,8 @@ async def connector_webhook(
             )
 
         except Exception as e:
+            if cursor_snapshot is not None:
+                _restore_webhook_cursor(connector, cursor_snapshot)
             logger.exception(
                 "[CONNECTOR] Failed to process webhook",
                 connection_id=connection.connection_id,

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -1,4 +1,5 @@
 import copy
+import json
 from datetime import UTC, datetime
 from typing import Any
 
@@ -69,6 +70,53 @@ async def _allowed_connector_types_for_request(
         return connector_types
     access_map = await get_access_map(session)
     return [t for t in connector_types if access_map.get(t, True)]
+
+
+async def _parse_connector_webhook_payload(
+    request: Request,
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Read a connector webhook body without 500ing on Google Drive's empty POST.
+
+    Drive push notifications set ``Content-Type: application/json`` and send an
+    empty body — the channel id is only in ``X-Goog-*`` headers. ``request.json()``
+    raises ``JSONDecodeError`` on that payload, which used to abort the whole
+    handler before any sync ran.
+    """
+    headers = dict(request.headers)
+    if request.method != "POST":
+        return dict(request.query_params), headers
+
+    body = await request.body()
+    content_type = headers.get("content-type", "").lower()
+    if "application/json" in content_type:
+        if not body:
+            return {}, headers
+        try:
+            parsed = json.loads(body)
+        except json.JSONDecodeError:
+            return {"raw_body": body.decode("utf-8", errors="replace")}, headers
+        if isinstance(parsed, dict):
+            return parsed, headers
+        return {"_json": parsed}, headers
+
+    return {"raw_body": body.decode("utf-8", errors="replace") if body else ""}, headers
+
+
+async def _webhook_sync_jwt(connector_service, session_manager, connection, user) -> str | None:
+    """Mint the same OpenSearch JWT sync uses, even when no browser session is live.
+
+    Connector webhooks arrive from Google/Graph, not the logged-in user. Looking
+    up ``user.jwt_token`` then querying indexed files under DLS returned an empty
+    set whenever the user wasn't in the in-memory session, so every change was
+    dropped as out-of-scope.
+    """
+    jwt_token = user.jwt_token if user else None
+    get_jwt = getattr(type(connector_service), "_get_effective_sync_jwt", None)
+    if callable(get_jwt):
+        return await connector_service._get_effective_sync_jwt(connection.user_id, jwt_token)
+    if session_manager is None:
+        return jwt_token
+    return session_manager.get_effective_jwt_token(connection.user_id, jwt_token)
 
 
 def _connector_sync_should_replace(connector_type: str) -> bool:
@@ -1761,23 +1809,7 @@ async def connector_webhook(
         pass
 
     try:
-        # Get the raw payload and headers
-        payload = {}
-        headers = dict(request.headers)
-
-        if request.method == "POST":
-            content_type = headers.get("content-type", "").lower()
-            if "application/json" in content_type:
-                payload = await request.json()
-            else:
-                # Some webhooks send form data or plain text
-                body = await request.body()
-                payload = {"raw_body": body.decode("utf-8") if body else ""}
-        else:
-            # GET webhooks use query params
-            payload = dict(request.query_params)
-
-        # Add headers to payload for connector processing
+        payload, headers = await _parse_connector_webhook_payload(request)
         payload["_headers"] = headers
         payload["_method"] = request.method
 
@@ -1815,9 +1847,24 @@ async def connector_webhook(
 
             # Let the connector handle the webhook and return affected file IDs
             affected_files = await connector.handle_webhook(payload)
+            persist_cursor = getattr(
+                type(connector_service.connection_manager), "persist_webhook_cursor", None
+            )
+            if callable(persist_cursor):
+                try:
+                    await connector_service.connection_manager.persist_webhook_cursor(
+                        connection, connector
+                    )
+                except Exception:
+                    logger.exception(
+                        "Failed to persist webhook change cursor",
+                        connection_id=connection.connection_id,
+                    )
 
             user = session_manager.get_user(connection.user_id)
-            jwt_token = user.jwt_token if user else None
+            jwt_token = await _webhook_sync_jwt(
+                connector_service, session_manager, connection, user
+            )
 
             # Scope guard: a connection's picker selection is not persisted, so
             # the connector can't filter the change feed to it. Restrict webhook

--- a/src/api/connectors.py
+++ b/src/api/connectors.py
@@ -134,7 +134,9 @@ def _restore_webhook_cursor(connector, snapshot: tuple[Any, Any]) -> None:
         connector._delta_link = delta_link
 
 
-async def _persist_webhook_cursor_after_processing(connector_service, connection, connector) -> None:
+async def _persist_webhook_cursor_after_processing(
+    connector_service, connection, connector
+) -> None:
     """Persist cursors via ConnectorService after scope lookup / sync succeed."""
     persist_fn = getattr(type(connector_service), "persist_webhook_cursor", None)
     if not callable(persist_fn):
@@ -1951,9 +1953,7 @@ async def connector_webhook(
                     "reason": "no_specific_files",
                 }
 
-            await _persist_webhook_cursor_after_processing(
-                connector_service, connection, connector
-            )
+            await _persist_webhook_cursor_after_processing(connector_service, connection, connector)
 
             return JSONResponse(
                 {

--- a/src/app/lifespan.py
+++ b/src/app/lifespan.py
@@ -71,12 +71,12 @@ async def _periodic_backup(services):
 async def _periodic_webhook_renewal(services):
     """Renew connector webhook subscriptions before they expire.
 
-    The first pass is forced: a stored expiration does not mean Google/Graph
-    is still watching. Backend restarts used to cancel provider channels on
-    shutdown and then skip renewal because expiry was still hours away, so
-    rename/change notifications went silent until the user reconnected.
+    Recreate only expired, near-expiry, or missing channels. Shutdown no
+    longer cancels Google/Graph watches, so a force-recreate on every
+    process start is unnecessary and harmful: Drive cannot PATCH a channel,
+    so force means stop-then-create. If stop succeeds and create fails
+    (or the tunnel is down), auto-sync stays dead until the user reconnects.
 
-    Later passes only recreate channels that are expired or near expiry.
     Provider subscriptions are short-lived (Google Drive ~24h, Microsoft
     Graph 3 days) and go silent without renewal.
     """
@@ -88,7 +88,6 @@ async def _periodic_webhook_renewal(services):
     # Connections are loaded in ConnectorService.initialize() before uvicorn
     # serves. A short settle lets OAuth clients come up; do not wait a full
     # minute — auto-sync should work as soon as the process is up.
-    first_pass = True
     await asyncio.sleep(2)
 
     while True:
@@ -97,9 +96,7 @@ async def _periodic_webhook_renewal(services):
             if connector_service:
                 stats = await connector_service.connection_manager.renew_expiring_subscriptions(
                     WEBHOOK_RENEWAL_THRESHOLD_SECONDS,
-                    force=first_pass,
                 )
-                first_pass = False
                 if stats["renewed"] or stats["failed"]:
                     logger.info("Webhook subscription renewal pass completed", **stats)
                 else:

--- a/src/app/lifespan.py
+++ b/src/app/lifespan.py
@@ -35,46 +35,6 @@ from utils.telemetry import Category, MessageId, TelemetryClient
 logger = get_logger(__name__)
 
 
-async def cleanup_subscriptions_proper(services):
-    """Cancel all active webhook subscriptions"""
-    logger.info("Cancelling active webhook subscriptions")
-
-    try:
-        connector_service = services["connector_service"]
-        await connector_service.connection_manager.load_connections()
-
-        all_connections = await connector_service.connection_manager.list_connections()
-        active_connections = [
-            c for c in all_connections if c.is_active and c.config.get("webhook_channel_id")
-        ]
-
-        for connection in active_connections:
-            try:
-                logger.info(
-                    "Cancelling subscription for connection",
-                    connection_id=connection.connection_id,
-                )
-                connector = await connector_service.get_connector(connection.connection_id)
-                if connector:
-                    subscription_id = connection.config.get("webhook_channel_id")
-                    await connector.cleanup_subscription(subscription_id)
-                    logger.info("Cancelled subscription", subscription_id=subscription_id)
-            except Exception as e:
-                logger.error(
-                    "Failed to cancel subscription",
-                    connection_id=connection.connection_id,
-                    error=str(e),
-                )
-
-        logger.info(
-            "Finished cancelling subscriptions",
-            subscription_count=len(active_connections),
-        )
-
-    except Exception as e:
-        logger.error("Failed to cleanup subscriptions", error=str(e))
-
-
 async def _periodic_backup(services):
     """Run flow backups every 5 minutes once onboarding is complete."""
     while True:
@@ -111,26 +71,35 @@ async def _periodic_backup(services):
 async def _periodic_webhook_renewal(services):
     """Renew connector webhook subscriptions before they expire.
 
-    Checks immediately at startup (subscriptions may have lapsed while the
-    app was down), then on a fixed interval. Provider subscriptions are
-    short-lived (Google Drive ~24h, Microsoft Graph 3 days) and go silent
-    without renewal.
+    The first pass is forced: a stored expiration does not mean Google/Graph
+    is still watching. Backend restarts used to cancel provider channels on
+    shutdown and then skip renewal because expiry was still hours away, so
+    rename/change notifications went silent until the user reconnected.
+
+    Later passes only recreate channels that are expired or near expiry.
+    Provider subscriptions are short-lived (Google Drive ~24h, Microsoft
+    Graph 3 days) and go silent without renewal.
     """
     from config.settings import (
         WEBHOOK_RENEWAL_INTERVAL_SECONDS,
         WEBHOOK_RENEWAL_THRESHOLD_SECONDS,
     )
 
-    # Let startup_tasks finish loading connections before the first pass
-    await asyncio.sleep(60)
+    # Connections are loaded in ConnectorService.initialize() before uvicorn
+    # serves. A short settle lets OAuth clients come up; do not wait a full
+    # minute — auto-sync should work as soon as the process is up.
+    first_pass = True
+    await asyncio.sleep(2)
 
     while True:
         try:
             connector_service = services.get("connector_service")
             if connector_service:
                 stats = await connector_service.connection_manager.renew_expiring_subscriptions(
-                    WEBHOOK_RENEWAL_THRESHOLD_SECONDS
+                    WEBHOOK_RENEWAL_THRESHOLD_SECONDS,
+                    force=first_pass,
                 )
+                first_pass = False
                 if stats["renewed"] or stats["failed"]:
                     logger.info("Webhook subscription renewal pass completed", **stats)
                 else:
@@ -414,7 +383,10 @@ async def run_shutdown(app: FastAPI):
     except Exception as e:
         logger.error("Error during graceful OpenSearch shutdown", error=str(e))
 
-    await cleanup_subscriptions_proper(services)
+    # Leave Google/Graph webhook channels in place across process restarts.
+    # Cancelling them here made auto-sync dead until the next reconnect:
+    # stored webhook_expiration still looked healthy, so startup renewal
+    # skipped recreation while the provider had already stopped notifying.
     # Cleanup task service (cancels background tasks and process pool)
     await services["task_service"].shutdown()
     # Cleanup async clients (this will also close OpenSearch client if not already closed)

--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -725,12 +725,19 @@ class ConnectionManager:
         if changed:
             await self.save_connections()
 
-    async def renew_expiring_subscriptions(self, threshold_seconds: int) -> dict[str, int]:
+    async def renew_expiring_subscriptions(
+        self, threshold_seconds: int, *, force: bool = False
+    ) -> dict[str, int]:
         """Renew webhook subscriptions that are expired, near expiry, or missing.
 
         Connections with a webhook_url but no live subscription (failed initial
         setup) are healed here too. Failures are per-connection; one bad
         connection never blocks the rest. Returns counters for logging.
+
+        ``force=True`` ignores stored expiration and re-establishes every
+        watched connection. Use that on process start: a far-future
+        ``webhook_expiration`` does not mean the provider channel survived
+        the previous process.
         """
         stats = {"checked": 0, "renewed": 0, "failed": 0, "skipped": 0}
         now = datetime.now(UTC)
@@ -743,7 +750,7 @@ class ConnectionManager:
 
             channel_id = _stored_webhook_subscription_id(connection.config)
             has_subscription = bool(channel_id)
-            if has_subscription:
+            if has_subscription and not force:
                 expiration = _parse_webhook_expiration(connection.config.get("webhook_expiration"))
                 if expiration and (expiration - now).total_seconds() > threshold_seconds:
                     stats["skipped"] += 1

--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -701,7 +701,29 @@ class ConnectionManager:
         page_token = getattr(getattr(connector, "cfg", None), "changes_page_token", None)
         if page_token:
             cfg["changes_page_token"] = page_token
+        delta_link = getattr(connector, "_delta_link", None)
+        if delta_link:
+            cfg["delta_link"] = delta_link
         await self.save_connections()
+
+    async def persist_webhook_cursor(
+        self, connection_config: ConnectionConfig, connector: BaseConnector
+    ) -> None:
+        """Save Drive/Graph change cursors after a webhook so the next
+        notification (or a process restart) does not skip or re-scan changes.
+        """
+        cfg = connection_config.config
+        changed = False
+        page_token = getattr(getattr(connector, "cfg", None), "changes_page_token", None)
+        if page_token and cfg.get("changes_page_token") != page_token:
+            cfg["changes_page_token"] = page_token
+            changed = True
+        delta_link = getattr(connector, "_delta_link", None)
+        if delta_link and cfg.get("delta_link") != delta_link:
+            cfg["delta_link"] = delta_link
+            changed = True
+        if changed:
+            await self.save_connections()
 
     async def renew_expiring_subscriptions(self, threshold_seconds: int) -> dict[str, int]:
         """Renew webhook subscriptions that are expired, near expiry, or missing.

--- a/src/connectors/connection_manager.py
+++ b/src/connectors/connection_manager.py
@@ -719,8 +719,14 @@ class ConnectionManager:
             cfg["changes_page_token"] = page_token
             changed = True
         delta_link = getattr(connector, "_delta_link", None)
-        if delta_link and cfg.get("delta_link") != delta_link:
-            cfg["delta_link"] = delta_link
+        if delta_link:
+            if cfg.get("delta_link") != delta_link:
+                cfg["delta_link"] = delta_link
+                changed = True
+        elif "delta_link" in cfg:
+            # Graph 410 reset: drop the invalid cursor so a restart does not
+            # keep sending it.
+            del cfg["delta_link"]
             changed = True
         if changed:
             await self.save_connections()
@@ -735,9 +741,9 @@ class ConnectionManager:
         connection never blocks the rest. Returns counters for logging.
 
         ``force=True`` ignores stored expiration and re-establishes every
-        watched connection. Use that on process start: a far-future
-        ``webhook_expiration`` does not mean the provider channel survived
-        the previous process.
+        watched connection. Do not use that on every process start: Drive
+        cannot extend a channel in place, so force is stop-then-create and
+        can leave auto-sync dead if recreation fails.
         """
         stats = {"checked": 0, "renewed": 0, "failed": 0, "skipped": 0}
         now = datetime.now(UTC)

--- a/src/connectors/google_drive/connector.py
+++ b/src/connectors/google_drive/connector.py
@@ -28,6 +28,21 @@ from .oauth import GoogleDriveOAuth
 logger = get_logger(__name__)
 
 
+def _http_error_is_not_found(err: Exception) -> bool:
+    """True when Google already dropped the watch (404 / notFound)."""
+    status = getattr(err, "status_code", None)
+    if status is None:
+        status = getattr(getattr(err, "resp", None), "status", None)
+    try:
+        status_int = int(status) if status is not None else None
+    except (TypeError, ValueError):
+        status_int = None
+    if status_int == 404:
+        return True
+    msg = str(err).lower()
+    return "notfound" in msg
+
+
 # -------------------------
 # Config model
 # -------------------------
@@ -1004,7 +1019,8 @@ class GoogleDriveConnector(BaseConnector):
         3) self.cfg.resource_id (as a last-resort override provided by caller/config)
 
         Returns:
-            bool: True if the stop call succeeded, otherwise False.
+            bool: True if the stop call succeeded or the channel is already
+            gone (404). False only when we cannot confirm it is stopped.
         """
         # 1) Ensure auth/service
         ok = await self.authenticate()
@@ -1050,25 +1066,29 @@ class GoogleDriveConnector(BaseConnector):
             self.service.channels().stop(
                 body={"id": subscription_id, "resourceId": resource_id}
             ).execute()
-
-            # 4) Clear local bookkeeping
-            if (
-                getattr(self, "_active_channel", None)
-                and self._active_channel.get("channel_id") == subscription_id
-            ):
-                self._active_channel = {}
-
-            if hasattr(self, "_subscriptions") and isinstance(self._subscriptions, dict):
-                self._subscriptions.pop(subscription_id, None)
-
-            return True
-
         except Exception as e:
-            try:
-                logger.error(f"cleanup_subscription failed for {subscription_id}: {e}")
-            except Exception:
-                pass
-            return False
+            if not _http_error_is_not_found(e):
+                try:
+                    logger.error(f"cleanup_subscription failed for {subscription_id}: {e}")
+                except Exception:
+                    pass
+                return False
+            logger.info(
+                "Google Drive webhook channel already gone; treating as cleaned up",
+                subscription_id=subscription_id,
+            )
+
+        # 4) Clear local bookkeeping
+        if (
+            getattr(self, "_active_channel", None)
+            and self._active_channel.get("channel_id") == subscription_id
+        ):
+            self._active_channel = {}
+
+        if hasattr(self, "_subscriptions") and isinstance(self._subscriptions, dict):
+            self._subscriptions.pop(subscription_id, None)
+
+        return True
 
     async def handle_webhook(self, payload: dict[str, Any]) -> list[str]:
         """
@@ -1387,6 +1407,7 @@ class GoogleDriveConnector(BaseConnector):
             return True
 
         except HttpError as e:
+            if _http_error_is_not_found(e):
+                return True
             logger.error("Failed to cleanup subscription", error=str(e))
-
             return False

--- a/src/connectors/onedrive/connector.py
+++ b/src/connectors/onedrive/connector.py
@@ -1144,13 +1144,26 @@ class OneDriveConnector(BaseConnector):
             # the delta query enumerates the whole drive, so only keep recently
             # modified files instead of re-syncing everything.
             first_sweep = self._delta_link is None
-            url = self._delta_link or f"{self._graph_base_url}/me/drive/root/delta"
+            full_delta_url = f"{self._graph_base_url}/me/drive/root/delta"
+            url = self._delta_link or full_delta_url
             cutoff = datetime.now(UTC) - timedelta(minutes=10)
 
             affected_files: list[str] = []
             async with httpx.AsyncClient() as client:
                 while url:
                     response = await client.get(url, headers=headers, timeout=30)
+                    if response.status_code == 410 and not first_sweep:
+                        # Invalid/expired delta token: drop it and reconcile
+                        # from a full delta so persist_webhook_cursor can
+                        # remove the stored cursor instead of keeping it.
+                        logger.warning(
+                            "OneDrive Graph delta cursor rejected (410); "
+                            "resetting and reconciling from full delta"
+                        )
+                        self._delta_link = None
+                        first_sweep = True
+                        url = full_delta_url
+                        continue
                     response.raise_for_status()
                     data = response.json()
 

--- a/src/connectors/onedrive/connector.py
+++ b/src/connectors/onedrive/connector.py
@@ -68,8 +68,8 @@ class OneDriveConnector(BaseConnector):
         self.client_id = None
         self.client_secret = None
         self.redirect_uri = config.get("redirect_uri", "http://localhost")
-        # Graph delta link for webhook change tracking (in-memory per instance)
-        self._delta_link: str | None = None
+        # Graph delta cursor; restored from connection config across restarts
+        self._delta_link: str | None = config.get("delta_link")
         self._base_url = config.get("base_url")  # Generic URL field for OneDrive/SharePoint domain
         logger.debug(f"OneDrive connector initialized with base_url from config: {self._base_url}")
 

--- a/src/connectors/service.py
+++ b/src/connectors/service.py
@@ -46,6 +46,18 @@ class ConnectorService:
         """Get a connector by connection ID"""
         return await self.connection_manager.get_connector(connection_id)
 
+    async def persist_webhook_cursor(self, connection, connector) -> None:
+        """Persist Drive/Graph change cursors after webhook processing succeeds.
+
+        Looked up on ``type(self)`` by the webhook route so MagicMock services
+        in tests do not auto-invoke it. Raises on save failure so the route
+        can leave the in-memory cursor unadvanced.
+        """
+        persist = getattr(type(self.connection_manager), "persist_webhook_cursor", None)
+        if not callable(persist):
+            return
+        await self.connection_manager.persist_webhook_cursor(connection, connector)
+
     async def _get_effective_sync_jwt(
         self,
         user_id: str,

--- a/src/connectors/sharepoint/connector.py
+++ b/src/connectors/sharepoint/connector.py
@@ -1091,13 +1091,26 @@ class SharePointConnector(BaseConnector):
             # the delta query enumerates the whole drive, so only keep recently
             # modified files instead of re-syncing everything.
             first_sweep = self._delta_link is None
-            url = self._delta_link or f"{self._graph_base_url}/{resource}/delta"
+            full_delta_url = f"{self._graph_base_url}/{resource}/delta"
+            url = self._delta_link or full_delta_url
             cutoff = datetime.now(UTC) - timedelta(minutes=10)
 
             affected_files: list[str] = []
             async with httpx.AsyncClient() as client:
                 while url:
                     response = await client.get(url, headers=headers, timeout=30)
+                    if response.status_code == 410 and not first_sweep:
+                        # Invalid/expired delta token: drop it and reconcile
+                        # from a full delta so persist_webhook_cursor can
+                        # remove the stored cursor instead of keeping it.
+                        logger.warning(
+                            "SharePoint Graph delta cursor rejected (410); "
+                            "resetting and reconciling from full delta"
+                        )
+                        self._delta_link = None
+                        first_sweep = True
+                        url = full_delta_url
+                        continue
                     response.raise_for_status()
                     data = response.json()
 

--- a/src/connectors/sharepoint/connector.py
+++ b/src/connectors/sharepoint/connector.py
@@ -69,8 +69,8 @@ class SharePointConnector(BaseConnector):
         self.client_id = None
         self.client_secret = None
         self.tenant_id = config.get("tenant_id", "common")
-        # Graph delta link for webhook change tracking (in-memory per instance)
-        self._delta_link: str | None = None
+        # Graph delta cursor; restored from connection config across restarts
+        self._delta_link: str | None = config.get("delta_link")
         # base_url is the generic field name, sharepoint_url is kept for backward compatibility
         self.sharepoint_url = config.get("base_url") or config.get("sharepoint_url")
         logger.debug(

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -1097,9 +1097,7 @@ class ConnectorFileProcessor(TaskProcessor):
                         shared=self.shared,
                         connector_type=connector_type,
                     )
-                    if indexed_name and (
-                        not file_task.filename or file_task.filename == file_id
-                    ):
+                    if indexed_name and (not file_task.filename or file_task.filename == file_id):
                         file_task.filename = indexed_name
 
                     deleted_chunks = await self._delete_connector_chunks(

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -424,6 +424,39 @@ class TaskProcessor:
         filename = (hits[0].get("_source") or {}).get("filename")
         return filename if isinstance(filename, str) and filename.strip() else None
 
+    async def _connector_chunks_exist(
+        self,
+        file_id: str,
+        opensearch_client,
+        owner_user_id: str,
+        shared: bool = False,
+        connector_type: str | None = None,
+    ) -> bool:
+        """Return True when any indexed chunk remains for this connector file id.
+
+        Raises on search failure so callers can fail the task instead of
+        treating a lookup error as "already gone".
+        """
+        from connectors.chunk_cleanup import build_connector_file_chunks_query
+
+        if not file_id:
+            return False
+        response = await opensearch_client.search(
+            index=get_index_name(),
+            body={
+                "size": 1,
+                "_source": False,
+                "query": build_connector_file_chunks_query(
+                    [file_id],
+                    connector_type=connector_type,
+                    owner_user_id=owner_user_id,
+                    shared=shared,
+                ),
+            },
+        )
+        hits = response.get("hits", {}).get("hits", [])
+        return bool(hits)
+
     async def _delete_connector_chunks(
         self,
         file_id: str,
@@ -432,13 +465,14 @@ class TaskProcessor:
         keep_filenames: list[str] | None = None,
         shared: bool = False,
         connector_type: str | None = None,
-    ) -> int:
+    ) -> int | None:
         """Delete indexed chunks for a connector file by its STABLE id.
 
         Deletion semantics (dual-field id match, connector/owner/shared scoping,
-        rename ``keep_filenames``) live in ``connectors.chunk_cleanup``. This
-        wrapper is best-effort: logs and returns 0 on failure so a cleanup miss
-        never fails the task.
+        rename ``keep_filenames``) live in ``connectors.chunk_cleanup``.
+
+        Returns the number of chunks deleted, or ``None`` when cleanup failed
+        so callers do not treat an error as a successful zero-delete.
 
         ``connector_type`` scopes the match to one connector type — the same
         value the chunks were indexed under — so an id that collides with a
@@ -463,7 +497,7 @@ class TaskProcessor:
                 file_id=file_id,
                 error=str(e),
             )
-            return 0
+            return None
 
     async def process_document_standard(
         self,
@@ -1075,6 +1109,40 @@ class ConnectorFileProcessor(TaskProcessor):
                         shared=self.shared,
                         connector_type=connector_type,
                     )
+                    if deleted_chunks is None:
+                        file_task.status = TaskStatus.FAILED
+                        file_task.error = (
+                            "Failed to remove indexed chunks after the file was "
+                            "deleted at the source."
+                        )
+                        file_task.updated_at = time.time()
+                        upload_task.failed_files += 1
+                        return
+                    if deleted_chunks == 0:
+                        try:
+                            still_indexed = await self._connector_chunks_exist(
+                                file_id,
+                                opensearch_client,
+                                self.user_id,
+                                shared=self.shared,
+                                connector_type=connector_type,
+                            )
+                        except Exception as exist_err:
+                            logger.error(
+                                "Could not confirm indexed chunks were removed",
+                                file_id=file_id,
+                                error=str(exist_err),
+                            )
+                            still_indexed = True
+                        if still_indexed:
+                            file_task.status = TaskStatus.FAILED
+                            file_task.error = (
+                                "File no longer exists at source, but indexed "
+                                "chunks could not be removed."
+                            )
+                            file_task.updated_at = time.time()
+                            upload_task.failed_files += 1
+                            return
 
                     logger.info(
                         "File no longer exists at source — removed from index",
@@ -1138,17 +1206,23 @@ class ConnectorFileProcessor(TaskProcessor):
             # Match against file_task.filename — the cleaned name the file is
             # actually indexed under — so duplicate/rename detection lines up
             # with how chunks are keyed.
-            renamed = (
-                await self._delete_connector_chunks(
-                    document.id,
-                    opensearch_client,
-                    self.user_id,
-                    keep_filenames=get_filename_aliases(file_task.filename),
-                    shared=self.shared,
-                    connector_type=connector_type,
-                )
-                > 0
+            deleted_stale = await self._delete_connector_chunks(
+                document.id,
+                opensearch_client,
+                self.user_id,
+                keep_filenames=get_filename_aliases(file_task.filename),
+                shared=self.shared,
+                connector_type=connector_type,
             )
+            if deleted_stale is None:
+                file_task.status = TaskStatus.FAILED
+                file_task.error = (
+                    "Failed to clean up previous indexed chunks for this connector file."
+                )
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+                return
+            renamed = deleted_stale > 0
 
             # Create temporary file from document content
             suffix = os.path.splitext(file_task.filename)[1]
@@ -1164,6 +1238,17 @@ class ConnectorFileProcessor(TaskProcessor):
 
                 if not renamed and await self.check_document_exists(file_hash, opensearch_client):
                     await self._reconcile_shared_owner(file_task.filename)
+                    # Stale-chunk delete can return 0 on a real rename (DLS
+                    # hid the old-name hits, or connector_type is missing on
+                    # older chunks). Still rewrite filename/timestamps by
+                    # stable id so the UI does not keep the old name.
+                    await self.connector_service._update_connector_metadata(
+                        document,
+                        self.user_id,
+                        connector_type,
+                        self.jwt_token,
+                        indexed_filename=file_task.filename,
+                    )
                     file_task.status = TaskStatus.COMPLETED
                     file_task.result = {"status": "unchanged", "id": file_hash}
                     file_task.updated_at = time.time()

--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -379,6 +379,51 @@ class TaskProcessor:
             logger.error("Failed to delete existing document", filename=filename, error=str(e))
             raise
 
+    async def _lookup_indexed_connector_filename(
+        self,
+        file_id: str,
+        opensearch_client,
+        owner_user_id: str,
+        shared: bool = False,
+        connector_type: str | None = None,
+    ) -> str | None:
+        """Return the indexed filename for a connector file id, if any.
+
+        Webhook deletion events often have no remote name (the file is already
+        gone), so the task falls back to the raw Drive/Graph id. The index
+        still has the name until we delete the chunks.
+        """
+        from connectors.chunk_cleanup import build_connector_file_chunks_query
+
+        if not file_id:
+            return None
+        try:
+            response = await opensearch_client.search(
+                index=get_index_name(),
+                body={
+                    "size": 1,
+                    "_source": ["filename"],
+                    "query": build_connector_file_chunks_query(
+                        [file_id],
+                        connector_type=connector_type,
+                        owner_user_id=owner_user_id,
+                        shared=shared,
+                    ),
+                },
+            )
+        except Exception as e:
+            logger.debug(
+                "Could not look up indexed filename for deleted connector file",
+                file_id=file_id,
+                error=str(e),
+            )
+            return None
+        hits = response.get("hits", {}).get("hits", [])
+        if not hits:
+            return None
+        filename = (hits[0].get("_source") or {}).get("filename")
+        return filename if isinstance(filename, str) and filename.strip() else None
+
     async def _delete_connector_chunks(
         self,
         file_id: str,
@@ -1011,6 +1056,18 @@ class ConnectorFileProcessor(TaskProcessor):
                             self.user_id, self.jwt_token
                         )
                     )
+                    indexed_name = await self._lookup_indexed_connector_filename(
+                        file_id,
+                        opensearch_client,
+                        self.user_id,
+                        shared=self.shared,
+                        connector_type=connector_type,
+                    )
+                    if indexed_name and (
+                        not file_task.filename or file_task.filename == file_id
+                    ):
+                        file_task.filename = indexed_name
+
                     deleted_chunks = await self._delete_connector_chunks(
                         file_id,
                         opensearch_client,
@@ -1019,25 +1076,21 @@ class ConnectorFileProcessor(TaskProcessor):
                         connector_type=connector_type,
                     )
 
-                    logger.warning(
+                    logger.info(
                         "File no longer exists at source — removed from index",
                         file_id=file_id,
+                        filename=file_task.filename,
                         connection_id=self.connection_id,
                         deleted_chunks=deleted_chunks,
-                        error=str(e),
                     )
-                    file_task.status = TaskStatus.SKIPPED
+                    # Completed, not skipped: the UI treats skipped as a warning
+                    # (duplicate-filename skips). Source deletion is successful
+                    # cleanup — the file should not land in the Warning chip.
+                    file_task.status = TaskStatus.COMPLETED
                     file_task.result = {
-                        "status": "skipped",
+                        "status": "deleted",
                         "reason": "deleted_at_source",
                         "deleted_chunks": deleted_chunks,
-                        # Human-readable message so the tasks view shows this
-                        # successful cleanup instead of falling back to
-                        # "Unknown error" for a skip with no message.
-                        "warning": (
-                            f"File no longer exists at source; removed from index "
-                            f"({deleted_chunks} chunk(s) deleted)."
-                        ),
                     }
                     file_task.updated_at = time.time()
                     upload_task.successful_files += 1
@@ -1130,10 +1183,19 @@ class ConnectorFileProcessor(TaskProcessor):
                             delete_document_ids,
                         )
 
+                        write_client = clients.opensearch
+                        if write_client is None:
+                            raise RuntimeError("Backend OpenSearch write client is unavailable")
+
                         # Match both fields: bucket-connector chunks carry the
                         # raw connector id in connector_file_id (document_id is
                         # a hash), while pre-migration chunks only have it in
                         # document_id.
+                        # DLS-safe: enumerate with the user-scoped client, then
+                        # delete with the platform writer. The webhook-minted
+                        # openrag_user JWT can search but cannot
+                        # indices:data/write/delete — using it here 403'd and
+                        # left the old filename in the index after a rename.
                         chunk_ids = await collect_visible_document_ids(
                             opensearch_client,
                             index=get_index_name(),
@@ -1151,7 +1213,7 @@ class ConnectorFileProcessor(TaskProcessor):
                             },
                         )
                         deleted_count = await delete_document_ids(
-                            opensearch_client,
+                            write_client,
                             index=get_index_name(),
                             document_ids=chunk_ids,
                             refresh=True,

--- a/tests/unit/connectors/test_google_drive_webhook_events.py
+++ b/tests/unit/connectors/test_google_drive_webhook_events.py
@@ -72,3 +72,42 @@ async def test_handle_webhook_includes_removed_and_trashed_files():
     # The changes query must request the `removed` flag
     list_kwargs = connector.service.changes.return_value.list.call_args.kwargs
     assert "removed" in list_kwargs["fields"]
+
+
+def test_http_error_is_not_found():
+    from connectors.google_drive.connector import _http_error_is_not_found
+
+    not_found = MagicMock()
+    not_found.status_code = 404
+    assert _http_error_is_not_found(not_found) is True
+
+    resp_only = MagicMock(spec=["resp"])
+    resp_only.resp = MagicMock(status=404)
+    assert _http_error_is_not_found(resp_only) is True
+
+    assert _http_error_is_not_found(Exception("backendError")) is False
+
+
+@pytest.mark.asyncio
+async def test_cleanup_subscription_treats_404_as_success():
+    """A channel already stopped (previous process shutdown) must not block recreate."""
+    from connectors.google_drive.connector import GoogleDriveConfig, GoogleDriveConnector
+
+    connector = GoogleDriveConnector.__new__(GoogleDriveConnector)
+    connector.cfg = GoogleDriveConfig(
+        client_id="fake-client-id",
+        client_secret="fake-client-secret",
+        token_file="/tmp/fake-token.json",
+        resource_id="resource-1",
+    )
+    connector.authenticate = AsyncMock(return_value=True)
+    connector._active_channel = {"channel_id": "chan-1", "resource_id": "resource-1"}
+    err = MagicMock()
+    err.status_code = 404
+    err.__str__ = lambda self: "HttpError 404 notFound"
+    service = MagicMock()
+    service.channels.return_value.stop.return_value.execute.side_effect = err
+    connector.service = service
+
+    assert await connector.cleanup_subscription("chan-1") is True
+    assert connector._active_channel == {}

--- a/tests/unit/connectors/test_webhook_renewal.py
+++ b/tests/unit/connectors/test_webhook_renewal.py
@@ -121,6 +121,24 @@ async def test_healthy_subscription_is_skipped(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_force_renews_healthy_subscription(tmp_path):
+    """Process start must re-establish watches even when stored expiry is far away.
+
+    Shutdown used to cancel Google/Graph channels while leaving webhook_expiration
+    intact; without force, that pair is skipped forever and auto-sync stays dead.
+    """
+    connection = _make_connection(webhook_expiration=_iso_in(48))
+    connector = _make_connector()
+    manager = _make_manager(tmp_path, [connection])
+    manager.get_connector = AsyncMock(return_value=connector)
+
+    stats = await manager.renew_expiring_subscriptions(THRESHOLD, force=True)
+
+    assert stats == {"checked": 1, "renewed": 1, "failed": 0, "skipped": 0}
+    connector.setup_subscription.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "expiration",
     [_iso_in(1), _iso_in(-1), None],

--- a/tests/unit/connectors/test_webhook_renewal.py
+++ b/tests/unit/connectors/test_webhook_renewal.py
@@ -438,3 +438,55 @@ async def test_google_drive_has_no_inplace_renewal(tmp_path):
     )
 
     assert await connector.renew_subscription("channel-1") is None
+
+
+@pytest.mark.asyncio
+async def test_persist_webhook_cursor_saves_drive_and_graph_cursors(tmp_path):
+    from connectors.connection_manager import ConnectionConfig, ConnectionManager
+
+    manager = ConnectionManager(connections_file=str(tmp_path / "connections.json"))
+    manager.save_connections = AsyncMock()
+    connection = ConnectionConfig(
+        connection_id="conn-1",
+        connector_type="google_drive",
+        name="drive",
+        config={"webhook_channel_id": "chan-1"},
+    )
+
+    class _Cfg:
+        changes_page_token = "token-2"
+
+    connector = MagicMock()
+    connector.cfg = _Cfg()
+    connector._delta_link = "https://graph.microsoft.com/v1.0/delta?token=next"
+
+    await manager.persist_webhook_cursor(connection, connector)
+
+    assert connection.config["changes_page_token"] == "token-2"
+    assert connection.config["delta_link"] == "https://graph.microsoft.com/v1.0/delta?token=next"
+    manager.save_connections.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_persist_webhook_cursor_skips_save_when_unchanged(tmp_path):
+    from connectors.connection_manager import ConnectionConfig, ConnectionManager
+
+    manager = ConnectionManager(connections_file=str(tmp_path / "connections.json"))
+    manager.save_connections = AsyncMock()
+    connection = ConnectionConfig(
+        connection_id="conn-1",
+        connector_type="google_drive",
+        name="drive",
+        config={"changes_page_token": "token-2"},
+    )
+
+    class _Cfg:
+        changes_page_token = "token-2"
+
+    connector = MagicMock()
+    connector.cfg = _Cfg()
+    connector._delta_link = None
+
+    await manager.persist_webhook_cursor(connection, connector)
+
+    manager.save_connections.assert_not_awaited()

--- a/tests/unit/connectors/test_webhook_renewal.py
+++ b/tests/unit/connectors/test_webhook_renewal.py
@@ -122,10 +122,11 @@ async def test_healthy_subscription_is_skipped(tmp_path):
 
 @pytest.mark.asyncio
 async def test_force_renews_healthy_subscription(tmp_path):
-    """Process start must re-establish watches even when stored expiry is far away.
+    """force=True recreates even when stored expiry is far away.
 
-    Shutdown used to cancel Google/Graph channels while leaving webhook_expiration
-    intact; without force, that pair is skipped forever and auto-sync stays dead.
+    Kept as an explicit operator/API path. Periodic renewal no longer
+    force-recreates on every process start (that stop+create cycle can
+    drop Drive watches when the tunnel is down).
     """
     connection = _make_connection(webhook_expiration=_iso_in(48))
     connector = _make_connector()
@@ -508,3 +509,28 @@ async def test_persist_webhook_cursor_skips_save_when_unchanged(tmp_path):
     await manager.persist_webhook_cursor(connection, connector)
 
     manager.save_connections.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_persist_webhook_cursor_clears_reset_delta_link(tmp_path):
+    """A Graph 410 reset sets _delta_link to None; persist must drop the stored
+    invalid cursor instead of leaving it in connections.json."""
+    from connectors.connection_manager import ConnectionConfig, ConnectionManager
+
+    manager = ConnectionManager(connections_file=str(tmp_path / "connections.json"))
+    manager.save_connections = AsyncMock()
+    connection = ConnectionConfig(
+        connection_id="conn-1",
+        connector_type="onedrive",
+        name="onedrive",
+        config={"delta_link": "https://graph.microsoft.com/v1.0/delta?token=stale"},
+    )
+
+    connector = MagicMock()
+    connector.cfg = None
+    connector._delta_link = None
+
+    await manager.persist_webhook_cursor(connection, connector)
+
+    assert "delta_link" not in connection.config
+    manager.save_connections.assert_awaited_once()

--- a/tests/unit/connectors/test_webhook_type_alias.py
+++ b/tests/unit/connectors/test_webhook_type_alias.py
@@ -310,6 +310,87 @@ async def test_webhook_deletion_of_indexed_file_still_syncs(monkeypatch):
     assert synced_ids == ["deleted-file"]
 
 
+class _RecordingWebhookService:
+    """Non-MagicMock service so persist_webhook_cursor on the class is invoked."""
+
+    def __init__(self, connection, handler):
+        self.connection_manager = MagicMock()
+        self.connection_manager._create_connector = MagicMock(return_value=_FakeDriveConnector())
+        self.connection_manager.get_connection_by_webhook_id = AsyncMock(return_value=connection)
+        self.connection_manager.persist_webhook_cursor = AsyncMock()
+        self._get_connector = AsyncMock(return_value=handler)
+        self.sync_specific_files = AsyncMock(return_value="task-1")
+        self.events: list[str] = []
+
+    async def _get_effective_sync_jwt(self, user_id, jwt_token=None):
+        return "jwt"
+
+    async def persist_webhook_cursor(self, connection, connector):
+        self.events.append("persist")
+        await self.connection_manager.persist_webhook_cursor(connection, connector)
+
+
+@pytest.mark.asyncio
+async def test_webhook_persists_cursor_after_successful_sync(monkeypatch):
+    from api.connectors import connector_webhook
+
+    connection = _scope_guard_connection()
+    handler = MagicMock()
+    handler.handle_webhook = AsyncMock(return_value=["indexed-file"])
+    handler.cfg = MagicMock()
+    handler.cfg.changes_page_token = "token-after"
+    handler._delta_link = None
+    service = _RecordingWebhookService(connection, handler)
+
+    async def _sync(*args, **kwargs):
+        service.events.append("sync")
+        return "task-1"
+
+    service.sync_specific_files = AsyncMock(side_effect=_sync)
+    _mock_indexed_files(monkeypatch, ["indexed-file"])
+
+    request = _FakeRequest({"content-type": "application/json", "x-goog-channel-id": "chan-1"})
+    response = await connector_webhook(
+        "google_drive",
+        request,
+        connector_service=service,
+        session_manager=MagicMock(),
+        session=MagicMock(),
+    )
+
+    assert json.loads(response.body)["task_id"] == "task-1"
+    assert service.events == ["sync", "persist"]
+    service.connection_manager.persist_webhook_cursor.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_webhook_does_not_persist_cursor_when_sync_fails(monkeypatch):
+    from api.connectors import connector_webhook
+
+    connection = _scope_guard_connection()
+    handler = MagicMock()
+    handler.handle_webhook = AsyncMock(return_value=["indexed-file"])
+    handler.cfg = MagicMock()
+    handler.cfg.changes_page_token = "token-after"
+    handler._delta_link = "delta-after"
+    service = _RecordingWebhookService(connection, handler)
+    service.sync_specific_files = AsyncMock(side_effect=RuntimeError("queue failed"))
+    _mock_indexed_files(monkeypatch, ["indexed-file"])
+
+    request = _FakeRequest({"content-type": "application/json", "x-goog-channel-id": "chan-1"})
+    response = await connector_webhook(
+        "google_drive",
+        request,
+        connector_service=service,
+        session_manager=MagicMock(),
+        session=MagicMock(),
+    )
+
+    assert response.status_code == 500
+    assert "persist" not in service.events
+    service.connection_manager.persist_webhook_cursor.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_webhook_unknown_type_is_ignored_not_500():
     from api.connectors import connector_webhook
@@ -365,8 +446,9 @@ def _graph_connector(module_path: str, cls_name: str, tmp_path, webhook_url: str
 class _FakeDeltaClient:
     """Stands in for httpx.AsyncClient; serves Graph delta GET responses."""
 
-    def __init__(self, pages: list[dict]):
+    def __init__(self, pages: list[dict], status_codes: list[int] | None = None):
         self._pages = pages
+        self._status_codes = status_codes
         self.requested_urls: list[str] = []
 
     def __call__(self, *args, **kwargs):
@@ -379,21 +461,28 @@ class _FakeDeltaClient:
         return False
 
     async def get(self, url, headers=None, timeout=None):
+        idx = len(self.requested_urls)
         self.requested_urls.append(url)
+        status = (
+            self._status_codes[idx]
+            if self._status_codes is not None and idx < len(self._status_codes)
+            else 200
+        )
+        payload = self._pages[idx] if idx < len(self._pages) else {}
 
         class _Resp:
-            status_code = 200
-
-            def __init__(self, payload):
+            def __init__(self, payload, status_code):
                 self._payload = payload
+                self.status_code = status_code
 
             def raise_for_status(self):
-                pass
+                if self.status_code >= 400:
+                    raise RuntimeError(f"HTTP {self.status_code}")
 
             def json(self):
                 return self._payload
 
-        return _Resp(self._pages[len(self.requested_urls) - 1])
+        return _Resp(payload, status)
 
 
 GRAPH_NOTIFICATION = {"value": [{"resource": "me/drive/root", "changeType": "updated"}]}
@@ -482,6 +571,36 @@ async def test_graph_webhook_uses_stored_delta_link(
     assert affected == ["file-old"]
     assert fake_client.requested_urls == ["https://graph.microsoft.com/v1.0/delta?token=prev"]
     assert connector._delta_link == "https://graph.microsoft.com/v1.0/delta?token=next"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("module_path,cls_name,connector_type", GRAPH_CONNECTORS)
+async def test_graph_webhook_resets_delta_link_on_410(
+    tmp_path, monkeypatch, module_path, cls_name, connector_type
+):
+    """HTTP 410 means the stored delta token is gone. Reset it and reconcile
+    from a full delta so persist_webhook_cursor can drop the invalid cursor."""
+    import httpx
+
+    connector = _graph_connector(module_path, cls_name, tmp_path, webhook_url=None)
+    connector._delta_link = "https://graph.microsoft.com/v1.0/delta?token=stale"
+
+    recovered = {
+        "value": [
+            {"id": "file-recent", "file": {}, "lastModifiedDateTime": _recent_iso()},
+        ],
+        "@odata.deltaLink": "https://graph.microsoft.com/v1.0/delta?token=fresh",
+    }
+    fake_client = _FakeDeltaClient([{}, recovered], status_codes=[410, 200])
+    monkeypatch.setattr(httpx, "AsyncClient", fake_client)
+
+    affected = await connector.handle_webhook(GRAPH_NOTIFICATION)
+
+    assert affected == ["file-recent"]
+    assert connector._delta_link == "https://graph.microsoft.com/v1.0/delta?token=fresh"
+    assert fake_client.requested_urls[0] == "https://graph.microsoft.com/v1.0/delta?token=stale"
+    assert fake_client.requested_urls[1].endswith("/delta")
+    assert "token=stale" not in fake_client.requested_urls[1]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/connectors/test_webhook_type_alias.py
+++ b/tests/unit/connectors/test_webhook_type_alias.py
@@ -26,16 +26,19 @@ if str(SRC) not in sys.path:
 
 
 class _FakeRequest:
-    def __init__(self, headers: dict[str, str]):
+    def __init__(self, headers: dict[str, str], body: bytes = b"{}"):
         self.method = "POST"
         self.headers = headers
         self.query_params: dict[str, str] = {}
+        self._body = body
 
     async def json(self):
-        return {}
+        if not self._body:
+            raise json.JSONDecodeError("Expecting value", "", 0)
+        return json.loads(self._body)
 
     async def body(self):
-        return b"{}"
+        return self._body
 
 
 class _FakeDriveConnector:
@@ -103,6 +106,58 @@ async def test_webhook_accepts_legacy_google_type(path_type):
     # The legacy path segment must be normalized before any connector lookup.
     assert body["connector_type"] == "google_drive"
     assert body["connection_id"] == "conn-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("body", [b"", b"not-json"])
+async def test_webhook_accepts_empty_or_invalid_json_body(body):
+    """Google Drive push notifications POST an empty JSON body (channel id is
+    only in X-Goog-* headers). Invalid/empty JSON must not 500 — that used to
+    drop every Drive change/delete notification."""
+    from api.connectors import connector_webhook
+
+    connection = MagicMock()
+    connection.connection_id = "conn-1"
+    connection.user_id = "user-1"
+    connection.is_active = True
+
+    service = _webhook_service("chan-1", connection)
+    session_manager = MagicMock()
+    session_manager.get_user = MagicMock(return_value=None)
+
+    request = _FakeRequest(
+        {"content-type": "application/json", "x-goog-channel-id": "chan-1"},
+        body=body,
+    )
+    response = await connector_webhook(
+        "google_drive",
+        request,
+        connector_service=service,
+        session_manager=session_manager,
+        session=MagicMock(),
+    )
+
+    assert response.status_code == 200
+    body_json = json.loads(response.body)
+    assert body_json["status"] == "processed"
+    assert body_json["connection_id"] == "conn-1"
+    service._get_connector.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_webhook_sync_jwt_mints_via_connector_service():
+    """Webhooks have no browser session; the helper must mint the same JWT
+    sync uses so the indexed-file scope guard is not an empty set."""
+    from api.connectors import _webhook_sync_jwt
+
+    class _Svc:
+        async def _get_effective_sync_jwt(self, user_id, jwt_token=None):
+            return f"minted-{user_id}"
+
+    connection = MagicMock()
+    connection.user_id = "user-1"
+    token = await _webhook_sync_jwt(_Svc(), MagicMock(), connection, None)
+    assert token == "minted-user-1"
 
 
 def _mock_indexed_files(monkeypatch, indexed_ids: list[str]):
@@ -382,6 +437,26 @@ async def test_graph_webhook_runs_delta_query(
     assert affected == ["file-recent", "file-gone"]
     assert connector._delta_link == "https://graph.microsoft.com/v1.0/delta?token=abc"
     assert fake_client.requested_urls[0].endswith("/delta")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("module_path,cls_name,connector_type", GRAPH_CONNECTORS)
+async def test_graph_connector_loads_delta_link_from_config(
+    tmp_path, module_path, cls_name, connector_type
+):
+    """A persisted delta_link must survive connector reconstruction (restart)
+    so the next webhook is incremental instead of a first-sweep that can miss
+    the change that triggered it."""
+    import importlib
+
+    cls = getattr(importlib.import_module(module_path), cls_name)
+    connector = cls(
+        {
+            "token_file": str(tmp_path / "token.json"),
+            "delta_link": "https://graph.microsoft.com/v1.0/delta?token=saved",
+        }
+    )
+    assert connector._delta_link == "https://graph.microsoft.com/v1.0/delta?token=saved"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_connector_processor_filename_dedupe.py
+++ b/tests/unit/test_connector_processor_filename_dedupe.py
@@ -252,6 +252,119 @@ async def test_connector_processor_deletes_chunks_when_source_returns_404(
 
 
 @pytest.mark.asyncio
+async def test_connector_processor_fails_when_deleted_chunk_cleanup_errors(
+    monkeypatch, backend_write_client
+):
+    """A delete-at-source must not complete when chunk cleanup fails (None)."""
+    monkeypatch.setattr("config.settings.DISABLE_INGEST_WITH_LANGFLOW", True)
+    processor = _build_connector_processor(replace_duplicates=False)
+
+    opensearch_client = AsyncMock()
+    opensearch_client.search = AsyncMock(
+        return_value={"hits": {"hits": [{"_id": "chunk-1"}]}, "_scroll_id": None}
+    )
+    processor.document_service.session_manager.get_user_opensearch_client.return_value = (
+        opensearch_client
+    )
+    processor._delete_connector_chunks = AsyncMock(return_value=None)
+
+    connector = MagicMock()
+    connector.get_file_content = AsyncMock(side_effect=FileNotFoundError("404 Not Found"))
+    processor.connector_service.get_connector = AsyncMock(return_value=connector)
+    connection = MagicMock()
+    connection.connector_type = "sharepoint"
+    processor.connector_service.connection_manager = MagicMock()
+    processor.connector_service.connection_manager.get_connection = AsyncMock(
+        return_value=connection
+    )
+
+    file_task = _make_file_task()
+    upload_task = _make_upload_task()
+
+    await processor.process_item(upload_task, "file-id-1", file_task)
+
+    assert file_task.status == TaskStatus.FAILED
+    assert upload_task.failed_files == 1
+    assert upload_task.successful_files == 0
+    backend_write_client.delete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_connector_processor_fails_when_zero_delete_leaves_chunks(
+    monkeypatch, backend_write_client
+):
+    """Zero chunks deleted is success only when a follow-up lookup finds none."""
+    monkeypatch.setattr("config.settings.DISABLE_INGEST_WITH_LANGFLOW", True)
+    processor = _build_connector_processor(replace_duplicates=False)
+
+    opensearch_client = AsyncMock()
+    opensearch_client.search = AsyncMock(
+        return_value={
+            "hits": {"hits": [{"_id": "chunk-1", "_source": {"filename": "gone.pdf"}}]},
+            "_scroll_id": None,
+        }
+    )
+    processor.document_service.session_manager.get_user_opensearch_client.return_value = (
+        opensearch_client
+    )
+    processor._delete_connector_chunks = AsyncMock(return_value=0)
+
+    connector = MagicMock()
+    connector.get_file_content = AsyncMock(side_effect=FileNotFoundError("404 Not Found"))
+    processor.connector_service.get_connector = AsyncMock(return_value=connector)
+    connection = MagicMock()
+    connection.connector_type = "sharepoint"
+    processor.connector_service.connection_manager = MagicMock()
+    processor.connector_service.connection_manager.get_connection = AsyncMock(
+        return_value=connection
+    )
+
+    file_task = _make_file_task()
+    upload_task = _make_upload_task()
+
+    await processor.process_item(upload_task, "file-id-1", file_task)
+
+    assert file_task.status == TaskStatus.FAILED
+    assert upload_task.failed_files == 1
+
+
+@pytest.mark.asyncio
+async def test_connector_processor_completes_zero_delete_when_index_empty(
+    monkeypatch, backend_write_client
+):
+    monkeypatch.setattr("config.settings.DISABLE_INGEST_WITH_LANGFLOW", True)
+    processor = _build_connector_processor(replace_duplicates=False)
+
+    opensearch_client = AsyncMock()
+    opensearch_client.search = AsyncMock(
+        return_value={"hits": {"hits": []}, "_scroll_id": None}
+    )
+    processor.document_service.session_manager.get_user_opensearch_client.return_value = (
+        opensearch_client
+    )
+    processor._delete_connector_chunks = AsyncMock(return_value=0)
+
+    connector = MagicMock()
+    connector.get_file_content = AsyncMock(side_effect=FileNotFoundError("404 Not Found"))
+    processor.connector_service.get_connector = AsyncMock(return_value=connector)
+    connection = MagicMock()
+    connection.connector_type = "sharepoint"
+    processor.connector_service.connection_manager = MagicMock()
+    processor.connector_service.connection_manager.get_connection = AsyncMock(
+        return_value=connection
+    )
+
+    file_task = _make_file_task()
+    upload_task = _make_upload_task()
+
+    await processor.process_item(upload_task, "file-id-1", file_task)
+
+    assert file_task.status == TaskStatus.COMPLETED
+    assert (file_task.result or {}).get("deleted_chunks") == 0
+    assert upload_task.successful_files == 1
+
+
+@pytest.mark.asyncio
 async def test_connector_processor_indexes_cleaned_filename(monkeypatch):
     """MIME-enforced extensions must be indexed under the same name used for dedupe."""
     monkeypatch.setattr("config.settings.DISABLE_INGEST_WITH_LANGFLOW", True)
@@ -512,6 +625,7 @@ async def test_langflow_connector_processor_hash_unchanged_path_preserved(monkey
     assert file_task.status == TaskStatus.COMPLETED
     assert (file_task.result or {}).get("status") == "unchanged"
     processor.connector_service.langflow_service.upload_and_ingest_file.assert_not_called()
+    processor.connector_service._update_connector_metadata.assert_awaited()
 
 
 # ---------------------------------------------------------------------------
@@ -569,6 +683,35 @@ async def test_no_rename_unchanged_still_short_circuits(monkeypatch, backend_wri
     assert (file_task.result or {}).get("status") == "unchanged"
     mock_process.assert_not_called()
     backend_write_client.delete.assert_not_awaited()
+    processor.connector_service._update_connector_metadata.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_unchanged_hash_rewrites_filename_when_stale_delete_misses(
+    monkeypatch, backend_write_client
+):
+    """A Drive rename with unchanged bytes can miss stale-chunk delete (0 hits).
+    Still rewrite indexed filename via metadata update so the UI is not stuck
+    on the old name."""
+    monkeypatch.setattr("config.settings.DISABLE_INGEST_WITH_LANGFLOW", True)
+    processor = _build_connector_processor(replace_duplicates=True)
+    document = _make_document(filename="Renamed.pdf")
+    _wire_connector_processor(
+        processor, document, filename_exists=False, hash_exists=True, rename_stale_exists=False
+    )
+
+    file_task = _make_file_task()
+    upload_task = _make_upload_task()
+
+    with patch.object(processor, "process_document_standard", new=AsyncMock()) as mock_process:
+        await processor.process_item(upload_task, "file-id-1", file_task)
+
+    assert (file_task.result or {}).get("status") == "unchanged"
+    mock_process.assert_not_called()
+    meta = processor.connector_service._update_connector_metadata
+    meta.assert_awaited_once()
+    assert meta.await_args.args[0] is document
+    assert meta.await_args.kwargs.get("indexed_filename") == "Renamed.pdf"
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_connector_processor_filename_dedupe.py
+++ b/tests/unit/test_connector_processor_filename_dedupe.py
@@ -200,9 +200,7 @@ async def test_connector_processor_deletes_chunks_when_source_returns_404(
     # enumerates chunk _ids for delete.
     opensearch_client.search = AsyncMock(
         return_value={
-            "hits": {
-                "hits": [{"_id": "chunk-1", "_source": {"filename": "Quarterly.pdf"}}]
-            },
+            "hits": {"hits": [{"_id": "chunk-1", "_source": {"filename": "Quarterly.pdf"}}]},
             "_scroll_id": None,
         }
     )
@@ -336,9 +334,7 @@ async def test_connector_processor_completes_zero_delete_when_index_empty(
     processor = _build_connector_processor(replace_duplicates=False)
 
     opensearch_client = AsyncMock()
-    opensearch_client.search = AsyncMock(
-        return_value={"hits": {"hits": []}, "_scroll_id": None}
-    )
+    opensearch_client.search = AsyncMock(return_value={"hits": {"hits": []}, "_scroll_id": None})
     processor.document_service.session_manager.get_user_opensearch_client.return_value = (
         opensearch_client
     )

--- a/tests/unit/test_connector_processor_filename_dedupe.py
+++ b/tests/unit/test_connector_processor_filename_dedupe.py
@@ -196,9 +196,15 @@ async def test_connector_processor_deletes_chunks_when_source_returns_404(
     processor = _build_connector_processor(replace_duplicates=False)
 
     opensearch_client = AsyncMock()
-    # collect_visible_document_ids issues a scroll search; return one chunk _id
+    # First search recovers the indexed filename; the scroll search then
+    # enumerates chunk _ids for delete.
     opensearch_client.search = AsyncMock(
-        return_value={"hits": {"hits": [{"_id": "chunk-1"}]}, "_scroll_id": None}
+        return_value={
+            "hits": {
+                "hits": [{"_id": "chunk-1", "_source": {"filename": "Quarterly.pdf"}}]
+            },
+            "_scroll_id": None,
+        }
     )
     processor.document_service.session_manager.get_user_opensearch_client.return_value = (
         opensearch_client
@@ -215,13 +221,17 @@ async def test_connector_processor_deletes_chunks_when_source_returns_404(
     )
 
     file_task = _make_file_task()
+    file_task.filename = "file-id-1"
     upload_task = _make_upload_task()
 
     await processor.process_item(upload_task, "file-id-1", file_task)
 
-    assert file_task.status == TaskStatus.SKIPPED
+    assert file_task.status == TaskStatus.COMPLETED
+    assert file_task.filename == "Quarterly.pdf"
+    assert (file_task.result or {}).get("status") == "deleted"
     assert (file_task.result or {}).get("reason") == "deleted_at_source"
     assert (file_task.result or {}).get("deleted_chunks") == 1
+    assert "warning" not in (file_task.result or {})
     assert upload_task.successful_files == 1
     # Concrete chunk deletes go through the backend write client.
     backend_write_client.delete.assert_awaited_once()
@@ -473,9 +483,11 @@ async def test_langflow_connector_processor_deletes_chunks_when_source_returns_4
 
     await processor.process_item(upload_task, "file-id-1", file_task)
 
-    assert file_task.status == TaskStatus.SKIPPED
+    assert file_task.status == TaskStatus.COMPLETED
+    assert (file_task.result or {}).get("status") == "deleted"
     assert (file_task.result or {}).get("reason") == "deleted_at_source"
     assert (file_task.result or {}).get("deleted_chunks") == 1
+    assert "warning" not in (file_task.result or {})
     assert file_task.error is None
     assert upload_task.successful_files == 1
     assert upload_task.failed_files == 0


### PR DESCRIPTION
issue: https://github.ibm.com/lakehouse/tracker/issues/75531
Connector webhooks from Google Drive / OneDrive / SharePoint now actually ingest change and delete events


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook handling for empty, invalid, and non-JSON requests.
  * Webhook-triggered synchronizations now work reliably, including scoped access scenarios.
  * Deleted source files are now completed cleanly, with filenames recovered when available.
  * Already-removed Google Drive channels no longer cause cleanup failures.

* **Improvements**
  * Webhook cursors persist across restarts for Google Drive, OneDrive, and SharePoint.
  * Webhook subscriptions renew immediately after startup and remain active across service restarts.
  * Connector synchronization state is preserved more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->