### PR TITLE
Fix search bar clear/submit buttons requiring two clicks

### DIFF
--- a/frontend/components/knowledge-search-bar.tsx
+++ b/frontend/components/knowledge-search-bar.tsx
@@ -1,4 +1,4 @@
-import { ArrowRight, RefreshCw, Search, X } from "lucide-react";
+import { ArrowRight, Download, RefreshCw, Search, X } from "lucide-react";
 import { type ChangeEvent, type FormEvent, useCallback, useState } from "react";
 import { toast } from "sonner";
 import { useRefreshOpenragDocs } from "@/app/api/mutations/useRefreshOpenragDocs";
@@ -133,7 +133,7 @@ export const KnowledgeSearchBar = () => {
             onChange={(e: ChangeEvent<HTMLInputElement>) =>
               setSearchQueryInput(e.target.value)
             }
-            className="h-full w-full bg-transparent text-sm text-[hsl(var(--placeholder))] placeholder:text-[hsl(var(--placeholder))] focus:outline-none focus:ring-0"
+            className="h-full w-full bg-transparent text-sm text-foreground placeholder:text-[hsl(var(--placeholder))] focus:outline-none focus:ring-0"
           />
           {searchQueryInput && (
             <button
@@ -175,7 +175,12 @@ export const KnowledgeSearchBar = () => {
             type="button"
             variant="ghost"
             disabled={refreshOpenragDocsMutation.isPending}
-            className="h-auto flex-shrink-0 rounded-none px-3 text-sm hover:bg-accent hover:text-foreground"
+            aria-label={
+              refreshOpenragDocsMutation.isPending
+                ? "Refreshing docs..."
+                : "Fetch latest docs"
+            }
+            className="h-auto flex-shrink-0 rounded-none px-3 text-sm hover:bg-accent hover:text-foreground gap-2"
             onClick={async () => {
               try {
                 toast.info("Refreshing OpenRAG docs...");
@@ -190,9 +195,12 @@ export const KnowledgeSearchBar = () => {
               }
             }}
           >
-            {refreshOpenragDocsMutation.isPending
-              ? "Refreshing docs..."
-              : "Fetch latest docs"}
+            <Download className="h-4 w-4 flex-shrink-0" />
+            <span className="hidden lg:inline">
+              {refreshOpenragDocsMutation.isPending
+                ? "Refreshing docs..."
+                : "Fetch latest docs"}
+            </span>
           </Button>
         </RequirePermission>
         <div className="ml-auto">

--- a/frontend/components/knowledge-search-bar.tsx
+++ b/frontend/components/knowledge-search-bar.tsx
@@ -135,7 +135,7 @@ export const KnowledgeSearchBar = () => {
             }
             className="h-full w-full bg-transparent text-sm text-[hsl(var(--placeholder))] placeholder:text-[hsl(var(--placeholder))] focus:outline-none focus:ring-0"
           />
-          {queryOverride && (
+          {searchQueryInput && (
             <button
               type="button"
               aria-label="Clear search"
@@ -147,7 +147,10 @@ export const KnowledgeSearchBar = () => {
           )}
           <Button
             variant="ghost"
-            className="h-auto rounded-none hover:bg-accent hover:text-foreground p-2 hidden group-focus-within/input:block"
+            className={cn(
+              "h-auto rounded-none hover:bg-accent hover:text-foreground p-2 hidden group-focus-within/input:block",
+              searchQueryInput && "block",
+            )}
             type="submit"
           >
             <ArrowRight className="h-4 w-4 text-[var(--icon-primary)]" />


### PR DESCRIPTION
## Summary

Two fixes to the IBM/cloud-brand knowledge search bar (`KnowledgeSearchBar`):

**1. Clear/submit buttons required two clicks (#81151)**

Both buttons based their visibility on stale/focus-only signals (committed query, CSS `:focus-within`) instead of the live input value, causing a layout reflow between mousedown and mouseup that swallowed the first click. Both now key off the live input value, matching the existing pattern in `knowledge-search-input.tsx`.

| Before (1 click on Clear) | After (1 click on Clear) |
| --- | --- |
| <img width="900" height="260" alt="81151-clear-before" src="https://github.com/user-attachments/assets/4adb3b84-7d15-4313-abca-9a65c4d6da55" /> | <img width="900" height="260" alt="81151-clear-after" src="https://github.com/user-attachments/assets/ca070232-6163-412d-91c8-cba83ca75cec" /> |

**2. Low-contrast search text + narrow-viewport clipping**

- Typed search text was styled with the same faint color as its placeholder, making queries hard to read. It now uses the standard foreground text color.
- Below ~900px the toolbar (search, sync, fetch docs, add knowledge) squeezed the search input down to nothing and could clip the "Add knowledge" button off-screen, since none of the action buttons shrink. "Fetch latest docs" now collapses to an icon-only button below the `lg` breakpoint, freeing enough width to keep the input usable.

| Before | After |
| --- | --- |
| <img width="900" height="260" alt="81151-contrast-before" src="https://github.com/user-attachments/assets/03b727ca-836e-4cd5-96ce-759fb82affab" /> | <img width="900" height="260" alt="81151-contrast-after" src="https://github.com/user-attachments/assets/96bff3cb-050c-4180-9971-42280a5d7eca" /> |
| <img width="640" height="160" alt="81151-narrow-before" src="https://github.com/user-attachments/assets/342fcbe6-6249-4fcd-b182-15364f9daa7a" /> (900px wide) | <img width="640" height="160" alt="81151-narrow-after" src="https://github.com/user-attachments/assets/70f60d19-c1fb-48d1-9e97-46bac2b8cb54" /> (900px wide) |

Fixes #81151

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Search bar controls now accurately reflect the text currently entered.
  - The submit button remains available whenever a search query is present, including when the field is not focused.
  - Search input text is now displayed with improved contrast.

- **Accessibility**
  - The latest documentation button now provides a clearer label while loading.

- **Style**
  - The latest documentation button includes a download icon and a more compact mobile layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
