### PR TITLE
fix: retry transient OpenSearch bulk failures instead of failing the …

### DIFF
--- a/src/services/document_index_writer.py
+++ b/src/services/document_index_writer.py
@@ -7,6 +7,7 @@ indexing chunks into the documents index.
 
 from __future__ import annotations
 
+import asyncio
 import datetime
 import hashlib
 import json
@@ -19,6 +20,25 @@ from utils.group_acl import unique_acl_principal_labels, unique_acl_principals
 from utils.logging_config import get_logger
 
 logger = get_logger(__name__)
+
+# A single bulk() call executes every item independently, so one item hitting
+# a transient condition (cluster under load, a shard temporarily unavailable)
+# sets `errors: true` for the whole response even though the rest of the
+# document's chunks were written successfully. That makes an entire file look
+# "failed" in the task counters even when it's actually indexed and visible.
+# Retrying the whole request is safe here because every op is an idempotent
+# upsert, so re-sending already-succeeded items has no effect.
+_BULK_RETRYABLE_ERROR_TYPES = frozenset(
+    {
+        "es_rejected_execution_exception",
+        "process_cluster_event_timeout_exception",
+        "unavailable_shards_exception",
+        "timeout_exception",
+        "version_conflict_engine_exception",
+    }
+)
+_MAX_BULK_RETRIES = 2
+_BULK_RETRY_DELAY_SECONDS = 0.5
 
 
 @dataclass
@@ -134,7 +154,7 @@ class DocumentIndexWriter:
                 )
             )
 
-        result = await client.bulk(body=bulk_body, refresh=refresh)
+        result = await self._bulk_with_retry(client, bulk_body, refresh=refresh)
         self._raise_for_bulk_errors(result)
         if final:
             await self._refresh(index_name)
@@ -314,6 +334,34 @@ class DocumentIndexWriter:
         if "filesize" in normalized and "file_size" not in normalized:
             normalized["file_size"] = normalized["filesize"]
         return normalized
+
+    @staticmethod
+    def _bulk_errors_are_retryable(result: Any) -> bool:
+        if not isinstance(result, dict):
+            return False
+        for item in result.get("items", []):
+            action = item.get("index") or item.get("create") or item.get("update") or item
+            error = action.get("error")
+            if error and error.get("type") not in _BULK_RETRYABLE_ERROR_TYPES:
+                return False
+        return True
+
+    async def _bulk_with_retry(
+        self, client: Any, bulk_body: list[dict[str, Any]], *, refresh: bool | str
+    ) -> Any:
+        result = await client.bulk(body=bulk_body, refresh=refresh)
+        for attempt in range(_MAX_BULK_RETRIES):
+            if not isinstance(result, dict) or not result.get("errors"):
+                return result
+            if not self._bulk_errors_are_retryable(result):
+                return result
+            logger.warning(
+                "Retrying OpenSearch bulk write after transient error",
+                attempt=attempt + 1,
+            )
+            await asyncio.sleep(_BULK_RETRY_DELAY_SECONDS * (attempt + 1))
+            result = await client.bulk(body=bulk_body, refresh=refresh)
+        return result
 
     @staticmethod
     def _raise_for_bulk_errors(result: Any) -> None:

--- a/tests/unit/test_document_index_writer_bulk_retry.py
+++ b/tests/unit/test_document_index_writer_bulk_retry.py
@@ -51,7 +51,10 @@ async def test_retries_transient_error_and_recovers(monkeypatch):
                         "index": {
                             "_id": "chunk-2",
                             "status": 429,
-                            "error": {"type": "es_rejected_execution_exception", "reason": "queue full"},
+                            "error": {
+                                "type": "es_rejected_execution_exception",
+                                "reason": "queue full",
+                            },
                         }
                     },
                 ],

--- a/tests/unit/test_document_index_writer_bulk_retry.py
+++ b/tests/unit/test_document_index_writer_bulk_retry.py
@@ -1,0 +1,119 @@
+"""`_bulk_with_retry` must retry transient bulk failures but not real ones.
+
+A single bulk() call executes every item independently, so one item hitting a
+transient condition (e.g. the write thread pool briefly rejecting a request)
+sets `errors: true` for the whole response even though the rest of the
+document's chunks were written. Since every op is an idempotent upsert,
+retrying the same request is safe and should recover from that case without
+marking the whole document as failed. A genuine content/schema error must
+still raise immediately, without wasting retries.
+"""
+
+from typing import Any
+
+import pytest
+
+from services.document_index_writer import DocumentIndexWriter
+
+
+class ScriptedBulkClient:
+    """Returns each scripted response in order, one per `bulk()` call."""
+
+    def __init__(self, responses: list[dict[str, Any]]) -> None:
+        self.responses = responses
+        self.calls = 0
+
+    async def bulk(self, *, body: list[dict[str, Any]], refresh: bool | str) -> dict[str, Any]:
+        response = self.responses[min(self.calls, len(self.responses) - 1)]
+        self.calls += 1
+        return response
+
+
+def _bulk_body() -> list[dict[str, Any]]:
+    return [
+        {"index": {"_id": "chunk-1"}},
+        {"text": "a"},
+        {"index": {"_id": "chunk-2"}},
+        {"text": "b"},
+    ]
+
+
+@pytest.mark.asyncio
+async def test_retries_transient_error_and_recovers(monkeypatch):
+    monkeypatch.setattr("services.document_index_writer._BULK_RETRY_DELAY_SECONDS", 0)
+    client = ScriptedBulkClient(
+        [
+            {
+                "errors": True,
+                "items": [
+                    {"index": {"_id": "chunk-1", "status": 201}},
+                    {
+                        "index": {
+                            "_id": "chunk-2",
+                            "status": 429,
+                            "error": {"type": "es_rejected_execution_exception", "reason": "queue full"},
+                        }
+                    },
+                ],
+            },
+            {"errors": False, "items": [{"index": {"_id": "chunk-1", "status": 201}}]},
+        ]
+    )
+
+    writer = DocumentIndexWriter()
+    result = await writer._bulk_with_retry(client, _bulk_body(), refresh=False)
+
+    assert client.calls == 2
+    assert result["errors"] is False
+
+
+@pytest.mark.asyncio
+async def test_does_not_retry_non_retryable_error(monkeypatch):
+    monkeypatch.setattr("services.document_index_writer._BULK_RETRY_DELAY_SECONDS", 0)
+    client = ScriptedBulkClient(
+        [
+            {
+                "errors": True,
+                "items": [
+                    {
+                        "index": {
+                            "_id": "chunk-2",
+                            "status": 400,
+                            "error": {"type": "mapper_parsing_exception", "reason": "bad field"},
+                        }
+                    },
+                ],
+            },
+        ]
+    )
+
+    writer = DocumentIndexWriter()
+    result = await writer._bulk_with_retry(client, _bulk_body(), refresh=False)
+
+    assert client.calls == 1
+    assert result["errors"] is True
+
+
+@pytest.mark.asyncio
+async def test_gives_up_after_max_retries_still_failing(monkeypatch):
+    monkeypatch.setattr("services.document_index_writer._BULK_RETRY_DELAY_SECONDS", 0)
+    persistent_failure = {
+        "errors": True,
+        "items": [
+            {
+                "index": {
+                    "_id": "chunk-2",
+                    "status": 429,
+                    "error": {"type": "es_rejected_execution_exception", "reason": "queue full"},
+                }
+            },
+        ],
+    }
+    client = ScriptedBulkClient([persistent_failure])
+
+    writer = DocumentIndexWriter()
+    result = await writer._bulk_with_retry(client, _bulk_body(), refresh=False)
+
+    # Initial attempt + _MAX_BULK_RETRIES retries, all exhausted.
+    assert client.calls == 3
+    assert result["errors"] is True


### PR DESCRIPTION
…whole file

A single bulk() call carries every chunk of a document, and OpenSearch sets errors: true on the response if even one item in that request failed - even when the rest of the chunks were written successfully. That RuntimeError propagates up and marks the entire file as failed (upload_task.failed_files += 1), even though the file is actually indexed and searchable. This matches issue #1234's symptom: files that show up correctly in Knowledge (built from OpenSearch aggregations, independent of the task counters) are still counted as failed in the task list.

Since every bulk op is an idempotent upsert, retrying the identical request is safe. Add DocumentIndexWriter._bulk_with_retry, which retries the whole bulk() call (up to 2 times, with backoff) only when every failing item's error type looks transient (rejected_execution, cluster event timeout, unavailable shards, timeout, version conflict). A genuine content/schema error (e.g. mapper_parsing_exception) is not retried and still fails fast.

Fixes #1234

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Bulk document indexing retries only failed items, preserving successful results from earlier attempts.
  - Temporary failures can recover without resending the entire batch, reducing duplicate processing and improving reliability under load.
  - Non-retryable errors are reported promptly, while repeated temporary failures stop after a limited number of attempts.
  - Incomplete bulk responses and reported errors are now surfaced accurately.

- **Tests**
  - Expanded coverage for partial retries, recovery, error handling, and persistent failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->