### PR TITLE
fix: Creates task for fetch docs w/ langflow ingest disabled

### DIFF
--- a/src/models/url.py
+++ b/src/models/url.py
@@ -62,7 +62,7 @@ class UrlProcessor(TaskProcessor):
                 is_sample_data=self.is_sample_data,
                 connector_type=self.connector_type,
             )
-            await processor.process_document_standard(
+            result = await processor.process_document_standard(
                 file_path=temp_file_path,
                 file_hash=hash_id(temp_file_path),
                 owner_user_id=self.owner_user_id,
@@ -75,9 +75,16 @@ class UrlProcessor(TaskProcessor):
                 is_sample_data=self.is_sample_data,
             )
 
-            file_task.status = TaskStatus.COMPLETED
-            file_task.updated_at = time.time()
-            upload_task.successful_files += 1
+            if result.get("status") == "error":
+                file_task.status = TaskStatus.FAILED
+                file_task.error = result.get("error") or "Failed to process document"
+                file_task.updated_at = time.time()
+                upload_task.failed_files += 1
+            else:
+                file_task.status = TaskStatus.COMPLETED
+                file_task.result = result
+                file_task.updated_at = time.time()
+                upload_task.successful_files += 1
 
         except Exception as e:
             file_task.status = TaskStatus.FAILED

--- a/src/models/url.py
+++ b/src/models/url.py
@@ -1,3 +1,4 @@
+import os
 import time
 from typing import Any
 
@@ -7,6 +8,95 @@ from .processors import TaskProcessor
 from .tasks import FileTask, TaskStatus, UploadTask
 
 logger = get_logger(__name__)
+
+
+class UrlProcessor(TaskProcessor):
+    """Processor for URL ingestion using the traditional (non-Langflow) pipeline."""
+
+    def __init__(
+        self,
+        document_service,
+        models_service,
+        docs_url: str,
+        crawl_depth: int,
+        owner_user_id: str = None,
+        jwt_token: str = None,
+        owner_name: str = None,
+        owner_email: str = None,
+        connector_type: str = "openrag_docs",
+        is_sample_data: bool = False,
+    ):
+        super().__init__(document_service=document_service, models_service=models_service)
+        self.docs_url = docs_url
+        self.crawl_depth = crawl_depth
+        self.owner_user_id = owner_user_id
+        self.jwt_token = jwt_token
+        self.owner_name = owner_name
+        self.owner_email = owner_email
+        self.connector_type = connector_type
+        self.is_sample_data = is_sample_data
+
+    async def process_item(self, upload_task: UploadTask, item: str, file_task: FileTask) -> None:
+        from utils.hash_utils import hash_id
+        from utils.url_content_fetcher import materialize_url_as_text_file
+
+        from .processors import DocumentFileProcessor
+
+        file_task.status = TaskStatus.RUNNING
+        file_task.updated_at = time.time()
+
+        temp_file_path = None
+        try:
+            temp_file_path, title = await materialize_url_as_text_file(
+                docs_url=self.docs_url,
+                crawl_depth=self.crawl_depth,
+            )
+
+            processor = DocumentFileProcessor(
+                self.document_service,
+                models_service=self.models_service,
+                owner_user_id=self.owner_user_id,
+                jwt_token=self.jwt_token,
+                owner_name=self.owner_name,
+                owner_email=self.owner_email,
+                is_sample_data=self.is_sample_data,
+                connector_type=self.connector_type,
+            )
+            await processor.process_document_standard(
+                file_path=temp_file_path,
+                file_hash=hash_id(temp_file_path),
+                owner_user_id=self.owner_user_id,
+                original_filename=title,
+                jwt_token=self.jwt_token,
+                owner_name=self.owner_name,
+                owner_email=self.owner_email,
+                file_size=os.path.getsize(temp_file_path),
+                connector_type=self.connector_type,
+                is_sample_data=self.is_sample_data,
+            )
+
+            file_task.status = TaskStatus.COMPLETED
+            file_task.updated_at = time.time()
+            upload_task.successful_files += 1
+
+        except Exception as e:
+            file_task.status = TaskStatus.FAILED
+            file_task.error = str(e)
+            file_task.updated_at = time.time()
+            upload_task.failed_files += 1
+            raise
+        finally:
+            if temp_file_path:
+                try:
+                    os.unlink(temp_file_path)
+                except FileNotFoundError:
+                    pass
+                except Exception as e:
+                    logger.error(
+                        "Failed to clean temporary URL docs file",
+                        path=temp_file_path,
+                        error=str(e),
+                    )
 
 
 class LangflowUrlProcessor(TaskProcessor):

--- a/src/services/default_docs_service.py
+++ b/src/services/default_docs_service.py
@@ -28,7 +28,6 @@ from config.settings import (
 )
 from utils.logging_config import get_logger
 from utils.telemetry import Category, MessageId, TelemetryClient
-from utils.url_content_fetcher import materialize_url_as_text_file
 from utils.version_utils import OPENRAG_VERSION
 
 logger = get_logger(__name__)
@@ -68,8 +67,7 @@ async def ingest_openrag_docs_when_ready(
             )
             if get_openrag_config().knowledge.disable_ingest_with_langflow:
                 task_id = await _ingest_default_documents_url(
-                    document_service=document_service,
-                    models_service=models_service,
+                    task_service=task_service,
                     docs_url=DEFAULT_DOCS_URL,
                     crawl_depth=DEFAULT_DOCS_CRAWL_DEPTH,
                     jwt_token=jwt_token,
@@ -301,8 +299,7 @@ async def _ingest_default_documents_url_langflow(
 
 
 async def _ingest_default_documents_url(
-    document_service,
-    models_service,
+    task_service,
     docs_url: str,
     crawl_depth: int,
     jwt_token=None,
@@ -311,55 +308,33 @@ async def _ingest_default_documents_url(
     if not docs_url:
         raise ValueError("DEFAULT_DOCS_URL is not configured")
 
+    from session_manager import AnonymousUser
+
+    anonymous_user = AnonymousUser()
+
     logger.info(
         "Running default URL docs ingestion with OpenRAG processor",
         docs_url=docs_url,
         crawl_depth=crawl_depth,
     )
-    temp_file_path, title = await materialize_url_as_text_file(
+
+    task_id = await task_service.create_url_upload_task(
+        owner_user_id=None,
         docs_url=docs_url,
         crawl_depth=crawl_depth,
+        jwt_token=jwt_token,
+        owner_name=anonymous_user.name,
+        owner_email=anonymous_user.email,
+        connector_type="openrag_docs",
+        is_sample_data=True,
     )
-    try:
-        from models.processors import DocumentFileProcessor
-        from session_manager import AnonymousUser
-        from utils.hash_utils import hash_id
 
-        anonymous_user = AnonymousUser()
-
-        processor = DocumentFileProcessor(
-            document_service,
-            models_service=models_service,
-            owner_user_id=None,
-            jwt_token=jwt_token,
-            owner_name=anonymous_user.name,
-            owner_email=anonymous_user.email,
-            is_sample_data=True,
-            connector_type="openrag_docs",
-        )
-        await processor.process_document_standard(
-            file_path=temp_file_path,
-            file_hash=hash_id(temp_file_path),
-            owner_user_id=None,
-            original_filename=title,
-            jwt_token=jwt_token,
-            owner_name=anonymous_user.name,
-            owner_email=anonymous_user.email,
-            file_size=os.path.getsize(temp_file_path),
-            connector_type="openrag_docs",
-            is_sample_data=True,
-        )
-    finally:
-        try:
-            os.unlink(temp_file_path)
-        except FileNotFoundError:
-            pass
-        except Exception as e:
-            logger.error(
-                "Failed to clean temporary default URL docs file",
-                path=temp_file_path,
-                error=str(e),
-            )
+    logger.info(
+        "Started URL ingestion task for default documents",
+        task_id=task_id,
+        docs_url=docs_url,
+    )
+    return task_id
 
 
 async def _delete_existing_default_docs(session_manager, connector_type: str, jwt_token=None):

--- a/src/services/default_docs_service.py
+++ b/src/services/default_docs_service.py
@@ -147,7 +147,6 @@ async def ingest_default_documents_when_ready(
                 models_service,
                 task_service,
                 file_paths,
-                existing_task_id=task_id,
                 connector_type="local",
                 jwt_token=jwt_token,
             )
@@ -158,7 +157,6 @@ async def ingest_default_documents_when_ready(
                 session_manager,
                 task_service,
                 file_paths,
-                existing_task_id=task_id,
                 connector_type="local",
                 jwt_token=jwt_token,
             )
@@ -183,7 +181,6 @@ async def _ingest_default_documents_langflow(
     session_manager,
     task_service,
     file_paths,
-    existing_task_id: str = None,
     connector_type: str = "openrag_docs",
     jwt_token=None,
 ):
@@ -227,7 +224,6 @@ async def _ingest_default_documents_langflow(
         settings=None,
         replace_duplicates=True,
         connector_type=connector_type,
-        existing_task_id=existing_task_id,
         temp_file_paths=[],
     )
 
@@ -635,7 +631,6 @@ async def _ingest_default_documents_openrag(
     task_service,
     file_paths,
     connector_type: str = "openrag_docs",
-    existing_task_id: str = None,
     jwt_token=None,
 ):
     """Ingest default documents using traditional OpenRAG processor."""
@@ -660,9 +655,7 @@ async def _ingest_default_documents_openrag(
         connector_type=connector_type,
     )
 
-    task_id = await task_service.create_custom_task(
-        "anonymous", file_paths, processor, existing_task_id=existing_task_id
-    )
+    task_id = await task_service.create_custom_task("anonymous", file_paths, processor)
     logger.info(
         "Started traditional OpenRAG ingestion task",
         task_id=task_id,

--- a/src/services/task_service.py
+++ b/src/services/task_service.py
@@ -350,6 +350,37 @@ class TaskService:
             preview_mode=preview_mode,
         )
 
+    async def create_url_upload_task(
+        self,
+        owner_user_id: str,
+        docs_url: str,
+        crawl_depth: int,
+        jwt_token: str = None,
+        owner_name: str = None,
+        owner_email: str = None,
+        connector_type: str = "openrag_docs",
+        is_sample_data: bool = False,
+        existing_task_id: str = None,
+    ) -> str:
+        """Create a new upload task for traditional (non-Langflow) URL ingestion."""
+        from models.url import UrlProcessor
+
+        processor = UrlProcessor(
+            document_service=self.document_service,
+            models_service=self.models_service,
+            docs_url=docs_url,
+            crawl_depth=crawl_depth,
+            owner_user_id=owner_user_id,
+            jwt_token=jwt_token,
+            owner_name=owner_name,
+            owner_email=owner_email,
+            connector_type=connector_type,
+            is_sample_data=is_sample_data,
+        )
+        return await self.create_custom_task(
+            owner_user_id, [docs_url], processor, existing_task_id=existing_task_id
+        )
+
     async def create_langflow_url_upload_task(
         self,
         owner_user_id: str,

--- a/tests/unit/services/test_default_docs_jwt.py
+++ b/tests/unit/services/test_default_docs_jwt.py
@@ -121,4 +121,8 @@ async def test_local_default_docs_get_separate_task_from_url_ingest(
         )
 
     assert task_id == "local-task"
-    assert local_helper.await_args.kwargs.get("existing_task_id") is None
+    local_helper.assert_awaited_once()
+    call_args, call_kwargs = local_helper.await_args
+    assert "url-task" not in call_args
+    assert "url-task" not in call_kwargs.values()
+    assert call_kwargs.get("existing_task_id") is None

--- a/tests/unit/services/test_default_docs_jwt.py
+++ b/tests/unit/services/test_default_docs_jwt.py
@@ -1,5 +1,7 @@
 import sys
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -11,6 +13,7 @@ if str(SRC) not in sys.path:
 from services.default_docs_service import (  # noqa: E402
     _ingest_default_documents_langflow,
     _ingest_default_documents_url_langflow,
+    ingest_default_documents_when_ready,
 )
 
 
@@ -70,3 +73,52 @@ async def test_default_url_docs_use_effective_jwt_helper():
     assert task_id == "url-task"
     assert session_manager.calls == [("anonymous", None)]
     assert task_service.url_kwargs["jwt_token"] == "Bearer default-doc-token"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("disable_langflow", "local_helper_name"),
+    [
+        (True, "_ingest_default_documents_openrag"),
+        (False, "_ingest_default_documents_langflow"),
+    ],
+)
+async def test_local_default_docs_get_separate_task_from_url_ingest(
+    tmp_path, disable_langflow, local_helper_name
+):
+    local_doc = tmp_path / "local.md"
+    local_doc.write_text("local default documentation")
+    config = SimpleNamespace(
+        knowledge=SimpleNamespace(disable_ingest_with_langflow=disable_langflow)
+    )
+    local_helper = AsyncMock(return_value="local-task")
+
+    with (
+        patch(
+            "services.default_docs_service.get_openrag_config",
+            return_value=config,
+        ),
+        patch(
+            "services.default_docs_service.ingest_openrag_docs_when_ready",
+            new=AsyncMock(return_value="url-task"),
+        ),
+        patch("services.default_docs_service._get_documents_dir", return_value=str(tmp_path)),
+        patch(
+            f"services.default_docs_service.{local_helper_name}",
+            new=local_helper,
+        ),
+        patch(
+            "services.default_docs_service.TelemetryClient.send_event",
+            new=AsyncMock(),
+        ),
+    ):
+        task_id = await ingest_default_documents_when_ready(
+            document_service=object(),
+            models_service=object(),
+            task_service=object(),
+            langflow_file_service=object(),
+            session_manager=object(),
+        )
+
+    assert task_id == "local-task"
+    assert local_helper.await_args.kwargs.get("existing_task_id") is None

--- a/tests/unit/test_url_processor.py
+++ b/tests/unit/test_url_processor.py
@@ -1,0 +1,111 @@
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from models.tasks import FileTask, TaskStatus, UploadTask
+from models.url import UrlProcessor
+from services.task_service import TaskService
+
+
+@pytest.mark.asyncio
+async def test_url_processor_retains_successful_processing_result(tmp_path):
+    materialized_file = tmp_path / "docs.txt"
+    materialized_file.write_text("documentation")
+    result = {"status": "indexed", "id": "document-id"}
+
+    document_processor = MagicMock()
+    document_processor.process_document_standard = AsyncMock(return_value=result)
+    processor = UrlProcessor(
+        document_service=MagicMock(),
+        models_service=MagicMock(),
+        docs_url="https://docs.example.test",
+        crawl_depth=1,
+    )
+    upload_task = UploadTask(task_id="url-task", total_files=1)
+    file_task = FileTask(file_path=processor.docs_url)
+
+    with (
+        patch(
+            "utils.url_content_fetcher.materialize_url_as_text_file",
+            new=AsyncMock(return_value=(str(materialized_file), "OpenRAG docs")),
+        ),
+        patch("models.processors.DocumentFileProcessor", return_value=document_processor),
+    ):
+        await processor.process_item(upload_task, processor.docs_url, file_task)
+
+    assert file_task.status == TaskStatus.COMPLETED
+    assert file_task.result == result
+    assert upload_task.successful_files == 1
+    assert upload_task.failed_files == 0
+
+
+@pytest.mark.asyncio
+async def test_url_processor_marks_structured_processing_error_as_failed(tmp_path):
+    materialized_file = tmp_path / "docs.txt"
+    materialized_file.write_text("documentation")
+
+    document_processor = MagicMock()
+    document_processor.process_document_standard = AsyncMock(
+        return_value={"status": "error", "error": "No text content could be extracted"}
+    )
+    processor = UrlProcessor(
+        document_service=MagicMock(),
+        models_service=MagicMock(),
+        docs_url="https://docs.example.test",
+        crawl_depth=1,
+    )
+    upload_task = UploadTask(task_id="url-task", total_files=1)
+    file_task = FileTask(file_path=processor.docs_url)
+
+    with (
+        patch(
+            "utils.url_content_fetcher.materialize_url_as_text_file",
+            new=AsyncMock(return_value=(str(materialized_file), "OpenRAG docs")),
+        ),
+        patch("models.processors.DocumentFileProcessor", return_value=document_processor),
+    ):
+        await processor.process_item(upload_task, processor.docs_url, file_task)
+
+    assert file_task.status == TaskStatus.FAILED
+    assert file_task.error == "No text content could be extracted"
+    assert upload_task.failed_files == 1
+    assert upload_task.successful_files == 0
+    assert not materialized_file.exists()
+
+
+@pytest.mark.asyncio
+async def test_create_url_upload_task_wires_url_processor_context():
+    document_service = MagicMock()
+    models_service = MagicMock()
+    task_service = TaskService(
+        document_service=document_service,
+        models_service=models_service,
+    )
+    task_service.create_custom_task = AsyncMock(return_value="url-task")
+
+    task_id = await task_service.create_url_upload_task(
+        owner_user_id="owner-id",
+        docs_url="https://docs.example.test",
+        crawl_depth=2,
+        jwt_token="Bearer token",
+        owner_name="Owner Name",
+        owner_email="owner@example.test",
+        connector_type="openrag_docs",
+        is_sample_data=True,
+    )
+
+    assert task_id == "url-task"
+    owner_user_id, items, processor = task_service.create_custom_task.await_args.args
+    assert owner_user_id == "owner-id"
+    assert items == ["https://docs.example.test"]
+    assert isinstance(processor, UrlProcessor)
+    assert processor.document_service is document_service
+    assert processor.models_service is models_service
+    assert processor.owner_user_id == "owner-id"
+    assert processor.docs_url == "https://docs.example.test"
+    assert processor.crawl_depth == 2
+    assert processor.jwt_token == "Bearer token"
+    assert processor.owner_name == "Owner Name"
+    assert processor.owner_email == "owner@example.test"
+    assert processor.connector_type == "openrag_docs"
+    assert processor.is_sample_data is True


### PR DESCRIPTION
The Issue/Previous Behavior:
- When Langflow ingestion is used a task shows in the task panel when fetching the latest OpenRAG docs
- When Langflow Ingest is disabled there is no task created. Docs are still properly fetched but the status isn't well communicated to users


How to test
- Turn on `Disable Langflow Ingest`
- Click the `Fetch latest docs` button in the KT
- Confirm there was a task created in the task panel



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added scheduled URL ingestion with configurable crawl depth, ownership details, connector settings, sample-data handling, and task tracking.
  * Added clear completion and failure statuses for URL processing, including error details and progress counters.
  * Temporary files are automatically removed after processing.

* **Improvements**
  * Default documents now start in a separate task instead of being appended to URL ingestion tasks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->