### PR TITLE
fix: make custom model selection provider-aware

### DIFF
--- a/frontend/app/onboarding/_components/advanced.test.tsx
+++ b/frontend/app/onboarding/_components/advanced.test.tsx
@@ -1,0 +1,62 @@
+import { describe, expect, it, vi } from "vitest";
+import { TooltipProvider } from "@/components/ui/tooltip";
+import { renderWithProviders, screen, userEvent } from "@/test-utils/render";
+import { AdvancedOnboarding } from "./advanced";
+
+describe("AdvancedOnboarding custom models", () => {
+  it("accepts a language model that is absent from provider inventory", async () => {
+    const setLanguageModel = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <TooltipProvider>
+        <AdvancedOnboarding
+          languageModels={[]}
+          languageModel=""
+          setLanguageModel={setLanguageModel}
+        />
+      </TooltipProvider>,
+    );
+
+    const selector = screen.getByTestId("language-model-selector");
+    expect(selector).toBeEnabled();
+    await user.click(selector);
+    await user.type(
+      screen.getByTestId("model-search-input"),
+      "acme/private-model",
+    );
+    await user.click(
+      screen.getByTestId("model-custom-option-acme/private-model"),
+    );
+
+    expect(setLanguageModel).toHaveBeenCalledWith("acme/private-model");
+  });
+
+  it("accepts an embedding model that is absent from provider inventory", async () => {
+    const setEmbeddingModel = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <TooltipProvider>
+        <AdvancedOnboarding
+          embeddingModels={[]}
+          embeddingModel=""
+          setEmbeddingModel={setEmbeddingModel}
+        />
+      </TooltipProvider>,
+    );
+
+    const selector = screen.getByTestId("embedding-model-selector");
+    expect(selector).toBeEnabled();
+    await user.click(selector);
+    await user.type(
+      screen.getByTestId("model-search-input"),
+      "acme/private-embedding",
+    );
+    await user.click(
+      screen.getByTestId("model-custom-option-acme/private-embedding"),
+    );
+
+    expect(setEmbeddingModel).toHaveBeenCalledWith("acme/private-embedding");
+  });
+});

--- a/frontend/app/onboarding/_components/advanced.tsx
+++ b/frontend/app/onboarding/_components/advanced.tsx
@@ -38,6 +38,7 @@ export function AdvancedOnboarding({
         >
           <ModelSelector
             options={embeddingModels}
+            custom
             data-testid="embedding-model-selector"
             icon={icon}
             value={embeddingModel}
@@ -54,6 +55,7 @@ export function AdvancedOnboarding({
         >
           <ModelSelector
             options={languageModels}
+            custom
             data-testid="language-model-selector"
             icon={icon}
             value={languageModel}

--- a/frontend/components/models/model-selector.test.tsx
+++ b/frontend/components/models/model-selector.test.tsx
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { renderWithProviders, screen, userEvent } from "@/test-utils/render";
+import { ModelSelector } from "./model-selector";
+
+describe("ModelSelector custom entries", () => {
+  it("offers a typed model under every configured provider group", async () => {
+    const onValueChange = vi.fn();
+    const user = userEvent.setup();
+
+    renderWithProviders(
+      <ModelSelector
+        groupedOptions={[
+          {
+            group: "OpenAI",
+            provider: "openai",
+            options: [{ value: "gpt-4o", label: "gpt-4o" }],
+          },
+          {
+            group: "Anthropic",
+            provider: "anthropic",
+            options: [{ value: "claude-sonnet-4", label: "Claude Sonnet 4" }],
+          },
+        ]}
+        custom
+        value=""
+        onValueChange={onValueChange}
+        defaultOpen
+      />,
+    );
+
+    await user.type(
+      screen.getByTestId("model-search-input"),
+      "acme/private-model",
+    );
+
+    expect(
+      screen.getByRole("option", {
+        name: "Use openai:acme/private-model",
+      }),
+    ).toBeInTheDocument();
+    await user.click(
+      screen.getByRole("option", {
+        name: "Use anthropic:acme/private-model",
+      }),
+    );
+
+    expect(onValueChange).toHaveBeenCalledWith(
+      "acme/private-model",
+      "anthropic",
+    );
+  });
+});

--- a/frontend/components/models/model-selector.tsx
+++ b/frontend/components/models/model-selector.tsx
@@ -188,7 +188,16 @@ export function ModelSelector({
               !isRetiringSoon(option) ||
               isSelectedRow(option, value, selectedProvider, group),
           );
-      if (deferredSearch && matches.length === 0 && deprecatedCount === 0) {
+      // A custom name still needs one action per configured provider. Keeping
+      // otherwise-empty groups visible makes provider selection deterministic
+      // instead of falling back to a single provider-less row whenever the
+      // typed name has no catalogue match.
+      if (
+        deferredSearch &&
+        matches.length === 0 &&
+        deprecatedCount === 0 &&
+        !allowCustomEntry
+      ) {
         return [];
       }
       // Collapsed groups show a preview; the trailing row expands them. The cap
@@ -209,6 +218,7 @@ export function ModelSelector({
     deprecatedGroups,
     value,
     selectedProvider,
+    allowCustomEntry,
   ]);
   const visibleOptions = useMemo(() => {
     if (groupedOptions) return [];
@@ -435,8 +445,12 @@ export function ModelSelector({
                       {showCustom && (
                         <CommandItem
                           value={`${group.group}-${customValue}`}
-                          aria-label={customValue}
-                          data-testid={`model-custom-option-${customValue}`}
+                          aria-label={
+                            groupProvider
+                              ? `Use ${groupProvider}:${customValue}`
+                              : `Use ${customValue}`
+                          }
+                          data-testid={`model-custom-option-${groupProvider ?? "unknown"}-${customValue}`}
                           onSelect={() => {
                             if (
                               customValue !== value ||


### PR DESCRIPTION
## Summary
- keep every configured provider available when entering an off-catalog model name
- make provider-specific custom model choices explicit and accessible
- allow custom language and embedding model names during provider onboarding, including when inventory is empty
- add regression coverage for grouped provider selection and both onboarding model fields

## Root cause
Grouped search removed provider groups that had no catalog match. An unknown model name therefore fell back to one provider-less action, so users could not reliably associate the custom model with the intended provider. Advanced onboarding also omitted the custom-entry option, leaving empty model selectors disabled.

Related to #771 (addresses the custom model-name path; does not close the broader custom-provider/skip-onboarding request).

## Testing
- `npm test` — 25 files, 282 tests passed
- `npm run typecheck`
- `npm run lint` — passed; existing repository warnings remain
- `biome check` on all four changed files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Advanced onboarding now supports selecting custom language and embedding models not listed in the available inventory.
  - Custom model entries can be selected for each configured provider.

- **Bug Fixes**
  - Provider groups remain available during model searches, even when no matching models are found.
  - Improved accessibility labels and test identifiers for custom model options.

- **Tests**
  - Added coverage for custom model selection in onboarding and the model selector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->