### PR TITLE
fix: Improve handling of no LF image processing

### DIFF
--- a/src/models/processors.py
+++ b/src/models/processors.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING, Any, Literal
 from config.settings import clients, get_embedding_model, get_index_name, get_openrag_config
 from session_manager import AnonymousUser
 from utils.document_processing import (
-    IMAGE_PLACEHOLDER,
     extract_relevant,
     process_text_file,
     resplit_chunks_character_windows,
@@ -531,18 +530,6 @@ class TaskProcessor:
         # This ensures the length of chunks matches the length of the embeddings array,
         # since chunk_texts_for_embeddings also drops empty texts.
         slim_doc["chunks"] = [c for c in slim_doc["chunks"] if c.get("text") and c["text"].strip()]
-
-        # A placeholder preserves picture provenance for otherwise empty documents,
-        # but it is not searchable content and must not turn ingestion into a false
-        # success or consume an embedding request.
-        if slim_doc["chunks"] and all(
-            chunk["text"].strip() == IMAGE_PLACEHOLDER for chunk in slim_doc["chunks"]
-        ):
-            logger.error(
-                "No searchable content extracted — document contains only image placeholders",
-                file_hash=file_hash,
-            )
-            return {"status": "error", "error": "No text content could be extracted from document"}
 
         litellm_embedding_model = (
             await self.models_service.get_litellm_model_name(embedding_model)

--- a/src/utils/document_processing.py
+++ b/src/utils/document_processing.py
@@ -208,6 +208,12 @@ def resplit_chunks_character_windows(
         if not isinstance(text, str):
             out.append(dict(ch) if isinstance(ch, dict) else ch)
             continue
+        # This marker is a semantic signal that Docling detected an image even
+        # though it extracted no text. Keep it intact so image-only documents
+        # remain ingestible and display the same placeholder as the Langflow path.
+        if text.strip() == IMAGE_PLACEHOLDER:
+            out.append(dict(ch))
+            continue
         if len(text) <= chunk_size:
             out.append(dict(ch))
             continue

--- a/tests/unit/test_document_processing_resplit.py
+++ b/tests/unit/test_document_processing_resplit.py
@@ -1,6 +1,6 @@
 """Tests for resplit_chunks_character_windows."""
 
-from src.utils.document_processing import resplit_chunks_character_windows
+from src.utils.document_processing import IMAGE_PLACEHOLDER, resplit_chunks_character_windows
 
 
 def test_invalid_returns_original():
@@ -23,6 +23,14 @@ def test_short_text_unchanged_count():
     assert len(out) == 1
     assert out[0]["text"] == "short"
     assert out[0]["page"] == 2
+
+
+def test_image_placeholder_is_not_split():
+    chunks = [{"page": 1, "type": "picture", "text": IMAGE_PLACEHOLDER}]
+
+    out = resplit_chunks_character_windows(chunks, 1, 0)
+
+    assert out == chunks
 
 
 def test_long_text_windows_with_overlap():

--- a/tests/unit/test_processors_image_only.py
+++ b/tests/unit/test_processors_image_only.py
@@ -7,8 +7,20 @@ from models.processors import TaskProcessor
 
 
 @pytest.mark.asyncio
-async def test_placeholder_only_document_returns_no_text_error_before_embedding(monkeypatch):
-    embedding_create = AsyncMock(side_effect=AssertionError("placeholder must not be embedded"))
+@pytest.mark.parametrize(
+    ("pictures", "chunk_size", "expected_result"),
+    [
+        ([{"prov": [{"page_no": 1}], "annotations": []}], None, "indexed"),
+        ([{"prov": [{"page_no": 1}], "annotations": []}], 1, "indexed"),
+        ([], None, "error"),
+    ],
+)
+async def test_image_only_placeholder_succeeds_but_empty_document_fails(
+    monkeypatch, pictures, chunk_size, expected_result
+):
+    embedding_create = AsyncMock(
+        return_value=SimpleNamespace(data=[{"embedding": [0.1, 0.2, 0.3]}])
+    )
     monkeypatch.setattr(
         "models.processors.clients",
         SimpleNamespace(
@@ -23,21 +35,30 @@ async def test_placeholder_only_document_returns_no_text_error_before_embedding(
         lambda: SimpleNamespace(
             knowledge=SimpleNamespace(
                 embedding_model="text-embedding-3-small",
-                chunk_size=None,
+                chunk_size=chunk_size,
                 chunk_overlap=None,
             )
         ),
     )
     monkeypatch.setattr(
         "services.document_service.chunk_texts_for_embeddings",
-        lambda texts, max_tokens: [texts],
+        lambda texts, max_tokens: [texts] if texts else [],
     )
 
     user_client = SimpleNamespace()
+    indexed: dict = {}
+
+    class FakeDocumentIndexWriter:
+        async def index_chunks(self, context, chunks, *, final=False):
+            indexed["context"] = context
+            indexed["chunks"] = chunks
+            indexed["final"] = final
+
     document_service = SimpleNamespace(
         session_manager=SimpleNamespace(
             get_user_opensearch_client=lambda user_id, jwt_token: user_client
-        )
+        ),
+        document_index_writer=FakeDocumentIndexWriter(),
     )
     models_service = SimpleNamespace(
         get_litellm_model_name=AsyncMock(return_value="text-embedding-3-small")
@@ -52,7 +73,7 @@ async def test_placeholder_only_document_returns_no_text_error_before_embedding(
                 },
                 "texts": [],
                 "tables": [],
-                "pictures": [{"prov": [{"page_no": 1}], "annotations": []}],
+                "pictures": pictures,
             }
         )
     )
@@ -68,8 +89,20 @@ async def test_placeholder_only_document_returns_no_text_error_before_embedding(
         picture_descriptions=False,
     )
 
-    assert result == {
-        "status": "error",
-        "error": "No text content could be extracted from document",
-    }
-    embedding_create.assert_not_awaited()
+    if expected_result == "error":
+        assert result == {
+            "status": "error",
+            "error": "No text content could be extracted from document",
+        }
+        embedding_create.assert_not_awaited()
+        assert indexed == {}
+        return
+
+    assert result == {"status": "indexed", "id": "image-hash"}
+    embedding_create.assert_awaited_once_with(
+        model="text-embedding-3-small", input=["<!-- image -->"]
+    )
+    assert indexed["final"] is True
+    assert len(indexed["chunks"]) == 1
+    assert indexed["chunks"][0].text == "<!-- image -->"
+    assert indexed["chunks"][0].page == 1


### PR DESCRIPTION
If 
```
Disabled Langflow Ingestion: True
Picture Descriptions: True
```
Image only pdf upload works as expected

```
Disabled Langflow Ingestion: True
Picture Descriptions: False
```
Upload fails with The file appears corrupted or invalid and cannot be processed. Upload a valid file.

if `Disable Langflow Ingestion` is off it processes the file w/ langflow and returns an empty `<!-- image -->` tag this PR matches this expected behavior

Fix non-Langflow ingestion for image-only documents when picture descriptions are disabled.

Previously, Docling detected the image and produced <!-- image -->, but the processor explicitly rejected placeholder-only documents as empty. This change allows the single placeholder to be embedded and indexed, matching Langflow behavior, while genuinely empty documents still fail. It also prevents custom chunk sizes from splitting the placeholder.

Tests cover successful image-only ingestion, exact placeholder indexing, small chunk sizes, and truly empty documents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Documents containing only images can now be processed and indexed successfully.
  * Image placeholders remain intact during document chunking, even with small chunk sizes.
  * Empty documents without images continue to return an appropriate error.
* **Tests**
  * Added coverage for image-only documents and placeholder preservation across supported chunking configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->