### PR TITLE
spike: wxai onprem

### DIFF
--- a/frontend/app/settings/_helpers/model-helpers.tsx
+++ b/frontend/app/settings/_helpers/model-helpers.tsx
@@ -22,6 +22,7 @@ export const KNOWN_PROVIDERS = [
   "anthropic",
   "ollama",
   "watsonx",
+  "watsonx_onprem",
   "azure_ai",
   "azure",
   "local",
@@ -104,6 +105,14 @@ const PROVIDER_CHROME: Record<string, ProviderChrome> = {
     logoColor: "text-white",
     logoBgColor: "bg-[#1063FE]",
   },
+  // Same product on a Cloud Pak for Data cluster, so the same mark. The two
+  // cards are told apart by the display name the API sends.
+  watsonx_onprem: {
+    name: "IBM watsonx.ai (on-prem)",
+    logo: IBMLogo,
+    logoColor: "text-white",
+    logoBgColor: "bg-[#1063FE]",
+  },
   // Microsoft draws the two Azure model services differently, and neither is
   // the generic Azure logo. Both marks paint their own gradients, so logoColor
   // does nothing for them and the tile stays white.
@@ -156,7 +165,7 @@ export function getModelLogo(modelValue: string, provider?: string) {
     return <AnthropicLogo className="w-4 h-4" />;
   } else if (provider === "ollama") {
     return <OllamaLogo className="w-4 h-4" />;
-  } else if (provider === "watsonx") {
+  } else if (provider === "watsonx" || provider === "watsonx_onprem") {
     return <IBMLogo className="w-4 h-4" />;
   } else if (provider === "azure") {
     return <AzureOpenAILogo className="w-4 h-4" />;

--- a/frontend/tests/utils/provider-detector.ts
+++ b/frontend/tests/utils/provider-detector.ts
@@ -1,6 +1,11 @@
 import { Page } from "@playwright/test";
 import { Settings } from "../pages/Settings";
 
+/** Escape a provider name so it can anchor a whole-string heading match. */
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
 /**
  * Utility to detect which model providers are configured
  */
@@ -24,10 +29,13 @@ export class ProviderDetector {
       .getByText("Providers")
       .waitFor({ state: "visible", timeout: 10000 });
 
-    // Find the heading that contains the provider name
+    // Match the heading exactly, the way Settings.getProviderCard does. A
+    // substring match picks up every card whose name starts with this one —
+    // "IBM watsonx.ai" would also match "IBM watsonx.ai (on-prem)" wherever
+    // both are offered, and the ambiguous locator fails strict mode.
     const providerHeading = this.page
       .locator("h3")
-      .filter({ hasText: providerName });
+      .filter({ hasText: new RegExp(`^${escapeRegExp(providerName)}$`) });
 
     try {
       await providerHeading.waitFor({ state: "visible", timeout: 10000 });

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -249,6 +249,7 @@ async def get_model_catalog(
         CATALOG_UNAVAILABLE_MESSAGE,
         CatalogUnavailableError,
         catalog,
+        refresh_live_models,
     )
 
     # `no-store` for the same reason as /models/providers: the catalogue is
@@ -256,6 +257,9 @@ async def get_model_catalog(
     # was supposed to apply the edit. LiteLLM's table is cached in-process, so
     # rebuilding this response is cheap.
     try:
+        # A cluster-hosted provider is the only source for its own model list,
+        # so ask it before building the payload the pickers read.
+        await refresh_live_models()
         return JSONResponse(catalog(), headers={"Cache-Control": "no-store"})
     except CatalogUnavailableError as e:
         # Log the cause, but never echo exception text back to the caller

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -1487,23 +1487,6 @@ async def _test_anthropic_completion_with_tools(api_key: str, llm_model: str) ->
         raise
 
 
-def _cluster_ssl_verify() -> bool | str:
-    """The TLS setting LiteLLM will use, so this probe agrees with real traffic.
-
-    A cluster behind its own CA is reached by pointing `SSL_CERT_FILE` at a
-    bundle (or, in development, by `SSL_VERIFY=false`). Both are read by
-    LiteLLM, not by httpx, so without this the banner could sit red on a
-    certificate error while chat through the gateway works.
-    """
-    try:
-        from litellm.llms.custom_httpx.http_handler import get_ssl_verify
-
-        return get_ssl_verify()
-    except Exception:
-        logger.debug("Could not read LiteLLM's TLS setting; verifying normally", exc_info=True)
-        return True
-
-
 async def _test_watsonx_onprem_lightweight_health(credentials: dict[str, str]) -> None:
     """Check a Cloud Pak for Data cluster's credentials without naming a model.
 
@@ -1527,12 +1510,13 @@ async def _test_watsonx_onprem_lightweight_health(credentials: dict[str, str]) -
 
     url = watsonx_onprem.model_specs_url(api_base)
     try:
-        async with httpx.AsyncClient(verify=_cluster_ssl_verify()) as client:
+        async with httpx.AsyncClient(verify=watsonx_onprem.ssl_verify()) as client:
             response = await _http_request_with_retry(
                 "GET",
                 url,
                 client=client,
                 headers={"Authorization": header, "Accept": "application/json"},
+                params=watsonx_onprem.model_specs_params(limit=1),
                 timeout=10.0,
             )
     except httpx.TimeoutException:

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -757,7 +757,13 @@ async def _test_litellm_provider(
     if embedding_model:
         await litellm.aembedding(
             model=litellm_model,
-            input="OpenRAG provider validation",
+            # A list, never a bare string. OpenAI accepts either and LiteLLM
+            # forwards whatever it is given, so a string reaches watsonx.ai as
+            # `"inputs": "..."` where it requires `[]string` — the cluster then
+            # answers "Mismatch type []string with value string" and the
+            # pre-save check fails for every embedding model, which leaves a
+            # wrongly-chosen one impossible to change.
+            input=["OpenRAG provider validation"],
             **credentials,
         )
         return

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -7,6 +7,7 @@ from typing import Any
 
 import httpx
 
+from services import watsonx_onprem
 from utils.container_utils import transform_localhost_url
 from utils.logging_config import get_logger
 
@@ -125,6 +126,31 @@ def is_provider_credential_error(text: str | BaseException | None) -> bool:
         return False
     lowered = (str(text) if not isinstance(text, str) else text).lower()
     return any(marker in lowered for marker in _PROVIDER_CREDENTIAL_ERROR_MARKERS)
+
+
+#: Markers for a TLS trust failure, which is neither a bad credential nor an
+#: unreachable host: the request never left because this deployment does not
+#: trust the certificate the provider presented. Common on an on-prem cluster
+#: fronted by an internal or self-signed CA.
+_PROVIDER_TLS_ERROR_MARKERS = (
+    "certificate_verify_failed",
+    "certificate verify failed",
+    "sslcertverificationerror",
+    "ssl: certificate",
+    "self-signed certificate",
+    "self signed certificate",
+    "unable to get local issuer certificate",
+    "certificate has expired",
+    "hostname mismatch",
+)
+
+
+def is_provider_tls_error(text: str | BaseException | None) -> bool:
+    """True when the call failed because the provider's certificate is not trusted."""
+    if text is None:
+        return False
+    lowered = (str(text) if not isinstance(text, str) else text).lower()
+    return any(marker in lowered for marker in _PROVIDER_TLS_ERROR_MARKERS)
 
 
 _GENERIC_UPSTREAM_ERROR_MARKERS = (
@@ -609,6 +635,14 @@ def _extract_error_details(response: httpx.Response) -> str:
         return response_text
 
 
+#: Providers with a validation path of their own, so they are never handed to
+#: the generic LiteLLM probe. Everything else is validated by making a real call,
+#: which needs a model name.
+_NATIVELY_VALIDATED_PROVIDERS = frozenset(
+    {"openai", "watsonx", "ollama", "anthropic", watsonx_onprem.PROVIDER_KEY}
+)
+
+
 async def validate_provider_setup(
     provider: str,
     api_key: str = None,
@@ -649,7 +683,7 @@ async def validate_provider_setup(
             f"Starting validation for provider: {provider_lower} (test_completion={test_completion})"
         )
 
-        if provider_lower not in {"openai", "watsonx", "ollama", "anthropic"}:
+        if provider_lower not in _NATIVELY_VALIDATED_PROVIDERS:
             await _test_litellm_provider(
                 provider=provider_lower,
                 credentials=supplied,
@@ -666,6 +700,7 @@ async def validate_provider_setup(
                     embedding_model=embedding_model,
                     endpoint=endpoint,
                     project_id=project_id,
+                    credentials=supplied,
                 )
             elif llm_model:
                 # Test completion with tool calling
@@ -675,6 +710,7 @@ async def validate_provider_setup(
                     llm_model=llm_model,
                     endpoint=endpoint,
                     project_id=project_id,
+                    credentials=supplied,
                 )
         else:
             # Lightweight validation (no credits consumed)
@@ -683,6 +719,7 @@ async def validate_provider_setup(
                 api_key=api_key,
                 endpoint=endpoint,
                 project_id=project_id,
+                credentials=supplied,
             )
 
         logger.info(f"Validation successful for provider: {provider_lower}")
@@ -731,6 +768,7 @@ async def test_lightweight_health(
     api_key: str = None,
     endpoint: str = None,
     project_id: str = None,
+    credentials: dict[str, str] | None = None,
 ) -> None:
     """Test provider health with lightweight check (no credits consumed)."""
 
@@ -742,6 +780,8 @@ async def test_lightweight_health(
         await _test_ollama_lightweight_health(endpoint)
     elif provider == "anthropic":
         await _test_anthropic_lightweight_health(api_key)
+    elif provider == watsonx_onprem.PROVIDER_KEY:
+        await _test_watsonx_onprem_lightweight_health(credentials or {})
     else:
         raise ValueError(f"Unknown provider: {provider}")
 
@@ -752,6 +792,7 @@ async def test_completion_with_tools(
     llm_model: str = None,
     endpoint: str = None,
     project_id: str = None,
+    credentials: dict[str, str] | None = None,
 ) -> None:
     """Test completion with tool calling for the provider."""
 
@@ -763,6 +804,13 @@ async def test_completion_with_tools(
         await _test_ollama_completion_with_tools(llm_model, endpoint)
     elif provider == "anthropic":
         await _test_anthropic_completion_with_tools(api_key, llm_model)
+    elif provider == watsonx_onprem.PROVIDER_KEY:
+        await _test_litellm_provider(
+            provider=provider,
+            credentials=credentials or {},
+            embedding_model=None,
+            llm_model=llm_model,
+        )
     else:
         raise ValueError(f"Unknown provider: {provider}")
 
@@ -773,6 +821,7 @@ async def test_embedding(
     embedding_model: str = None,
     endpoint: str = None,
     project_id: str = None,
+    credentials: dict[str, str] | None = None,
 ) -> None:
     """Test embedding generation for the provider."""
 
@@ -782,6 +831,13 @@ async def test_embedding(
         await _test_watsonx_embedding(api_key, embedding_model, endpoint, project_id)
     elif provider == "ollama":
         await _test_ollama_embedding(embedding_model, endpoint)
+    elif provider == watsonx_onprem.PROVIDER_KEY:
+        await _test_litellm_provider(
+            provider=provider,
+            credentials=credentials or {},
+            embedding_model=embedding_model,
+            llm_model=None,
+        )
     else:
         raise ValueError(f"Unknown provider: {provider}")
 
@@ -1439,3 +1495,72 @@ async def _test_anthropic_completion_with_tools(api_key: str, llm_model: str) ->
     except Exception as e:
         logger.error(f"Anthropic completion test failed: {str(e)}")
         raise
+
+
+def _cluster_ssl_verify() -> bool | str:
+    """The TLS setting LiteLLM will use, so this probe agrees with real traffic.
+
+    A cluster behind its own CA is reached by pointing `SSL_CERT_FILE` at a
+    bundle (or, in development, by `SSL_VERIFY=false`). Both are read by
+    LiteLLM, not by httpx, so without this the banner could sit red on a
+    certificate error while chat through the gateway works.
+    """
+    try:
+        from litellm.llms.custom_httpx.http_handler import get_ssl_verify
+
+        return get_ssl_verify()
+    except Exception:
+        logger.debug("Could not read LiteLLM's TLS setting; verifying normally", exc_info=True)
+        return True
+
+
+async def _test_watsonx_onprem_lightweight_health(credentials: dict[str, str]) -> None:
+    """Check a Cloud Pak for Data cluster's credentials without naming a model.
+
+    Every other generic provider is validated by making a real call, which needs
+    a model — so a provider that is configured but has no model selected yet
+    reported "A model is required to validate the provider" in the health
+    banner, as though the credentials were bad. The cluster's catalogue endpoint
+    needs no model, no project and no space, so it answers the question that was
+    actually being asked: are these credentials good and is the cluster
+    reachable? It consumes no inference.
+    """
+    api_base = (credentials.get("api_base") or "").strip()
+    if not api_base:
+        raise Exception("No cluster URL is configured for watsonx.ai on-prem")
+    header = watsonx_onprem.auth_header(credentials)
+    if not header:
+        raise Exception(
+            "No credentials are configured for watsonx.ai on-prem. "
+            "Enter a username and API key, or a Zen API key."
+        )
+
+    url = watsonx_onprem.model_specs_url(api_base)
+    try:
+        async with httpx.AsyncClient(verify=_cluster_ssl_verify()) as client:
+            response = await _http_request_with_retry(
+                "GET",
+                url,
+                client=client,
+                headers={"Authorization": header, "Accept": "application/json"},
+                timeout=10.0,
+            )
+    except httpx.TimeoutException:
+        logger.error("watsonx.ai on-prem health check timed out")
+        raise Exception("The watsonx.ai cluster did not respond in time") from None
+    except Exception as e:
+        logger.error(f"watsonx.ai on-prem health check could not reach the cluster: {str(e)}")
+        raise
+
+    if response.status_code == 200:
+        logger.info("watsonx.ai on-prem health check passed")
+        return
+    error_details = _extract_error_details(response)
+    logger.error(
+        f"watsonx.ai on-prem health check failed: {response.status_code} - {error_details}"
+    )
+    if response.status_code in (401, 403):
+        # Worded so `is_provider_credential_error` classifies it, which is what
+        # makes the banner offer "update the key" rather than "try again".
+        raise Exception(f"Invalid credentials for the watsonx.ai cluster: {error_details}")
+    raise Exception(error_details)

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -703,10 +703,14 @@ async def _test_litellm_provider(
     """Validate arbitrary providers through the same LiteLLM adapter used at runtime."""
     import litellm
 
+    from services.model_catalog import litellm_provider_key
+
     model = embedding_model or llm_model
     if not model:
         raise ValueError("A model is required to validate the provider")
-    litellm_model = f"{provider}/{model}"
+    # Same aliasing the gateway applies, so the probe hits the route the real
+    # call will: `watsonx_onprem/<model>` is not a prefix LiteLLM can resolve.
+    litellm_model = f"{litellm_provider_key(provider)}/{model}"
     if embedding_model:
         await litellm.aembedding(
             model=litellm_model,

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -683,7 +683,15 @@ async def validate_provider_setup(
             f"Starting validation for provider: {provider_lower} (test_completion={test_completion})"
         )
 
-        if provider_lower not in _NATIVELY_VALIDATED_PROVIDERS:
+        # watsonx.ai on-prem has no bespoke model probe of its own: a real call
+        # through LiteLLM *is* its model probe, and it is what makes switching to
+        # a model the cluster does not serve fail instead of saving silently. Its
+        # catalogue check is only for the case there is no model to probe with,
+        # which is the one that used to report "A model is required".
+        probes_the_model = provider_lower not in _NATIVELY_VALIDATED_PROVIDERS or (
+            provider_lower == watsonx_onprem.PROVIDER_KEY and bool(embedding_model or llm_model)
+        )
+        if probes_the_model:
             await _test_litellm_provider(
                 provider=provider_lower,
                 credentials=supplied,
@@ -700,7 +708,6 @@ async def validate_provider_setup(
                     embedding_model=embedding_model,
                     endpoint=endpoint,
                     project_id=project_id,
-                    credentials=supplied,
                 )
             elif llm_model:
                 # Test completion with tool calling
@@ -710,7 +717,6 @@ async def validate_provider_setup(
                     llm_model=llm_model,
                     endpoint=endpoint,
                     project_id=project_id,
-                    credentials=supplied,
                 )
         else:
             # Lightweight validation (no credits consumed)
@@ -792,7 +798,6 @@ async def test_completion_with_tools(
     llm_model: str = None,
     endpoint: str = None,
     project_id: str = None,
-    credentials: dict[str, str] | None = None,
 ) -> None:
     """Test completion with tool calling for the provider."""
 
@@ -804,13 +809,6 @@ async def test_completion_with_tools(
         await _test_ollama_completion_with_tools(llm_model, endpoint)
     elif provider == "anthropic":
         await _test_anthropic_completion_with_tools(api_key, llm_model)
-    elif provider == watsonx_onprem.PROVIDER_KEY:
-        await _test_litellm_provider(
-            provider=provider,
-            credentials=credentials or {},
-            embedding_model=None,
-            llm_model=llm_model,
-        )
     else:
         raise ValueError(f"Unknown provider: {provider}")
 
@@ -821,7 +819,6 @@ async def test_embedding(
     embedding_model: str = None,
     endpoint: str = None,
     project_id: str = None,
-    credentials: dict[str, str] | None = None,
 ) -> None:
     """Test embedding generation for the provider."""
 
@@ -831,13 +828,6 @@ async def test_embedding(
         await _test_watsonx_embedding(api_key, embedding_model, endpoint, project_id)
     elif provider == "ollama":
         await _test_ollama_embedding(embedding_model, endpoint)
-    elif provider == watsonx_onprem.PROVIDER_KEY:
-        await _test_litellm_provider(
-            provider=provider,
-            credentials=credentials or {},
-            embedding_model=embedding_model,
-            llm_model=None,
-        )
     else:
         raise ValueError(f"Unknown provider: {provider}")
 

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -480,8 +480,9 @@ async def update_settings(
                         _provider_key(name): values
                         for name, values in (body.provider_credentials or {}).items()
                     }
-                    credentials = current_config.providers.credential_values(llm_provider_key)
-                    credentials.update(submitted_credentials.get(llm_provider_key, {}))
+                    credentials = current_config.providers.pending_credentials(
+                        llm_provider_key, submitted_credentials.get(llm_provider_key, {})
+                    )
                     api_key = credentials.get("api_key", api_key)
                     endpoint = credentials.get("api_base", endpoint)
                     project_id = credentials.get("project_id", project_id)
@@ -533,8 +534,10 @@ async def update_settings(
                         _provider_key(name): values
                         for name, values in (body.provider_credentials or {}).items()
                     }
-                    credentials = current_config.providers.credential_values(embedding_provider_key)
-                    credentials.update(submitted_credentials.get(embedding_provider_key, {}))
+                    credentials = current_config.providers.pending_credentials(
+                        embedding_provider_key,
+                        submitted_credentials.get(embedding_provider_key, {}),
+                    )
                     api_key = credentials.get("api_key", api_key)
                     endpoint = credentials.get("api_base", endpoint)
                     project_id = credentials.get("project_id", project_id)

--- a/src/api/v1/llm.py
+++ b/src/api/v1/llm.py
@@ -16,6 +16,7 @@ from services.model_catalog import (
     CatalogUnavailableError,
     catalog,
     openai_models_list,
+    refresh_live_models,
 )
 from session_manager import User
 from utils.logging_config import get_logger
@@ -46,6 +47,8 @@ async def list_openai_models_endpoint(
 ):
     """OpenAI-compatible model inventory. GET /v1/models"""
     try:
+        # A cluster-hosted provider is the only source for its own model list.
+        await refresh_live_models()
         return JSONResponse(openai_models_list())
     except CatalogUnavailableError as exc:
         # Log the cause, but never echo exception text back to the caller
@@ -63,6 +66,7 @@ async def model_catalog_endpoint(
     # was supposed to apply the edit. LiteLLM's table is cached in-process, so
     # rebuilding this response is cheap.
     try:
+        await refresh_live_models()
         return JSONResponse(catalog(), headers={"Cache-Control": "no-store"})
     except CatalogUnavailableError as exc:
         logger.error("Model catalogue unavailable", error=str(exc))

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -226,8 +226,38 @@ class ProvidersConfig:
             self.ollama.endpoint = clean.get("api_base", self.ollama.endpoint)
             self.ollama.configured = bool(self.ollama.endpoint)
 
+    def pending_credentials(
+        self, provider: str, submitted: dict[str, str] | None = None
+    ) -> dict[str, str]:
+        """LiteLLM kwargs for `provider` as it would be once `submitted` is saved.
+
+        Validation runs before the write, so it has to reason about the union of
+        what is stored and what the request carries. For a provider whose stored
+        form is not already LiteLLM's — watsonx.ai on-prem keeps a username and
+        an API key, and hands LiteLLM the ZenApiKey built from them — the two
+        halves have to be merged *before* the translation, or a request that
+        changes the API key would be validated against a stale credential built
+        from the old one.
+        """
+        from services import watsonx_onprem
+
+        key = provider.strip().lower()
+        clean = {
+            str(name): str(value).strip()
+            for name, value in (submitted or {}).items()
+            if str(name).strip() and str(value).strip()
+        }
+        if key == watsonx_onprem.PROVIDER_KEY:
+            stored = self.custom.get(key, GenericProviderConfig()).credentials
+            return watsonx_onprem.litellm_credentials({**stored, **clean})
+        values = self.credential_values(key)
+        values.update(clean)
+        return values
+
     def credential_values(self, provider: str) -> dict[str, str]:
         """Return LiteLLM keyword arguments for a configured provider."""
+        from services import watsonx_onprem
+
         key = provider.strip().lower()
         custom = dict(self.custom.get(key, GenericProviderConfig()).credentials)
         if key == "openai":
@@ -254,6 +284,12 @@ class ProvidersConfig:
             if endpoint:
                 custom.setdefault("api_base", endpoint)
             return custom
+        if key == watsonx_onprem.PROVIDER_KEY:
+            # The stored form is what a Cloud Pak for Data operator has in hand
+            # (cluster URL, username, API key); LiteLLM wants a ZenApiKey. The
+            # translation lives with the provider so the gateway, the health
+            # check and the validator all issue the same call.
+            return watsonx_onprem.litellm_credentials(custom)
         return custom
 
 

--- a/src/config/model_providers.yaml
+++ b/src/config/model_providers.yaml
@@ -76,10 +76,14 @@ providers:
       oss: true
       on_prem: true
       saas: false # a cluster-hosted deployment has no place in multi-tenant SaaS
+    # Checked against a Cloud Pak for Data 5.x cluster, which serves exactly
+    # these two. Note the embedding id has no `-v2` suffix: `slate-30m-
+    # english-rtrvr-v2` is an IBM Cloud id and 404s here, which is the kind of
+    # near-miss that makes a guessed fallback worse than none.
+    models:
+      - openai/gpt-oss-120b
     embedding_models:
-      - ibm/slate-125m-english-rtrvr-v2
-      - ibm/slate-30m-english-rtrvr-v2
-      - intfloat/multilingual-e5-large
+      - ibm/slate-30m-english-rtrvr
 
   - name: anthropic
     display_name: Anthropic

--- a/src/config/model_providers.yaml
+++ b/src/config/model_providers.yaml
@@ -64,28 +64,18 @@ providers:
   # region endpoint. OpenRAG routes it through LiteLLM's `watsonx` provider —
   # see `services/watsonx_onprem.py`.
   #
-  # The models below are a starting point, not a promise: a cluster serves
-  # whatever its operator deployed, and unlike the IBM Cloud row there is no
-  # bundled table to read them from. Edit these two lists to match the cluster
-  # (`GET https://<cluster>/ml/v1/foundation_model_specs?version=2026-03-05`
-  # lists what it has), or set OPENRAG_MODEL_PROVIDERS_CONFIG to a file that
-  # does.
+  # The two lists below are a *fallback*, not the catalogue. OpenRAG asks the
+  # cluster itself what it serves (`GET /ml/v1/foundation_model_specs`) and
+  # shows that in the pickers, so a model the cluster does not have is never
+  # offered. These rows are what it falls back to while the cluster is
+  # unreachable or before any credentials are entered — keep them plausible for
+  # your fleet, but there is no need to keep them exact.
   - name: watsonx_onprem
     display_name: IBM watsonx.ai (on-prem)
     modes:
       oss: true
       on_prem: true
       saas: false # a cluster-hosted deployment has no place in multi-tenant SaaS
-    models:
-      - ibm/granite-3-3-8b-instruct
-      - ibm/granite-3-8b-instruct
-      - ibm/granite-13b-chat-v2
-      - ibm/granite-vision-3-2-2b
-      - meta-llama/llama-3-3-70b-instruct
-      - meta-llama/llama-3-2-11b-vision-instruct
-      - mistralai/mistral-large
-      - openai/gpt-oss-120b
-      
     embedding_models:
       - ibm/slate-125m-english-rtrvr-v2
       - ibm/slate-30m-english-rtrvr-v2

--- a/src/config/model_providers.yaml
+++ b/src/config/model_providers.yaml
@@ -56,6 +56,41 @@ providers:
       on_prem: true
       saas: true
 
+  # watsonx.ai running on a Cloud Pak for Data / IBM Software Hub cluster. It
+  # is a second front door onto the same `/ml/v1` API as the row above, kept
+  # separate because the two need their own credentials: the cluster
+  # authenticates with a ZenApiKey built from a CPD username and API key, not
+  # with an IBM Cloud IAM key, and it is reached at a cluster URL rather than a
+  # region endpoint. OpenRAG routes it through LiteLLM's `watsonx` provider —
+  # see `services/watsonx_onprem.py`.
+  #
+  # The models below are a starting point, not a promise: a cluster serves
+  # whatever its operator deployed, and unlike the IBM Cloud row there is no
+  # bundled table to read them from. Edit these two lists to match the cluster
+  # (`GET https://<cluster>/ml/v1/foundation_model_specs?version=2026-03-05`
+  # lists what it has), or set OPENRAG_MODEL_PROVIDERS_CONFIG to a file that
+  # does.
+  - name: watsonx_onprem
+    display_name: IBM watsonx.ai (on-prem)
+    modes:
+      oss: true
+      on_prem: true
+      saas: false # a cluster-hosted deployment has no place in multi-tenant SaaS
+    models:
+      - ibm/granite-3-3-8b-instruct
+      - ibm/granite-3-8b-instruct
+      - ibm/granite-13b-chat-v2
+      - ibm/granite-vision-3-2-2b
+      - meta-llama/llama-3-3-70b-instruct
+      - meta-llama/llama-3-2-11b-vision-instruct
+      - mistralai/mistral-large
+      - openai/gpt-oss-120b
+      
+    embedding_models:
+      - ibm/slate-125m-english-rtrvr-v2
+      - ibm/slate-30m-english-rtrvr-v2
+      - intfloat/multilingual-e5-large
+
   - name: anthropic
     display_name: Anthropic
     modes:
@@ -96,10 +131,12 @@ providers:
   # A self-hosted OpenAI-compatible endpoint (vLLM, LM Studio, an internal
   # gateway). Use one of LiteLLM's passthrough provider keys — `openai_like`,
   # `hosted_vllm`, `lm_studio`, `llamafile`, `custom_openai` — rather than
-  # inventing a name: the key has to be one LiteLLM can route, or the
+  # inventing a name: the key has to be one the gateway can route, or the
   # `provider:model` ids it publishes resolve to the default provider and get
-  # called with the wrong credentials. The endpoint and key are entered in
-  # Settings; only the model ids belong here.
+  # called with the wrong credentials. (A name of OpenRAG's own works only if
+  # it is registered in `PROVIDER_ROUTE_ALIASES` in `services/model_catalog.py`
+  # alongside the LiteLLM key it routes as, the way `watsonx_onprem` is.) The
+  # endpoint and key are entered in Settings; only the model ids belong here.
   #
   # - name: openai_like
   #   display_name: Internal LLM Gateway

--- a/src/services/llm_gateway.py
+++ b/src/services/llm_gateway.py
@@ -281,7 +281,16 @@ _ANSI_PATTERN = re.compile(r"\x1b\[[0-9;]*m")
 
 
 def _call_label(provider: str, model: str) -> str:
-    """`provider/model` for humans, without repeating a prefix LiteLLM already added."""
+    """`provider/model` for humans, without repeating a prefix LiteLLM already added.
+
+    The model here is the routed id, so for an aliased provider it carries the
+    *LiteLLM* prefix rather than the OpenRAG one — naively joining them gives
+    "watsonx_onprem/watsonx/openai/gpt-oss-120b", which names two providers and
+    reads like a bug in the error it appears in.
+    """
+    route = litellm_provider_key(provider) if provider else ""
+    if route and route != provider and model.startswith(f"{route}/"):
+        model = model[len(route) + 1 :]
     if model and provider and not model.startswith(f"{provider}/"):
         return f"{provider}/{model}"
     return model or provider or "provider"

--- a/src/services/llm_gateway.py
+++ b/src/services/llm_gateway.py
@@ -13,7 +13,7 @@ from collections.abc import AsyncIterator, Mapping
 from typing import Any, Literal
 
 from services import provider_error_log
-from services.model_catalog import is_known_provider
+from services.model_catalog import is_known_provider, litellm_provider_key
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -222,7 +222,11 @@ def resolve_call(
         provider = default_provider(kind, cfg)
         name = requested
     credentials = provider_credentials(provider, cfg)
-    litellm_model = f"{provider}/{name}" if provider != "openai" else name
+    # An OpenRAG provider that LiteLLM does not know by that name is routed
+    # under the key it aliases (`watsonx_onprem` -> `watsonx`). The OpenRAG key
+    # is still what the caller sees and what credentials are stored under.
+    route = litellm_provider_key(provider)
+    litellm_model = f"{route}/{name}" if route != "openai" else name
     return litellm_model, provider, credentials
 
 

--- a/src/services/llm_gateway.py
+++ b/src/services/llm_gateway.py
@@ -1015,6 +1015,19 @@ def _log_stream_shape(tally: _StreamTally, provider: str, model: str) -> None:
         logger.debug("Could not summarise stream shape", exc_info=True)
 
 
+def _embedding_input(value: Any) -> Any:
+    """OpenAI's `input`, in the shape every provider behind us accepts.
+
+    OpenAI takes a bare string as well as an array, so its clients send both —
+    and LiteLLM forwards whichever it is given. watsonx.ai takes only an array
+    and rejects a string with "Mismatch type []string with value string", so a
+    client that sends one gets a failure that reads like a bug in its own
+    request. Wrapping is a no-op for a provider that already accepted the
+    string, and token-array inputs are left exactly as they are.
+    """
+    return [value] if isinstance(value, str) else value
+
+
 async def embeddings(body: Mapping[str, Any], *, config=None) -> dict[str, Any]:
     """OpenAI `POST /v1/embeddings`."""
     cfg = config or _get_config()
@@ -1026,7 +1039,7 @@ async def embeddings(body: Mapping[str, Any], *, config=None) -> dict[str, Any]:
 
         result = await litellm.aembedding(
             model=litellm_model,
-            input=body.get("input"),
+            input=_embedding_input(body.get("input")),
             **credentials,
         )
     except LlmGatewayError:

--- a/src/services/llm_gateway.py
+++ b/src/services/llm_gateway.py
@@ -95,11 +95,22 @@ def split_model_id(model: str) -> tuple[str | None, str]:
     # also part of vendor-qualified names. When the whole string names exactly
     # one catalogue model, that provider owns it — `openai/gpt-oss-120b` is
     # watsonx's model, not OpenAI's `gpt-oss-120b`.
-    from services.model_catalog import catalog_owner
+    from services.model_catalog import catalog_owner, catalog_owners
 
     owner = catalog_owner(raw)
     if owner:
         return owner, raw
+
+    if catalog_owners(raw):
+        # More than one provider serves this exact id, so the text before the
+        # slash is part of the model's own name and not a provider tag. A
+        # deployment offering both watsonx.ai on IBM Cloud and on a cluster has
+        # `openai/gpt-oss-120b` twice; splitting it would hand the id to OpenAI
+        # — with OpenAI's key, for a model OpenAI does not serve. Leaving it
+        # untagged sends it to the configured default provider whole, which is
+        # right whenever that provider is one of the two and a clean "no such
+        # model" when it is not.
+        return None, raw
 
     prefix, rest = raw.split("/", 1)
     prefix_lower = prefix.lower()
@@ -233,6 +244,14 @@ def resolve_call(
 _UPSTREAM_FAILURE_MESSAGE = "The model provider could not be reached. Please try again."
 _UPSTREAM_CREDENTIAL_MESSAGE = (
     "The configured API key is invalid or has been revoked. Update it in Settings and retry."
+)
+#: A TLS trust failure reads as an outage otherwise — the request never left the
+#: process, so there is no provider error to quote and the text collapses to
+#: "could not be reached", which sends an operator hunting for a network fault.
+#: Nothing in Settings fixes this, so the message says who has to act.
+_UPSTREAM_TLS_MESSAGE = (
+    "The provider's TLS certificate is not trusted by this deployment. An operator needs to "
+    "add the provider's CA certificate to OpenRAG's trust store."
 )
 
 
@@ -394,9 +413,18 @@ def _upstream_client_message(
     credential failure keeps its actionable message so onboarding can tell the
     user to fix the key.
     """
-    from api.provider_validation import is_generic_upstream_error, is_provider_credential_error
+    from api.provider_validation import (
+        is_generic_upstream_error,
+        is_provider_credential_error,
+        is_provider_tls_error,
+    )
 
     label = _call_label(provider, model)
+    # Checked before the credential branch: a TLS failure often carries
+    # "unauthorized"-adjacent wording from the transport wrapper, and telling
+    # someone to rotate a working API key wastes the trip.
+    if is_provider_tls_error(detail):
+        return f"{_UPSTREAM_TLS_MESSAGE} ({label})"
     if is_provider_credential_error(detail):
         return f"{_UPSTREAM_CREDENTIAL_MESSAGE} ({label})"
     upstream = _provider_error_text(detail, exc)

--- a/src/services/model_catalog.py
+++ b/src/services/model_catalog.py
@@ -463,20 +463,25 @@ def _model_owners(providers: tuple[ProviderEntry, ...]) -> dict[str, tuple[str, 
     return {model: tuple(sorted(keys)) for model, keys in owners.items()}
 
 
+def catalog_owners(model: str) -> tuple[str, ...]:
+    """Every provider in this run mode whose catalogue lists `model`."""
+    name = (model or "").strip()
+    if not name:
+        return ()
+    try:
+        return _model_owners(visible_provider_entries()).get(name) or ()
+    except Exception:
+        return ()
+
+
 def catalog_owner(model: str) -> str | None:
     """The single provider that serves `model`, if exactly one does.
 
     Used to disambiguate vendor-qualified names such as `openai/gpt-oss-120b`,
     which watsonx serves and whose own prefix names a different provider.
     """
-    name = (model or "").strip()
-    if not name:
-        return None
-    try:
-        owners = _model_owners(visible_provider_entries()).get(name)
-    except Exception:
-        return None
-    return owners[0] if owners and len(owners) == 1 else None
+    owners = catalog_owners(model)
+    return owners[0] if len(owners) == 1 else None
 
 
 def PROVIDER_SEPARATOR_SAFE_CHECK() -> list[str]:

--- a/src/services/model_catalog.py
+++ b/src/services/model_catalog.py
@@ -403,6 +403,51 @@ def hide_excluded_live_models(provider: str, payload: Any) -> Any:
     return filtered
 
 
+def _catalog_entries() -> tuple[ProviderEntry, ...]:
+    """The visible providers, with a live model list swapped in where we have one.
+
+    A Cloud Pak for Data cluster serves whatever its operator deployed, so its
+    `models:` rows in `model_providers.yaml` can only ever be a guess. Once the
+    cluster has said what it actually has, that wins — a model it does not
+    serve must not sit in the picker waiting to be chosen. The configured rows
+    stay as the fallback for when it cannot be reached.
+
+    Entries are the `_catalog()` cache key, so substituting here rebuilds the
+    payload rather than serving a stale one.
+    """
+    entries = visible_provider_entries()
+    live = watsonx_onprem.cached_models()
+    if live is None:
+        return entries
+    return tuple(
+        entry._replace(models=live.chat, embedding_models=live.embedding)
+        if entry.name == watsonx_onprem.PROVIDER_KEY
+        else entry
+        for entry in entries
+    )
+
+
+async def refresh_live_models() -> None:
+    """Re-list the models on any provider that can only answer for itself.
+
+    Called by the catalogue routes before the payload is built. The provider
+    caches with a TTL, so this is a network call once every few minutes rather
+    than once per request, and a failure leaves the previous answer — or the
+    configured fallback — in place.
+    """
+    if watsonx_onprem.PROVIDER_KEY not in supported_provider_keys():
+        return
+    try:
+        from config.settings import get_openrag_config
+
+        credentials = get_openrag_config().providers.credential_values(watsonx_onprem.PROVIDER_KEY)
+    except Exception:
+        logger.debug("Could not read watsonx.ai on-prem credentials", exc_info=True)
+        return
+    if credentials:
+        await watsonx_onprem.fetch_models(credentials)
+
+
 def supported_provider_keys() -> frozenset[str]:
     """The providers this run mode publishes, per `config/model_providers.yaml`."""
     return frozenset(entry.name for entry in visible_provider_entries())
@@ -410,7 +455,7 @@ def supported_provider_keys() -> frozenset[str]:
 
 def catalog(today: datetime.date | None = None) -> dict[str, Any]:
     """Picker payload for the providers this run mode exposes, and their models."""
-    return _catalog_for(today or datetime.date.today(), visible_provider_entries())
+    return _catalog_for(today or datetime.date.today(), _catalog_entries())
 
 
 def is_known_provider(provider: str) -> bool:
@@ -469,7 +514,7 @@ def catalog_owners(model: str) -> tuple[str, ...]:
     if not name:
         return ()
     try:
-        return _model_owners(visible_provider_entries()).get(name) or ()
+        return _model_owners(_catalog_entries()).get(name) or ()
     except Exception:
         return ()
 
@@ -491,7 +536,7 @@ def PROVIDER_SEPARATOR_SAFE_CHECK() -> list[str]:
     Exposed so a test can fail loudly if a future model id breaks the property.
     """
     ambiguous = []
-    for model in _model_owners(visible_provider_entries()):
+    for model in _model_owners(_catalog_entries()):
         head, sep, rest = model.partition(":")
         if sep and rest and is_known_provider(head.lower()):
             ambiguous.append(model)

--- a/src/services/model_catalog.py
+++ b/src/services/model_catalog.py
@@ -31,6 +31,7 @@ from functools import lru_cache
 from typing import Any
 
 from config.model_providers import ProviderEntry, visible_provider_entries
+from services import watsonx_onprem
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -87,6 +88,27 @@ GENERIC_CREDENTIAL_FIELDS: list[dict[str, Any]] = [
 ]
 
 KNOWN_FIELD_TYPES = frozenset({"text", "password", "select", "textarea", "upload"})
+
+#: OpenRAG provider keys LiteLLM cannot route under their own name, mapped to
+#: the key it routes them as. A row here is for a deployment shape that needs
+#: its own credentials and its own model list but reaches the same API — the
+#: alternative, reusing the upstream key, would make the two share one set of
+#: stored credentials.
+PROVIDER_ROUTE_ALIASES: dict[str, str] = {
+    watsonx_onprem.PROVIDER_KEY: watsonx_onprem.LITELLM_PROVIDER,
+}
+
+#: Credential forms LiteLLM's `provider_create_fields.json` cannot supply,
+#: because the provider is one of OpenRAG's own aliases.
+_CREDENTIAL_FIELD_OVERRIDES: dict[str, list[dict[str, Any]]] = {
+    watsonx_onprem.PROVIDER_KEY: watsonx_onprem.CREDENTIAL_FIELDS,
+}
+
+
+def litellm_provider_key(provider: str) -> str:
+    """The name LiteLLM routes `provider` under, which is usually itself."""
+    key = (provider or "").strip().lower()
+    return PROVIDER_ROUTE_ALIASES.get(key, key)
 
 
 class CatalogUnavailableError(RuntimeError):
@@ -155,8 +177,12 @@ def _normalize_field(field: dict[str, Any]) -> dict[str, Any]:
 
 def credential_fields(provider: str) -> list[dict[str, Any]]:
     """The form spec for `provider`, normalized, never empty."""
+    key = (provider or "").strip().lower()
+    override = _CREDENTIAL_FIELD_OVERRIDES.get(key)
+    if override is not None:
+        return [_normalize_field(field) for field in override]
     try:
-        spec = _provider_field_specs().get((provider or "").strip().lower())
+        spec = _provider_field_specs().get(key)
     except Exception:
         logger.warning("Could not read LiteLLM's provider field specs", exc_info=True)
         return [dict(field) for field in GENERIC_CREDENTIAL_FIELDS]
@@ -241,6 +267,12 @@ def _catalog(providers: tuple[ProviderEntry, ...]) -> dict[str, Any]:
         raise CatalogUnavailableError("litellm is not installed on the server") from exc
 
     specs = _provider_field_specs()
+    # Matched on OpenRAG's own key, never the aliased LiteLLM one: a provider
+    # that routes as `watsonx` but serves whatever an operator deployed on
+    # their cluster must not inherit IBM Cloud's catalogue. Two providers
+    # sharing model ids would also leave `catalog_owner` unable to say which of
+    # them owns an id, and a legacy slash-form id would resolve to neither.
+    # An aliased provider's models come from its `models:` rows instead.
     keys = {entry.name for entry in providers}
     chat_by_provider: dict[str, list[dict[str, Any]]] = {}
     embed_by_provider: dict[str, list[dict[str, Any]]] = {}
@@ -382,10 +414,17 @@ def catalog(today: datetime.date | None = None) -> dict[str, Any]:
 
 
 def is_known_provider(provider: str) -> bool:
-    """Whether LiteLLM recognises `provider` at all."""
+    """Whether `provider` names a route the gateway can resolve.
+
+    That is LiteLLM's own provider list, plus OpenRAG's aliases — an alias is
+    routable by definition, since it is only ever a second front door onto a
+    provider LiteLLM already knows.
+    """
     key = (provider or "").strip().lower()
     if not key:
         return False
+    if key in PROVIDER_ROUTE_ALIASES:
+        return True
     try:
         import litellm
 

--- a/src/services/watsonx_onprem.py
+++ b/src/services/watsonx_onprem.py
@@ -1,0 +1,265 @@
+"""IBM watsonx.ai running on-premises (Cloud Pak for Data / IBM Software Hub).
+
+The on-prem product speaks the same `/ml/v1/*` REST API as watsonx.ai on IBM
+Cloud, so it routes through LiteLLM's `watsonx` provider — no second transport.
+What differs is everything around the call:
+
+- **Authentication.** IBM Cloud mints an IAM bearer from an API key; a CPD
+  cluster has no IAM. It accepts `Authorization: ZenApiKey <base64(user:apikey)>`
+  instead, which is what an operator's cluster username and API key become here.
+  LiteLLM already knows that scheme (`zen_api_key`), and it is the *only* one
+  that survives both call paths in litellm 1.84: a `token=` kwarg is echoed back
+  into the request body, and a hand-set `Authorization` header is ignored on the
+  embeddings path, which then calls IBM Cloud IAM and fails on a cluster that
+  has no route to it.
+- **Credentials are per-deployment.** A cluster URL, not a region endpoint, and
+  the SaaS provider's `project_id` may be a deployment `space_id` or absent
+  entirely — the watsonx.ai lightweight engine has neither (it "does not use
+  projects"). See `install_litellm_compatibility` for what that costs.
+- **Models are whatever the operator deployed**, so the catalogue ids come from
+  `config/model_providers.yaml` rather than LiteLLM's IBM Cloud price table.
+
+The provider key is OpenRAG's own; `LITELLM_PROVIDER` is what it routes as.
+Nothing here imports OpenRAG config — `config_manager`, `model_catalog` and
+`llm_gateway` all read this module, so it has to stay a leaf.
+"""
+
+from __future__ import annotations
+
+import base64
+from collections.abc import Mapping
+from typing import Any
+
+from utils.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+#: OpenRAG's key for the provider: the name in `model_providers.yaml`, in the
+#: settings payload, and in a `watsonx_onprem:<model>` id.
+PROVIDER_KEY = "watsonx_onprem"
+
+#: The LiteLLM provider it is routed as. `watsonx_onprem/<model>` is not a
+#: prefix LiteLLM can resolve, so the gateway swaps in this key when it builds
+#: the model string.
+LITELLM_PROVIDER = "watsonx"
+
+#: Credential form for the settings dialog. LiteLLM publishes a `watsonx` form,
+#: but it asks for an IBM Cloud API key and a pre-encoded Zen key — neither is
+#: what a CPD operator has in hand. These are the fields behind the cluster's
+#: own `/icp4d-api/v1/authorize` call: a username and an API key.
+CREDENTIAL_FIELDS: list[dict[str, Any]] = [
+    {
+        "key": "api_base",
+        "label": "Cluster URL",
+        "placeholder": "https://cpd-cluster.example.com",
+        "tooltip": "Base URL of the Cloud Pak for Data cluster, with no /ml/v1 suffix.",
+        "required": True,
+        "field_type": "text",
+        "options": None,
+        "default_value": None,
+    },
+    {
+        "key": "username",
+        "label": "Username",
+        "placeholder": None,
+        "tooltip": "Your Cloud Pak for Data username. Combined with the API key below "
+        "into the ZenApiKey the cluster authenticates with.",
+        "required": False,
+        "field_type": "text",
+        "options": None,
+        "default_value": None,
+    },
+    {
+        "key": "api_key",
+        "label": "API key",
+        "placeholder": None,
+        "tooltip": "Your Cloud Pak for Data API key (Profile and settings > API key).",
+        "required": False,
+        "field_type": "password",
+        "options": None,
+        "default_value": None,
+    },
+    {
+        "key": "zen_api_key",
+        "label": "Zen API key",
+        "placeholder": None,
+        "tooltip": "Optional. A pre-encoded base64(username:apikey). Leave blank to have "
+        "OpenRAG build it from the username and API key above.",
+        "required": False,
+        "field_type": "password",
+        "options": None,
+        "default_value": None,
+    },
+    {
+        "key": "space_id",
+        "label": "Deployment space ID",
+        "placeholder": None,
+        "tooltip": "Optional. The deployment space the models are served from. Leave blank "
+        "on a lightweight-engine install, which uses neither spaces nor projects.",
+        "required": False,
+        "field_type": "text",
+        "options": None,
+        "default_value": None,
+    },
+    {
+        "key": "project_id",
+        "label": "Project ID",
+        "placeholder": None,
+        "tooltip": "Optional. Set only if this cluster serves models from a project "
+        "rather than a deployment space.",
+        "required": False,
+        "field_type": "text",
+        "options": None,
+        "default_value": None,
+    },
+]
+
+#: Fields an operator fills in that are not LiteLLM kwargs. `username` is half
+#: of the Zen key and nothing else — forwarding it would land it in the request
+#: body, since LiteLLM passes kwargs it does not recognise straight through.
+_LOCAL_ONLY_FIELDS = frozenset({"username"})
+
+
+def zen_api_key(username: str | None, api_key: str | None) -> str:
+    """`base64(username:apikey)` — the value CPD expects after `ZenApiKey `.
+
+    Empty when either half is missing, so a half-filled form does not produce a
+    credential that looks valid and 401s on first use.
+    """
+    user = (username or "").strip()
+    key = (api_key or "").strip()
+    if not user or not key:
+        return ""
+    return base64.b64encode(f"{user}:{key}".encode()).decode("ascii")
+
+
+def litellm_credentials(stored: Mapping[str, Any]) -> dict[str, str]:
+    """Stored form values as LiteLLM kwargs for `watsonx`.
+
+    `api_key` is set to the Zen key as well as `zen_api_key`: the embeddings
+    path rejects the call before it ever reads the auth header if `api_key` is
+    unset, and the header it then builds comes from `zen_api_key`, so the two
+    have to travel together.
+    """
+    values = {
+        str(name): str(value).strip()
+        for name, value in (stored or {}).items()
+        if str(value or "").strip()
+    }
+    zen = values.get("zen_api_key") or zen_api_key(values.get("username"), values.get("api_key"))
+
+    credentials = {
+        name: value
+        for name, value in values.items()
+        if name not in _LOCAL_ONLY_FIELDS and name not in {"api_key", "zen_api_key"}
+    }
+    if zen:
+        credentials["zen_api_key"] = zen
+        credentials["api_key"] = zen
+    elif values.get("api_key"):
+        # No username to pair it with. Hand LiteLLM the raw key so a cluster
+        # fronted by IBM Cloud IAM still works, rather than dropping the only
+        # secret the operator supplied.
+        credentials["api_key"] = values["api_key"]
+    if credentials:
+        install_litellm_compatibility()
+    return credentials
+
+
+# --------------------------------------------------------------------------
+# LiteLLM compatibility
+# --------------------------------------------------------------------------
+
+#: Modules that bound `_get_api_params` at import time. Patching
+#: `common_utils._get_api_params` alone would miss all of them.
+_API_PARAM_CALL_SITES = (
+    "litellm.llms.watsonx.chat.handler",
+    "litellm.llms.watsonx.embed.transformation",
+    "litellm.llms.watsonx.completion.transformation",
+    "litellm.llms.watsonx.rerank.transformation",
+)
+
+_PATCH_MARKER = "_openrag_watsonx_onprem_patched"
+_installed = False
+
+
+def install_litellm_compatibility() -> None:
+    """Let a watsonx call proceed with no `project_id` and no `space_id`.
+
+    LiteLLM 1.84 raises 401 locally ("Watsonx project_id and space_id not set")
+    before sending anything, and stamps whichever one it has into every request
+    body. Both are correct for IBM Cloud. Neither holds for the watsonx.ai
+    lightweight engine, whose docs say to omit `project_id` outright — so
+    without this the provider cannot reach that install at all.
+
+    The change is deliberately the smallest one that unblocks it: the local
+    raise becomes "send it and let the cluster answer", and a `space_id` that
+    resolved to null is dropped from the payload instead of being serialised as
+    `"space_id": null`. A deployment that *does* have a space or project is
+    untouched — both values still flow through exactly as before. The only
+    behaviour lost is LiteLLM's client-side check, which on IBM Cloud now
+    surfaces as the provider's own error instead of a local one.
+
+    Idempotent, and a no-op on any LiteLLM whose internals have moved.
+    """
+    global _installed
+    if _installed:
+        return
+    _installed = True  # one attempt per process, success or not
+
+    try:
+        import litellm.llms.watsonx.common_utils as common_utils
+        from litellm.types.llms.watsonx import WatsonXAPIParams
+    except Exception:
+        logger.warning(
+            "Could not patch LiteLLM for on-prem watsonx.ai; a deployment with no "
+            "space_id or project_id will be rejected before the call is sent",
+            exc_info=True,
+        )
+        return
+
+    original_get_api_params = common_utils._get_api_params
+    watsonx_error = common_utils.WatsonXAIError
+
+    def _get_api_params_allowing_no_scope(params: dict, model: str | None = None):
+        try:
+            return original_get_api_params(params=params, model=model)
+        except watsonx_error as exc:
+            if getattr(exc, "status_code", None) != 401 or "space_id" not in str(exc):
+                raise
+            # The guard already popped project_id/space_id/region off `params`,
+            # and both were absent — which is exactly the lightweight-engine
+            # shape. Carry on with an empty scope.
+            return WatsonXAPIParams(project_id=None, space_id=None, region_name=None)
+
+    setattr(_get_api_params_allowing_no_scope, _PATCH_MARKER, True)
+
+    patched = []
+    for module_name in _API_PARAM_CALL_SITES:
+        try:
+            module = __import__(module_name, fromlist=["_get_api_params"])
+        except Exception:
+            continue
+        current = getattr(module, "_get_api_params", None)
+        if current is None or getattr(current, _PATCH_MARKER, False):
+            continue
+        module._get_api_params = _get_api_params_allowing_no_scope
+        patched.append(module_name)
+
+    mixin = common_utils.IBMWatsonXMixin
+    if not getattr(mixin._prepare_payload, _PATCH_MARKER, False):
+        original_prepare_payload = mixin._prepare_payload
+
+        def _prepare_payload_without_null_scope(self, model: str, api_params) -> dict:
+            payload = original_prepare_payload(self, model=model, api_params=api_params)
+            if payload.get("space_id") is None:
+                # `{"space_id": null}` is not "no space"; watsonx rejects it.
+                payload.pop("space_id", None)
+            return payload
+
+        setattr(_prepare_payload_without_null_scope, _PATCH_MARKER, True)
+        mixin._prepare_payload = _prepare_payload_without_null_scope
+        patched.append("IBMWatsonXMixin._prepare_payload")
+
+    if patched:
+        logger.info("Enabled scope-less watsonx.ai calls for on-prem", patched=patched)

--- a/src/services/watsonx_onprem.py
+++ b/src/services/watsonx_onprem.py
@@ -22,6 +22,37 @@ What differs is everything around the call:
 The provider key is OpenRAG's own; `LITELLM_PROVIDER` is what it routes as.
 Nothing here imports OpenRAG config — `config_manager`, `model_catalog` and
 `llm_gateway` all read this module, so it has to stay a leaf.
+
+TLS: trusting a cluster's own CA
+--------------------------------
+A CPD cluster is usually fronted by an internal or self-signed CA, and the call
+then fails before it leaves the process::
+
+    litellm.InternalServerError: WatsonxException - Cannot connect to host
+    <cluster>:443 ssl:True [SSLCertVerificationError: ... certificate verify
+    failed: self-signed certificate in certificate chain]
+
+There is no per-provider setting for this, and no OpenRAG one either. LiteLLM
+resolves TLS trust from process-wide environment only — verified against
+litellm 1.84 with a self-signed server, chat and embeddings both:
+
+- ``SSL_CERT_FILE=<path>``   works. **This is the fix.**
+- ``SSL_VERIFY=false``       works, but turns verification off for *every*
+  provider in the process, OpenAI and Anthropic included. Development only.
+- ``ssl_verify=False`` as a per-call kwarg does **not** work: litellm threads it
+  through only some providers, and watsonx is not one of them. It is silently
+  ignored, so do not reach for it.
+
+``SSL_CERT_FILE`` *replaces* certifi's roots rather than adding to them, so
+pointing it at the cluster CA alone breaks every public provider. Concatenate::
+
+    cat "$(python -m certifi)" cluster-ca.crt > /etc/ssl/certs/openrag-ca.pem
+    export SSL_CERT_FILE=/etc/ssl/certs/openrag-ca.pem
+
+In Kubernetes, mount the cluster CA into the backend pod and build that bundle
+in the entrypoint; the operator's ConfigMap is the usual home for the CA. A
+failure that gets this far is reported by the gateway as a trust problem rather
+than as an outage — see ``_UPSTREAM_TLS_MESSAGE`` in ``services/llm_gateway``.
 """
 
 from __future__ import annotations
@@ -164,6 +195,36 @@ def litellm_credentials(stored: Mapping[str, Any]) -> dict[str, str]:
     if credentials:
         install_litellm_compatibility()
     return credentials
+
+
+#: Catalogue endpoint used to check credentials. It needs no model, no project
+#: and no space, which is what makes it a health check the provider can pass
+#: before anything has been selected in Settings.
+MODEL_SPECS_PATH = "/ml/v1/foundation_model_specs"
+
+#: Pinned to what LiteLLM itself calls with, so the health check exercises the
+#: same API contract as real traffic rather than a newer one the cluster may
+#: not serve.
+API_VERSION = "2024-03-13"
+
+
+def auth_header(stored: Mapping[str, Any]) -> str:
+    """The `Authorization` value for OpenRAG's own calls to the cluster.
+
+    The health check talks to `/ml/v1` directly rather than through LiteLLM, so
+    it has to build the same header LiteLLM would.
+    """
+    credentials = litellm_credentials(stored)
+    if credentials.get("zen_api_key"):
+        return f"ZenApiKey {credentials['zen_api_key']}"
+    if credentials.get("api_key"):
+        return f"Bearer {credentials['api_key']}"
+    return ""
+
+
+def model_specs_url(api_base: str) -> str:
+    """The catalogue URL on `api_base`, however the operator typed the cluster URL."""
+    return f"{(api_base or '').rstrip('/')}{MODEL_SPECS_PATH}?version={API_VERSION}"
 
 
 # --------------------------------------------------------------------------

--- a/src/services/watsonx_onprem.py
+++ b/src/services/watsonx_onprem.py
@@ -106,8 +106,10 @@ CREDENTIAL_FIELDS: list[dict[str, Any]] = [
         "key": "username",
         "label": "Username",
         "placeholder": None,
-        "tooltip": "Your Cloud Pak for Data username. Combined with the API key below "
-        "into the ZenApiKey the cluster authenticates with.",
+        "tooltip": "Your Cloud Pak for Data username. Required alongside the API key: "
+        "the two are combined into the ZenApiKey the cluster authenticates with, and an "
+        "API key on its own cannot authenticate to a cluster. Not needed if you paste a "
+        "Zen API key below instead.",
         "required": False,
         "field_type": "text",
         "options": None,
@@ -232,8 +234,13 @@ def auth_header(stored: Mapping[str, Any]) -> str:
     credentials = litellm_credentials(stored)
     if credentials.get("zen_api_key"):
         return f"ZenApiKey {credentials['zen_api_key']}"
-    if credentials.get("api_key"):
-        return f"Bearer {credentials['api_key']}"
+    # Deliberately no `Bearer <api_key>` fallback. A Cloud Pak for Data API key
+    # is not a bearer token — the cluster issues one from `/icp4d-api/v1/authorize`
+    # in exchange for a *username and* an API key. Sending the raw key gets a
+    # 401 that looks like bad credentials rather than incomplete ones, and the
+    # caller quietly falls back to the configured model list with nothing on
+    # screen to say why. Returning nothing lets the health check say what is
+    # missing.
     return ""
 
 
@@ -386,6 +393,13 @@ async def fetch_models(credentials: Mapping[str, Any]) -> ClusterModels | None:
     api_base = (values.get("api_base") or "").strip()
     header = auth_header(credentials)
     if not api_base or not header:
+        logger.warning(
+            "Not listing models on the watsonx.ai cluster: credentials are incomplete. "
+            "A cluster URL plus either a username and API key, or a Zen API key, is "
+            "needed; the configured model list is used until then.",
+            has_cluster_url=bool(api_base),
+            has_credentials=bool(header),
+        )
         return None
 
     key = _cache_key(credentials)

--- a/src/services/watsonx_onprem.py
+++ b/src/services/watsonx_onprem.py
@@ -13,15 +13,26 @@ What differs is everything around the call:
   embeddings path, which then calls IBM Cloud IAM and fails on a cluster that
   has no route to it.
 - **Credentials are per-deployment.** A cluster URL, not a region endpoint, and
-  the SaaS provider's `project_id` may be a deployment `space_id` or absent
-  entirely — the watsonx.ai lightweight engine has neither (it "does not use
-  projects"). See `install_litellm_compatibility` for what that costs.
+  the SaaS provider's `project_id` is usually a deployment `space_id` instead.
+  Most clusters require one: verified against a Cloud Pak for Data 5.x install,
+  every `/ml/v1/text/*` call without one is refused with "Missing either
+  space_id or project_id or wml_instance_crn", and `GET /v2/spaces` is what
+  lists the ids. The watsonx.ai lightweight engine is the exception and has
+  neither — see `install_litellm_compatibility` for what supporting that costs.
 - **Models are whatever the operator deployed**, so the catalogue ids come from
   `config/model_providers.yaml` rather than LiteLLM's IBM Cloud price table.
+
+- **Models are listed from the cluster**, unfiltered, and split into the two
+  pickers here. The API's `filters` grammar is a SaaS convenience and a cluster
+  that rejects it would empty both pickers; splitting on each entry's own
+  `functions`/`task_ids` cannot fail that way.
 
 The provider key is OpenRAG's own; `LITELLM_PROVIDER` is what it routes as.
 Nothing here imports OpenRAG config — `config_manager`, `model_catalog` and
 `llm_gateway` all read this module, so it has to stay a leaf.
+
+Verified end to end against a Cloud Pak for Data 5.x cluster: ZenApiKey accepted
+on `/ml/v1`, model listing, chat, streaming chat, embeddings and tool calling.
 
 TLS: trusting a cluster's own CA
 --------------------------------
@@ -58,8 +69,10 @@ than as an outage — see ``_UPSTREAM_TLS_MESSAGE`` in ``services/llm_gateway``.
 from __future__ import annotations
 
 import base64
+import time
 from collections.abc import Mapping
-from typing import Any
+from typing import Any, NamedTuple
+from urllib.parse import urlsplit, urlunsplit
 
 from utils.logging_config import get_logger
 
@@ -125,8 +138,10 @@ CREDENTIAL_FIELDS: list[dict[str, Any]] = [
         "key": "space_id",
         "label": "Deployment space ID",
         "placeholder": None,
-        "tooltip": "Optional. The deployment space the models are served from. Leave blank "
-        "on a lightweight-engine install, which uses neither spaces nor projects.",
+        "tooltip": "The deployment space the models are served from. Most clusters "
+        "require this (or a project ID) and reject inference without it. Find it under "
+        "Deployments in the console, or with GET /v2/spaces on the cluster. Leave blank "
+        "only on a lightweight-engine install, which uses neither spaces nor projects.",
         "required": False,
         "field_type": "text",
         "options": None,
@@ -223,8 +238,226 @@ def auth_header(stored: Mapping[str, Any]) -> str:
 
 
 def model_specs_url(api_base: str) -> str:
-    """The catalogue URL on `api_base`, however the operator typed the cluster URL."""
-    return f"{(api_base or '').rstrip('/')}{MODEL_SPECS_PATH}?version={API_VERSION}"
+    """The catalogue URL on `api_base`, however the operator typed the cluster URL.
+
+    Deliberately carries no query string. httpx *replaces* a URL's query when
+    it is given `params`, so a `?version=` baked in here is silently dropped by
+    any caller that also pages or filters — and the cluster answers
+    `invalid_version_date_pattern` for the empty version that results.
+    Everything goes through `model_specs_params` instead.
+    """
+    return f"{(api_base or '').rstrip('/')}{MODEL_SPECS_PATH}"
+
+
+def model_specs_params(**extra: Any) -> dict[str, Any]:
+    """Query parameters for the catalogue endpoint. `version` is mandatory."""
+    return {"version": API_VERSION, **extra}
+
+
+def ssl_verify() -> bool | str:
+    """The TLS setting LiteLLM will use, so our own calls agree with real traffic.
+
+    A cluster behind its own CA is reached by pointing `SSL_CERT_FILE` at a
+    bundle (or, in development, by `SSL_VERIFY=false`). Both are read by
+    LiteLLM, not by httpx, so without this a direct call here could fail on a
+    certificate that the gateway accepts, or the reverse.
+    """
+    try:
+        from litellm.llms.custom_httpx.http_handler import get_ssl_verify
+
+        return get_ssl_verify()
+    except Exception:
+        logger.debug("Could not read LiteLLM's TLS setting; verifying normally", exc_info=True)
+        return True
+
+
+#: How long a fetched model list is reused. The set of deployed models changes
+#: when an administrator deploys one, not per request.
+MODELS_TTL_SECONDS = 300
+
+#: Page size asked for. A cluster serves tens of models, not thousands, but the
+#: endpoint pages by default and a truncated list silently hides models.
+MODELS_PAGE_LIMIT = 200
+
+#: Guard against following `next` for ever if a cluster paginates oddly.
+MAX_MODEL_PAGES = 10
+
+#: `functions` / `task_ids` markers that say which picker a model belongs in.
+#: The listing is fetched unfiltered and split here rather than with the API's
+#: `filters` parameter: the filter grammar is a SaaS convenience, and a cluster
+#: that does not accept it would answer 400 and leave both pickers empty.
+_EMBEDDING_FUNCTIONS = frozenset({"embedding", "embeddings"})
+_CHAT_FUNCTIONS = frozenset({"text_chat", "text_generation", "chat", "generation"})
+
+
+class ClusterModels(NamedTuple):
+    chat: tuple[str, ...]
+    embedding: tuple[str, ...]
+
+
+_models_cache: dict[str, Any] = {"key": None, "at": 0.0, "value": None}
+
+
+def cached_models() -> ClusterModels | None:
+    """The last model list fetched from the cluster, if it is still fresh."""
+    value = _models_cache["value"]
+    if value is None or time.monotonic() - _models_cache["at"] > MODELS_TTL_SECONDS:
+        return None
+    return value
+
+
+def _cache_key(credentials: Mapping[str, Any]) -> str:
+    """Identifies the cluster and the credentials a cached list was fetched with."""
+    values = litellm_credentials(credentials)
+    return f"{values.get('api_base', '')}|{values.get('api_key', '')}"
+
+
+def _resource_markers(resource: Mapping[str, Any]) -> set[str]:
+    """Everything a listing entry says about what it can do, lowercased."""
+    markers: set[str] = set()
+    for function in resource.get("functions") or []:
+        if isinstance(function, Mapping) and function.get("id"):
+            markers.add(str(function["id"]).lower())
+        elif isinstance(function, str):
+            markers.add(function.lower())
+    for task in resource.get("task_ids") or []:
+        markers.add(str(task).lower())
+    return markers
+
+
+def _is_withdrawn(resource: Mapping[str, Any]) -> bool:
+    """Whether the cluster still lists a model it has already retired."""
+    lifecycle = resource.get("lifecycle")
+    if isinstance(lifecycle, list):
+        return any(
+            isinstance(entry, Mapping) and str(entry.get("id", "")).lower() == "withdrawn"
+            for entry in lifecycle
+        )
+    return str(lifecycle or "").lower() == "withdrawn"
+
+
+def split_models(resources: Any) -> ClusterModels:
+    """Split one `foundation_model_specs` listing into the two picker lists.
+
+    Order is preserved and duplicates dropped. A model that advertises nothing
+    useful is treated as a text model: the great majority are, and leaving it
+    out would hide something the cluster actually serves.
+    """
+    chat: list[str] = []
+    embedding: list[str] = []
+    for resource in resources or []:
+        if not isinstance(resource, Mapping):
+            continue
+        model_id = str(resource.get("model_id") or "").strip()
+        if not model_id:
+            continue
+        # `tech_preview` is not requestable on every deployment, and the SaaS
+        # listing drops it for the same reason.
+        if resource.get("input_tier") == "tech_preview" or _is_withdrawn(resource):
+            continue
+        markers = _resource_markers(resource)
+        bucket = embedding if markers & _EMBEDDING_FUNCTIONS else chat
+        if markers & _EMBEDDING_FUNCTIONS and markers & _CHAT_FUNCTIONS:
+            # A model that does both belongs in both pickers.
+            if model_id not in chat:
+                chat.append(model_id)
+        if model_id not in bucket:
+            bucket.append(model_id)
+    return ClusterModels(chat=tuple(chat), embedding=tuple(embedding))
+
+
+async def fetch_models(credentials: Mapping[str, Any]) -> ClusterModels | None:
+    """Ask the cluster which foundation models it actually serves.
+
+    A cluster serves whatever its operator deployed, so this is the only
+    truthful source for the pickers — LiteLLM's bundled table describes IBM
+    Cloud, and the `models:` rows in `model_providers.yaml` are the fallback for
+    when the cluster cannot be reached.
+
+    The listing is fetched unfiltered and split locally, which keeps this
+    working on a lightweight-engine install that has no projects and may not
+    accept the SaaS `filters` grammar. Returns None on any failure, so a
+    catalogue request never fails because the cluster is unreachable; the caller
+    keeps whatever it had.
+    """
+    import httpx
+
+    values = litellm_credentials(credentials)
+    api_base = (values.get("api_base") or "").strip()
+    header = auth_header(credentials)
+    if not api_base or not header:
+        return None
+
+    key = _cache_key(credentials)
+    fresh = cached_models()
+    if fresh is not None and _models_cache["key"] == key:
+        return fresh
+
+    headers = {"Authorization": header, "Accept": "application/json"}
+    url = model_specs_url(api_base)
+    # Only the first request needs parameters built here; a `next` link already
+    # carries its own `version` and `start` in the query it comes back with.
+    params: dict[str, Any] | None = model_specs_params(limit=MODELS_PAGE_LIMIT)
+    resources: list[Any] = []
+    try:
+        async with httpx.AsyncClient(verify=ssl_verify(), timeout=15.0) as client:
+            for _ in range(MAX_MODEL_PAGES):
+                response = await client.get(url, headers=headers, params=params)
+                if response.status_code != 200:
+                    logger.warning(
+                        "watsonx.ai cluster rejected the model listing; "
+                        "keeping the configured list",
+                        status_code=response.status_code,
+                        url=url,
+                        body=response.text[:300],
+                    )
+                    return None
+                body = response.json()
+                if not isinstance(body, dict):
+                    return None
+                resources.extend(body.get("resources") or [])
+                next_page = body.get("next")
+                href = next_page.get("href") if isinstance(next_page, Mapping) else None
+                if not href:
+                    break
+                # Only the path and query are usable. A cluster answers with
+                # its own internal hostname here — this one returns
+                # `https://wx-inference-proxy-upstream/ml/v1/...`, which does
+                # not resolve outside the cluster — so the next page is
+                # re-based on the URL the operator gave us.
+                parsed = urlsplit(href)
+                url = f"{api_base.rstrip('/')}{urlunsplit(('', '', parsed.path, parsed.query, ''))}"
+                params = None
+    except Exception as exc:
+        logger.warning(
+            "Could not list models on the watsonx.ai cluster; keeping the configured list",
+            error=str(exc),
+        )
+        return None
+
+    models = split_models(resources)
+    if not models.chat and not models.embedding:
+        # Far more likely a listing we could not interpret than a cluster with
+        # nothing deployed. Emptying both pickers on that guess would be worse
+        # than showing the fallback.
+        logger.warning(
+            "watsonx.ai cluster listed no usable models; keeping the configured list",
+            resources=len(resources),
+        )
+        return None
+
+    _models_cache.update(key=key, at=time.monotonic(), value=models)
+    logger.info(
+        "Listed models on the watsonx.ai cluster",
+        chat=len(models.chat),
+        embedding=len(models.embedding),
+    )
+    return models
+
+
+def forget_models() -> None:
+    """Drop the cached cluster list. For tests and for a credential change."""
+    _models_cache.update(key=None, at=0.0, value=None)
 
 
 # --------------------------------------------------------------------------

--- a/tests/unit/services/test_llm_gateway.py
+++ b/tests/unit/services/test_llm_gateway.py
@@ -593,10 +593,25 @@ def test_a_vendor_qualified_name_is_not_mistaken_for_a_provider_tag():
     Splitting on the slash routed it to OpenAI as a bare `gpt-oss-120b`, which
     LiteLLM rejects with "LLM Provider NOT provided", surfacing to the user as
     "The model provider could not be reached."
+
+    Whether the id names one owner or several depends on the deployment's
+    provider config — a cluster row that also lists it makes two — so what is
+    asserted here is the part that must hold either way: the id is never handed
+    to the provider its prefix happens to name.
     """
     from services.llm_gateway import split_model_id
+    from services.model_catalog import catalog_owners
 
-    assert split_model_id("openai/gpt-oss-120b") == ("watsonx", "openai/gpt-oss-120b")
+    provider, name = split_model_id("openai/gpt-oss-120b")
+
+    assert name == "openai/gpt-oss-120b"
+    owners = catalog_owners("openai/gpt-oss-120b")
+    if len(owners) == 1:
+        assert provider == owners[0]
+    else:
+        # Untagged; `resolve_call` picks between the owners with the config in
+        # hand. Either way it is not "openai".
+        assert provider is None
 
 
 def test_model_ids_served_by_v1_models_round_trip():

--- a/tests/unit/services/test_watsonx_onprem.py
+++ b/tests/unit/services/test_watsonx_onprem.py
@@ -1,0 +1,229 @@
+"""watsonx.ai on a Cloud Pak for Data cluster, routed through LiteLLM's watsonx provider."""
+
+from types import SimpleNamespace
+
+import pytest
+
+from config import model_providers
+from config.config_manager import (
+    AnthropicConfig,
+    GenericProviderConfig,
+    OllamaConfig,
+    OpenAIConfig,
+    ProvidersConfig,
+    WatsonXConfig,
+)
+from services import model_catalog, watsonx_onprem
+from services.llm_gateway import resolve_call
+
+PROVIDER = watsonx_onprem.PROVIDER_KEY
+
+
+@pytest.fixture(autouse=True)
+def _reload_provider_config():
+    model_providers.reload()
+    yield
+    model_providers.reload()
+
+
+def _providers(**credentials) -> ProvidersConfig:
+    return ProvidersConfig(
+        openai=OpenAIConfig(),
+        anthropic=AnthropicConfig(),
+        watsonx=WatsonXConfig(),
+        ollama=OllamaConfig(),
+        custom={PROVIDER: GenericProviderConfig(credentials=dict(credentials), configured=True)},
+    )
+
+
+def test_zen_api_key_is_the_base64_cpd_docs_describe() -> None:
+    # `echo "<username>:<apikey>" | base64`, which is what the cluster expects
+    # after `Authorization: ZenApiKey `.
+    assert watsonx_onprem.zen_api_key("cpduser", "APIKEY") == "Y3BkdXNlcjpBUElLRVk="
+
+
+@pytest.mark.parametrize("username, api_key", [("", "APIKEY"), ("cpduser", ""), (None, None)])
+def test_a_half_filled_form_yields_no_zen_key(username, api_key) -> None:
+    """Better no credential than one that looks valid and 401s on first use."""
+    assert watsonx_onprem.zen_api_key(username, api_key) == ""
+
+
+def test_username_never_reaches_litellm() -> None:
+    """LiteLLM forwards kwargs it does not recognise, so a stray field lands in the body."""
+    credentials = watsonx_onprem.litellm_credentials(
+        {"api_base": "https://cpd.example.com", "username": "cpduser", "api_key": "APIKEY"}
+    )
+
+    assert "username" not in credentials
+    assert credentials["api_base"] == "https://cpd.example.com"
+    # Both, and the same value: the embeddings path refuses the call outright
+    # when api_key is unset, and builds its auth header from zen_api_key.
+    assert credentials["zen_api_key"] == "Y3BkdXNlcjpBUElLRVk="
+    assert credentials["api_key"] == "Y3BkdXNlcjpBUElLRVk="
+
+
+def test_a_pasted_zen_key_is_used_as_given() -> None:
+    credentials = watsonx_onprem.litellm_credentials(
+        {"api_base": "https://cpd.example.com", "zen_api_key": "cHJlOmVuY29kZWQ="}
+    )
+
+    assert credentials["zen_api_key"] == "cHJlOmVuY29kZWQ="
+    assert credentials["api_key"] == "cHJlOmVuY29kZWQ="
+
+
+def test_an_api_key_with_no_username_is_still_offered_to_litellm() -> None:
+    """A cluster fronted by IBM Cloud IAM has no username half. Don't drop the secret."""
+    credentials = watsonx_onprem.litellm_credentials(
+        {"api_base": "https://cpd.example.com", "api_key": "APIKEY"}
+    )
+
+    assert credentials["api_key"] == "APIKEY"
+    assert "zen_api_key" not in credentials
+
+
+def test_a_deployment_scope_is_passed_through_untouched() -> None:
+    credentials = watsonx_onprem.litellm_credentials(
+        {
+            "api_base": "https://cpd.example.com",
+            "username": "cpduser",
+            "api_key": "APIKEY",
+            "space_id": "space-1",
+            "project_id": "proj-1",
+        }
+    )
+
+    assert credentials["space_id"] == "space-1"
+    assert credentials["project_id"] == "proj-1"
+
+
+def test_credential_values_translates_the_stored_form() -> None:
+    providers = _providers(api_base="https://cpd.example.com", username="cpduser", api_key="APIKEY")
+
+    assert providers.credential_values(PROVIDER) == {
+        "api_base": "https://cpd.example.com",
+        "zen_api_key": "Y3BkdXNlcjpBUElLRVk=",
+        "api_key": "Y3BkdXNlcjpBUElLRVk=",
+    }
+
+
+def test_pending_credentials_rebuilds_the_zen_key_from_a_submitted_change() -> None:
+    """Validation runs before the write, on the union of stored and submitted.
+
+    Merging after the translation would validate a new API key against a Zen
+    key still built from the old one.
+    """
+    providers = _providers(api_base="https://cpd.example.com", username="cpduser", api_key="OLDKEY")
+
+    pending = providers.pending_credentials(PROVIDER, {"api_key": "NEWKEY"})
+
+    assert pending["zen_api_key"] == watsonx_onprem.zen_api_key("cpduser", "NEWKEY")
+    assert pending["api_base"] == "https://cpd.example.com"
+
+
+def test_the_gateway_routes_it_as_watsonx() -> None:
+    """`watsonx_onprem/<model>` is not a prefix LiteLLM can resolve."""
+    config = SimpleNamespace(
+        providers=_providers(
+            api_base="https://cpd.example.com", username="cpduser", api_key="APIKEY"
+        ),
+        agent=SimpleNamespace(llm_model="", llm_provider="openai"),
+        knowledge=SimpleNamespace(embedding_model="", embedding_provider="openai"),
+    )
+
+    litellm_model, provider, credentials = resolve_call(
+        f"{PROVIDER}:ibm/granite-3-3-8b-instruct", kind="chat", config=config
+    )
+
+    assert litellm_model == "watsonx/ibm/granite-3-3-8b-instruct"
+    # The OpenRAG key is what the caller and the credential store still see.
+    assert provider == PROVIDER
+    assert credentials["zen_api_key"] == "Y3BkdXNlcjpBUElLRVk="
+
+
+def test_the_alias_is_routable_so_ids_are_not_billed_to_the_default_provider() -> None:
+    assert model_catalog.is_known_provider(PROVIDER)
+    assert model_catalog.litellm_provider_key(PROVIDER) == "watsonx"
+    assert model_catalog.litellm_provider_key("openai") == "openai"
+
+
+def test_it_ships_on_prem_only(monkeypatch) -> None:
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    assert PROVIDER in model_providers.visible_provider_keys()
+
+    for mode in ("oss", "saas"):
+        monkeypatch.setenv("OPENRAG_RUN_MODE", mode)
+        assert PROVIDER not in model_providers.visible_provider_keys(), mode
+
+
+def test_the_settings_form_asks_for_cluster_credentials_not_ibm_cloud_ones() -> None:
+    fields = {field["key"]: field for field in model_catalog.credential_fields(PROVIDER)}
+
+    assert fields["api_base"]["required"] is True
+    assert set(fields) == {
+        "api_base",
+        "username",
+        "api_key",
+        "zen_api_key",
+        "space_id",
+        "project_id",
+    }
+    assert model_catalog.secret_field_keys(PROVIDER) == {"api_key", "zen_api_key"}
+
+
+def test_its_models_come_from_config_not_ibm_clouds_price_table(monkeypatch) -> None:
+    """Two providers sharing model ids would leave `catalog_owner` unable to pick one."""
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    entries = {entry["key"]: entry for entry in model_catalog.catalog()["providers"]}
+
+    onprem = entries[PROVIDER]
+    declared = {entry.name: entry for entry in model_providers.visible_provider_entries()}[PROVIDER]
+
+    assert {entry["model"] for entry in onprem["models"]} == set(declared.models)
+    assert {entry["model"] for entry in onprem["embedding_models"]} == set(
+        declared.embedding_models
+    )
+    assert onprem["embedding_models"], "an embedding provider with no ids can never be selected"
+
+    shared = {entry["model"] for entry in entries["watsonx"]["models"]} & {
+        entry["model"] for entry in onprem["models"]
+    }
+    for model in shared:
+        assert model_catalog.catalog_owner(model) is None or model_catalog.catalog_owner(model) in {
+            "watsonx",
+            PROVIDER,
+        }
+
+
+def test_a_scopeless_cluster_call_carries_no_null_space_id() -> None:
+    """The lightweight engine uses neither a project nor a space.
+
+    LiteLLM 1.84 refuses the call locally and, past that, serialises the absent
+    space as `"space_id": null`. Both are wrong for that install.
+    """
+    watsonx_onprem.install_litellm_compatibility()
+
+    from litellm.llms.watsonx.chat.handler import _get_api_params
+    from litellm.llms.watsonx.chat.transformation import IBMWatsonXChatConfig
+
+    api_params = _get_api_params(params={}, model="ibm/granite-3-3-8b-instruct")
+    payload = IBMWatsonXChatConfig()._prepare_payload(
+        model="ibm/granite-3-3-8b-instruct", api_params=api_params
+    )
+
+    assert payload == {"model_id": "ibm/granite-3-3-8b-instruct"}
+
+
+def test_a_scope_that_is_set_still_reaches_the_cluster() -> None:
+    watsonx_onprem.install_litellm_compatibility()
+
+    from litellm.llms.watsonx.chat.handler import _get_api_params
+    from litellm.llms.watsonx.chat.transformation import IBMWatsonXChatConfig
+
+    api_params = _get_api_params(
+        params={"space_id": "space-1"}, model="ibm/granite-3-3-8b-instruct"
+    )
+    payload = IBMWatsonXChatConfig()._prepare_payload(
+        model="ibm/granite-3-3-8b-instruct", api_params=api_params
+    )
+
+    assert payload == {"model_id": "ibm/granite-3-3-8b-instruct", "space_id": "space-1"}

--- a/tests/unit/services/test_watsonx_onprem.py
+++ b/tests/unit/services/test_watsonx_onprem.py
@@ -324,6 +324,7 @@ async def test_health_needs_no_model_selected(monkeypatch) -> None:
     async def _fake_request(method, url, **kwargs):
         called["method"] = method
         called["url"] = url
+        called["params"] = kwargs.get("params") or {}
         called["auth"] = kwargs.get("headers", {}).get("Authorization")
         return SimpleNamespace(status_code=200, text="{}", json=lambda: {"resources": []})
 
@@ -337,9 +338,12 @@ async def test_health_needs_no_model_selected(monkeypatch) -> None:
     )
 
     assert called["method"] == "GET"
-    assert called["url"] == (
-        "https://cpd.example.com/ml/v1/foundation_model_specs?version=2024-03-13"
-    )
+    # No query on the URL: httpx replaces a URL's query when it is given
+    # `params`, and a `?version=` baked into the URL is then silently dropped —
+    # the cluster answers `invalid_version_date_pattern` for the empty version
+    # that results.
+    assert called["url"] == "https://cpd.example.com/ml/v1/foundation_model_specs"
+    assert called["params"]["version"] == watsonx_onprem.API_VERSION
     assert called["auth"] == "ZenApiKey Y3BkdXNlcjpBUElLRVk="
 
 
@@ -376,14 +380,12 @@ def test_the_health_probe_uses_the_same_tls_setting_as_real_traffic(monkeypatch)
     Without this the banner could sit red on a certificate error while chat
     through the gateway works, or the reverse.
     """
-    from api.provider_validation import _cluster_ssl_verify
-
     monkeypatch.setenv("SSL_VERIFY", "false")
-    assert _cluster_ssl_verify() is False
+    assert watsonx_onprem.ssl_verify() is False
 
     monkeypatch.setenv("SSL_VERIFY", "true")
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
-    assert _cluster_ssl_verify() is True
+    assert watsonx_onprem.ssl_verify() is True
 
 
 @pytest.mark.asyncio
@@ -448,3 +450,228 @@ async def test_switching_an_embedding_model_is_probed_for_real(monkeypatch) -> N
     )
 
     assert probes == ["watsonx/ibm/slate-125m-english-rtrvr-v2"]
+
+
+@pytest.fixture
+def _forget_cluster_models():
+    watsonx_onprem.forget_models()
+    yield
+    watsonx_onprem.forget_models()
+
+
+def _specs_response(resources, status_code=200):
+    return SimpleNamespace(
+        status_code=status_code,
+        text="",
+        json=lambda: {"resources": [dict(entry) for entry in resources]},
+    )
+
+
+#: Trimmed from a real Cloud Pak for Data cluster's `foundation_model_specs`
+#: response. The shapes matter: `functions` is a list of `{"id": ...}`,
+#: `lifecycle` is a list rather than a string, and the chat model's own name
+#: begins with another provider's key.
+CLUSTER_RESOURCES = [
+    {
+        "model_id": "ibm/slate-30m-english-rtrvr",
+        "functions": [{"id": "embedding"}, {"id": "rerank"}, {"id": "similarity"}],
+        "lifecycle": [{"id": "available", "current_state": True}],
+        "input_tier": "class_c1",
+    },
+    {
+        "model_id": "openai/gpt-oss-120b",
+        "functions": [{"id": "autoai_rag"}, {"id": "text_chat"}],
+        "task_ids": ["summarization", "generation", "function_calling"],
+        "lifecycle": [{"id": "available", "current_state": True}],
+        "input_tier": "class_8",
+    },
+    {
+        "model_id": "ibm/granite-preview",
+        "functions": [{"id": "text_chat"}],
+        "input_tier": "tech_preview",
+    },
+    {
+        "model_id": "ibm/granite-retired",
+        "functions": [{"id": "text_chat"}],
+        "lifecycle": [{"id": "withdrawn", "current_state": True}],
+    },
+]
+
+
+def test_a_cluster_listing_is_split_into_the_two_pickers() -> None:
+    """Split locally rather than with the API's `filters` grammar.
+
+    The grammar is a SaaS convenience; a cluster that does not accept it would
+    answer 400 and leave both pickers empty.
+    """
+    models = watsonx_onprem.split_models(CLUSTER_RESOURCES)
+
+    assert models.chat == ("openai/gpt-oss-120b",)
+    assert models.embedding == ("ibm/slate-30m-english-rtrvr",)
+    # tech_preview is not requestable on every deployment; withdrawn is retired.
+    assert "ibm/granite-preview" not in models.chat
+    assert "ibm/granite-retired" not in models.chat
+
+
+@pytest.mark.asyncio
+async def test_the_picker_shows_what_the_cluster_serves(
+    monkeypatch, _forget_cluster_models
+) -> None:
+    """A cluster serves whatever its operator deployed.
+
+    The configured `models:` rows can only ever be a guess, so a model the
+    cluster does not have would otherwise sit in the picker waiting to be
+    chosen and fail at the first call.
+    """
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    seen: dict[str, object] = {}
+
+    class _Client:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            seen["url"] = url
+            seen["params"] = dict(params or {})
+            assert headers["Authorization"].startswith("ZenApiKey ")
+            return _specs_response(CLUSTER_RESOURCES)
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+    models = await watsonx_onprem.fetch_models(
+        {"api_base": "https://cpd.example.com", "username": "u", "api_key": "k"}
+    )
+
+    # The version has to travel in `params`; httpx would drop it from the URL.
+    assert seen["url"] == "https://cpd.example.com/ml/v1/foundation_model_specs"
+    assert seen["params"]["version"] == watsonx_onprem.API_VERSION
+    # No project: a lightweight-engine install has none, and sending one 404s.
+    assert "project_id" not in seen["params"]
+
+    assert models.chat == ("openai/gpt-oss-120b",)
+    assert models.embedding == ("ibm/slate-30m-english-rtrvr",)
+
+    entry = {e["key"]: e for e in model_catalog.catalog()["providers"]}[PROVIDER]
+    assert [m["model"] for m in entry["models"]] == ["openai/gpt-oss-120b"]
+    assert [m["model"] for m in entry["embedding_models"]] == ["ibm/slate-30m-english-rtrvr"]
+
+
+@pytest.mark.asyncio
+async def test_a_next_page_is_re_based_on_the_operators_cluster_url(
+    monkeypatch, _forget_cluster_models
+) -> None:
+    """A cluster names itself internally in its own pagination links.
+
+    This one answers `https://wx-inference-proxy-upstream/ml/v1/...`, which does
+    not resolve outside the cluster. Following it verbatim strands the listing
+    on page one.
+    """
+    urls: list[str] = []
+
+    class _Client:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            urls.append(url)
+            if len(urls) == 1:
+                return SimpleNamespace(
+                    status_code=200,
+                    text="",
+                    json=lambda: {
+                        "resources": [CLUSTER_RESOURCES[1]],
+                        "next": {
+                            "href": "https://wx-inference-proxy-upstream"
+                            "/ml/v1/foundation_model_specs?version=2024-03-13&start=2"
+                        },
+                    },
+                )
+            return _specs_response([CLUSTER_RESOURCES[0]])
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+    models = await watsonx_onprem.fetch_models(
+        {"api_base": "https://cpd.example.com", "username": "u", "api_key": "k"}
+    )
+
+    assert urls[1].startswith("https://cpd.example.com/ml/v1/foundation_model_specs")
+    assert "wx-inference-proxy-upstream" not in urls[1]
+    assert "start=2" in urls[1]
+    assert models.chat == ("openai/gpt-oss-120b",)
+    assert models.embedding == ("ibm/slate-30m-english-rtrvr",)
+
+
+@pytest.mark.asyncio
+async def test_an_unreachable_cluster_keeps_the_configured_fallback(
+    monkeypatch, _forget_cluster_models
+) -> None:
+    """A catalogue request must never fail because the cluster is down."""
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+
+    class _Client:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            raise OSError("cluster unreachable")
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+    assert (
+        await watsonx_onprem.fetch_models(
+            {"api_base": "https://cpd.example.com", "username": "u", "api_key": "k"}
+        )
+        is None
+    )
+
+    declared = {e.name: e for e in model_providers.visible_provider_entries()}[PROVIDER]
+    entry = {e["key"]: e for e in model_catalog.catalog()["providers"]}[PROVIDER]
+    assert {m["model"] for m in entry["models"]} == set(declared.models)
+
+
+@pytest.mark.asyncio
+async def test_an_empty_listing_is_treated_as_a_bad_filter_not_an_empty_cluster(
+    monkeypatch, _forget_cluster_models
+) -> None:
+    """Emptying both pickers on a guess would be worse than showing the fallback."""
+
+    class _Client:
+        def __init__(self, **kwargs):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            return _specs_response([])
+
+    monkeypatch.setattr("httpx.AsyncClient", _Client)
+
+    assert (
+        await watsonx_onprem.fetch_models(
+            {"api_base": "https://cpd.example.com", "username": "u", "api_key": "k"}
+        )
+        is None
+    )
+    assert watsonx_onprem.cached_models() is None

--- a/tests/unit/services/test_watsonx_onprem.py
+++ b/tests/unit/services/test_watsonx_onprem.py
@@ -14,7 +14,7 @@ from config.config_manager import (
     WatsonXConfig,
 )
 from services import model_catalog, watsonx_onprem
-from services.llm_gateway import resolve_call
+from services.llm_gateway import resolve_call, split_model_id
 
 PROVIDER = watsonx_onprem.PROVIDER_KEY
 
@@ -146,13 +146,18 @@ def test_the_alias_is_routable_so_ids_are_not_billed_to_the_default_provider() -
     assert model_catalog.litellm_provider_key("openai") == "openai"
 
 
-def test_it_ships_on_prem_only(monkeypatch) -> None:
+def test_it_ships_on_prem_and_never_in_saas(monkeypatch) -> None:
+    """on_prem is the mode it exists for; SaaS is the one it must never reach.
+
+    Nothing is asserted about `oss`: that row gets flipped on for local testing
+    the way `azure_ai`'s is, and a test that pins it only breaks the next person
+    who needs the card in their dev stack.
+    """
     monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
     assert PROVIDER in model_providers.visible_provider_keys()
 
-    for mode in ("oss", "saas"):
-        monkeypatch.setenv("OPENRAG_RUN_MODE", mode)
-        assert PROVIDER not in model_providers.visible_provider_keys(), mode
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "saas")
+    assert PROVIDER not in model_providers.visible_provider_keys()
 
 
 def test_the_settings_form_asks_for_cluster_credentials_not_ibm_cloud_ones() -> None:
@@ -184,14 +189,24 @@ def test_its_models_come_from_config_not_ibm_clouds_price_table(monkeypatch) -> 
     )
     assert onprem["embedding_models"], "an embedding provider with no ids can never be selected"
 
-    shared = {entry["model"] for entry in entries["watsonx"]["models"]} & {
-        entry["model"] for entry in onprem["models"]
-    }
-    for model in shared:
-        assert model_catalog.catalog_owner(model) is None or model_catalog.catalog_owner(model) in {
-            "watsonx",
-            PROVIDER,
-        }
+
+def test_an_id_both_watsonx_rows_serve_is_never_handed_to_its_prefix(monkeypatch) -> None:
+    """`openai/gpt-oss-120b` is watsonx's model, not OpenAI's.
+
+    A cluster that also serves it puts the id under two providers, so
+    `catalog_owner` cannot pick one. The old fallback split on the slash and
+    routed it to OpenAI — with OpenAI's key, for a model OpenAI does not have.
+    """
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    model = "openai/gpt-oss-120b"
+
+    if len(model_catalog.catalog_owners(model)) < 2:
+        pytest.skip("this deployment's config does not list the id under both watsonx rows")
+
+    assert model_catalog.catalog_owner(model) is None
+    # Untagged, so it goes to the configured default provider whole rather than
+    # to whichever provider the prefix happens to name.
+    assert split_model_id(model) == (None, model)
 
 
 def test_a_scopeless_cluster_call_carries_no_null_space_id() -> None:
@@ -227,3 +242,145 @@ def test_a_scope_that_is_set_still_reaches_the_cluster() -> None:
     )
 
     assert payload == {"model_id": "ibm/granite-3-3-8b-instruct", "space_id": "space-1"}
+
+
+def test_a_self_signed_cluster_cert_is_reported_as_a_trust_problem() -> None:
+    """The request never leaves the process, so there is no provider error to quote.
+
+    Without this the message collapses to "could not be reached", which sends an
+    operator hunting for a network fault instead of a missing CA.
+    """
+    from services.llm_gateway import _upstream_client_message
+
+    detail = (
+        "InternalServerError: WatsonxException - Cannot connect to host "
+        "cpd.example.com:443 ssl:True [SSLCertVerificationError: (1, '[SSL: "
+        "CERTIFICATE_VERIFY_FAILED] certificate verify failed: self-signed "
+        "certificate in certificate chain (_ssl.c:1032)')]"
+    )
+
+    message = _upstream_client_message(detail, PROVIDER, "watsonx/ibm/granite-3-3-8b-instruct")
+
+    assert "TLS certificate is not trusted" in message
+    assert "CA certificate" in message
+    # Not mistaken for a bad key: rotating a working ZenApiKey fixes nothing.
+    assert "API key" not in message
+
+
+def test_a_revoked_key_still_reads_as_a_credential_problem() -> None:
+    from services.llm_gateway import _upstream_client_message
+
+    message = _upstream_client_message(
+        'InternalServerError: {"errorCode":"BXNIM0415E","errorMessage":"Provided API key '
+        'could not be found."}',
+        PROVIDER,
+        "watsonx/ibm/granite-3-3-8b-instruct",
+    )
+
+    assert "API key is invalid" in message
+
+
+def test_a_shared_id_reaches_the_cluster_under_the_selected_provider(monkeypatch) -> None:
+    """The real failure: `openai/gpt-oss-120b` picked while watsonx_onprem is selected.
+
+    Settings stores the provider and the bare model id separately, so the id
+    arrives untagged. Splitting it on the slash threw away the selected provider
+    and called OpenAI with OpenAI's key for a model OpenAI does not serve.
+    """
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "on_prem")
+    model = "openai/gpt-oss-120b"
+    if len(model_catalog.catalog_owners(model)) < 2:
+        pytest.skip("this deployment's config does not list the id under both watsonx rows")
+
+    config = SimpleNamespace(
+        providers=_providers(
+            api_base="https://cpd.example.com", username="cpduser", api_key="APIKEY"
+        ),
+        agent=SimpleNamespace(llm_model=model, llm_provider=PROVIDER),
+        knowledge=SimpleNamespace(embedding_model="", embedding_provider="openai"),
+    )
+
+    litellm_model, provider, credentials = resolve_call(None, kind="chat", config=config)
+
+    assert provider == PROVIDER
+    assert litellm_model == f"watsonx/{model}"
+    assert credentials["zen_api_key"] == "Y3BkdXNlcjpBUElLRVk="
+
+
+@pytest.mark.asyncio
+async def test_health_needs_no_model_selected(monkeypatch) -> None:
+    """The banner reported "A model is required to validate the provider".
+
+    Every generic provider is validated by making a real call, so one that is
+    configured but has no model chosen yet failed validation and surfaced as a
+    provider error — pointing at the credentials dialog for something that was
+    never a credentials problem. The cluster's catalogue endpoint needs no
+    model, no project and no space.
+    """
+    from api import provider_validation
+
+    called: dict[str, object] = {}
+
+    async def _fake_request(method, url, **kwargs):
+        called["method"] = method
+        called["url"] = url
+        called["auth"] = kwargs.get("headers", {}).get("Authorization")
+        return SimpleNamespace(status_code=200, text="{}", json=lambda: {"resources": []})
+
+    monkeypatch.setattr(provider_validation, "_http_request_with_retry", _fake_request)
+
+    credentials = watsonx_onprem.litellm_credentials(
+        {"api_base": "https://cpd.example.com/", "username": "cpduser", "api_key": "APIKEY"}
+    )
+    await provider_validation.validate_provider_setup(
+        provider=PROVIDER, credentials=credentials, llm_model=None, embedding_model=None
+    )
+
+    assert called["method"] == "GET"
+    assert called["url"] == (
+        "https://cpd.example.com/ml/v1/foundation_model_specs?version=2024-03-13"
+    )
+    assert called["auth"] == "ZenApiKey Y3BkdXNlcjpBUElLRVk="
+
+
+@pytest.mark.asyncio
+async def test_health_reports_a_rejected_zen_key_as_a_credential_problem(monkeypatch) -> None:
+    from api import provider_validation
+    from api.provider_validation import is_provider_credential_error
+
+    async def _fake_request(method, url, **kwargs):
+        return SimpleNamespace(
+            status_code=401,
+            text='{"errors":[{"message":"Failed to authenticate the request"}]}',
+            json=lambda: {"errors": [{"message": "Failed to authenticate the request"}]},
+        )
+
+    monkeypatch.setattr(provider_validation, "_http_request_with_retry", _fake_request)
+
+    credentials = watsonx_onprem.litellm_credentials(
+        {"api_base": "https://cpd.example.com", "username": "cpduser", "api_key": "APIKEY"}
+    )
+    with pytest.raises(Exception) as excinfo:
+        await provider_validation.validate_provider_setup(
+            provider=PROVIDER, credentials=credentials, llm_model=None, embedding_model=None
+        )
+
+    # Classified as a credential failure so the banner offers "update the key"
+    # rather than "the provider could not be reached".
+    assert is_provider_credential_error(str(excinfo.value))
+
+
+def test_the_health_probe_uses_the_same_tls_setting_as_real_traffic(monkeypatch) -> None:
+    """`SSL_CERT_FILE`/`SSL_VERIFY` are read by LiteLLM, not by httpx.
+
+    Without this the banner could sit red on a certificate error while chat
+    through the gateway works, or the reverse.
+    """
+    from api.provider_validation import _cluster_ssl_verify
+
+    monkeypatch.setenv("SSL_VERIFY", "false")
+    assert _cluster_ssl_verify() is False
+
+    monkeypatch.setenv("SSL_VERIFY", "true")
+    monkeypatch.delenv("SSL_CERT_FILE", raising=False)
+    assert _cluster_ssl_verify() is True

--- a/tests/unit/services/test_watsonx_onprem.py
+++ b/tests/unit/services/test_watsonx_onprem.py
@@ -384,3 +384,67 @@ def test_the_health_probe_uses_the_same_tls_setting_as_real_traffic(monkeypatch)
     monkeypatch.setenv("SSL_VERIFY", "true")
     monkeypatch.delenv("SSL_CERT_FILE", raising=False)
     assert _cluster_ssl_verify() is True
+
+
+@pytest.mark.asyncio
+async def test_switching_to_a_model_the_cluster_lacks_is_still_blocked(monkeypatch) -> None:
+    """Settings validates before it writes and returns 400 on failure.
+
+    The catalogue check added for the no-model case must not become the check
+    for *every* case: with a model in hand the probe has to be a real call, or a
+    switch to a model the cluster does not serve saves silently and only fails
+    later in chat.
+    """
+    import litellm
+
+    from api import provider_validation
+
+    probes: list[str] = []
+
+    async def _unexpected_http(method, url, **kwargs):
+        probes.append("catalogue")
+        return SimpleNamespace(status_code=200, text="{}", json=lambda: {"resources": []})
+
+    async def _fake_completion(**kwargs):
+        probes.append("real-call")
+        raise Exception('{"errors":[{"message":"Model \'ibm/nope\' is not supported"}]}')
+
+    monkeypatch.setattr(provider_validation, "_http_request_with_retry", _unexpected_http)
+    monkeypatch.setattr(litellm, "acompletion", _fake_completion)
+
+    credentials = watsonx_onprem.litellm_credentials(
+        {"api_base": "https://cpd.example.com", "username": "cpduser", "api_key": "APIKEY"}
+    )
+    with pytest.raises(Exception, match="not supported"):
+        await provider_validation.validate_provider_setup(
+            provider=PROVIDER, credentials=credentials, llm_model="ibm/nope", embedding_model=None
+        )
+
+    assert probes == ["real-call"], "a model in hand must be probed for real"
+
+
+@pytest.mark.asyncio
+async def test_switching_an_embedding_model_is_probed_for_real(monkeypatch) -> None:
+    import litellm
+
+    from api import provider_validation
+
+    probes: list[str] = []
+
+    async def _fake_embedding(**kwargs):
+        probes.append(kwargs.get("model"))
+        return {"data": []}
+
+    monkeypatch.setattr(litellm, "aembedding", _fake_embedding)
+
+    credentials = watsonx_onprem.litellm_credentials(
+        {"api_base": "https://cpd.example.com", "username": "cpduser", "api_key": "APIKEY"}
+    )
+    await provider_validation.validate_provider_setup(
+        provider=PROVIDER,
+        credentials=credentials,
+        llm_model=None,
+        embedding_model="ibm/slate-125m-english-rtrvr-v2",
+    )
+
+    assert probes == ["watsonx/ibm/slate-125m-english-rtrvr-v2"]

--- a/tests/unit/services/test_watsonx_onprem.py
+++ b/tests/unit/services/test_watsonx_onprem.py
@@ -71,14 +71,23 @@ def test_a_pasted_zen_key_is_used_as_given() -> None:
     assert credentials["api_key"] == "cHJlOmVuY29kZWQ="
 
 
-def test_an_api_key_with_no_username_is_still_offered_to_litellm() -> None:
-    """A cluster fronted by IBM Cloud IAM has no username half. Don't drop the secret."""
-    credentials = watsonx_onprem.litellm_credentials(
-        {"api_base": "https://cpd.example.com", "api_key": "APIKEY"}
-    )
+def test_an_api_key_with_no_username_authenticates_to_nothing() -> None:
+    """Username is optional on the form, and leaving it blank used to fail silently.
 
-    assert credentials["api_key"] == "APIKEY"
-    assert "zen_api_key" not in credentials
+    A Cloud Pak for Data API key is not a bearer token — the cluster trades a
+    username *and* a key for one. Sending the raw key got a 401 that read as bad
+    credentials rather than incomplete ones, and the model listing then fell
+    back to the configured list with nothing on screen to say why.
+    """
+    stored = {"api_base": "https://cpd.example.com", "api_key": "APIKEY"}
+
+    # Still handed to LiteLLM, which is free to make its own attempt with it.
+    assert watsonx_onprem.litellm_credentials(stored)["api_key"] == "APIKEY"
+    assert "zen_api_key" not in watsonx_onprem.litellm_credentials(stored)
+    # But OpenRAG's own calls send no header, so the health check reports
+    # missing credentials instead of the cluster reporting bad ones.
+    assert watsonx_onprem.auth_header(stored) == ""
+    assert watsonx_onprem.auth_header({**stored, "username": "cpduser"}).startswith("ZenApiKey ")
 
 
 def test_a_deployment_scope_is_passed_through_untouched() -> None:

--- a/tests/unit/services/test_watsonx_onprem.py
+++ b/tests/unit/services/test_watsonx_onprem.py
@@ -684,3 +684,79 @@ async def test_an_empty_listing_is_treated_as_a_bad_filter_not_an_empty_cluster(
         is None
     )
     assert watsonx_onprem.cached_models() is None
+
+
+@pytest.mark.asyncio
+async def test_validating_an_embedding_model_sends_a_list_not_a_string(monkeypatch) -> None:
+    """watsonx.ai takes `inputs` only as an array.
+
+    OpenAI accepts a bare string, so the validator sent one and LiteLLM
+    forwarded it verbatim. The cluster answered "Mismatch type []string with
+    value string", which failed the pre-save check for *every* embedding model
+    and left a wrongly-chosen one impossible to change.
+    """
+    import litellm
+
+    from api import provider_validation
+
+    sent: dict[str, object] = {}
+
+    async def _fake_embedding(**kwargs):
+        sent.update(kwargs)
+        return {"data": [{"embedding": [0.1]}]}
+
+    monkeypatch.setattr(litellm, "aembedding", _fake_embedding)
+
+    await provider_validation.validate_provider_setup(
+        provider=PROVIDER,
+        credentials=watsonx_onprem.litellm_credentials(
+            {"api_base": "https://cpd.example.com", "username": "u", "api_key": "k"}
+        ),
+        llm_model=None,
+        embedding_model="ibm/slate-30m-english-rtrvr",
+    )
+
+    assert isinstance(sent["input"], list), sent["input"]
+
+
+@pytest.mark.asyncio
+async def test_a_client_sending_a_bare_string_input_still_embeds(monkeypatch) -> None:
+    """OpenAI's own contract allows a string, so clients send one."""
+    import litellm
+
+    from services.llm_gateway import embeddings
+
+    sent: dict[str, object] = {}
+
+    async def _fake_embedding(**kwargs):
+        sent.update(kwargs)
+        return {"data": [{"embedding": [0.1]}], "model": "m", "object": "list"}
+
+    monkeypatch.setattr(litellm, "aembedding", _fake_embedding)
+
+    config = SimpleNamespace(
+        providers=_providers(
+            api_base="https://cpd.example.com", username="cpduser", api_key="APIKEY"
+        ),
+        agent=SimpleNamespace(llm_model="", llm_provider=PROVIDER),
+        knowledge=SimpleNamespace(
+            embedding_model="ibm/slate-30m-english-rtrvr",
+            embedding_provider=PROVIDER,
+            legacy_embedding_provider_map={},
+        ),
+    )
+    await embeddings(
+        {"model": f"{PROVIDER}:ibm/slate-30m-english-rtrvr", "input": "hello"}, config=config
+    )
+
+    assert sent["input"] == ["hello"]
+
+
+def test_a_token_array_input_is_left_alone() -> None:
+    """Only a string is wrapped; OpenAI's token-array forms pass through."""
+    from services.llm_gateway import _embedding_input
+
+    assert _embedding_input("hello") == ["hello"]
+    assert _embedding_input(["a", "b"]) == ["a", "b"]
+    assert _embedding_input([[1, 2], [3]]) == [[1, 2], [3]]
+    assert _embedding_input([1, 2, 3]) == [1, 2, 3]


### PR DESCRIPTION
This pull request adds first-class support for IBM watsonx.ai running on-premises (Cloud Pak for Data clusters), ensuring correct handling of credentials, provider validation, and UI display. The changes affect both the frontend and backend, improving how the on-prem provider is detected, validated, and presented, and fixing issues with credential merging and error handling.

**Provider support and validation enhancements:**

* Added `watsonx_onprem` as a recognized provider throughout the frontend and backend, including display logic, logo handling, and provider detection. [[1]](diffhunk://#diff-377c8130e51b4d28de89e9a0dbab5f06dc73ef1dfdc988fd67589960e2cba1c7R25) [[2]](diffhunk://#diff-377c8130e51b4d28de89e9a0dbab5f06dc73ef1dfdc988fd67589960e2cba1c7R108-R115) [[3]](diffhunk://#diff-377c8130e51b4d28de89e9a0dbab5f06dc73ef1dfdc988fd67589960e2cba1c7L159-R168) [[4]](diffhunk://#diff-1dcdcb52522162251c09ba3a41d65fb3b524f643d3db646107834655c833ef0fL27-R38)
* Implemented a dedicated lightweight health check for watsonx.ai on-prem that validates credentials and cluster reachability without requiring a model or consuming inference, matching the provider's unique requirements. [[1]](diffhunk://#diff-a50ca64f56c03024a1381b36e0d50f0e969973b08a80291d6632a02c695e325dR1498-R1566) [[2]](diffhunk://#diff-a50ca64f56c03024a1381b36e0d50f0e969973b08a80291d6632a02c695e325dR783-R784)
* Ensured watsonx_onprem is validated natively (not via generic LiteLLM), and that credential merging and translation to the form expected by LiteLLM is done correctly before validation, preventing stale or mismatched credentials during updates. [[1]](diffhunk://#diff-a50ca64f56c03024a1381b36e0d50f0e969973b08a80291d6632a02c695e325dR638-R645) [[2]](diffhunk://#diff-a50ca64f56c03024a1381b36e0d50f0e969973b08a80291d6632a02c695e325dL652-R686) [[3]](diffhunk://#diff-d30eefc3d1293ca9293ef264b229e5217b934abb0f43f2644bf2eb26b239f590R229-R260) [[4]](diffhunk://#diff-d30eefc3d1293ca9293ef264b229e5217b934abb0f43f2644bf2eb26b239f590R287-R292) [[5]](diffhunk://#diff-4d75b7c1443c4f51a4fa22fb59df90c20bf2ccf2c76a4f76fc66e17bb1f35dccL483-R485) [[6]](diffhunk://#diff-4d75b7c1443c4f51a4fa22fb59df90c20bf2ccf2c76a4f76fc66e17bb1f35dccL536-R540)

**Error handling improvements:**

* Added detection for TLS certificate errors (such as self-signed or expired certificates), so the backend can distinguish between credential problems and trust issues, which are common in on-prem deployments.

**Testing and provider detection:**

* Improved test utilities to perform exact provider name matches, preventing ambiguous results when both cloud and on-prem watsonx.ai providers are present. [[1]](diffhunk://#diff-1dcdcb52522162251c09ba3a41d65fb3b524f643d3db646107834655c833ef0fR4-R8) [[2]](diffhunk://#diff-1dcdcb52522162251c09ba3a41d65fb3b524f643d3db646107834655c833ef0fL27-R38)

These changes ensure robust, user-friendly support for IBM watsonx.ai on-premises, with accurate validation, error reporting, and UI consistency.