### PR TITLE
fix: improve knowledge table checkbox contrast in light mode

### DIFF
--- a/frontend/components/AgGrid/agGridStyles.css
+++ b/frontend/components/AgGrid/agGridStyles.css
@@ -14,7 +14,7 @@ body {
 
   /* Checkbox styling */
   --ag-checkbox-background-color: hsl(var(--background));
-  --ag-checkbox-border-color: hsl(var(--input));
+  --ag-checkbox-border-color: hsl(var(--muted-foreground));
   --ag-checkbox-checked-color: hsl(var(--primary));
   --ag-checkbox-unchecked-color: transparent;
 
@@ -30,7 +30,7 @@ body {
   }
 
   .ag-checkbox-input-wrapper {
-    border: 1px solid hsl(var(--input));
+    border: 1px solid hsl(var(--muted-foreground));
     background-color: hsl(var(--background));
   }
 


### PR DESCRIPTION
The AG Grid checkbox border used --input, which renders at ~1.3:1 contrast against the white background in light mode (WCAG 1.4.11 requires 3:1). Switching to --muted-foreground brings light mode to ~4.8:1 while leaving dark mode (~5.5:1) effectively unchanged.

Verified visually against the running dev stack: header select-all checkbox border goes from invisible to clearly outlined in light mode; dark mode is visually unaffected.

Fixes #816

## Screenshots

| | Before | After |
|---|---|---|
| **Light mode** | ![before light](https://raw.githubusercontent.com/langflow-ai/openrag/414c0d676d65a51cf1319d1e34d43c9e6561a10d/pr-assets/816/before-light.png) | ![after light](https://raw.githubusercontent.com/langflow-ai/openrag/414c0d676d65a51cf1319d1e34d43c9e6561a10d/pr-assets/816/after-light.png) |
| **Dark mode** | ![before dark](https://raw.githubusercontent.com/langflow-ai/openrag/414c0d676d65a51cf1319d1e34d43c9e6561a10d/pr-assets/816/before-dark.png) | ![after dark](https://raw.githubusercontent.com/langflow-ai/openrag/414c0d676d65a51cf1319d1e34d43c9e6561a10d/pr-assets/816/after-dark.png) |

In light mode the checkbox border is barely visible before the fix (~1.3:1 contrast) and clearly outlined after (~4.8:1). Dark mode is visually unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated AG Grid checkbox border colors to improve visual consistency and contrast.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
