### PR TITLE
fix: upgrade package versions for Langflow to fix CVEs

### DIFF
--- a/Dockerfile.langflow
+++ b/Dockerfile.langflow
@@ -10,8 +10,9 @@ RUN pip install --no-cache-dir --upgrade "pip>=26.1.2" \
 
 RUN pip install --no-cache-dir \
     --extra-index-url https://download.pytorch.org/whl/cpu \
-    torch==2.10.0 \
-    torchvision==0.25.0 \
+    torch==2.13.0 \
+    torchvision==0.28.0 \
+    "transformers>=5.10.1,<6.0.0" \
     docling \
     openai \
     langchain-openai \


### PR DESCRIPTION
This pull request updates the dependencies in the `Dockerfile.langflow` to ensure compatibility with newer versions and to add support for transformer models.

This fixes CVE-2026-9856 and CVE-2025-3000

Dependency updates and additions:

* Upgraded `torch` from version 2.10.0 to 2.13.0 and `torchvision` from 0.25.0 to 0.28.0 for improved features and compatibility.
* Added the `transformers` library with version constraints (`>=5.10.1,<6.0.0`) to support transformer-based models.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image’s machine-learning dependencies.
  * Added support for the specified Transformers 5.x release range.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->