### PR TITLE
fix: route Ollama chat calls through litellm's ollama_chat/ provider

### DIFF
--- a/src/services/llm_gateway.py
+++ b/src/services/llm_gateway.py
@@ -237,7 +237,26 @@ def resolve_call(
     # under the key it aliases (`watsonx_onprem` -> `watsonx`). The OpenRAG key
     # is still what the caller sees and what credentials are stored under.
     route = litellm_provider_key(provider)
-    litellm_model = f"{route}/{name}" if route != "openai" else name
+    if route == "openai":
+        litellm_model = name
+    elif provider == "ollama" and kind == "chat":
+        # LiteLLM's "ollama/" prefix routes chat calls to Ollama's legacy
+        # /api/generate completion endpoint, which has no native tool-calling
+        # support: LiteLLM hand-rolls the tool schemas into the prompt as text
+        # and parses the model's free-form response for a JSON-shaped tool
+        # call. Against small local models this reliably produces malformed
+        # tool-call JSON, and - observed directly via a request trace - the
+        # model echoing a prior tool result back verbatim as its "final
+        # answer" once the conversation gets long. "ollama_chat/" routes to
+        # /api/chat with LiteLLM's native `tools`/`tool_calls` support, which
+        # Ollama itself has supported for a long time and which this gateway
+        # already forwards `tools`/`tool_choice` for (see
+        # _LITELLM_FORWARDED_PARAMS above) - they were simply never reaching
+        # a code path that used them for Ollama. LiteLLM's embedding routing
+        # has no "ollama_chat" provider, so this is chat-only.
+        litellm_model = "ollama_chat/" + name
+    else:
+        litellm_model = f"{route}/{name}"
     return litellm_model, provider, credentials
 
 
@@ -291,6 +310,11 @@ def _call_label(provider: str, model: str) -> str:
     route = litellm_provider_key(provider) if provider else ""
     if route and route != provider and model.startswith(f"{route}/"):
         model = model[len(route) + 1 :]
+    elif provider == "ollama" and model.startswith("ollama_chat/"):
+        # Not caught by the alias branch above: "ollama" has no registered
+        # route alias, so route == provider here even though resolve_call()
+        # routed this specific (chat) call under "ollama_chat/" directly.
+        model = model[len("ollama_chat/") :]
     if model and provider and not model.startswith(f"{provider}/"):
         return f"{provider}/{model}"
     return model or provider or "provider"

--- a/tests/unit/services/test_llm_gateway.py
+++ b/tests/unit/services/test_llm_gateway.py
@@ -79,6 +79,25 @@ def test_resolve_call_watsonx_includes_project_and_endpoint():
     assert creds["api_base"] == "https://us-south.ml.cloud.ibm.com"
 
 
+def test_resolve_call_ollama_chat_uses_ollama_chat_prefix():
+    cfg = _config(agent=SimpleNamespace(llm_model="qwen3:8b", llm_provider="ollama"))
+    model, provider, creds = resolve_call(None, kind="chat", config=cfg)
+    assert provider == "ollama"
+    assert model == "ollama_chat/qwen3:8b"
+    assert creds["api_base"] == "http://localhost:11434"
+
+
+def test_resolve_call_ollama_embedding_keeps_ollama_prefix():
+    # LiteLLM has no "ollama_chat" embedding provider - only "ollama/" is
+    # ever a valid embedding route, so the chat-only rewrite must not apply here.
+    cfg = _config(
+        knowledge=SimpleNamespace(embedding_model="nomic-embed-text", embedding_provider="ollama")
+    )
+    model, provider, creds = resolve_call(None, kind="embedding", config=cfg)
+    assert provider == "ollama"
+    assert model == "ollama/nomic-embed-text"
+
+
 def test_legacy_text_embedding_3_small_routes_to_openai_not_selected_provider():
     cfg = _config(
         knowledge=SimpleNamespace(


### PR DESCRIPTION
## Summary

`resolve_call()` in `src/services/llm_gateway.py` builds every non-OpenAI,
non-aliased model id as `f"{route}/{name}"`, which for the built-in Ollama
provider produces `ollama/<model>`. LiteLLM treats `ollama/` and `ollama_chat/`
as two genuinely different routes:

- `ollama/*` → Ollama's **legacy `/api/generate` completion endpoint**. LiteLLM
  has no structured tool-calling support on this path: it hand-rolls every
  tool's JSON schema into the prompt as literal text and parses the model's
  free-form completion for a JSON-shaped tool call.
- `ollama_chat/*` → Ollama's **native `/api/chat` endpoint** with LiteLLM's
  real `tools`/`tool_calls` support — which this gateway already forwards
  (`tools`/`tool_choice` are both in `_LITELLM_FORWARDED_PARAMS`), it just
  never reached a code path that used them for Ollama.

I traced this live with a logging proxy between the backend and Ollama,
capturing every `/api/generate`/`/api/embed` call for one real `/v1/chat`
request end to end. For a question against a locally-ingested knowledge base,
the agent looped through 8 rounds of tool calls, and on the 9th its own
"answer" was **the previous tool result's raw JSON, echoed back verbatim** —
the hand-rolled completion-style prompt gave the model nothing but a wall of
text to pattern-match against, and it pattern-matched onto its own prior
output instead of synthesizing a final answer.

I believe this is the root cause of #951 ("some ollama-based models fail to
recognize tools") — not a per-model capability gap, but every Ollama chat call
going through a completion-style path with no structured tool-calling at all.
I haven't reproduced with the exact models in that report (`mistral-small3.2`,
`nemotron-3-nano`), so I'm not claiming this closes it outright, but the
mechanism fits: some models are just more robust to a hand-rolled JSON-in-text
protocol than others, which reads as "some models don't support tools" when
the real cause is upstream of any model's own tool-calling ability.

## Fix

Route Ollama **chat** calls through `ollama_chat/{name}` instead of
`ollama/{name}`. Embedding calls are untouched — LiteLLM has no `ollama_chat`
embedding provider, only `ollama/*` is ever valid there, so the rewrite is
gated on `kind == "chat"`. Also fixed `_call_label()`'s display-prefix
stripping so error messages don't leak `ollama_chat/` verbatim.

## Verification

Re-ran the identical failing question against the patched backend:

| | `ollama/qwen3:8b` (before) | `ollama_chat/qwen3:8b` (after) |
|---|---|---|
| Ollama endpoint hit | `/api/generate` (legacy) | `/api/chat` (native) |
| Model calls to converge | 9 | 2 |
| Wall-clock | ~309s | ~66s |
| Response | raw retrieved-chunk JSON dump | correct, natural-language answer with inline citation |

Reproduced and fixed against `qwen3:8b`; the mechanism (LiteLLM provider
routing) is model-independent, so it should apply to any Ollama-backed chat
model.

## Test plan

- [x] `uv run pytest tests/unit/services/test_llm_gateway.py` — 72 passed,
      including two new tests:
      `test_resolve_call_ollama_chat_uses_ollama_chat_prefix` and
      `test_resolve_call_ollama_embedding_keeps_ollama_prefix`
- [x] `uv run pytest tests/unit` — same 29 pre-existing failures/2 collection
      errors on this branch as on unmodified `main` (confirmed by diffing
      against a stashed run), no regressions introduced
- [x] `ruff check` clean on both changed files
- [ ] Manual: configure Ollama as the agent LLM provider, ask a question that
      requires a tool call, confirm `/v1/chat` returns a synthesized answer
      rather than raw tool output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ollama chat interactions now support native tool calling.
  * Human-readable model labels are displayed without redundant provider prefixes.

* **Bug Fixes**
  * Ollama embedding requests continue using the compatible embedding route.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->