### PR TITLE
chore: Update model providers configuration disable azure on cpd

### DIFF
--- a/src/config/model_providers.yaml
+++ b/src/config/model_providers.yaml
@@ -46,7 +46,7 @@ providers:
     display_name: Ollama
     modes:
       oss: true
-      on_prem: true
+      on_prem: false
       saas: false # local inference is not offered in SaaS
 
   - name: watsonx
@@ -66,8 +66,8 @@ providers:
     display_name: Azure AI Foundry
     modes:
       oss: true
-      on_prem: true
-      saas: true
+      on_prem: false
+      saas: false # local inference is not offered in SaaS
 
   # Azure OpenAI Service, which LiteLLM keys separately from Foundry above:
   # `azure_ai` is the Foundry catalogue (Llama, Phi, Mistral, Cohere, and the
@@ -77,8 +77,8 @@ providers:
     display_name: Azure OpenAI
     modes:
       oss: true
-      on_prem: true
-      saas: true
+      on_prem: false
+      saas: false
     # Azure serves the same OpenAI models, so it needs the same exclusions.
     # The plain name covers the regional ids (`eu/`, `us/`, `global/`) too.
     exclude_models:


### PR DESCRIPTION
This pull request updates the `src/config/model_providers.yaml` file to restrict the availability of several model providers in different deployment modes. The main impact is that on-premises and SaaS support is now disabled for Ollama, Azure AI Foundry, and Azure OpenAI.

Deployment mode changes:

* Set `on_prem` to `false` for the `Ollama`, `Azure AI Foundry`, and `Azure OpenAI` providers, disabling their use in on-premises deployments. [[1]](diffhunk://#diff-958aa21e4eb16bd34e91e93b12c8c5c28bc194c1bd7e7e6198feb265bfce119aL49-R49) [[2]](diffhunk://#diff-958aa21e4eb16bd34e91e93b12c8c5c28bc194c1bd7e7e6198feb265bfce119aL69-R70) [[3]](diffhunk://#diff-958aa21e4eb16bd34e91e93b12c8c5c28bc194c1bd7e7e6198feb265bfce119aL80-R81)
* Set `saas` to `false` for `Azure AI Foundry` and `Azure OpenAI`, disabling their use in SaaS deployments. [[1]](diffhunk://#diff-958aa21e4eb16bd34e91e93b12c8c5c28bc194c1bd7e7e6198feb265bfce119aL69-R70) [[2]](diffhunk://#diff-958aa21e4eb16bd34e91e93b12c8c5c28bc194c1bd7e7e6198feb265bfce119aL80-R81)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Configuration**
  - Updated AI provider availability by deployment mode:
    - Ollama is no longer offered in on-premises mode.
    - Azure AI Foundry and Azure OpenAI are no longer offered in on-premises or SaaS modes.
  - Open-source visibility remains enabled for these providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->