### PR TITLE
fix: pin astral-sh/setup-uv to v10.0.1

### DIFF
--- a/.github/workflows/build-multiarch.yml
+++ b/.github/workflows/build-multiarch.yml
@@ -239,7 +239,7 @@ jobs:
           python-version: '3.13'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v10
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Build wheel and source distribution
         run: |


### PR DESCRIPTION
changing astral version to 10.0.1 for python builds