### PR TITLE
fix: Add Azure auth-methods and pre-save validation

### DIFF
--- a/frontend/app/api/mutations/useOnboardingMutation.ts
+++ b/frontend/app/api/mutations/useOnboardingMutation.ts
@@ -23,6 +23,7 @@ export interface OnboardingVariables {
   watsonx_project_id?: string;
   ollama_endpoint?: string;
   provider_credentials?: Record<string, Record<string, string>>;
+  provider_auth_methods?: Record<string, string>;
 }
 
 interface OnboardingResponse {

--- a/frontend/app/api/mutations/useUpdateSettingsMutation.ts
+++ b/frontend/app/api/mutations/useUpdateSettingsMutation.ts
@@ -54,6 +54,7 @@ export interface UpdateSettingsRequest {
   // Bypass the "this provider's embedding models are still in use" guard.
   force_remove?: boolean;
   provider_credentials?: Record<string, Record<string, string>>;
+  provider_auth_methods?: Record<string, string>;
   remove_provider_config?: string;
 }
 

--- a/frontend/app/api/queries/useGetModelProvidersQuery.ts
+++ b/frontend/app/api/queries/useGetModelProvidersQuery.ts
@@ -7,6 +7,7 @@ import {
 export interface ModelProviderEntry {
   name: string;
   display_name: string;
+  badge?: string;
 }
 
 export interface ModelProvidersResponse {
@@ -32,7 +33,10 @@ export const useGetModelProvidersQuery = (
 
   return useQuery(
     {
-      queryKey: ["models", "providers"] as const,
+      // The response now carries display metadata (for example provider
+      // badges). Version the cache key so an HMR session that cached the old
+      // two-field shape fetches the enriched response immediately.
+      queryKey: ["models", "providers", "v2"] as const,
       queryFn: async (): Promise<ModelProvidersResponse> => {
         const response = await fetch("/api/models/providers");
         if (!response.ok) {

--- a/frontend/app/api/queries/useGetSettingsQuery.ts
+++ b/frontend/app/api/queries/useGetSettingsQuery.ts
@@ -60,6 +60,7 @@ export interface ProviderSettings {
       configured?: boolean;
       credential_values?: Record<string, string>;
       secret_fields?: string[];
+      auth_method?: string | null;
     }
   >;
 }

--- a/frontend/app/onboarding/_components/advanced.tsx
+++ b/frontend/app/onboarding/_components/advanced.tsx
@@ -1,10 +1,4 @@
 import { LabelWrapper } from "@/components/label-wrapper";
-import {
-  Accordion,
-  AccordionContent,
-  AccordionItem,
-  AccordionTrigger,
-} from "@/components/ui/accordion";
 import { ModelSelector } from "./model-selector";
 
 export function AdvancedOnboarding({
@@ -34,46 +28,39 @@ export function AdvancedOnboarding({
     setLanguageModel !== undefined;
 
   return (
-    <Accordion type="single" collapsible>
-      <AccordionItem value="item-1">
-        <AccordionTrigger data-testid="advanced-settings-button">
-          Advanced settings
-        </AccordionTrigger>
-        <AccordionContent className="space-y-6">
-          {hasEmbeddingModels && (
-            <LabelWrapper
-              label="Embedding model"
-              helperText="Model used for knowledge ingest and retrieval"
-              id="embedding-model"
-              required={true}
-            >
-              <ModelSelector
-                options={embeddingModels}
-                data-testid="embedding-model-selector"
-                icon={icon}
-                value={embeddingModel}
-                onValueChange={setEmbeddingModel}
-              />
-            </LabelWrapper>
-          )}
-          {hasLanguageModels && (
-            <LabelWrapper
-              label="Language model"
-              helperText="Model used for chat"
-              id="embedding-model"
-              required={true}
-            >
-              <ModelSelector
-                options={languageModels}
-                data-testid="language-model-selector"
-                icon={icon}
-                value={languageModel}
-                onValueChange={setLanguageModel}
-              />
-            </LabelWrapper>
-          )}
-        </AccordionContent>
-      </AccordionItem>
-    </Accordion>
+    <div className="space-y-6">
+      {hasEmbeddingModels && (
+        <LabelWrapper
+          label="Embedding model"
+          helperText="Model used for knowledge ingest and retrieval"
+          id="embedding-model"
+          required={true}
+        >
+          <ModelSelector
+            options={embeddingModels}
+            data-testid="embedding-model-selector"
+            icon={icon}
+            value={embeddingModel}
+            onValueChange={setEmbeddingModel}
+          />
+        </LabelWrapper>
+      )}
+      {hasLanguageModels && (
+        <LabelWrapper
+          label="Language model"
+          helperText="Model used for chat"
+          id="embedding-model"
+          required={true}
+        >
+          <ModelSelector
+            options={languageModels}
+            data-testid="language-model-selector"
+            icon={icon}
+            value={languageModel}
+            onValueChange={setLanguageModel}
+          />
+        </LabelWrapper>
+      )}
+    </div>
   );
 }

--- a/frontend/app/onboarding/_components/generic-onboarding.tsx
+++ b/frontend/app/onboarding/_components/generic-onboarding.tsx
@@ -9,6 +9,12 @@ import {
 } from "@/app/settings/_helpers/catalog-models";
 import { getProviderChrome } from "@/app/settings/_helpers/model-helpers";
 import { LabelInput } from "@/components/label-input";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import type { OnboardingVariables } from "../../api/mutations/useOnboardingMutation";
 import { AdvancedOnboarding } from "./advanced";
 
@@ -53,13 +59,58 @@ export function GenericOnboarding({
 
   const [credentials, setCredentials] = useState<Record<string, string>>({});
   const [model, setModel] = useState("");
+  const [azureAuthMethod, setAzureAuthMethod] = useState(
+    providers?.custom?.[provider]?.auth_method ?? "api_key",
+  );
+  const [onPremAuthMethod, setOnPremAuthMethod] = useState(
+    providers?.custom?.[provider]?.auth_method ?? "username_api_key",
+  );
+
+  const azureAuthGroups = [
+    { key: "api_key", label: "API key", fields: ["api_key"] },
+    {
+      key: "entra_token",
+      label: "Microsoft Entra access token",
+      fields: ["azure_ad_token"],
+    },
+    {
+      key: "service_principal",
+      label: "Microsoft Entra service principal",
+      fields: ["tenant_id", "client_id", "client_secret"],
+    },
+  ];
+  const onPremAuthGroups = [
+    {
+      key: "username_api_key",
+      label: "Username + API key",
+      fields: ["username", "api_key"],
+    },
+    { key: "zen_api_key", label: "Zen API key", fields: ["zen_api_key"] },
+  ];
 
   const syncParentSettings = (
     nextCredentials: Record<string, string>,
     nextModel: string,
   ) => {
     const submitted: Record<string, string> = {};
+    const activeAzureFields = new Set([
+      "api_base",
+      "api_version",
+      ...(azureAuthGroups.find((group) => group.key === azureAuthMethod)
+        ?.fields ?? []),
+    ]);
+    const activeOnPremFields = new Set([
+      "api_base",
+      "space_id",
+      "project_id",
+      ...(onPremAuthMethod === "zen_api_key"
+        ? ["zen_api_key"]
+        : ["username", "api_key"]),
+    ]);
     for (const [key, value] of Object.entries(nextCredentials)) {
+      if (provider === "azure" && !activeAzureFields.has(key)) continue;
+      if (provider === "watsonx_onprem" && !activeOnPremFields.has(key))
+        continue;
       const trimmed = (value ?? "").trim();
       if (trimmed !== "") {
         submitted[key] = trimmed;
@@ -74,6 +125,22 @@ export function GenericOnboarding({
       provider_credentials: Object.keys(submitted).length
         ? { ...prev.provider_credentials, [provider]: submitted }
         : prev.provider_credentials,
+      ...(provider === "azure"
+        ? {
+            provider_auth_methods: {
+              ...prev.provider_auth_methods,
+              azure: azureAuthMethod,
+            },
+          }
+        : {}),
+      ...(provider === "watsonx_onprem"
+        ? {
+            provider_auth_methods: {
+              ...prev.provider_auth_methods,
+              watsonx_onprem: onPremAuthMethod,
+            },
+          }
+        : {}),
     }));
   };
 
@@ -120,37 +187,174 @@ export function GenericOnboarding({
     syncParentSettings(credentials, newModel);
   };
 
+  const handleAzureAuthMethodChange = (method: string) => {
+    setAzureAuthMethod(method);
+    // The closure still holds the previous method during this event; submit
+    // just the new method's fields explicitly so inactive values stay local.
+    const active = new Set([
+      "api_base",
+      "api_version",
+      ...(azureAuthGroups.find((group) => group.key === method)?.fields ?? []),
+    ]);
+    const selected = Object.fromEntries(
+      Object.entries(credentials).filter(([key]) => active.has(key)),
+    );
+    setSettings((prev) => ({
+      ...prev,
+      provider_credentials: { ...prev.provider_credentials, azure: selected },
+      provider_auth_methods: { ...prev.provider_auth_methods, azure: method },
+    }));
+  };
+
+  const handleOnPremAuthMethodChange = (method: string) => {
+    setOnPremAuthMethod(method);
+    const active = new Set([
+      "api_base",
+      "space_id",
+      "project_id",
+      ...(method === "zen_api_key" ? ["zen_api_key"] : ["username", "api_key"]),
+    ]);
+    const selected = Object.fromEntries(
+      Object.entries(credentials).filter(([key]) => active.has(key)),
+    );
+    setSettings((prev) => ({
+      ...prev,
+      provider_credentials: {
+        ...prev.provider_credentials,
+        watsonx_onprem: selected,
+      },
+      provider_auth_methods: {
+        ...prev.provider_auth_methods,
+        watsonx_onprem: method,
+      },
+    }));
+  };
+
+  const renderField = (field: (typeof fields)[number]) => {
+    const isSecret =
+      field.field_type === "password" || field.field_type === "textarea";
+    const hasSaved = isSecret && savedSecrets.has(field.key);
+    return (
+      <div key={field.key} className="space-y-1">
+        <LabelInput
+          label={field.label}
+          helperText={field.tooltip ?? ""}
+          id={`onboarding-${provider}-${field.key}`}
+          type={field.field_type === "password" ? "password" : "text"}
+          required={field.required && !hasSaved}
+          placeholder={
+            hasSaved ? "•••••••••" : (field.placeholder ?? undefined)
+          }
+          value={credentials[field.key] ?? ""}
+          onChange={(e) => handleCredentialChange(field.key, e.target.value)}
+        />
+        {hasSaved && (
+          <p className="text-mmd text-muted-foreground">
+            A value is already saved. Leave this blank to keep it.
+          </p>
+        )}
+      </div>
+    );
+  };
+
   return (
     <>
       <div className="space-y-5">
-        {fields.map((field) => {
-          const isSecret =
-            field.field_type === "password" || field.field_type === "textarea";
-          const hasSaved = isSecret && savedSecrets.has(field.key);
-          return (
-            <div key={field.key} className="space-y-1">
-              <LabelInput
-                label={field.label}
-                helperText={field.tooltip ?? ""}
-                id={`onboarding-${provider}-${field.key}`}
-                type={field.field_type === "password" ? "password" : "text"}
-                required={field.required && !hasSaved}
-                placeholder={
-                  hasSaved ? "•••••••••" : (field.placeholder ?? undefined)
-                }
-                value={credentials[field.key] ?? ""}
-                onChange={(e) =>
-                  handleCredentialChange(field.key, e.target.value)
-                }
-              />
-              {hasSaved && (
-                <p className="text-mmd text-muted-foreground">
-                  A value is already saved. Leave this blank to keep it.
-                </p>
-              )}
-            </div>
-          );
-        })}
+        {provider === "azure" ? (
+          <>
+            {fields
+              .filter((field) => field.key === "api_base")
+              .map(renderField)}
+            <Accordion
+              type="single"
+              value={azureAuthMethod}
+              onValueChange={(method) =>
+                method && handleAzureAuthMethodChange(method)
+              }
+              className="space-y-2"
+            >
+              {azureAuthGroups.map((group) => (
+                <AccordionItem key={group.key} value={group.key}>
+                  <AccordionTrigger>
+                    {group.label}
+                    {group.key === "api_key" && (
+                      <span className="ml-2 rounded bg-muted px-2 py-0.5 text-xs">
+                        Recommended
+                      </span>
+                    )}
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4">
+                    {group.fields
+                      .map((key) => fields.find((field) => field.key === key))
+                      .filter((field): field is (typeof fields)[number] =>
+                        Boolean(field),
+                      )
+                      .map(renderField)}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+            <Accordion type="single" collapsible className="space-y-2">
+              <AccordionItem value="advanced">
+                <AccordionTrigger>Advanced settings</AccordionTrigger>
+                <AccordionContent className="space-y-4">
+                  {fields
+                    .filter((field) => field.key === "api_version")
+                    .map(renderField)}
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </>
+        ) : provider === "watsonx_onprem" ? (
+          <>
+            {fields
+              .filter((field) => field.key === "api_base")
+              .map(renderField)}
+            <Accordion
+              type="single"
+              value={onPremAuthMethod}
+              onValueChange={(method) =>
+                method && handleOnPremAuthMethodChange(method)
+              }
+              className="space-y-2"
+            >
+              {onPremAuthGroups.map((group) => (
+                <AccordionItem key={group.key} value={group.key}>
+                  <AccordionTrigger>
+                    {group.label}
+                    {group.key === "username_api_key" && (
+                      <span className="ml-2 rounded bg-muted px-2 py-0.5 text-xs">
+                        Recommended
+                      </span>
+                    )}
+                  </AccordionTrigger>
+                  <AccordionContent className="space-y-4">
+                    {group.fields
+                      .map((key) => fields.find((field) => field.key === key))
+                      .filter((field): field is (typeof fields)[number] =>
+                        Boolean(field),
+                      )
+                      .map(renderField)}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
+            <Accordion type="single" collapsible className="space-y-2">
+              <AccordionItem value="advanced">
+                <AccordionTrigger>Advanced settings</AccordionTrigger>
+                <AccordionContent className="space-y-4">
+                  {fields
+                    .filter((field) =>
+                      ["space_id", "project_id"].includes(field.key),
+                    )
+                    .map(renderField)}
+                </AccordionContent>
+              </AccordionItem>
+            </Accordion>
+          </>
+        ) : (
+          fields.map(renderField)
+        )}
         {models.length === 0 && (
           <p className="text-mmd text-muted-foreground">
             {chrome.name} publishes no {isEmbedding ? "embedding" : "language"}{" "}

--- a/frontend/app/onboarding/_components/onboarding-card.tsx
+++ b/frontend/app/onboarding/_components/onboarding-card.tsx
@@ -93,6 +93,13 @@ const OnboardingCard = ({
       ),
     [availableProviders],
   );
+  const providerBadges = useMemo(
+    () =>
+      Object.fromEntries(
+        availableProviders.map(({ name, badge }) => [name, badge]),
+      ),
+    [availableProviders],
+  );
   const providerKeys = useMemo(
     () =>
       orderProviders(
@@ -539,6 +546,10 @@ const OnboardingCard = ({
     if (generic && Object.keys(generic).length > 0) {
       onboardingData.provider_credentials = { [currentProvider]: generic };
     }
+    const authMethod = settings.provider_auth_methods?.[currentProvider];
+    if (authMethod) {
+      onboardingData.provider_auth_methods = { [currentProvider]: authMethod };
+    }
 
     trackButton({
       CTA: isEmbedding ? "Complete - Embedding Setup" : "Complete - LLM Setup",
@@ -641,6 +652,11 @@ const OnboardingCard = ({
                             />
                           </div>
                           {chrome.name}
+                          {providerBadges[providerKey] && (
+                            <span className="absolute right-0 top-0 rounded border border-muted-foreground/40 bg-muted px-1.5 py-0.5 text-xs font-medium text-muted-foreground">
+                              {providerBadges[providerKey]}
+                            </span>
+                          )}
                         </TabTrigger>
                       </TabsTrigger>
                     );

--- a/frontend/app/settings/_components/model-provider-card.tsx
+++ b/frontend/app/settings/_components/model-provider-card.tsx
@@ -14,6 +14,7 @@ export interface ModelProviderCardData {
   logo: (props: React.SVGProps<SVGSVGElement>) => React.ReactNode;
   logoColor: string;
   logoBgColor: string;
+  badge?: string;
 }
 
 interface ModelProviderCardProps {
@@ -30,7 +31,14 @@ export default function ModelProviderCard({
   onConfigure,
 }: ModelProviderCardProps) {
   const isCloudBrand = useIsCloudBrand();
-  const { providerKey, name, logo: Logo, logoColor, logoBgColor } = provider;
+  const {
+    providerKey,
+    name,
+    logo: Logo,
+    logoColor,
+    logoBgColor,
+    badge,
+  } = provider;
   const isEditSetup = isConfigured && !isUnhealthy;
 
   return (
@@ -46,6 +54,11 @@ export default function ModelProviderCard({
           (isCloudBrand ? "ring-2 ring-destructive" : "border-destructive"),
       )}
     >
+      {badge && (
+        <span className="absolute right-4 top-4 rounded border border-muted-foreground/40 bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground">
+          {badge}
+        </span>
+      )}
       <CardHeader>
         <div className="flex flex-col items-start justify-between">
           <div className="flex flex-col gap-3">

--- a/frontend/app/settings/_components/model-providers.tsx
+++ b/frontend/app/settings/_components/model-providers.tsx
@@ -100,7 +100,7 @@ export const ModelProviders = () => {
   return (
     <>
       <div className="grid gap-6 xs:grid-cols-1 md:grid-cols-2 lg:grid-cols-4">
-        {providers.map(({ name: providerKey, display_name }) => {
+        {providers.map(({ name: providerKey, display_name, badge }) => {
           const isLlmProvider = providerKey === currentLlmProvider;
           const isEmbeddingProvider = providerKey === currentEmbeddingProvider;
           const isProviderUnhealthy =
@@ -113,6 +113,7 @@ export const ModelProviders = () => {
               provider={{
                 providerKey,
                 ...getProviderChrome(providerKey, display_name),
+                badge,
               }}
               // `providers.custom` carries every provider the backend knows,
               // legacy four included, so one lookup covers config-added ones.

--- a/frontend/app/settings/_components/provider-settings-dialog.tsx
+++ b/frontend/app/settings/_components/provider-settings-dialog.tsx
@@ -61,6 +61,7 @@ const ProviderSettingsDialog = ({
   const [affectedModels, setAffectedModels] = useState<
     AffectedEmbeddingModel[] | undefined
   >(undefined);
+  const [azureAuthMethod, setAzureAuthMethod] = useState("api_key");
   const router = useRouter();
 
   const { data: settings = {} } = useGetSettingsQuery({
@@ -104,7 +105,10 @@ const ProviderSettingsDialog = ({
         ]),
       ),
     });
-  }, [open, fields, saved, methods]);
+    if (provider === "azure") {
+      setAzureAuthMethod(saved?.auth_method ?? "api_key");
+    }
+  }, [open, fields, saved, methods, provider]);
 
   const { handleSubmit } = methods;
 
@@ -143,7 +147,21 @@ const ProviderSettingsDialog = ({
     // Blank means "leave the stored value alone": the backend ignores empty
     // values, and secrets are never echoed back for us to resubmit.
     const credentials: Record<string, string> = {};
+    const azureAuthFields: Record<string, Set<string>> = {
+      api_key: new Set(["api_key"]),
+      entra_token: new Set(["azure_ad_token"]),
+      service_principal: new Set(["tenant_id", "client_id", "client_secret"]),
+    };
+    const allowedAzureFields = new Set([
+      "api_base",
+      "api_version",
+      "base_model",
+      ...(azureAuthFields[azureAuthMethod] ?? []),
+    ]);
     for (const [key, value] of Object.entries(data.credentials ?? {})) {
+      if (provider === "azure" && !allowedAzureFields.has(key)) {
+        continue;
+      }
       const trimmed = (value ?? "").trim();
       if (trimmed !== "") {
         credentials[key] = trimmed;
@@ -157,6 +175,9 @@ const ProviderSettingsDialog = ({
 
     settingsMutation.mutate({
       provider_credentials: { [provider]: credentials },
+      ...(provider === "azure"
+        ? { provider_auth_methods: { azure: azureAuthMethod } }
+        : {}),
     });
   };
 
@@ -191,10 +212,13 @@ const ProviderSettingsDialog = ({
 
             <div className="flex-1 min-h-0 overflow-y-auto min-w-0 px-1 -mx-1 py-1 space-y-4">
               <ProviderSettingsForm
+                provider={provider}
                 providerName={chrome.name}
                 fields={fields}
                 savedSecretFields={savedSecretFields}
                 saveError={methods.formState.errors.root?.message}
+                azureAuthMethod={azureAuthMethod}
+                onAzureAuthMethodChange={setAzureAuthMethod}
               />
 
               <LazyMotion features={domAnimation}>

--- a/frontend/app/settings/_components/provider-settings-dialog.tsx
+++ b/frontend/app/settings/_components/provider-settings-dialog.tsx
@@ -62,6 +62,7 @@ const ProviderSettingsDialog = ({
     AffectedEmbeddingModel[] | undefined
   >(undefined);
   const [azureAuthMethod, setAzureAuthMethod] = useState("api_key");
+  const [onPremAuthMethod, setOnPremAuthMethod] = useState("username_api_key");
   const router = useRouter();
 
   const { data: settings = {} } = useGetSettingsQuery({
@@ -107,6 +108,9 @@ const ProviderSettingsDialog = ({
     });
     if (provider === "azure") {
       setAzureAuthMethod(saved?.auth_method ?? "api_key");
+    }
+    if (provider === "watsonx_onprem") {
+      setOnPremAuthMethod(saved?.auth_method ?? "username_api_key");
     }
   }, [open, fields, saved, methods, provider]);
 
@@ -155,13 +159,22 @@ const ProviderSettingsDialog = ({
     const allowedAzureFields = new Set([
       "api_base",
       "api_version",
-      "base_model",
       ...(azureAuthFields[azureAuthMethod] ?? []),
+    ]);
+    const allowedOnPremFields = new Set([
+      "api_base",
+      "space_id",
+      "project_id",
+      ...(onPremAuthMethod === "zen_api_key"
+        ? ["zen_api_key"]
+        : ["username", "api_key"]),
     ]);
     for (const [key, value] of Object.entries(data.credentials ?? {})) {
       if (provider === "azure" && !allowedAzureFields.has(key)) {
         continue;
       }
+      if (provider === "watsonx_onprem" && !allowedOnPremFields.has(key))
+        continue;
       const trimmed = (value ?? "").trim();
       if (trimmed !== "") {
         credentials[key] = trimmed;
@@ -177,7 +190,9 @@ const ProviderSettingsDialog = ({
       provider_credentials: { [provider]: credentials },
       ...(provider === "azure"
         ? { provider_auth_methods: { azure: azureAuthMethod } }
-        : {}),
+        : provider === "watsonx_onprem"
+          ? { provider_auth_methods: { watsonx_onprem: onPremAuthMethod } }
+          : {}),
     });
   };
 
@@ -219,6 +234,8 @@ const ProviderSettingsDialog = ({
                 saveError={methods.formState.errors.root?.message}
                 azureAuthMethod={azureAuthMethod}
                 onAzureAuthMethodChange={setAzureAuthMethod}
+                onPremAuthMethod={onPremAuthMethod}
+                onOnPremAuthMethodChange={setOnPremAuthMethod}
               />
 
               <LazyMotion features={domAnimation}>

--- a/frontend/app/settings/_components/provider-settings-form.tsx
+++ b/frontend/app/settings/_components/provider-settings-form.tsx
@@ -28,6 +28,8 @@ export function ProviderSettingsForm({
   saveError,
   azureAuthMethod,
   onAzureAuthMethodChange,
+  onPremAuthMethod,
+  onOnPremAuthMethodChange,
 }: {
   provider: string;
   providerName: string;
@@ -36,6 +38,8 @@ export function ProviderSettingsForm({
   saveError?: string | null;
   azureAuthMethod?: string;
   onAzureAuthMethodChange?: (method: string) => void;
+  onPremAuthMethod?: string;
+  onOnPremAuthMethodChange?: (method: string) => void;
 }) {
   const {
     register,
@@ -120,16 +124,32 @@ export function ProviderSettingsForm({
       fields: ["tenant_id", "client_id", "client_secret"],
     },
   ];
-  const commonAzureFields = fields.filter(
-    (field) =>
-      !azureAuthGroups.some((group) => group.fields.includes(field.key)),
+  const azureConnectionFields = fields.filter(
+    (field) => field.key === "api_base",
+  );
+  const azureAdvancedFields = fields.filter(
+    (field) => field.key === "api_version",
+  );
+  const onPremAuthGroups = [
+    {
+      key: "username_api_key",
+      label: "Username + API key",
+      fields: ["username", "api_key"],
+    },
+    { key: "zen_api_key", label: "Zen API key", fields: ["zen_api_key"] },
+  ];
+  const onPremConnectionFields = fields.filter(
+    (field) => field.key === "api_base",
+  );
+  const onPremAdvancedFields = fields.filter((field) =>
+    ["space_id", "project_id"].includes(field.key),
   );
 
   return (
     <div className="min-w-0 space-y-4">
       {provider === "azure" ? (
         <>
-          {commonAzureFields.map(renderField)}
+          {azureConnectionFields.map(renderField)}
           <Accordion
             type="single"
             value={azureAuthMethod ?? "api_key"}
@@ -158,6 +178,55 @@ export function ProviderSettingsForm({
                 </AccordionContent>
               </AccordionItem>
             ))}
+          </Accordion>
+          <Accordion type="single" collapsible className="space-y-2">
+            <AccordionItem value="advanced">
+              <AccordionTrigger>Advanced settings</AccordionTrigger>
+              <AccordionContent className="space-y-4">
+                {azureAdvancedFields.map(renderField)}
+              </AccordionContent>
+            </AccordionItem>
+          </Accordion>
+        </>
+      ) : provider === "watsonx_onprem" ? (
+        <>
+          {onPremConnectionFields.map(renderField)}
+          <Accordion
+            type="single"
+            value={onPremAuthMethod ?? "username_api_key"}
+            onValueChange={(method) =>
+              method && onOnPremAuthMethodChange?.(method)
+            }
+            className="space-y-2"
+          >
+            {onPremAuthGroups.map((group) => (
+              <AccordionItem key={group.key} value={group.key}>
+                <AccordionTrigger>
+                  {group.label}
+                  {group.key === "username_api_key" && (
+                    <span className="ml-2 rounded bg-muted px-2 py-0.5 text-xs">
+                      Recommended
+                    </span>
+                  )}
+                </AccordionTrigger>
+                <AccordionContent className="space-y-4">
+                  {group.fields
+                    .map((key) => fields.find((field) => field.key === key))
+                    .filter((field): field is CatalogCredentialField =>
+                      Boolean(field),
+                    )
+                    .map(renderField)}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+          <Accordion type="single" collapsible className="space-y-2">
+            <AccordionItem value="advanced">
+              <AccordionTrigger>Advanced settings</AccordionTrigger>
+              <AccordionContent className="space-y-4">
+                {onPremAdvancedFields.map(renderField)}
+              </AccordionContent>
+            </AccordionItem>
           </Accordion>
         </>
       ) : (

--- a/frontend/app/settings/_components/provider-settings-form.tsx
+++ b/frontend/app/settings/_components/provider-settings-form.tsx
@@ -1,6 +1,12 @@
 import { useFormContext } from "react-hook-form";
 import type { CatalogCredentialField } from "@/app/settings/_helpers/catalog-models";
 import { LabelWrapper } from "@/components/label-wrapper";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 import { Input } from "@/components/ui/input";
 import { Textarea } from "@/components/ui/textarea";
 
@@ -15,15 +21,21 @@ export interface ProviderSettingsFormData {
  * further frontend work.
  */
 export function ProviderSettingsForm({
+  provider,
   providerName,
   fields,
   savedSecretFields,
   saveError,
+  azureAuthMethod,
+  onAzureAuthMethodChange,
 }: {
+  provider: string;
   providerName: string;
   fields: CatalogCredentialField[];
   savedSecretFields: string[];
   saveError?: string | null;
+  azureAuthMethod?: string;
+  onAzureAuthMethodChange?: (method: string) => void;
 }) {
   const {
     register,
@@ -32,70 +44,125 @@ export function ProviderSettingsForm({
 
   const saved = new Set(savedSecretFields);
 
+  const renderField = (field: CatalogCredentialField) => {
+    const error = errors.credentials?.[field.key]?.message;
+    const isSecret =
+      field.field_type === "password" || field.field_type === "textarea";
+    const hasSaved = isSecret && saved.has(field.key);
+    // A stored secret is never sent back to the browser, so an empty box
+    // means "keep what is saved" rather than "no value" — required only
+    // bites when nothing is stored yet.
+    const required = field.required && !hasSaved;
+
+    return (
+      <div key={field.key} className="min-w-0 space-y-2">
+        <LabelWrapper
+          label={field.label}
+          helperText={field.tooltip ?? undefined}
+          required={required}
+          id={`provider-field-${field.key}`}
+        >
+          {field.field_type === "textarea" ? (
+            <Textarea
+              {...register(`credentials.${field.key}`, {
+                required: required ? `${field.label} is required` : false,
+              })}
+              className={error ? "!border-destructive" : ""}
+              id={`provider-field-${field.key}`}
+              placeholder={
+                hasSaved ? "•••••••••" : (field.placeholder ?? undefined)
+              }
+            />
+          ) : (
+            <Input
+              {...register(`credentials.${field.key}`, {
+                required: required ? `${field.label} is required` : false,
+              })}
+              className={error ? "!border-destructive" : ""}
+              id={`provider-field-${field.key}`}
+              type={field.field_type === "password" ? "password" : "text"}
+              autoComplete={
+                field.field_type === "password" ? "new-password" : "off"
+              }
+              placeholder={
+                hasSaved ? "•••••••••" : (field.placeholder ?? undefined)
+              }
+            />
+          )}
+        </LabelWrapper>
+        {hasSaved && (
+          <p className="text-sm text-muted-foreground">
+            A value is already saved. Leave this blank to keep it.
+          </p>
+        )}
+        {error && (
+          <p
+            data-testid="provider-connection-error"
+            className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]"
+          >
+            {error}
+          </p>
+        )}
+      </div>
+    );
+  };
+
+  const azureAuthGroups = [
+    { key: "api_key", label: "API key", fields: ["api_key"] },
+    {
+      key: "entra_token",
+      label: "Microsoft Entra access token",
+      fields: ["azure_ad_token"],
+    },
+    {
+      key: "service_principal",
+      label: "Microsoft Entra service principal",
+      fields: ["tenant_id", "client_id", "client_secret"],
+    },
+  ];
+  const commonAzureFields = fields.filter(
+    (field) =>
+      !azureAuthGroups.some((group) => group.fields.includes(field.key)),
+  );
+
   return (
     <div className="min-w-0 space-y-4">
-      {fields.map((field) => {
-        const error = errors.credentials?.[field.key]?.message;
-        const isSecret =
-          field.field_type === "password" || field.field_type === "textarea";
-        const hasSaved = isSecret && saved.has(field.key);
-        // A stored secret is never sent back to the browser, so an empty box
-        // means "keep what is saved" rather than "no value" — required only
-        // bites when nothing is stored yet.
-        const required = field.required && !hasSaved;
-
-        return (
-          <div key={field.key} className="min-w-0 space-y-2">
-            <LabelWrapper
-              label={field.label}
-              helperText={field.tooltip ?? undefined}
-              required={required}
-              id={`provider-field-${field.key}`}
-            >
-              {field.field_type === "textarea" ? (
-                <Textarea
-                  {...register(`credentials.${field.key}`, {
-                    required: required ? `${field.label} is required` : false,
-                  })}
-                  className={error ? "!border-destructive" : ""}
-                  id={`provider-field-${field.key}`}
-                  placeholder={
-                    hasSaved ? "•••••••••" : (field.placeholder ?? undefined)
-                  }
-                />
-              ) : (
-                <Input
-                  {...register(`credentials.${field.key}`, {
-                    required: required ? `${field.label} is required` : false,
-                  })}
-                  className={error ? "!border-destructive" : ""}
-                  id={`provider-field-${field.key}`}
-                  type={field.field_type === "password" ? "password" : "text"}
-                  autoComplete={
-                    field.field_type === "password" ? "new-password" : "off"
-                  }
-                  placeholder={
-                    hasSaved ? "•••••••••" : (field.placeholder ?? undefined)
-                  }
-                />
-              )}
-            </LabelWrapper>
-            {hasSaved && (
-              <p className="text-sm text-muted-foreground">
-                A value is already saved. Leave this blank to keep it.
-              </p>
-            )}
-            {error && (
-              <p
-                data-testid="provider-connection-error"
-                className="text-sm text-destructive min-w-0 [overflow-wrap:anywhere]"
-              >
-                {error}
-              </p>
-            )}
-          </div>
-        );
-      })}
+      {provider === "azure" ? (
+        <>
+          {commonAzureFields.map(renderField)}
+          <Accordion
+            type="single"
+            value={azureAuthMethod ?? "api_key"}
+            onValueChange={(method) =>
+              method && onAzureAuthMethodChange?.(method)
+            }
+            className="space-y-2"
+          >
+            {azureAuthGroups.map((group) => (
+              <AccordionItem key={group.key} value={group.key}>
+                <AccordionTrigger>
+                  {group.label}
+                  {group.key === "api_key" && (
+                    <span className="ml-2 rounded bg-muted px-2 py-0.5 text-xs">
+                      Recommended
+                    </span>
+                  )}
+                </AccordionTrigger>
+                <AccordionContent className="space-y-4">
+                  {group.fields
+                    .map((key) => fields.find((field) => field.key === key))
+                    .filter((field): field is CatalogCredentialField =>
+                      Boolean(field),
+                    )
+                    .map(renderField)}
+                </AccordionContent>
+              </AccordionItem>
+            ))}
+          </Accordion>
+        </>
+      ) : (
+        fields.map(renderField)
+      )}
       {saveError && (
         <p
           data-testid="provider-connection-error"

--- a/frontend/app/settings/_helpers/catalog-models.ts
+++ b/frontend/app/settings/_helpers/catalog-models.ts
@@ -329,6 +329,7 @@ export interface SavedProviderSnapshot {
   project_id?: string;
   credential_values?: Record<string, string>;
   secret_fields?: string[];
+  auth_method?: string | null;
 }
 
 export interface SavedProvidersSnapshot {

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 import httpx
 
@@ -641,6 +642,17 @@ def _extract_error_details(response: httpx.Response) -> str:
 _NATIVELY_VALIDATED_PROVIDERS = frozenset({"openai", "azure", "watsonx", "ollama", "anthropic"})
 
 
+def is_azure_ai_foundry_endpoint(api_base: str | None) -> bool:
+    """Whether ``api_base`` is an Azure AI Foundry resource endpoint.
+
+    LiteLLM accepts the resource root and appends its own Foundry request path.
+    Such an endpoint must not use the Azure OpenAI-specific HTTP health check.
+    """
+    if not api_base:
+        return False
+    return (urlparse(api_base).hostname or "").endswith(".services.ai.azure.com")
+
+
 async def validate_provider_setup(
     provider: str,
     api_key: str = None,
@@ -687,10 +699,17 @@ async def validate_provider_setup(
         # catalogue check is only for the case there is no model to probe with,
         # which is the one that used to report "A model is required".
         enhancement = get_provider_enhancement(provider_lower)
+        azure_ai_foundry_endpoint = provider_lower == "azure" and is_azure_ai_foundry_endpoint(
+            supplied.get("api_base")
+        )
         probes_the_model = (
             bool(embedding_model or llm_model)
             if enhancement is not None
-            else provider_lower not in _NATIVELY_VALIDATED_PROVIDERS
+            else (
+                provider_lower not in _NATIVELY_VALIDATED_PROVIDERS
+                # Preserve main's Azure/LiteLLM route for Foundry resource URLs.
+                or (azure_ai_foundry_endpoint and bool(embedding_model or llm_model))
+            )
         )
         if probes_the_model:
             await _test_litellm_provider(
@@ -968,7 +987,12 @@ async def _test_openai_lightweight_health(api_key: str) -> None:
 
 
 async def _test_azure_lightweight_health(credentials: dict[str, str]) -> None:
-    """Validate Azure OpenAI credentials without selecting or billing a deployment."""
+    """Validate Azure OpenAI credentials without selecting or billing a deployment.
+
+    Azure deployment enumeration is an Azure Resource Manager operation, not an
+    Azure OpenAI data-plane operation.  The data plane does provide ``models``;
+    use that endpoint so a valid resource is not rejected with ResourceNotFound.
+    """
     api_base = credentials.get("api_base")
     api_version = credentials.get("api_version")
     api_key = credentials.get("api_key")
@@ -1008,7 +1032,7 @@ async def _test_azure_lightweight_health(credentials: dict[str, str]) -> None:
         headers["api-key"] = api_key or ""
     response = await _http_request_with_retry(
         "GET",
-        f"{api_base.rstrip('/')}/openai/deployments",
+        f"{api_base.rstrip('/')}/openai/models",
         headers=headers,
         params={"api-version": api_version or "2024-10-21"},
         timeout=30.0,

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -638,7 +638,9 @@ def _extract_error_details(response: httpx.Response) -> str:
 #: Providers with a validation path of their own, so they are never handed to
 #: the generic LiteLLM probe. Everything else is validated by making a real call,
 #: which needs a model name.
-_NATIVELY_VALIDATED_PROVIDERS = frozenset({"openai", "watsonx", "ollama", "anthropic"})
+_NATIVELY_VALIDATED_PROVIDERS = frozenset(
+    {"openai", "azure", "watsonx", "ollama", "anthropic", watsonx_onprem.PROVIDER_KEY}
+)
 
 
 async def validate_provider_setup(
@@ -787,6 +789,8 @@ async def test_lightweight_health(
 
     if provider == "openai":
         await _test_openai_lightweight_health(api_key)
+    elif provider == "azure":
+        await _test_azure_lightweight_health(credentials or {"api_key": api_key, "api_base": endpoint})
     elif provider == "watsonx":
         await _test_watsonx_lightweight_health(api_key, endpoint, project_id)
     elif provider == "ollama":
@@ -949,6 +953,56 @@ async def _test_openai_lightweight_health(api_key: str) -> None:
     except Exception as e:
         logger.error(f"OpenAI lightweight health check failed: {str(e)}")
         raise
+
+
+async def _test_azure_lightweight_health(credentials: dict[str, str]) -> None:
+    """Validate Azure OpenAI credentials without selecting or billing a deployment."""
+    api_base = credentials.get("api_base")
+    api_version = credentials.get("api_version")
+    api_key = credentials.get("api_key")
+    access_token = credentials.get("azure_ad_token")
+    if not (api_key or access_token or credentials.get("client_secret")):
+        raise ValueError("Azure credentials are required")
+    if not api_base:
+        raise ValueError("API Base is required")
+
+    if not access_token and credentials.get("client_secret"):
+        tenant_id = credentials.get("tenant_id")
+        client_id = credentials.get("client_id")
+        if not tenant_id or not client_id:
+            raise ValueError("tenant_id and client_id are required for Azure service principal")
+        token_response = await _http_request_with_retry(
+            "POST",
+            f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+            data={
+                "client_id": client_id,
+                "client_secret": credentials["client_secret"],
+                "grant_type": "client_credentials",
+                "scope": "https://cognitiveservices.azure.com/.default",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30.0,
+        )
+        if token_response.status_code != 200:
+            raise Exception(_extract_error_details(token_response))
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise ValueError("Azure service principal did not return an access token")
+
+    headers = {"Content-Type": "application/json"}
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    else:
+        headers["api-key"] = api_key or ""
+    response = await _http_request_with_retry(
+        "GET",
+        f"{api_base.rstrip('/')}/openai/deployments",
+        headers=headers,
+        params={"api-version": api_version or "2024-10-21"},
+        timeout=30.0,
+    )
+    if response.status_code != 200:
+        raise Exception(_extract_error_details(response))
 
 
 async def _test_openai_completion_with_tools(api_key: str, llm_model: str) -> None:

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -639,7 +639,7 @@ def _extract_error_details(response: httpx.Response) -> str:
 #: the generic LiteLLM probe. Everything else is validated by making a real call,
 #: which needs a model name.
 _NATIVELY_VALIDATED_PROVIDERS = frozenset(
-    {"openai", "watsonx", "ollama", "anthropic", watsonx_onprem.PROVIDER_KEY}
+    {"openai", "azure", "watsonx", "ollama", "anthropic", watsonx_onprem.PROVIDER_KEY}
 )
 
 
@@ -786,6 +786,8 @@ async def test_lightweight_health(
 
     if provider == "openai":
         await _test_openai_lightweight_health(api_key)
+    elif provider == "azure":
+        await _test_azure_lightweight_health(credentials or {"api_key": api_key, "api_base": endpoint})
     elif provider == "watsonx":
         await _test_watsonx_lightweight_health(api_key, endpoint, project_id)
     elif provider == "ollama":
@@ -948,6 +950,56 @@ async def _test_openai_lightweight_health(api_key: str) -> None:
     except Exception as e:
         logger.error(f"OpenAI lightweight health check failed: {str(e)}")
         raise
+
+
+async def _test_azure_lightweight_health(credentials: dict[str, str]) -> None:
+    """Validate Azure OpenAI credentials without selecting or billing a deployment."""
+    api_base = credentials.get("api_base")
+    api_version = credentials.get("api_version")
+    api_key = credentials.get("api_key")
+    access_token = credentials.get("azure_ad_token")
+    if not (api_key or access_token or credentials.get("client_secret")):
+        raise ValueError("Azure credentials are required")
+    if not api_base:
+        raise ValueError("API Base is required")
+
+    if not access_token and credentials.get("client_secret"):
+        tenant_id = credentials.get("tenant_id")
+        client_id = credentials.get("client_id")
+        if not tenant_id or not client_id:
+            raise ValueError("tenant_id and client_id are required for Azure service principal")
+        token_response = await _http_request_with_retry(
+            "POST",
+            f"https://login.microsoftonline.com/{tenant_id}/oauth2/v2.0/token",
+            data={
+                "client_id": client_id,
+                "client_secret": credentials["client_secret"],
+                "grant_type": "client_credentials",
+                "scope": "https://cognitiveservices.azure.com/.default",
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            timeout=30.0,
+        )
+        if token_response.status_code != 200:
+            raise Exception(_extract_error_details(token_response))
+        access_token = token_response.json().get("access_token")
+        if not access_token:
+            raise ValueError("Azure service principal did not return an access token")
+
+    headers = {"Content-Type": "application/json"}
+    if access_token:
+        headers["Authorization"] = f"Bearer {access_token}"
+    else:
+        headers["api-key"] = api_key or ""
+    response = await _http_request_with_retry(
+        "GET",
+        f"{api_base.rstrip('/')}/openai/deployments",
+        headers=headers,
+        params={"api-version": api_version or "2024-10-21"},
+        timeout=30.0,
+    )
+    if response.status_code != 200:
+        raise Exception(_extract_error_details(response))
 
 
 async def _test_openai_completion_with_tools(api_key: str, llm_model: str) -> None:

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -702,6 +702,18 @@ async def validate_provider_setup(
                 llm_model=llm_model,
             )
         elif test_completion:
+            if provider_lower == "azure":
+                # Azure deployments are user-defined, so a model completion is
+                # not a safe generic probe during onboarding. The deployments
+                # request still verifies the selected authentication method.
+                await test_lightweight_health(
+                    provider=provider_lower,
+                    api_key=api_key,
+                    endpoint=endpoint,
+                    project_id=project_id,
+                    credentials=supplied,
+                )
+                return
             # Full validation with completion/embedding tests (consumes credits)
             if embedding_model:
                 # Test embedding

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -638,9 +638,7 @@ def _extract_error_details(response: httpx.Response) -> str:
 #: Providers with a validation path of their own, so they are never handed to
 #: the generic LiteLLM probe. Everything else is validated by making a real call,
 #: which needs a model name.
-_NATIVELY_VALIDATED_PROVIDERS = frozenset(
-    {"openai", "azure", "watsonx", "ollama", "anthropic"}
-)
+_NATIVELY_VALIDATED_PROVIDERS = frozenset({"openai", "azure", "watsonx", "ollama", "anthropic"})
 
 
 async def validate_provider_setup(
@@ -790,7 +788,9 @@ async def test_lightweight_health(
     if provider == "openai":
         await _test_openai_lightweight_health(api_key)
     elif provider == "azure":
-        await _test_azure_lightweight_health(credentials or {"api_key": api_key, "api_base": endpoint})
+        await _test_azure_lightweight_health(
+            credentials or {"api_key": api_key, "api_base": endpoint}
+        )
     elif provider == "watsonx":
         await _test_watsonx_lightweight_health(api_key, endpoint, project_id)
     elif provider == "ollama":

--- a/src/api/provider_validation.py
+++ b/src/api/provider_validation.py
@@ -639,7 +639,7 @@ def _extract_error_details(response: httpx.Response) -> str:
 #: the generic LiteLLM probe. Everything else is validated by making a real call,
 #: which needs a model name.
 _NATIVELY_VALIDATED_PROVIDERS = frozenset(
-    {"openai", "azure", "watsonx", "ollama", "anthropic", watsonx_onprem.PROVIDER_KEY}
+    {"openai", "azure", "watsonx", "ollama", "anthropic"}
 )
 
 

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -143,6 +143,7 @@ def _custom_providers_for_settings(openrag_config) -> dict[str, GenericProviderC
             configured = configured or stored.configured
         return GenericProviderConfig(
             configured=configured,
+            auth_method=getattr(stored, "auth_method", None),
             credential_values={key: value for key, value in values.items() if value},
             secret_fields=list(dict.fromkeys(secrets)),
         )
@@ -455,6 +456,35 @@ async def update_settings(
         if should_validate:
             try:
                 logger.info("Running provider validation before modifying config")
+
+                # A generic provider save normally has no selected model to
+                # probe. Azure OpenAI is the exception: its deployments route
+                # validates the endpoint and API key without consuming tokens,
+                # so reject bad credentials before they are persisted.
+                for provider, submitted in (body.provider_credentials or {}).items():
+                    provider_key = _provider_key(provider)
+                    credentials = current_config.providers.pending_credentials(
+                        provider_key, submitted
+                    )
+                    if provider_key == "azure":
+                        auth_method = (body.provider_auth_methods or {}).get(provider_key)
+                        required_by_method = {
+                            "api_key": {"api_key"},
+                            "entra_token": {"azure_ad_token"},
+                            "service_principal": {"tenant_id", "client_id", "client_secret"},
+                        }
+                        required = required_by_method.get(auth_method or "")
+                        if required is None:
+                            raise ValueError("Choose an Azure authentication method")
+                        missing = sorted(name for name in required | {"api_base"} if not credentials.get(name))
+                        if missing:
+                            raise ValueError(f"{', '.join(missing)} is required for Azure OpenAI")
+                        await validate_provider_setup(
+                            provider=provider_key,
+                            api_key=credentials.get("api_key") or credentials.get("azure_ad_token"),
+                            endpoint=credentials.get("api_base"),
+                            credentials=credentials,
+                        )
 
                 # Validate LLM provider if being changed
                 if body.llm_provider is not None or body.llm_model is not None:
@@ -841,7 +871,11 @@ async def update_settings(
         # Update provider-specific settings
         provider_updated = False
         for provider, credentials in (body.provider_credentials or {}).items():
-            working_config.providers.set_credentials(provider, credentials)
+            working_config.providers.set_credentials(
+                provider,
+                credentials,
+                auth_method=(body.provider_auth_methods or {}).get(_provider_key(provider)),
+            )
             config_updated = True
             provider_updated = True
 

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -13,7 +13,11 @@ import json
 from fastapi import Depends, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from api.provider_validation import sanitize_provider_error_content, validate_provider_setup
+from api.provider_validation import (
+    is_azure_ai_foundry_endpoint,
+    sanitize_provider_error_content,
+    validate_provider_setup,
+)
 from api.settings.helpers import (
     _affected_embedding_models,
     _create_openrag_docs_filter,
@@ -458,9 +462,10 @@ async def update_settings(
                 logger.info("Running provider validation before modifying config")
 
                 # A generic provider save normally has no selected model to
-                # probe. Azure OpenAI is the exception: its deployments route
-                # validates the endpoint and API key without consuming tokens,
-                # so reject bad credentials before they are persisted.
+                # probe. Native Azure OpenAI is the exception: its models route
+                # validates the endpoint and API key without consuming tokens.
+                # Foundry resource URLs instead follow LiteLLM's model route,
+                # preserving the behavior they had on main.
                 for provider, submitted in (body.provider_credentials or {}).items():
                     provider_key = _provider_key(provider)
                     credentials = current_config.providers.pending_credentials(
@@ -481,12 +486,14 @@ async def update_settings(
                         )
                         if missing:
                             raise ValueError(f"{', '.join(missing)} is required for Azure OpenAI")
-                        await validate_provider_setup(
-                            provider=provider_key,
-                            api_key=credentials.get("api_key") or credentials.get("azure_ad_token"),
-                            endpoint=credentials.get("api_base"),
-                            credentials=credentials,
-                        )
+                        if not is_azure_ai_foundry_endpoint(credentials.get("api_base")):
+                            await validate_provider_setup(
+                                provider=provider_key,
+                                api_key=credentials.get("api_key")
+                                or credentials.get("azure_ad_token"),
+                                endpoint=credentials.get("api_base"),
+                                credentials=credentials,
+                            )
 
                 # Validate LLM provider if being changed
                 if body.llm_provider is not None or body.llm_model is not None:

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -476,7 +476,9 @@ async def update_settings(
                         required = required_by_method.get(auth_method or "")
                         if required is None:
                             raise ValueError("Choose an Azure authentication method")
-                        missing = sorted(name for name in required | {"api_base"} if not credentials.get(name))
+                        missing = sorted(
+                            name for name in required | {"api_base"} if not credentials.get(name)
+                        )
                         if missing:
                             raise ValueError(f"{', '.join(missing)} is required for Azure OpenAI")
                         await validate_provider_setup(

--- a/src/api/settings/endpoints.py
+++ b/src/api/settings/endpoints.py
@@ -1221,7 +1221,11 @@ async def onboarding(
             config_updated = True
 
         for provider, credentials in (body.provider_credentials or {}).items():
-            current_config.providers.set_credentials(provider, credentials)
+            current_config.providers.set_credentials(
+                provider,
+                credentials,
+                auth_method=(body.provider_auth_methods or {}).get(_provider_key(provider)),
+            )
             config_updated = True
 
         # Mark providers as configured if they were chosen during onboarding

--- a/src/api/settings/models.py
+++ b/src/api/settings/models.py
@@ -51,6 +51,7 @@ class SettingsUpdateBody(BaseModel):
     remove_anthropic_config: bool | None = None
     remove_watsonx_config: bool | None = None
     provider_credentials: dict[str, dict[str, str]] | None = None
+    provider_auth_methods: dict[str, str] | None = None
     remove_provider_config: str | None = None
     # Explicit confirmation that the caller accepts removing a provider whose
     # embedding models are still in use by indexed documents. Without this,
@@ -179,6 +180,7 @@ class OllamaProviderConfig(BaseModel):
 
 class GenericProviderConfig(BaseModel):
     configured: bool
+    auth_method: str | None = None
     credential_values: dict[str, str] = Field(default_factory=dict)
     secret_fields: list[str] = Field(default_factory=list)
 

--- a/src/api/settings/models.py
+++ b/src/api/settings/models.py
@@ -71,6 +71,7 @@ class OnboardingBody(BaseModel):
     watsonx_project_id: str | None = Field(None, min_length=1)
     ollama_endpoint: str | None = Field(None, min_length=1)
     provider_credentials: dict[str, dict[str, str]] | None = None
+    provider_auth_methods: dict[str, str] | None = None
 
 
 class CitationDisplayData(BaseModel):

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -156,6 +156,8 @@ class GenericProviderConfig:
     """Credentials for any LiteLLM provider not covered by legacy fields."""
 
     credentials: dict[str, str] = field(default_factory=dict)
+    # Provider-specific metadata which must not be forwarded to LiteLLM.
+    auth_method: str | None = None
     configured: bool = False
 
 
@@ -193,7 +195,9 @@ class ProvidersConfig:
             return self.ollama
         return self.custom.get(provider_lower, GenericProviderConfig())
 
-    def set_credentials(self, provider: str, credentials: dict[str, str]) -> None:
+    def set_credentials(
+        self, provider: str, credentials: dict[str, str], *, auth_method: str | None = None
+    ) -> None:
         """Upsert arbitrary LiteLLM credentials while preserving legacy config."""
         key = provider.strip().lower()
         clean = {
@@ -208,6 +212,24 @@ class ProvidersConfig:
             # picked as a fallback provider and called with no key at all.
             return
         previous = self.custom.get(key, GenericProviderConfig())
+        if key == "azure" and auth_method:
+            methods = {
+                "api_key": {"api_key"},
+                "entra_token": {"azure_ad_token"},
+                "service_principal": {"tenant_id", "client_id", "client_secret"},
+            }
+            active = methods.get(auth_method)
+            if active is None:
+                raise ValueError(f"Unknown Azure authentication method: {auth_method}")
+            shared = {"api_base", "api_version", "base_model"}
+            # Credentials for another authentication method must not leak into
+            # LiteLLM's call kwargs after the user switches methods.
+            previous.credentials = {
+                name: value
+                for name, value in previous.credentials.items()
+                if name in shared or name in active
+            }
+            previous.auth_method = auth_method
         previous.credentials.update(clean)
         previous.configured = True
         self.custom[key] = previous
@@ -396,6 +418,7 @@ class OpenRAGConfig:
                     credentials[key] = decrypt_secret(credentials[key])
             return GenericProviderConfig(
                 credentials=credentials,
+                auth_method=p_data.get("auth_method"),
                 configured=bool(p_data.get("configured", credentials)),
             )
 

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -156,6 +156,8 @@ class GenericProviderConfig:
     """Credentials for any LiteLLM provider not covered by legacy fields."""
 
     credentials: dict[str, str] = field(default_factory=dict)
+    # Provider-specific metadata which must not be forwarded to LiteLLM.
+    auth_method: str | None = None
     configured: bool = False
 
 
@@ -193,7 +195,9 @@ class ProvidersConfig:
             return self.ollama
         return self.custom.get(provider_lower, GenericProviderConfig())
 
-    def set_credentials(self, provider: str, credentials: dict[str, str]) -> None:
+    def set_credentials(
+        self, provider: str, credentials: dict[str, str], *, auth_method: str | None = None
+    ) -> None:
         """Upsert arbitrary LiteLLM credentials while preserving legacy config."""
         key = provider.strip().lower()
         clean = {
@@ -208,6 +212,24 @@ class ProvidersConfig:
             # picked as a fallback provider and called with no key at all.
             return
         previous = self.custom.get(key, GenericProviderConfig())
+        if key == "azure" and auth_method:
+            methods = {
+                "api_key": {"api_key"},
+                "entra_token": {"azure_ad_token"},
+                "service_principal": {"tenant_id", "client_id", "client_secret"},
+            }
+            active = methods.get(auth_method)
+            if active is None:
+                raise ValueError(f"Unknown Azure authentication method: {auth_method}")
+            shared = {"api_base", "api_version", "base_model"}
+            # Credentials for another authentication method must not leak into
+            # LiteLLM's call kwargs after the user switches methods.
+            previous.credentials = {
+                name: value
+                for name, value in previous.credentials.items()
+                if name in shared or name in active
+            }
+            previous.auth_method = auth_method
         previous.credentials.update(clean)
         previous.configured = True
         self.custom[key] = previous
@@ -394,6 +416,7 @@ class OpenRAGConfig:
                     credentials[key] = decrypt_secret(credentials[key])
             return GenericProviderConfig(
                 credentials=credentials,
+                auth_method=p_data.get("auth_method"),
                 configured=bool(p_data.get("configured", credentials)),
             )
 

--- a/src/config/config_manager.py
+++ b/src/config/config_manager.py
@@ -230,6 +230,20 @@ class ProvidersConfig:
                 if name in shared or name in active
             }
             previous.auth_method = auth_method
+        if key == "watsonx_onprem" and auth_method:
+            methods = {
+                "username_api_key": {"username", "api_key"},
+                "zen_api_key": {"zen_api_key"},
+            }
+            active = methods.get(auth_method)
+            if active is None:
+                raise ValueError(f"Unknown watsonx.ai on-prem authentication method: {auth_method}")
+            previous.credentials = {
+                name: value
+                for name, value in previous.credentials.items()
+                if name in {"api_base", "space_id", "project_id"} or name in active
+            }
+            previous.auth_method = auth_method
         previous.credentials.update(clean)
         previous.configured = True
         self.custom[key] = previous

--- a/src/config/model_providers.py
+++ b/src/config/model_providers.py
@@ -138,9 +138,11 @@ def _normalize(entry: Any, seen: set[str]) -> dict[str, Any] | None:
     if not isinstance(raw_modes, dict):
         raw_modes = {}
     display_name = str(entry.get("display_name") or "").strip() or name
+    badge = str(entry.get("badge") or "").strip()
     return {
         "name": name,
         "display_name": display_name,
+        "badge": badge,
         # Missing keys stay missing here; `is_visible` reads them as False.
         "modes": {str(mode).strip().lower(): _as_bool(value) for mode, value in raw_modes.items()},
         # Optional: ids the catalogue cannot learn from LiteLLM's static table.
@@ -271,7 +273,11 @@ def provider_visibility_payload(run_mode: str | None = None) -> dict[str, Any]:
     return {
         "run_mode": mode,
         "providers": [
-            {"name": entry["name"], "display_name": entry["display_name"]}
+            {
+                "name": entry["name"],
+                "display_name": entry["display_name"],
+                "badge": entry["badge"],
+            }
             for entry in visible_providers(mode)
         ],
     }

--- a/src/config/model_providers.yaml
+++ b/src/config/model_providers.yaml
@@ -71,7 +71,8 @@ providers:
   # unreachable or before any credentials are entered — keep them plausible for
   # your fleet, but there is no need to keep them exact.
   - name: watsonx_onprem
-    display_name: IBM watsonx.ai (on-prem)
+    display_name: IBM watsonx.ai
+    badge: On-prem
     modes:
       oss: true
       on_prem: true

--- a/tests/unit/api/test_settings_endpoints.py
+++ b/tests/unit/api/test_settings_endpoints.py
@@ -3,7 +3,7 @@ Unit tests for api.settings.endpoints
 Validates error handling in update_docling_preset endpoint.
 """
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 from fastapi import HTTPException
@@ -185,6 +185,77 @@ async def test_update_settings_vlm_azure_configured():
         saved_config = mock_save.call_args[0][0]
         assert saved_config.knowledge.vlm_provider == "azure"
         assert saved_config.knowledge.vlm_model == "azure/gpt-4.1"
+
+
+@pytest.mark.asyncio
+async def test_update_settings_rejects_azure_without_an_api_key():
+    """The API must enforce the Azure form requirement, not only the browser."""
+    from api.settings.endpoints import update_settings
+    from config.config_manager import OpenRAGConfig
+
+    config = OpenRAGConfig.from_dict({})
+    config.edited = True
+    body = SettingsUpdateBody(
+        provider_credentials={"azure": {"api_base": "https://example.openai.azure.com"}},
+        provider_auth_methods={"azure": "api_key"},
+    )
+    rbac = MagicMock()
+    rbac.has_permission = AsyncMock(return_value=True)
+
+    with patch("api.settings.endpoints.get_openrag_config", return_value=config):
+        response = await update_settings(
+            body=body,
+            session_manager=AsyncMock(),
+            user=MagicMock(spec=User),
+            models_service=MagicMock(),
+            rbac=rbac,
+        )
+
+    assert response.status_code == 400
+    assert b"api_key" in response.body
+
+
+@pytest.mark.asyncio
+async def test_update_settings_validates_azure_credentials_before_saving():
+    """A bad Azure endpoint/key must not become a configured provider."""
+    from api.settings.endpoints import update_settings
+    from config.config_manager import OpenRAGConfig
+
+    config = OpenRAGConfig.from_dict({})
+    config.edited = True
+    body = SettingsUpdateBody(
+        provider_credentials={
+            "azure": {
+                "api_key": "wrong-key",
+                "api_base": "https://example.openai.azure.com",
+            }
+        },
+        provider_auth_methods={"azure": "api_key"},
+    )
+    rbac = MagicMock()
+    rbac.has_permission = AsyncMock(return_value=True)
+
+    with (
+        patch("api.settings.endpoints.get_openrag_config", return_value=config),
+        patch(
+            "api.settings.endpoints.validate_provider_setup",
+            new_callable=AsyncMock,
+            side_effect=Exception("Access denied due to invalid subscription key"),
+        ) as validate,
+        patch("api.settings.endpoints.config_manager.save_config_file") as save,
+    ):
+        response = await update_settings(
+            body=body,
+            session_manager=AsyncMock(),
+            user=MagicMock(spec=User),
+            models_service=MagicMock(),
+            rbac=rbac,
+        )
+
+    assert response.status_code == 400
+    assert b"invalid subscription key" in response.body
+    validate.assert_awaited_once()
+    save.assert_not_called()
 
 
 @pytest.mark.parametrize(

--- a/tests/unit/services/test_model_catalog.py
+++ b/tests/unit/services/test_model_catalog.py
@@ -72,6 +72,11 @@ def test_openai_form_is_the_plain_one_not_the_compatible_variant() -> None:
     assert required == ["api_key"]
 
 
+def test_azure_openai_leaves_auth_fields_optional_for_method_selection() -> None:
+    """The UI selects one complete Azure auth method over LiteLLM's flat form."""
+    assert model_catalog.required_field_keys("azure") == ["api_base"]
+
+
 def test_an_unknown_provider_still_gets_a_usable_form() -> None:
     fields = model_catalog.credential_fields("some-private-gateway")
     assert [field["key"] for field in fields] == ["api_key", "api_base"]

--- a/tests/unit/test_openai_provider_check_retry.py
+++ b/tests/unit/test_openai_provider_check_retry.py
@@ -142,7 +142,11 @@ async def test_azure_lightweight_health_checks_endpoint_and_key(monkeypatch):
     monkeypatch.setattr("api.provider_validation._http_request_with_retry", fake_retry)
 
     await _test_azure_lightweight_health(
-        {"api_key": "azure-key", "api_base": "https://example.openai.azure.com/", "api_version": "2024-10-21"}
+        {
+            "api_key": "azure-key",
+            "api_base": "https://example.openai.azure.com/",
+            "api_version": "2024-10-21",
+        }
     )
 
     assert captured["method"] == "GET"

--- a/tests/unit/test_openai_provider_check_retry.py
+++ b/tests/unit/test_openai_provider_check_retry.py
@@ -11,6 +11,7 @@ from api.provider_validation import (
     _http_request_with_retry,
     _test_azure_lightweight_health,
     _test_openai_lightweight_health,
+    validate_provider_setup,
 )
 
 
@@ -150,7 +151,7 @@ async def test_azure_lightweight_health_checks_endpoint_and_key(monkeypatch):
     )
 
     assert captured["method"] == "GET"
-    assert captured["url"] == "https://example.openai.azure.com/openai/deployments"
+    assert captured["url"] == "https://example.openai.azure.com/openai/models"
     assert captured["headers"]["api-key"] == "azure-key"
     assert captured["params"] == {"api-version": "2024-10-21"}
 
@@ -159,3 +160,24 @@ async def test_azure_lightweight_health_checks_endpoint_and_key(monkeypatch):
 async def test_azure_lightweight_health_rejects_missing_credentials():
     with pytest.raises(ValueError, match="Azure credentials are required"):
         await _test_azure_lightweight_health({"api_base": "https://example.openai.azure.com"})
+
+
+@pytest.mark.asyncio
+async def test_azure_foundry_endpoint_uses_the_litellm_route(monkeypatch):
+    """Foundry resource roots must retain main's Azure/LiteLLM behavior."""
+    litellm_probe = AsyncMock()
+    health_check = AsyncMock()
+    monkeypatch.setattr("api.provider_validation._test_litellm_provider", litellm_probe)
+    monkeypatch.setattr("api.provider_validation.test_lightweight_health", health_check)
+
+    await validate_provider_setup(
+        provider="azure",
+        llm_model="gpt-4.1",
+        credentials={
+            "api_key": "azure-key",
+            "api_base": "https://example.services.ai.azure.com/",
+        },
+    )
+
+    litellm_probe.assert_awaited_once()
+    health_check.assert_not_awaited()

--- a/tests/unit/test_openai_provider_check_retry.py
+++ b/tests/unit/test_openai_provider_check_retry.py
@@ -7,7 +7,11 @@ from unittest.mock import AsyncMock
 import httpx
 import pytest
 
-from api.provider_validation import _http_request_with_retry, _test_openai_lightweight_health
+from api.provider_validation import (
+    _http_request_with_retry,
+    _test_azure_lightweight_health,
+    _test_openai_lightweight_health,
+)
 
 
 @pytest.mark.asyncio
@@ -125,3 +129,29 @@ async def test_openai_lightweight_health_succeeds_with_retry(monkeypatch):
     # Should run cleanly without raising exception
     await _test_openai_lightweight_health("sk-test-key")
     assert attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_azure_lightweight_health_checks_endpoint_and_key(monkeypatch):
+    captured = {}
+
+    async def fake_retry(method, url, **kwargs):
+        captured.update(method=method, url=url, **kwargs)
+        return httpx.Response(200, json={"data": []})
+
+    monkeypatch.setattr("api.provider_validation._http_request_with_retry", fake_retry)
+
+    await _test_azure_lightweight_health(
+        {"api_key": "azure-key", "api_base": "https://example.openai.azure.com/", "api_version": "2024-10-21"}
+    )
+
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://example.openai.azure.com/openai/deployments"
+    assert captured["headers"]["api-key"] == "azure-key"
+    assert captured["params"] == {"api-version": "2024-10-21"}
+
+
+@pytest.mark.asyncio
+async def test_azure_lightweight_health_rejects_missing_credentials():
+    with pytest.raises(ValueError, match="Azure credentials are required"):
+        await _test_azure_lightweight_health({"api_base": "https://example.openai.azure.com"})


### PR DESCRIPTION
Add support for selecting Azure OpenAI authentication methods and validate Azure credentials before persisting. Frontend: include provider_auth_methods in update payloads, render an accordion UI to choose between API key, Entra token, or service principal, and filter submitted Azure fields. Backend: accept provider_auth_methods, persist auth_method in config, sanitize credentials per-method, and validate Azure endpoints/credentials via a new lightweight Azure health check before saving. Tests: add unit tests for Azure validation, model-catalog behavior, and provider check retry. Updates also wire auth_method through models and config manager.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added authentication method selection for Azure and IBM watsonx.ai On-prem providers.
  - Provider settings now remember the selected authentication method and show only relevant credential fields.
  - Added provider badges, including an “On-prem” label for IBM watsonx.ai.
  - Onboarding advanced model selectors are now always visible.
  - Added support for Azure AI Foundry endpoints.

- **Bug Fixes**
  - Improved Azure credential validation and error reporting.
  - Switching authentication methods prevents unrelated credentials from being retained or submitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->