### PR TITLE
fix: exclude unsupported watsonx model IDs

### DIFF
--- a/src/config/model_providers.yaml
+++ b/src/config/model_providers.yaml
@@ -55,6 +55,18 @@ providers:
       oss: true
       on_prem: true
       saas: true
+    exclude_models:
+      # LiteLLM ids that do not match the API ids in IBM's model documentation.
+      - bigscience/mt0-xxl-13b
+      - google/flan-t5-xl-3b
+      - ibm/granite-guardian-3-2-2b
+      - ibm/granite-guardian-3-3-8b
+      - meta-llama/llama-4-maverick-17b
+      - mistralai/mistral-small-2503
+      - mistralai/pixtral-12b-2409
+      # Models reported unusable against watsonx.ai in tracker issue 82237.
+      - mistralai/mistral-medium-2505 # fails during streamed chat responses
+      - ibm/granite-3-3-8b-instruct # unsupported or removed by watsonx.ai
 
   - name: anthropic
     display_name: Anthropic

--- a/tests/unit/services/test_model_catalog.py
+++ b/tests/unit/services/test_model_catalog.py
@@ -401,6 +401,50 @@ def test_the_shipped_config_keeps_the_legacy_openai_generation_out(monkeypatch) 
     assert any(name.startswith("gpt-5.6") for name in models)
 
 
+def test_the_shipped_config_keeps_broken_watsonx_models_out_of_live_inventory(
+    monkeypatch,
+) -> None:
+    """Undocumented or broken watsonx.ai ids must not be offered in its picker."""
+    monkeypatch.setenv("OPENRAG_RUN_MODE", "oss")
+    excluded = [
+        "bigscience/mt0-xxl-13b",
+        "google/flan-t5-xl-3b",
+        "ibm/granite-guardian-3-2-2b",
+        "ibm/granite-guardian-3-3-8b",
+        "meta-llama/llama-4-maverick-17b",
+        "mistralai/mistral-small-2503",
+        "mistralai/pixtral-12b-2409",
+        "mistralai/mistral-medium-2505",
+        "ibm/granite-3-3-8b-instruct",
+    ]
+    retained = [
+        "bigscience/mt0-xxl",
+        "google/flan-t5-xl",
+        "ibm/granite-guardian-3-2b",
+        "ibm/granite-guardian-3-8b",
+        "meta-llama/llama-4-maverick-17b-128e-instruct-fp8",
+        "mistralai/mistral-small-3-1-24b-instruct-2503",
+        "mistralai/pixtral-12b",
+        "ibm/granite-4-h-small",
+    ]
+    payload = {
+        "language_models": [{"value": model} for model in excluded + retained],
+        "embedding_models": [{"value": "ibm/slate-125m-english-rtrvr"}],
+    }
+
+    filtered = model_catalog.hide_excluded_live_models("watsonx", payload)
+
+    assert [entry["value"] for entry in filtered["language_models"]] == retained
+    assert filtered["embedding_models"] == payload["embedding_models"]
+    catalogued = {
+        entry["model"]
+        for provider in model_catalog.catalog()["providers"]
+        if provider["key"] == "watsonx"
+        for entry in provider["models"]
+    }
+    assert not catalogued.intersection(excluded)
+
+
 def test_a_plain_name_also_excludes_its_regional_listings(monkeypatch, tmp_path) -> None:
     """Azure lists the same model per region; suppressing it means all of them."""
     monkeypatch.setenv(


### PR DESCRIPTION
## Summary

- exclude seven LiteLLM Watsonx IDs that do not match IBM documented API IDs
- exclude two Watsonx models reported unusable in lakehouse/tracker#82237
- cover both static LiteLLM catalogue and live Watsonx inventory filtering

## Testing

- 43 provider configuration and catalogue tests passed
- focused Watsonx regression test passed
- Ruff and git diff checks passed

## Known baseline issues

The full unit suite currently stops during collection because src/agent.py does not export _extract_delta_text or _extract_retrieval_sources. These failures are unrelated to this change.